### PR TITLE
fix triton implementation of modulate

### DIFF
--- a/fastvideo/ops/modulate/k_modulate.py
+++ b/fastvideo/ops/modulate/k_modulate.py
@@ -80,8 +80,7 @@ def _modulate_fwd(
     x = tl.load(x_ptrs, mask=block_mask, other=0.0)
     scale = tl.load(scale_ptrs, mask=block_mask, other=0.0)
     shift = tl.load(shift_ptrs, mask=block_mask, other=0.0)
-
-    output = x * (scale + 1) + shift
+    output = x * ((scale + 1).to(scale.dtype)) + shift
     # Write x + y back to DRAM.
     tl.store(output_ptr + rows[:, None] * m_stride + cols[None, :],
              output,

--- a/fastvideo/ops/modulate/k_modulate.py
+++ b/fastvideo/ops/modulate/k_modulate.py
@@ -1,0 +1,134 @@
+import triton
+import triton.language as tl
+
+CONFIG_LIST = [
+    triton.Config({
+        "BLOCK_M": 256,
+        "BLOCK_N": 32
+    }, num_stages=2, num_warps=4),
+    triton.Config({
+        "BLOCK_M": 128,
+        "BLOCK_N": 64
+    }, num_stages=2, num_warps=4),
+    triton.Config({
+        "BLOCK_M": 128,
+        "BLOCK_N": 32
+    }, num_stages=2, num_warps=4),
+    triton.Config({
+        "BLOCK_M": 64,
+        "BLOCK_N": 128
+    }, num_stages=2, num_warps=4),
+    triton.Config({
+        "BLOCK_M": 64,
+        "BLOCK_N": 64
+    }, num_stages=2, num_warps=4),
+    triton.Config({
+        "BLOCK_M": 64,
+        "BLOCK_N": 32
+    }, num_stages=2, num_warps=4),
+    triton.Config({
+        "BLOCK_M": 32,
+        "BLOCK_N": 64
+    }, num_stages=2, num_warps=4),
+    triton.Config({
+        "BLOCK_M": 32,
+        "BLOCK_N": 128
+    }, num_stages=2, num_warps=4),
+    triton.Config({
+        "BLOCK_M": 32,
+        "BLOCK_N": 256
+    }, num_stages=2, num_warps=4),
+]
+
+
+@triton.autotune(
+    configs=CONFIG_LIST,
+    key=["M", "N"],
+)
+@triton.jit
+def _modulate_fwd(
+    x_ptr,  # *Pointer* to first input vector.
+    output_ptr,  # *Pointer* to output vector.
+    scale_ptr,
+    shift_ptr,
+    m_stride,
+    s_stride,
+    M,
+    N,
+    seq_len,
+    BLOCK_M: tl.constexpr,  # Number of elements each program should process.
+    BLOCK_N: tl.constexpr,
+    # NOTE: `constexpr` so it can be used as a shape value.
+):
+    row_id = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
+    rows = row_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    batch_indices = rows // seq_len
+    # s_rows = (row_id // seq_len) * BLOCK_M
+
+    col_id = tl.program_id(axis=1)
+    cols = col_id * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    x_ptrs = x_ptr + rows[:, None] * m_stride + cols[None, :]
+    scale_ptrs = scale_ptr + batch_indices[:, None] * s_stride + cols[None, :]
+    shift_ptrs = shift_ptr + batch_indices[:, None] * s_stride + cols[None, :]
+
+    # scale_ptrs = scale_ptr + s_rows * s_stride + cols[None, :]
+    # shift_ptrs = shift_ptr + s_rows * s_stride + cols[None, :]
+
+    col_mask = cols[None, :] < N
+    block_mask = (rows[:, None] < M) & col_mask
+    x = tl.load(x_ptrs, mask=block_mask, other=0.0)
+    scale = tl.load(scale_ptrs, mask=block_mask, other=0.0)
+    shift = tl.load(shift_ptrs, mask=block_mask, other=0.0)
+
+    output = x * (scale + 1) + shift
+    # Write x + y back to DRAM.
+    tl.store(output_ptr + rows[:, None] * m_stride + cols[None, :],
+             output,
+             mask=block_mask)
+
+
+@triton.autotune(
+    configs=CONFIG_LIST,
+    key=["M", "N"],
+)
+@triton.jit
+def _modulate_bwd(
+    dx_ptr,  # *Pointer* to first input vector.
+    x_ptr,
+    dy_ptr,  # *Pointer* to output vector.
+    scale_ptr,
+    dscale_ptr,
+    m_stride,
+    s_stride,
+    M,
+    N,
+    seq_len,
+    BLOCK_M: tl.constexpr,  # Number of elements each program should process.
+    BLOCK_N: tl.constexpr,
+    # NOTE: `constexpr` so it can be used as a shape value.
+):
+    row_id = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
+    rows = row_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    batch_indices = rows // seq_len
+    col_id = tl.program_id(axis=1)
+    cols = col_id * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    x_ptrs = x_ptr + rows[:, None] * m_stride + cols[None, :]
+    dy_ptrs = dy_ptr + rows[:, None] * m_stride + cols[None, :]
+    dx_ptrs = dx_ptr + rows[:, None] * m_stride + cols[None, :]
+    dscale_ptrs = dscale_ptr + rows[:, None] * m_stride + cols[None, :]
+
+    scale_ptrs = scale_ptr + batch_indices[:, None] * s_stride + cols[None, :]
+
+    col_mask = cols[None, :] < N
+    block_mask = (rows[:, None] < M) & col_mask
+    x = tl.load(x_ptrs, mask=block_mask, other=0.0)
+    dy = tl.load(dy_ptrs, mask=block_mask, other=0.0)
+    scale = tl.load(scale_ptrs, mask=block_mask, other=0.0)
+
+    dx = dy * (1 + scale)
+    dscale = dy * x
+    # Write x + y back to DRAM.
+    tl.store(dx_ptrs, dx, mask=block_mask)
+    tl.store(dscale_ptrs, dscale, mask=block_mask)

--- a/fastvideo/ops/modulate/modulate.py
+++ b/fastvideo/ops/modulate/modulate.py
@@ -1,0 +1,68 @@
+import torch
+import triton
+
+from fastvideo.ops.modulate.k_modulate import _modulate_bwd, _modulate_fwd
+
+
+class _FusedModulate(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, x, scale, shift):
+        y = torch.empty_like(x)
+        batch, seq_len, dim = x.shape
+        M = batch * seq_len
+        N = dim
+        x = x.view(-1, dim).contiguous()
+        scale = scale.view(-1, dim).contiguous()
+        shift = shift.view(-1, dim).contiguous()
+
+        def grid(meta):
+            return (
+                triton.cdiv(batch * seq_len, meta["BLOCK_M"]),
+                triton.cdiv(dim, meta["BLOCK_N"]),
+            )
+
+        _modulate_fwd[grid](x, y, scale, shift, x.stride(0), scale.stride(0),
+                            M, N, seq_len)
+
+        ctx.save_for_backward(x, scale)
+        ctx.batch = batch
+        ctx.seq_len = seq_len
+        ctx.dim = dim
+        return y
+
+    @staticmethod
+    def backward(
+        ctx, dy
+    ):  # pragma: no cover  # this is covered, but called directly from C++
+        x, scale = ctx.saved_tensors
+
+        batch, seq_len, dim = ctx.batch, ctx.seq_len, ctx.dim
+        M = batch * seq_len
+        N = dim
+
+        # allocate output
+        dy = dy.contiguous()
+        dx = torch.empty_like(dy)
+        dscale = torch.empty_like(dy)
+        dshift = torch.sum(dy, dim=1)
+
+        def grid(meta):
+            return (
+                triton.cdiv(batch * seq_len, meta["BLOCK_M"]),
+                triton.cdiv(dim, meta["BLOCK_N"]),
+            )
+
+        _modulate_bwd[grid](dx, x, dy, scale, dscale, x.stride(0),
+                            scale.stride(0), M, N, seq_len)
+
+        dscale = torch.sum(dscale, dim=1)
+        return dx, dscale, dshift
+
+
+def fused_modulate(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+) -> torch.Tensor:
+    return _FusedModulate.apply(x, scale, shift)

--- a/tests/test_kernels/benchmark.py
+++ b/tests/test_kernels/benchmark.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2023, Tri Dao.
+"""Useful functions for writing test code."""
+
+import torch
+import torch.utils.benchmark as benchmark
+
+
+def get_abs_err(x, y):
+    return (x - y).flatten().abs().max().item()
+
+
+def get_err_ratio(x, y):
+    err = (x - y).flatten().square().mean().sqrt().item()
+    base = x.flatten().square().mean().sqrt().item()
+    return err / base
+
+
+def assert_close(prefix, ref, tri, ratio):
+    msg = f"{prefix} diff: {get_abs_err(ref, tri):.6f} ratio: {get_err_ratio(ref, tri):.6f}"
+    print(msg)
+    assert get_err_ratio(ref, tri) < ratio, msg
+
+
+def benchmark_forward(
+    fn,
+    *inputs,
+    repeats=10,
+    desc="",
+    verbose=True,
+    amp=False,
+    amp_dtype=torch.float16,
+    **kwinputs,
+):
+    """Use Pytorch Benchmark on the forward pass of an arbitrary function."""
+    if verbose:
+        print(desc, "- Forward pass")
+
+    def amp_wrapper(*inputs, **kwinputs):
+        with torch.autocast(device_type="cuda", dtype=amp_dtype, enabled=amp):
+            fn(*inputs, **kwinputs)
+
+    t = benchmark.Timer(
+        stmt="fn_amp(*inputs, **kwinputs)",
+        globals={
+            "fn_amp": amp_wrapper,
+            "inputs": inputs,
+            "kwinputs": kwinputs
+        },
+        num_threads=torch.get_num_threads(),
+    )
+    m = t.timeit(repeats)
+    if verbose:
+        print(m)
+    return t, m
+
+
+def benchmark_backward(
+    fn,
+    *inputs,
+    grad=None,
+    repeats=10,
+    desc="",
+    verbose=True,
+    amp=False,
+    amp_dtype=torch.float16,
+    **kwinputs,
+):
+    """Use Pytorch Benchmark on the backward pass of an arbitrary function."""
+    if verbose:
+        print(desc, "- Backward pass")
+    with torch.autocast(device_type="cuda", dtype=amp_dtype, enabled=amp):
+        y = fn(*inputs, **kwinputs)
+        if type(y) is tuple:
+            y = y[0]
+    if grad is None:
+        grad = torch.randn_like(y)
+    else:
+        if grad.shape != y.shape:
+            raise RuntimeError("Grad shape does not match output shape")
+
+    def f(*inputs, y, grad):
+        # Set .grad to None to avoid extra operation of gradient accumulation
+        for x in inputs:
+            if isinstance(x, torch.Tensor):
+                x.grad = None
+        y.backward(grad, retain_graph=True)
+
+    t = benchmark.Timer(
+        stmt="f(*inputs, y=y, grad=grad)",
+        globals={
+            "f": f,
+            "inputs": inputs,
+            "y": y,
+            "grad": grad
+        },
+        num_threads=torch.get_num_threads(),
+    )
+    m = t.timeit(repeats)
+    if verbose:
+        print(m)
+    return t, m
+
+
+def benchmark_combined(
+    fn,
+    *inputs,
+    grad=None,
+    repeats=10,
+    desc="",
+    verbose=True,
+    amp=False,
+    amp_dtype=torch.float16,
+    **kwinputs,
+):
+    """Use Pytorch Benchmark on the forward+backward pass of an arbitrary function."""
+    if verbose:
+        print(desc, "- Forward + Backward pass")
+    with torch.autocast(device_type="cuda", dtype=amp_dtype, enabled=amp):
+        y = fn(*inputs, **kwinputs)
+        if type(y) is tuple:
+            y = y[0]
+    if grad is None:
+        grad = torch.randn_like(y)
+    else:
+        if grad.shape != y.shape:
+            raise RuntimeError("Grad shape does not match output shape")
+
+    def f(grad, *inputs, **kwinputs):
+        for x in inputs:
+            if isinstance(x, torch.Tensor):
+                x.grad = None
+        with torch.autocast(device_type="cuda", dtype=amp_dtype, enabled=amp):
+            y = fn(*inputs, **kwinputs)
+            if type(y) is tuple:
+                y = y[0]
+        y.backward(grad, retain_graph=True)
+
+    t = benchmark.Timer(
+        stmt="f(grad, *inputs, **kwinputs)",
+        globals={
+            "f": f,
+            "fn": fn,
+            "inputs": inputs,
+            "grad": grad,
+            "kwinputs": kwinputs,
+        },
+        num_threads=torch.get_num_threads(),
+    )
+    m = t.timeit(repeats)
+    if verbose:
+        print(m)
+    return t, m
+
+
+def benchmark_fwd_bwd(
+    fn,
+    *inputs,
+    grad=None,
+    repeats=10,
+    desc="",
+    verbose=True,
+    amp=False,
+    amp_dtype=torch.float16,
+    **kwinputs,
+):
+    """Use Pytorch Benchmark on the forward+backward pass of an arbitrary function."""
+    return (
+        benchmark_forward(
+            fn,
+            *inputs,
+            repeats=repeats,
+            desc=desc,
+            verbose=verbose,
+            amp=amp,
+            amp_dtype=amp_dtype,
+            **kwinputs,
+        ),
+        benchmark_backward(
+            fn,
+            *inputs,
+            grad=grad,
+            repeats=repeats,
+            desc=desc,
+            verbose=verbose,
+            amp=amp,
+            amp_dtype=amp_dtype,
+            **kwinputs,
+        ),
+    )
+
+
+def benchmark_all(
+    fn,
+    *inputs,
+    grad=None,
+    repeats=10,
+    desc="",
+    verbose=True,
+    amp=False,
+    amp_dtype=torch.float16,
+    **kwinputs,
+):
+    """Use Pytorch Benchmark on the forward+backward pass of an arbitrary function."""
+    return (
+        benchmark_forward(
+            fn,
+            *inputs,
+            repeats=repeats,
+            desc=desc,
+            verbose=verbose,
+            amp=amp,
+            amp_dtype=amp_dtype,
+            **kwinputs,
+        ),
+        benchmark_backward(
+            fn,
+            *inputs,
+            grad=grad,
+            repeats=repeats,
+            desc=desc,
+            verbose=verbose,
+            amp=amp,
+            amp_dtype=amp_dtype,
+            **kwinputs,
+        ),
+        benchmark_combined(
+            fn,
+            *inputs,
+            grad=grad,
+            repeats=repeats,
+            desc=desc,
+            verbose=verbose,
+            amp=amp,
+            amp_dtype=amp_dtype,
+            **kwinputs,
+        ),
+    )
+
+
+def pytorch_profiler(
+    fn,
+    *inputs,
+    trace_filename=None,
+    backward=False,
+    amp=False,
+    amp_dtype=torch.float16,
+    cpu=False,
+    verbose=True,
+    **kwinputs,
+):
+    """Wrap benchmark functions in Pytorch profiler to see CUDA information."""
+    if backward:
+        with torch.autocast(device_type="cuda", dtype=amp_dtype, enabled=amp):
+            out = fn(*inputs, **kwinputs)
+            if type(out) is tuple:
+                out = out[0]
+            g = torch.randn_like(out)
+    for _ in range(30):  # Warm up
+        if backward:
+            for x in inputs:
+                if isinstance(x, torch.Tensor):
+                    x.grad = None
+        with torch.autocast(device_type="cuda", dtype=amp_dtype, enabled=amp):
+            out = fn(*inputs, **kwinputs)
+            if type(out) is tuple:
+                out = out[0]
+        # Backward should be done outside autocast
+        if backward:
+            out.backward(g, retain_graph=True)
+    activities = ([torch.profiler.ProfilerActivity.CPU]
+                  if cpu else []) + [torch.profiler.ProfilerActivity.CUDA]
+    with torch.profiler.profile(
+            activities=activities,
+            record_shapes=True,
+            # profile_memory=True,
+            with_stack=True,
+    ) as prof:
+        if backward:
+            for x in inputs:
+                if isinstance(x, torch.Tensor):
+                    x.grad = None
+        with torch.autocast(device_type="cuda", dtype=amp_dtype, enabled=amp):
+            out = fn(*inputs, **kwinputs)
+            if type(out) is tuple:
+                out = out[0]
+        if backward:
+            out.backward(g, retain_graph=True)
+    if verbose:
+        # print(prof.key_averages().table(sort_by="self_cuda_time_total", row_limit=50))
+        print(prof.key_averages().table(row_limit=50))
+    if trace_filename is not None:
+        prof.export_chrome_trace(trace_filename)
+
+
+def benchmark_memory(fn, *inputs, desc="", verbose=True, **kwinputs):
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.synchronize()
+    fn(*inputs, **kwinputs)
+    torch.cuda.synchronize()
+    mem = torch.cuda.max_memory_allocated() / ((2**20) * 1000)
+    if verbose:
+        print(f"{desc} max memory: {mem}GB")
+    torch.cuda.empty_cache()
+    return mem

--- a/tests/test_kernels/benchmark_modulate.py
+++ b/tests/test_kernels/benchmark_modulate.py
@@ -31,7 +31,7 @@ def time_bwd(func, *args, **kwargs):
 device = "cuda"
 dtype = torch.bfloat16
 
-batch_sizes = [8, 32]
+batch_sizes = [1, 8, 32]
 seq_lengths = [128, 512, 1024]
 hidden_dims = [768, 1024, 2048]
 

--- a/tests/test_kernels/benchmark_modulate.py
+++ b/tests/test_kernels/benchmark_modulate.py
@@ -1,0 +1,93 @@
+import torch
+from benchmark import (assert_close, benchmark_backward, benchmark_combined,
+                       benchmark_forward)
+from torch import nn
+
+from fastvideo.ops.modulate.modulate import fused_modulate
+
+
+def torch_modulate(x, scale, shift):
+    return x * (scale.unsqueeze(1) + 1) + shift.unsqueeze(1)
+
+
+# from flash_attn import flash_attn_func
+
+
+def time_fwd(func, *args, **kwargs):
+    time_fb = benchmark_forward(func, *args, **kwargs)
+    return time_fb[1].mean
+
+
+def time_fwd_bwd(func, *args, **kwargs):
+    time_fb = benchmark_combined(func, *args, **kwargs)
+    return time_fb[1].mean
+
+
+def time_bwd(func, *args, **kwargs):
+    time_fb = benchmark_backward(func, *args, **kwargs)
+    return time_fb[1].mean
+
+
+device = "cuda"
+dtype = torch.bfloat16
+
+batch_sizes = [8, 32]
+seq_lengths = [128, 512, 1024]
+hidden_dims = [768, 1024, 2048]
+
+# methods = (["torch", "triton", "thunderkitten"])
+methods = ["torch", "triton"]
+time_f = {}
+time_b = {}
+time_f_b = {}
+speed_f = {}
+speed_b = {}
+speed_f_b = {}
+for B in batch_sizes:
+    for T in seq_lengths:
+        for D in hidden_dims:
+            config = (B, T, D)
+            torch.cuda.manual_seed_all(1)
+            norm_func = nn.LayerNorm(D, elementwise_affine=False, eps=1e-6)
+            x = torch.randn(B,
+                            T,
+                            D,
+                            device="cuda",
+                            requires_grad=True,
+                            dtype=dtype)
+            x = norm_func(x.to(torch.float32)).to(dtype)
+            shift = torch.randn(B,
+                                D,
+                                device="cuda",
+                                requires_grad=True,
+                                dtype=dtype)
+            scale = torch.randn(B,
+                                D,
+                                device="cuda",
+                                requires_grad=True,
+                                dtype=dtype)
+            # test torch
+            o_ref = torch_modulate(x, scale, shift)
+            o_ref.sum().backward(retain_graph=True)
+            f_b = time_fwd_bwd(torch_modulate, x, scale, shift, verbose=False)
+            time_f_b[config, "torch"] = f_b
+            # test triton
+            o2 = fused_modulate(x, scale, shift)
+            o2.sum().backward(retain_graph=True)
+            f_b = time_fwd_bwd(fused_modulate, x, scale, shift, verbose=False)
+            time_f_b[config, "triton"] = f_b
+            # test if the results are close
+            assert_close("  o", o_ref, o2, 0.005)
+            # time_f_b[config, "thunderkitten"] = f_b
+
+            print(
+                f"### batch size={B}, seq length={T}, B={B}, hidden dim={D} ###"
+            )
+            for method in methods:
+                # time_f_b[config, method] = time_f[config, method] + time_b[config, method]
+                print(
+                    f"{method:>50} fwd + bwd:\t {time_f_b[config, method]*1000:>6.4f} ms "
+                )
+
+# with open('flash2_attn_time.plk', 'wb') as fp:
+#     pickle.dump((speed_f, speed_b, speed_f_b), fp, protocol=pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
The original modulate triton implementation (https://github.com/Vchitect/FasterCache/blob/02d05ef7edb48bdec01d2b4df6edfe7f472a41b9/fastercache/kernels/fused_modulate.py#L2) is not correct. I fix it and now it works with bfloat16 and float32.
tk implementation will be added later