### PR TITLE
[CI] Add test workflow improvements

### DIFF
--- a/.github/scripts/runpod_api.py
+++ b/.github/scripts/runpod_api.py
@@ -38,7 +38,7 @@ GITHUB_SHA = os.environ['GITHUB_SHA']
 GITHUB_REF = os.environ.get('GITHUB_REF', 'unknown')
 GITHUB_REPOSITORY = os.environ['GITHUB_REPOSITORY']
 RUN_ID = os.environ['GITHUB_RUN_ID']
-
+JOB_ID = os.environ['JOB_ID']
 PODS_API = "https://rest.runpod.io/v1/pods"
 HEADERS = {
     "Content-Type": "application/json",
@@ -50,7 +50,7 @@ def create_pod():
     """Create a RunPod instance"""
     print(f"Creating RunPod instance with GPU: {args.gpu_type}...")
     payload = {
-        "name": f"fastvideo-github-test-{RUN_ID}",
+        "name": f"fastvideo-{JOB_ID}-{RUN_ID}",
         "containerDiskInGb": args.disk_size,
         "volumeInGb": args.volume_size,
         "env": {
@@ -85,12 +85,15 @@ def wait_for_pod(pod_id):
             print("RunPod is running! Now waiting for ports to be assigned...")
             break
 
-        print(f"Current status: {status}, waiting... (attempt {attempts+1}/{max_attempts})")
+        print(
+            f"Current status: {status}, waiting... (attempt {attempts+1}/{max_attempts})"
+        )
         time.sleep(2)
         attempts += 1
-    
+
     if attempts >= max_attempts:
-        raise TimeoutError("Timed out waiting for RunPod to reach RUNNING state")
+        raise TimeoutError(
+            "Timed out waiting for RunPod to reach RUNNING state")
 
     # Wait for ports to be assigned
     max_attempts = 6
@@ -107,10 +110,12 @@ def wait_for_pod(pod_id):
             print(f"SSH Port: {port_mappings['22']}")
             break
 
-        print(f"Waiting for SSH port and public IP to be available... (attempt {attempts+1}/{max_attempts})")
+        print(
+            f"Waiting for SSH port and public IP to be available... (attempt {attempts+1}/{max_attempts})"
+        )
         time.sleep(10)
         attempts += 1
-    
+
     if attempts >= max_attempts:
         raise TimeoutError("Timed out waiting for RunPod SSH access")
 

--- a/.github/scripts/runpod_cleanup.py
+++ b/.github/scripts/runpod_cleanup.py
@@ -2,9 +2,10 @@ import json
 import os
 import sys
 import requests
+import uuid
 
 API_KEY = os.environ['RUNPOD_API_KEY']
-RUN_ID = os.environ['GITHUB_RUN_ID']
+RUN_ID = os.environ.get('GITHUB_RUN_ID', str(uuid.uuid4()))
 PODS_API = "https://rest.runpod.io/v1/pods"
 HEADERS = {
     "Content-Type": "application/json",

--- a/.github/scripts/runpod_cleanup.py
+++ b/.github/scripts/runpod_cleanup.py
@@ -1,0 +1,76 @@
+import json
+import os
+import sys
+import requests
+
+API_KEY = os.environ['RUNPOD_API_KEY']
+RUN_ID = os.environ['GITHUB_RUN_ID']
+PODS_API = "https://rest.runpod.io/v1/pods"
+HEADERS = {
+    "Content-Type": "application/json",
+    "Authorization": f"Bearer {API_KEY}"
+}
+
+
+def get_job_ids():
+    """Parse job IDs from environment variable"""
+    job_ids_str = os.environ.get('JOB_IDS')
+    try:
+        job_ids = json.loads(job_ids_str)
+        if not isinstance(job_ids, list):
+            print(f"Error: JOB_IDS is not a list.")
+            sys.exit(1)
+        return job_ids
+    except json.JSONDecodeError as e:
+        print(f"Error parsing JOB_IDS: {e}")
+        sys.exit(1)
+
+
+def cleanup_pods():
+    """Find and terminate RunPod instances"""
+    job_ids = get_job_ids()
+
+    print(f"RunPod Cleanup")
+    print(f"Run ID: {RUN_ID}")
+    print(f"Job IDs: {job_ids}")
+
+    # Get all pods associated with RunPod API_KEY
+    try:
+        response = requests.get(PODS_API, headers=HEADERS)
+        response.raise_for_status()
+        pods = response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error getting pods: {e}")
+        sys.exit(1)
+
+    # Find and terminate pods created by this workflow run
+    terminated_pods = []
+    for pod in pods:
+        pod_name = pod.get("name", "")
+        pod_id = pod.get("id")
+
+        # Check if this pod was created by one of our jobs
+        if any(f"{job_id}-{RUN_ID}" in pod_name for job_id in job_ids):
+            print(f"Found pod: {pod_id} ({pod_name})")
+            try:
+                print(f"Terminating pod {pod_id}...")
+                term_response = requests.delete(f"{PODS_API}/{pod_id}",
+                                                headers=HEADERS)
+                term_response.raise_for_status()
+                terminated_pods.append(pod_id)
+                print(f"Successfully terminated pod {pod_id}")
+            except requests.exceptions.RequestException as e:
+                print(f"Error terminating pod {pod_id}: {e}")
+                sys.exit(1)
+    if terminated_pods:
+        print(f"Terminated {len(terminated_pods)} pods: {terminated_pods}")
+    else:
+        print("No pods found to terminate.")
+
+
+def main():
+    cleanup_pods()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -35,7 +35,7 @@ jobs:
 
   encoder-test:
     needs: change-filter
-    if: ${{ needs.change-filter.outputs.encoder-test == 'true' && github.event.pull_request.draft == false }}
+    if: ${{ needs.change-filter.outputs.encoder-test == 'true' }}
     runs-on: ubuntu-latest
     environment: runpod-runners
     steps:
@@ -78,7 +78,7 @@ jobs:
 
   runpod-cleanup:
     needs: [encoder-test] # Add other jobs to this list as you create them
-    if: always() # Run even if previous jobs fail or are skipped
+    if: ${{ github.event.pull_request.draft == false && always() }} # Run even if previous jobs fail or are skipped
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -3,17 +3,39 @@ name: PR Test
 on:
   push:
     branches: [main]
+    paths:
+      - "fastvideo/**/*.py"
+      - ".github/workflows/pr-test.yml"
   pull_request:
     branches: [main]
     types: [opened, ready_for_review, synchronize, reopened]
+    paths:
+      - "fastvideo/**/*.py"
+      - ".github/workflows/pr-test.yml"
 
 concurrency:
   group: pr-test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  unit-test:
-    if: github.event.pull_request.draft == false
+  change-filter:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false }}
+    outputs:
+      encoder-test: ${{ steps.filter.outputs.encoder-test }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            encoder-test:
+              - 'fastvideo/v1/models/encoders/**'
+              - 'fastvideo/v1/models/loaders/**'
+
+  encoder-test:
+    needs: change-filter
+    if: ${{ needs.change-filter.outputs.encoder-test == 'true' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     environment: runpod-runners
     steps:
@@ -37,11 +59,13 @@ jobs:
 
       - name: Run tests on RunPod
         env:
+          JOB_ID: "encoder-test"
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REF: ${{ github.ref }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+        timeout-minutes: 30
         run: >-
           python .github/scripts/runpod_api.py 
           --gpu-type "NVIDIA A40"
@@ -51,3 +75,26 @@ jobs:
           pip install vllm &&
           pip install pytest &&
           pytest ./fastvideo/v1/tests/ --ignore=./fastvideo/v1/tests/old_tests/ -s"
+
+  runpod-cleanup:
+    needs: [encoder-test] # Add other jobs to this list as you create them
+    if: always() # Run even if previous jobs fail or are skipped
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Cleanup all RunPod instances
+        env:
+          JOB_IDS: '["encoder-test"]' # JSON array of job IDs
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: python .github/scripts/runpod_cleanup.py

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -78,8 +78,13 @@ jobs:
 
   runpod-cleanup:
     needs: [encoder-test] # Add other jobs to this list as you create them
-    if: ${{ github.event.pull_request.draft == false && always() }} # Run even if previous jobs fail or are skipped
+    if: >-
+      always() && 
+      ${{ github.event.pull_request.draft == false && 
+          (contains(needs.*.result, 'success') || 
+           contains(needs.*.result, 'failure')) }}
     runs-on: ubuntu-latest
+    environment: runpod-runners
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
To avoid triggering all workflows and jobs for all PRs, this change adds filters for triggering the pr-test workflow, as well as job level filters for running the encoder test job only if the v1/models/encoder/ or v1/models/loader/ files are changed.

- Workflow will trigger if the workflow file itself changes

\
\
Additionally, a new job `runpod-cleanup` is added as a failsafe in the event that any test jobs are unable to terminate their RunPod instances, and pods become stranded. This may happen due to the new timeout for the encoder test, which was added to prevent indefinitely running tests or hanging Github runners.

- This job will not touch any pods other than the ones started in the same workflow--pods are identified by their {JOB ID}-{WORKFLOW ID}
- This job only runs after all other test jobs have passed/failed/skipped/timed out, and will not interrupt running tests

- Normally this cleanup job will not find any pods to shutdown, as the test jobs will try to terminate their pods themselves