### PR TITLE
[CLI] Fix duplicate --num-gpus

### DIFF
--- a/fastvideo/v1/entrypoints/cli/cli_types.py
+++ b/fastvideo/v1/entrypoints/cli/cli_types.py
@@ -9,8 +9,7 @@ from fastvideo.v1.utils import FlexibleArgumentParser
 class CLISubcommand:
     """Base class for CLI subcommands"""
 
-    def __init__(self) -> None:
-        self.name = ""
+    name: str
 
     def cmd(self, args: argparse.Namespace) -> None:
         """Execute the command with the given arguments"""

--- a/fastvideo/v1/entrypoints/cli/generate.py
+++ b/fastvideo/v1/entrypoints/cli/generate.py
@@ -73,10 +73,6 @@ class GenerateSubcommand(CLISubcommand):
             required=False,
             help="Read CLI options from a config YAML file.")
 
-        generate_parser.add_argument("--num-gpus",
-                                     type=int,
-                                     default=1,
-                                     help="Number of GPUs to use")
         generate_parser.add_argument("--master-port",
                                      type=int,
                                      default=None,


### PR DESCRIPTION
Fixes issue where using the cli outputs  `argparse.ArgumentError: argument --num-gpus: conflicting option string: --num-gpus`, due to the argument being added to FastVideoArgs.

Also fixes issue where super().__init__() overwrites the GenerateSubcommand name, preventing proper validation.