### PR TITLE
[V1] Worker cleanup; Logging clean up; enables isort again

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,10 @@ repos:
   - id: codespell
     additional_dependencies: ['tomli']
     args: ['--toml', 'pyproject.toml']
-# - repo: https://github.com/PyCQA/isort
-#   rev: 0a0b7a830386ba6a31c2ec8316849ae4d1b8240d # 6.0.0
-#   hooks:
-#   - id: isort
+- repo: https://github.com/PyCQA/isort
+  rev: 0a0b7a830386ba6a31c2ec8316849ae4d1b8240d # 6.0.0
+  hooks:
+  - id: isort
 - repo: https://github.com/jackdewinter/pymarkdown
   rev: v0.9.29
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     additional_dependencies: ['tomli']
     args: ['--toml', 'pyproject.toml']
 - repo: https://github.com/PyCQA/isort
-  rev: 0a0b7a830386ba6a31c2ec8316849ae4d1b8240d # 6.0.0
+  rev: 6.0.1
   hooks:
   - id: isort
 - repo: https://github.com/jackdewinter/pymarkdown

--- a/fastvideo/v1/attention/layer.py
+++ b/fastvideo/v1/attention/layer.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -25,7 +25,8 @@ class DistributedAttention(nn.Module):
                  num_kv_heads: Optional[int] = None,
                  softmax_scale: Optional[float] = None,
                  causal: bool = False,
-                 supported_attention_backends: Optional[Tuple[_Backend]] = None,
+                 supported_attention_backends: Optional[Tuple[_Backend,
+                                                              ...]] = None,
                  prefix: str = "",
                  **extra_impl_args) -> None:
         super().__init__()
@@ -146,7 +147,8 @@ class LocalAttention(nn.Module):
                  num_kv_heads: Optional[int] = None,
                  softmax_scale: Optional[float] = None,
                  causal: bool = False,
-                 supported_attention_backends: Optional[Tuple[_Backend]] = None,
+                 supported_attention_backends: Optional[Tuple[_Backend,
+                                                              ...]] = None,
                  **extra_impl_args) -> None:
         super().__init__()
         if softmax_scale is None:

--- a/fastvideo/v1/attention/layer.py
+++ b/fastvideo/v1/attention/layer.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Optional
+from typing import Tuple, Optional
 
 import torch
 import torch.nn as nn
@@ -25,7 +25,7 @@ class DistributedAttention(nn.Module):
                  num_kv_heads: Optional[int] = None,
                  softmax_scale: Optional[float] = None,
                  causal: bool = False,
-                 supported_attention_backends: Optional[List[_Backend]] = None,
+                 supported_attention_backends: Optional[Tuple[_Backend]] = None,
                  prefix: str = "",
                  **extra_impl_args) -> None:
         super().__init__()
@@ -146,7 +146,7 @@ class LocalAttention(nn.Module):
                  num_kv_heads: Optional[int] = None,
                  softmax_scale: Optional[float] = None,
                  causal: bool = False,
-                 supported_attention_backends: Optional[List[_Backend]] = None,
+                 supported_attention_backends: Optional[Tuple[_Backend]] = None,
                  **extra_impl_args) -> None:
         super().__init__()
         if softmax_scale is None:

--- a/fastvideo/v1/attention/selector.py
+++ b/fastvideo/v1/attention/selector.py
@@ -4,7 +4,7 @@
 import os
 from contextlib import contextmanager
 from functools import cache
-from typing import Generator, Tuple, Optional, Type, cast
+from typing import Generator, Optional, Tuple, Type, cast
 
 import torch
 
@@ -82,7 +82,7 @@ def get_global_forced_attn_backend() -> Optional[_Backend]:
 def get_attn_backend(
     head_size: int,
     dtype: torch.dtype,
-    supported_attention_backends: Optional[Tuple[_Backend]] = None,
+    supported_attention_backends: Optional[Tuple[_Backend, ...]] = None,
 ) -> Type[AttentionBackend]:
     return _cached_get_attn_backend(head_size, dtype,
                                     supported_attention_backends)
@@ -92,7 +92,7 @@ def get_attn_backend(
 def _cached_get_attn_backend(
     head_size: int,
     dtype: torch.dtype,
-    supported_attention_backends: Optional[Tuple[_Backend]] = None,
+    supported_attention_backends: Optional[Tuple[_Backend, ...]] = None,
 ) -> Type[AttentionBackend]:
     # Check whether a particular choice of backend was
     # previously forced.

--- a/fastvideo/v1/attention/selector.py
+++ b/fastvideo/v1/attention/selector.py
@@ -84,7 +84,8 @@ def get_attn_backend(
     dtype: torch.dtype,
     supported_attention_backends: Optional[Tuple[_Backend]] = None,
 ) -> Type[AttentionBackend]:
-    return _cached_get_attn_backend(head_size, dtype, supported_attention_backends)
+    return _cached_get_attn_backend(head_size, dtype,
+                                    supported_attention_backends)
 
 
 @cache

--- a/fastvideo/v1/attention/selector.py
+++ b/fastvideo/v1/attention/selector.py
@@ -3,7 +3,8 @@
 
 import os
 from contextlib import contextmanager
-from typing import Generator, List, Optional, Type, cast
+from functools import cache
+from typing import Generator, Tuple, Optional, Type, cast
 
 import torch
 
@@ -81,7 +82,16 @@ def get_global_forced_attn_backend() -> Optional[_Backend]:
 def get_attn_backend(
     head_size: int,
     dtype: torch.dtype,
-    supported_attention_backends: Optional[List[_Backend]] = None,
+    supported_attention_backends: Optional[Tuple[_Backend]] = None,
+) -> Type[AttentionBackend]:
+    return _cached_get_attn_backend(head_size, dtype, supported_attention_backends)
+
+
+@cache
+def _cached_get_attn_backend(
+    head_size: int,
+    dtype: torch.dtype,
+    supported_attention_backends: Optional[Tuple[_Backend]] = None,
 ) -> Type[AttentionBackend]:
     # Check whether a particular choice of backend was
     # previously forced.

--- a/fastvideo/v1/configs/__init__.py
+++ b/fastvideo/v1/configs/__init__.py
@@ -1,7 +1,7 @@
-from fastvideo.v1.configs.hunyuan import HunyuanConfig, FastHunyuanConfig
-from fastvideo.v1.configs.wan import WanT2V480PConfig, WanI2V480PConfig
 from fastvideo.v1.configs.base import BaseConfig, SlidingTileAttnConfig
+from fastvideo.v1.configs.hunyuan import FastHunyuanConfig, HunyuanConfig
 from fastvideo.v1.configs.registry import get_pipeline_config_cls_for_name
+from fastvideo.v1.configs.wan import WanI2V480PConfig, WanT2V480PConfig
 
 __all__ = [
     "HunyuanConfig", "FastHunyuanConfig", "BaseConfig", "SlidingTileAttnConfig",

--- a/fastvideo/v1/configs/hunyuan.py
+++ b/fastvideo/v1/configs/hunyuan.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 from fastvideo.v1.configs.base import BaseConfig
 
 

--- a/fastvideo/v1/configs/registry.py
+++ b/fastvideo/v1/configs/registry.py
@@ -1,14 +1,14 @@
 """Registry for pipeline weight-specific configurations."""
 
 import os
-from typing import Dict, Type, Optional, Callable
+from typing import Callable, Dict, Optional, Type
 
 from fastvideo.v1.configs.base import BaseConfig
-from fastvideo.v1.configs.hunyuan import HunyuanConfig, FastHunyuanConfig
-from fastvideo.v1.configs.wan import WanT2V480PConfig, WanI2V480PConfig
-
-from fastvideo.v1.utils import maybe_download_model_index, verify_model_config_and_directory
+from fastvideo.v1.configs.hunyuan import FastHunyuanConfig, HunyuanConfig
+from fastvideo.v1.configs.wan import WanI2V480PConfig, WanT2V480PConfig
 from fastvideo.v1.logger import init_logger
+from fastvideo.v1.utils import (maybe_download_model_index,
+                                verify_model_config_and_directory)
 
 logger = init_logger(__name__)
 

--- a/fastvideo/v1/configs/wan.py
+++ b/fastvideo/v1/configs/wan.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+
 from fastvideo.v1.configs.base import BaseConfig
 
 

--- a/fastvideo/v1/distributed/__init__.py
+++ b/fastvideo/v1/distributed/__init__.py
@@ -2,14 +2,10 @@
 
 from fastvideo.v1.distributed.communication_op import *
 from fastvideo.v1.distributed.parallel_state import (
-    init_distributed_environment,
-    initialize_model_parallel,
-    get_sequence_model_parallel_rank,
-    get_sequence_model_parallel_world_size,
-    get_tensor_model_parallel_rank,
-    get_tensor_model_parallel_world_size,
-    cleanup_dist_env_and_memory,
-)
+    cleanup_dist_env_and_memory, get_sequence_model_parallel_rank,
+    get_sequence_model_parallel_world_size, get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size, init_distributed_environment,
+    initialize_model_parallel)
 from fastvideo.v1.distributed.utils import *
 
 __all__ = [

--- a/fastvideo/v1/entrypoints/video_generator.py
+++ b/fastvideo/v1/entrypoints/video_generator.py
@@ -8,8 +8,8 @@ diffusion models.
 
 import os
 import time
-from typing import Any, Callable, Dict, List, Optional, Union
 from dataclasses import asdict
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import imageio
 import numpy as np
@@ -17,11 +17,10 @@ import torch
 import torchvision
 from einops import rearrange
 
+from fastvideo.v1.configs import get_pipeline_config_cls_for_name
 from fastvideo.v1.fastvideo_args import FastVideoArgs
 from fastvideo.v1.logger import init_logger
 from fastvideo.v1.pipelines import ForwardBatch
-from fastvideo.v1.configs import get_pipeline_config_cls_for_name
-
 from fastvideo.v1.utils import align_to
 from fastvideo.v1.worker.executor import Executor
 

--- a/fastvideo/v1/fastvideo_args.py
+++ b/fastvideo/v1/fastvideo_args.py
@@ -7,8 +7,8 @@ import dataclasses
 from contextlib import contextmanager
 from typing import List, Optional
 
-from fastvideo.v1.utils import FlexibleArgumentParser
 from fastvideo.v1.logger import init_logger
+from fastvideo.v1.utils import FlexibleArgumentParser
 
 logger = init_logger(__name__)
 

--- a/fastvideo/v1/models/dits/base.py
+++ b/fastvideo/v1/models/dits/base.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -15,7 +15,9 @@ class BaseDiT(nn.Module, ABC):
     _param_names_mapping: dict
     hidden_size: int
     num_attention_heads: int
-    _supported_attention_backends: Tuple[_Backend] = ()
+    # always supports torch_sdpa
+    _supported_attention_backends: Tuple[_Backend,
+                                         ...] = (_Backend.TORCH_SDPA, )
 
     def __init_subclass__(cls) -> None:
         required_class_attrs = [
@@ -55,5 +57,5 @@ class BaseDiT(nn.Module, ABC):
                 )
 
     @property
-    def supported_attention_backends(self) -> Tuple[_Backend]:
+    def supported_attention_backends(self) -> Tuple[_Backend, ...]:
         return self._supported_attention_backends

--- a/fastvideo/v1/models/dits/base.py
+++ b/fastvideo/v1/models/dits/base.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple
 
 import torch
 from torch import nn
@@ -15,7 +15,7 @@ class BaseDiT(nn.Module, ABC):
     _param_names_mapping: dict
     hidden_size: int
     num_attention_heads: int
-    _supported_attention_backends: List[_Backend] = []
+    _supported_attention_backends: Tuple[_Backend] = ()
 
     def __init_subclass__(cls) -> None:
         required_class_attrs = [
@@ -55,5 +55,5 @@ class BaseDiT(nn.Module, ABC):
                 )
 
     @property
-    def supported_attention_backends(self) -> List[_Backend]:
+    def supported_attention_backends(self) -> Tuple[_Backend]:
         return self._supported_attention_backends

--- a/fastvideo/v1/models/dits/hunyuanvideo.py
+++ b/fastvideo/v1/models/dits/hunyuanvideo.py
@@ -92,7 +92,7 @@ class MMDoubleStreamBlock(nn.Module):
         num_attention_heads: int,
         mlp_ratio: float,
         dtype: Optional[torch.dtype] = None,
-        supported_attention_backends: Optional[List[_Backend]] = None,
+        supported_attention_backends: Optional[Tuple[_Backend]] = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -299,7 +299,7 @@ class MMSingleStreamBlock(nn.Module):
         num_attention_heads: int,
         mlp_ratio: float = 4.0,
         dtype: Optional[torch.dtype] = None,
-        supported_attention_backends: Optional[List[_Backend]] = None,
+        supported_attention_backends: Optional[Tuple[_Backend]] = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -436,9 +436,9 @@ class HunyuanVideoTransformer3DModel(BaseDiT):
         lambda n, m: "single" in n and str.isdigit(n.split(".")[-1]),
         lambda n, m: "refiner" in n and str.isdigit(n.split(".")[-1]),
     ]
-    _supported_attention_backends = [
+    _supported_attention_backends = (
         _Backend.SLIDING_TILE_ATTN, _Backend.FLASH_ATTN, _Backend.TORCH_SDPA
-    ]
+    )
     _param_names_mapping = {
         # 1. context_embedder.time_text_embed submodules (specific rules, applied first):
         r"^context_embedder\.time_text_embed\.timestep_embedder\.linear_1\.(.*)$":
@@ -896,9 +896,9 @@ class IndividualTokenRefinerBlock(nn.Module):
             num_heads=num_attention_heads,
             head_size=hidden_size // num_attention_heads,
             # TODO: remove hardcode; remove STA
-            supported_attention_backends=[
+            supported_attention_backends=(
                 _Backend.FLASH_ATTN, _Backend.TORCH_SDPA
-            ],
+            ),
         )
 
     def forward(self, x, c):

--- a/fastvideo/v1/models/dits/hunyuanvideo.py
+++ b/fastvideo/v1/models/dits/hunyuanvideo.py
@@ -92,7 +92,7 @@ class MMDoubleStreamBlock(nn.Module):
         num_attention_heads: int,
         mlp_ratio: float,
         dtype: Optional[torch.dtype] = None,
-        supported_attention_backends: Optional[Tuple[_Backend]] = None,
+        supported_attention_backends: Optional[Tuple[_Backend, ...]] = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -299,7 +299,7 @@ class MMSingleStreamBlock(nn.Module):
         num_attention_heads: int,
         mlp_ratio: float = 4.0,
         dtype: Optional[torch.dtype] = None,
-        supported_attention_backends: Optional[Tuple[_Backend]] = None,
+        supported_attention_backends: Optional[Tuple[_Backend, ...]] = None,
         prefix: str = "",
     ):
         super().__init__()

--- a/fastvideo/v1/models/dits/hunyuanvideo.py
+++ b/fastvideo/v1/models/dits/hunyuanvideo.py
@@ -436,9 +436,8 @@ class HunyuanVideoTransformer3DModel(BaseDiT):
         lambda n, m: "single" in n and str.isdigit(n.split(".")[-1]),
         lambda n, m: "refiner" in n and str.isdigit(n.split(".")[-1]),
     ]
-    _supported_attention_backends = (
-        _Backend.SLIDING_TILE_ATTN, _Backend.FLASH_ATTN, _Backend.TORCH_SDPA
-    )
+    _supported_attention_backends = (_Backend.SLIDING_TILE_ATTN,
+                                     _Backend.FLASH_ATTN, _Backend.TORCH_SDPA)
     _param_names_mapping = {
         # 1. context_embedder.time_text_embed submodules (specific rules, applied first):
         r"^context_embedder\.time_text_embed\.timestep_embedder\.linear_1\.(.*)$":
@@ -896,9 +895,8 @@ class IndividualTokenRefinerBlock(nn.Module):
             num_heads=num_attention_heads,
             head_size=hidden_size // num_attention_heads,
             # TODO: remove hardcode; remove STA
-            supported_attention_backends=(
-                _Backend.FLASH_ATTN, _Backend.TORCH_SDPA
-            ),
+            supported_attention_backends=(_Backend.FLASH_ATTN,
+                                          _Backend.TORCH_SDPA),
         )
 
     def forward(self, x, c):

--- a/fastvideo/v1/models/dits/wanvideo.py
+++ b/fastvideo/v1/models/dits/wanvideo.py
@@ -119,9 +119,9 @@ class WanSelfAttention(nn.Module):
                                    dropout_rate=0,
                                    softmax_scale=None,
                                    causal=False,
-                                   supported_attention_backends=[
+                                   supported_attention_backends=(
                                        _Backend.FLASH_ATTN, _Backend.TORCH_SDPA
-                                   ])
+                                   ))
 
     def forward(self, x: torch.Tensor, context: torch.Tensor,
                 context_lens: int):
@@ -169,7 +169,7 @@ class WanI2VCrossAttention(WanSelfAttention):
             window_size=(-1, -1),
             qk_norm=True,
             eps=1e-6,
-            supported_attention_backends: Optional[List[str]] = None) -> None:
+            supported_attention_backends: Optional[Tuple[str]] = None) -> None:
         super().__init__(dim, num_heads, window_size, qk_norm, eps,
                          supported_attention_backends)
 
@@ -218,7 +218,7 @@ class WanTransformerBlock(nn.Module):
                  cross_attn_norm: bool = False,
                  eps: float = 1e-6,
                  added_kv_proj_dim: Optional[int] = None,
-                 supported_attention_backends: Optional[List[_Backend]] = None,
+                 supported_attention_backends: Optional[Tuple[_Backend]] = None,
                  prefix: str = ""):
         super().__init__()
 
@@ -351,9 +351,9 @@ class WanTransformer3DModel(BaseDiT):
     _fsdp_shard_conditions = [
         lambda n, m: "blocks" in n and str.isdigit(n.split(".")[-1]),
     ]
-    _supported_attention_backends = [
+    _supported_attention_backends = (
         _Backend.SLIDING_TILE_ATTN, _Backend.FLASH_ATTN, _Backend.TORCH_SDPA
-    ]
+    )
     _param_names_mapping = {
         r"^patch_embedding\.(.*)$":
         r"patch_embedding.proj.\1",

--- a/fastvideo/v1/models/dits/wanvideo.py
+++ b/fastvideo/v1/models/dits/wanvideo.py
@@ -163,13 +163,14 @@ class WanT2VCrossAttention(WanSelfAttention):
 class WanI2VCrossAttention(WanSelfAttention):
 
     def __init__(
-            self,
-            dim: int,
-            num_heads: int,
-            window_size=(-1, -1),
-            qk_norm=True,
-            eps=1e-6,
-            supported_attention_backends: Optional[Tuple[str]] = None) -> None:
+        self,
+        dim: int,
+        num_heads: int,
+        window_size=(-1, -1),
+        qk_norm=True,
+        eps=1e-6,
+        supported_attention_backends: Optional[Tuple[_Backend, ...]] = None
+    ) -> None:
         super().__init__(dim, num_heads, window_size, qk_norm, eps,
                          supported_attention_backends)
 
@@ -218,7 +219,8 @@ class WanTransformerBlock(nn.Module):
                  cross_attn_norm: bool = False,
                  eps: float = 1e-6,
                  added_kv_proj_dim: Optional[int] = None,
-                 supported_attention_backends: Optional[Tuple[_Backend]] = None,
+                 supported_attention_backends: Optional[Tuple[_Backend,
+                                                              ...]] = None,
                  prefix: str = ""):
         super().__init__()
 

--- a/fastvideo/v1/models/dits/wanvideo.py
+++ b/fastvideo/v1/models/dits/wanvideo.py
@@ -114,14 +114,14 @@ class WanSelfAttention(nn.Module):
         self.norm_k = RMSNorm(dim, eps=eps) if qk_norm else nn.Identity()
 
         # Scaled dot product attention
-        self.attn = LocalAttention(num_heads=num_heads,
-                                   head_size=self.head_dim,
-                                   dropout_rate=0,
-                                   softmax_scale=None,
-                                   causal=False,
-                                   supported_attention_backends=(
-                                       _Backend.FLASH_ATTN, _Backend.TORCH_SDPA
-                                   ))
+        self.attn = LocalAttention(
+            num_heads=num_heads,
+            head_size=self.head_dim,
+            dropout_rate=0,
+            softmax_scale=None,
+            causal=False,
+            supported_attention_backends=(_Backend.FLASH_ATTN,
+                                          _Backend.TORCH_SDPA))
 
     def forward(self, x: torch.Tensor, context: torch.Tensor,
                 context_lens: int):
@@ -351,9 +351,8 @@ class WanTransformer3DModel(BaseDiT):
     _fsdp_shard_conditions = [
         lambda n, m: "blocks" in n and str.isdigit(n.split(".")[-1]),
     ]
-    _supported_attention_backends = (
-        _Backend.SLIDING_TILE_ATTN, _Backend.FLASH_ATTN, _Backend.TORCH_SDPA
-    )
+    _supported_attention_backends = (_Backend.SLIDING_TILE_ATTN,
+                                     _Backend.FLASH_ATTN, _Backend.TORCH_SDPA)
     _param_names_mapping = {
         r"^patch_embedding\.(.*)$":
         r"patch_embedding.proj.\1",

--- a/fastvideo/v1/models/encoders/base.py
+++ b/fastvideo/v1/models/encoders/base.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Tuple
 
 from torch import nn
 
@@ -6,7 +6,7 @@ from fastvideo.v1.platforms import _Backend
 
 
 class BaseEncoder(nn.Module):
-    _supported_attention_backends: List[_Backend] = []
+    _supported_attention_backends: Tuple[_Backend] = ()
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__()
@@ -19,5 +19,5 @@ class BaseEncoder(nn.Module):
         pass
 
     @property
-    def supported_attention_backends(self) -> List[_Backend]:
+    def supported_attention_backends(self) -> Tuple[_Backend]:
         return self._supported_attention_backends

--- a/fastvideo/v1/models/encoders/base.py
+++ b/fastvideo/v1/models/encoders/base.py
@@ -6,7 +6,8 @@ from fastvideo.v1.platforms import _Backend
 
 
 class BaseEncoder(nn.Module):
-    _supported_attention_backends: Tuple[_Backend] = ()
+    _supported_attention_backends: Tuple[_Backend,
+                                         ...] = (_Backend.TORCH_SDPA, )
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__()
@@ -19,5 +20,5 @@ class BaseEncoder(nn.Module):
         pass
 
     @property
-    def supported_attention_backends(self) -> Tuple[_Backend]:
+    def supported_attention_backends(self) -> Tuple[_Backend, ...]:
         return self._supported_attention_backends

--- a/fastvideo/v1/models/encoders/clip.py
+++ b/fastvideo/v1/models/encoders/clip.py
@@ -469,7 +469,7 @@ class CLIPTextTransformer(nn.Module):
 
 
 class CLIPTextModel(BaseEncoder):
-    _supported_attention_backends = [_Backend.FLASH_ATTN, _Backend.TORCH_SDPA]
+    _supported_attention_backends = (_Backend.FLASH_ATTN, _Backend.TORCH_SDPA)
 
     def __init__(
         self,
@@ -619,7 +619,7 @@ class CLIPVisionModel(BaseEncoder, SupportsQuant):
     config_class = CLIPVisionConfig
     main_input_name = "pixel_values"
     packed_modules_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
-    _supported_attention_backends = [_Backend.FLASH_ATTN, _Backend.TORCH_SDPA]
+    _supported_attention_backends = (_Backend.FLASH_ATTN, _Backend.TORCH_SDPA)
 
     def __init__(
         self,

--- a/fastvideo/v1/models/encoders/llama.py
+++ b/fastvideo/v1/models/encoders/llama.py
@@ -280,7 +280,7 @@ class LlamaDecoderLayer(nn.Module):
 
 
 class LlamaModel(BaseEncoder):
-    _supported_attention_backends = [_Backend.FLASH_ATTN, _Backend.TORCH_SDPA]
+    _supported_attention_backends = (_Backend.FLASH_ATTN, _Backend.TORCH_SDPA)
 
     def __init__(self,
                  config: LlamaConfig,

--- a/fastvideo/v1/models/vaes/wanvae.py
+++ b/fastvideo/v1/models/vaes/wanvae.py
@@ -14,17 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextvars
+from contextlib import contextmanager
 from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from contextlib import contextmanager
-import contextvars
 
 from fastvideo.v1.layers.activation import get_act_fn
 from fastvideo.v1.models.utils import auto_attributes
-from fastvideo.v1.models.vaes.common import ParallelTiledVAE, DiagonalGaussianDistribution
+from fastvideo.v1.models.vaes.common import (DiagonalGaussianDistribution,
+                                             ParallelTiledVAE)
 
 CACHE_T = 2
 

--- a/fastvideo/v1/pipelines/stages/clip_image_encoding.py
+++ b/fastvideo/v1/pipelines/stages/clip_image_encoding.py
@@ -7,8 +7,8 @@ This module contains implementations of image encoding stages for diffusion pipe
 
 import torch
 
-from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.fastvideo_args import FastVideoArgs
+from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.logger import init_logger
 from fastvideo.v1.models.vision_utils import load_image
 from fastvideo.v1.pipelines.pipeline_batch_info import ForwardBatch

--- a/fastvideo/v1/pipelines/stages/clip_text_encoding.py
+++ b/fastvideo/v1/pipelines/stages/clip_text_encoding.py
@@ -7,8 +7,8 @@ This module contains implementations of prompt encoding stages for diffusion pip
 
 import torch
 
-from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.fastvideo_args import FastVideoArgs
+from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.logger import init_logger
 from fastvideo.v1.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.v1.pipelines.stages.base import PipelineStage

--- a/fastvideo/v1/pipelines/stages/denoising.py
+++ b/fastvideo/v1/pipelines/stages/denoising.py
@@ -16,8 +16,8 @@ from fastvideo.v1.distributed import (get_sequence_model_parallel_rank,
                                       get_sequence_model_parallel_world_size)
 from fastvideo.v1.distributed.communication_op import (
     sequence_model_parallel_all_gather)
-from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.fastvideo_args import FastVideoArgs
+from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.logger import init_logger
 from fastvideo.v1.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.v1.pipelines.stages.base import PipelineStage

--- a/fastvideo/v1/pipelines/stages/denoising.py
+++ b/fastvideo/v1/pipelines/stages/denoising.py
@@ -180,8 +180,7 @@ class DenoisingStage(PipelineStage):
                         dtype=torch.float16,  # TODO(will): hack
                         supported_attention_backends=(
                             _Backend.SLIDING_TILE_ATTN, _Backend.FLASH_ATTN,
-                            _Backend.TORCH_SDPA
-                        )  # hack
+                            _Backend.TORCH_SDPA)  # hack
                     )
                     if st_attn_available and self.attn_backend == SlidingTileAttentionBackend:
                         self.attn_metadata_builder_cls = self.attn_backend.get_builder_cls(

--- a/fastvideo/v1/pipelines/stages/denoising.py
+++ b/fastvideo/v1/pipelines/stages/denoising.py
@@ -178,10 +178,10 @@ class DenoisingStage(PipelineStage):
                     self.attn_backend = get_attn_backend(
                         head_size=attn_head_size,
                         dtype=torch.float16,  # TODO(will): hack
-                        supported_attention_backends=[
+                        supported_attention_backends=(
                             _Backend.SLIDING_TILE_ATTN, _Backend.FLASH_ATTN,
                             _Backend.TORCH_SDPA
-                        ]  # hack
+                        )  # hack
                     )
                     if st_attn_available and self.attn_backend == SlidingTileAttentionBackend:
                         self.attn_metadata_builder_cls = self.attn_backend.get_builder_cls(

--- a/fastvideo/v1/pipelines/stages/llama_encoding.py
+++ b/fastvideo/v1/pipelines/stages/llama_encoding.py
@@ -9,8 +9,8 @@ from typing import TypedDict
 
 import torch
 
-from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.fastvideo_args import FastVideoArgs
+from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.logger import init_logger
 from fastvideo.v1.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.v1.pipelines.stages.base import PipelineStage

--- a/fastvideo/v1/pipelines/stages/t5_encoding.py
+++ b/fastvideo/v1/pipelines/stages/t5_encoding.py
@@ -6,8 +6,8 @@ This module contains implementations of prompt encoding stages for diffusion pip
 """
 import torch
 
-from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.fastvideo_args import FastVideoArgs
+from fastvideo.v1.forward_context import set_forward_context
 from fastvideo.v1.logger import init_logger
 from fastvideo.v1.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.v1.pipelines.stages.base import PipelineStage

--- a/fastvideo/v1/pipelines/wan/wan_i2v_pipeline.py
+++ b/fastvideo/v1/pipelines/wan/wan_i2v_pipeline.py
@@ -9,10 +9,13 @@ using the modular pipeline architecture.
 from fastvideo.v1.fastvideo_args import FastVideoArgs
 from fastvideo.v1.logger import init_logger
 from fastvideo.v1.pipelines.composed_pipeline_base import ComposedPipelineBase
+
+# isort: off
 from fastvideo.v1.pipelines.stages import (
     CLIPImageEncodingStage, ConditioningStage, DecodingStage, DenoisingStage,
     EncodingStage, InputValidationStage, LatentPreparationStage,
     T5EncodingStage, TimestepPreparationStage)
+# isort: on
 
 logger = init_logger(__name__)
 

--- a/fastvideo/v1/utils.py
+++ b/fastvideo/v1/utils.py
@@ -2,22 +2,23 @@
 # Adapted from vllm: https://github.com/vllm-project/vllm/blob/v0.7.3/vllm/utils.py
 
 import argparse
+import ctypes
 import hashlib
 import importlib
-import ctypes
-import signal
 import inspect
 import json
 import math
-import traceback
 import os
+import signal
 import sys
 import tempfile
-from functools import wraps, partial
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast, Callable, Tuple
+import traceback
 from dataclasses import asdict, fields
-import cloudpickle
+from functools import partial, wraps
+from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
+                    Union, cast)
 
+import cloudpickle
 import filelock
 import torch
 import yaml
@@ -476,6 +477,7 @@ def maybe_download_model_index(model_name_or_path: str) -> Dict[str, Any]:
         The parsed model_index.json as a dictionary
     """
     import tempfile
+
     from huggingface_hub import hf_hub_download
 
     # If it's a local path, verify it directly

--- a/fastvideo/v1/utils.py
+++ b/fastvideo/v1/utils.py
@@ -13,7 +13,6 @@ import signal
 import sys
 import tempfile
 import traceback
-import multiprocessing
 from dataclasses import asdict, fields
 from functools import partial, wraps
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
@@ -588,9 +587,3 @@ class TypeBasedDispatcher:
             if isinstance(obj, ty):
                 return fn(obj)
         raise ValueError(f"Invalid object: {obj}")
-
-
-def get_mp_context():
-    os.environ["FASTVIDEO_WORKER_MULTIPROC_METHOD"] = "spawn"
-    mp_method = envs.FASTVIDEO_WORKER_MULTIPROC_METHOD
-    return multiprocessing.get_context(mp_method)

--- a/fastvideo/v1/utils.py
+++ b/fastvideo/v1/utils.py
@@ -13,6 +13,7 @@ import signal
 import sys
 import tempfile
 import traceback
+import multiprocessing
 from dataclasses import asdict, fields
 from functools import partial, wraps
 from typing import (Any, Callable, Dict, List, Optional, Tuple, Type, TypeVar,
@@ -587,3 +588,9 @@ class TypeBasedDispatcher:
             if isinstance(obj, ty):
                 return fn(obj)
         raise ValueError(f"Invalid object: {obj}")
+
+
+def get_mp_context():
+    os.environ["FASTVIDEO_WORKER_MULTIPROC_METHOD"] = "spawn"
+    mp_method = envs.FASTVIDEO_WORKER_MULTIPROC_METHOD
+    return multiprocessing.get_context(mp_method)

--- a/fastvideo/v1/worker/executor.py
+++ b/fastvideo/v1/worker/executor.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Callable, List, Tuple, Any, Optional, Union, TypeVar, Dict, cast
+from typing import (Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union,
+                    cast)
 
 from fastvideo.v1.fastvideo_args import FastVideoArgs
 from fastvideo.v1.pipelines import ForwardBatch

--- a/fastvideo/v1/worker/gpu_worker.py
+++ b/fastvideo/v1/worker/gpu_worker.py
@@ -7,7 +7,6 @@ import sys
 from typing import Any, Dict, Optional, cast, TextIO
 
 import psutil
-import setproctitle
 import torch
 
 from fastvideo.v1.distributed import (cleanup_dist_env_and_memory,
@@ -17,8 +16,7 @@ from fastvideo.v1.fastvideo_args import FastVideoArgs
 from fastvideo.v1.logger import init_logger
 from fastvideo.v1.pipelines import ForwardBatch, build_pipeline
 from fastvideo.v1.utils import (get_exception_traceback,
-                                kill_itself_when_parent_died,
-                                get_mp_context)
+                                kill_itself_when_parent_died, get_mp_context)
 
 logger = init_logger(__name__)
 

--- a/fastvideo/v1/worker/gpu_worker.py
+++ b/fastvideo/v1/worker/gpu_worker.py
@@ -1,10 +1,11 @@
 import contextlib
 import faulthandler
 import gc
+import multiprocessing as mp
 import os
 import signal
 import sys
-from typing import Any, Dict, Optional, cast, TextIO
+from typing import Any, Dict, Optional, TextIO, cast
 
 import psutil
 import torch
@@ -16,7 +17,7 @@ from fastvideo.v1.fastvideo_args import FastVideoArgs
 from fastvideo.v1.logger import init_logger
 from fastvideo.v1.pipelines import ForwardBatch, build_pipeline
 from fastvideo.v1.utils import (get_exception_traceback,
-                                kill_itself_when_parent_died, get_mp_context)
+                                kill_itself_when_parent_died)
 
 logger = init_logger(__name__)
 
@@ -167,7 +168,7 @@ def init_worker_distributed_environment(
 def run_worker_process(fastvideo_args: FastVideoArgs, local_rank: int,
                        rank: int, pipe):
     # Add process-specific prefix to stdout and stderr
-    process_name = get_mp_context().current_process().name
+    process_name = mp.current_process().name
     pid = os.getpid()
     _add_prefix(sys.stdout, process_name, pid)
     _add_prefix(sys.stderr, process_name, pid)

--- a/fastvideo/v1/worker/gpu_worker.py
+++ b/fastvideo/v1/worker/gpu_worker.py
@@ -1,23 +1,22 @@
-import torch
-from typing import Optional, Dict, Any, cast
-import setproctitle
-import psutil
+import contextlib
 import faulthandler
-import signal
 import gc
 import os
-import contextlib
+import signal
+from typing import Any, Dict, Optional, cast
 
+import psutil
+import setproctitle
+import torch
+
+from fastvideo.v1.distributed import (cleanup_dist_env_and_memory,
+                                      init_distributed_environment,
+                                      initialize_model_parallel)
 from fastvideo.v1.fastvideo_args import FastVideoArgs
 from fastvideo.v1.logger import init_logger
-from fastvideo.v1.pipelines import ForwardBatch
-from fastvideo.v1.distributed import (
-    init_distributed_environment,
-    initialize_model_parallel,
-)
-from fastvideo.v1.utils import kill_itself_when_parent_died, get_exception_traceback
-from fastvideo.v1.pipelines import build_pipeline
-from fastvideo.v1.distributed import cleanup_dist_env_and_memory
+from fastvideo.v1.pipelines import ForwardBatch, build_pipeline
+from fastvideo.v1.utils import (get_exception_traceback,
+                                kill_itself_when_parent_died)
 
 logger = init_logger(__name__)
 
@@ -39,37 +38,11 @@ class Worker:
         # TODO(will): add request dispatcher
         # self._request_dispatcher = TypeBasedDispatcher(
         #     [
-        # (TokenizedGenerateReqInput, self.handle_generate_request),
-        # (TokenizedEmbeddingReqInput, self.handle_embedding_request),
-        # (FlushCacheReq, self.flush_cache_wrapped),
-        # (AbortReq, self.abort_request),
-        # (OpenSessionReqInput, self.open_session),
-        # (CloseSessionReqInput, self.close_session),
-        # (UpdateWeightFromDiskReqInput, self.update_weights_from_disk),
-        # (InitWeightsUpdateGroupReqInput, self.init_weights_update_group),
-        # (
-        #     UpdateWeightsFromDistributedReqInput,
-        #     self.update_weights_from_distributed,
-        # ),
-        # (UpdateWeightsFromTensorReqInput, self.update_weights_from_tensor),
-        # (GetWeightsByNameReqInput, self.get_weights_by_name),
-        # (ReleaseMemoryOccupationReqInput, self.release_memory_occupation),
-        # (ResumeMemoryOccupationReqInput, self.resume_memory_occupation),
-        # (ProfileReq, self.profile),
-        # (GetInternalStateReq, self.get_internal_state),
-        # (SetInternalStateReq, self.set_internal_state),
         # (RpcReqInput, self.handle_rpc_request),
         # (GenerateRequest, self.handle_generate_request),
         # (ExpertDistributionReq, self.expert_distribution_handle),
         #     ]
         # )
-
-    # def handle_rpc_request(self, req: RpcReqInput) -> RpcReqOutput:
-    #     pass
-
-    # def handle_generate_request(self, req: GenerateRequest) -> None:
-    #     logger.info(f"Worker {self.rank} received generate request")
-    #     pass
 
     def init_device(self) -> None:
         """Initialize the device for the worker."""

--- a/fastvideo/v1/worker/multiproc_executor.py
+++ b/fastvideo/v1/worker/multiproc_executor.py
@@ -1,17 +1,18 @@
-import signal
-import psutil
-import multiprocessing as mp
-import time
-from typing import List, Callable, Any, Optional, Union, cast
-from multiprocessing.process import BaseProcess
 import atexit
 import contextlib
+import multiprocessing as mp
+import signal
+import time
+from multiprocessing.process import BaseProcess
+from typing import Any, Callable, List, Optional, Union, cast
 
-from fastvideo.v1.worker.executor import Executor
+import psutil
+
 from fastvideo.v1.fastvideo_args import FastVideoArgs
 from fastvideo.v1.logger import init_logger
-from fastvideo.v1.worker.gpu_worker import run_worker_process
 from fastvideo.v1.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.v1.worker.executor import Executor
+from fastvideo.v1.worker.gpu_worker import run_worker_process
 
 logger = init_logger(__name__)
 

--- a/fastvideo/v1/worker/multiproc_executor.py
+++ b/fastvideo/v1/worker/multiproc_executor.py
@@ -57,12 +57,12 @@ class MultiprocExecutor(Executor):
             self.worker_pipes.append(executor_pipe)
 
             worker = self.mp.Process(target=run_worker_process,
-                                name=f"FVWorkerProc-{rank}",
-                                kwargs=dict(
-                                    fastvideo_args=self.fastvideo_args,
-                                    local_rank=rank,
-                                    rank=rank,
-                                    pipe=worker_pipe))
+                                     name=f"FVWorkerProc-{rank}",
+                                     kwargs=dict(
+                                         fastvideo_args=self.fastvideo_args,
+                                         local_rank=rank,
+                                         rank=rank,
+                                         pipe=worker_pipe))
             worker.start()
             self.workers.append(worker)
         logger.info("Workers: %s", self.workers)


### PR DESCRIPTION
Changes:
- Adds process name and pid prefix to worker logging
- change supported_attn_backends's type from List to Tuple to support caching get_attn_backend(); eliminates spam logging msg from cuda.py
 