### PR TITLE
chore: Release FastVideo 0.0.2 and update python requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Dev in progress and highly experimental.
 - ```2024/12/17```: `FastVideo` v1.0 is released.
 
 ## 🔧 Installation from source
-The code is tested on Python 3.10.0, CUDA 12.4 and H100.
+The code is tested on Python 3.10-3.12, CUDA 12.4 and H100.
 
 ```
 # Clone FastVideo

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -2,12 +2,20 @@
 
 # 🔧 Installation
 
-FastVideo currently only supports Linux and CUDA GPUs. The code is tested on Python 3.10.0 and CUDA 12.4, primarily with NVIDIA H100 GPUs.
+FastVideo currently only supports Linux and NVIDIA CUDA GPUs.
 
-## Prerequisites
+FastVideo has been tested on the following GPUs, but it should work on any GPUs that supports CUDA 12.4+, please create an issue if you discover any issues:
+- RTX 4090
+- A40
+- L40S
+- A100
+- H100
 
-- CUDA 12.4 installed and supported
-- Linux operating system
+## Requirements
+
+- OS: Linux
+- Python: 3.10-3.12
+- CUDA 12.4+ (Untested on CUDA < 12.4)
 
 ## Installation Options
 
@@ -19,7 +27,9 @@ pip install fastvideo
 
 ### Option 2: Installation from Source
 
-#### 1. Install Miniconda (if not already installed)
+We recommend using a Python environment such as Conda.
+
+#### 1. [Optional] Install Miniconda (if not already installed)
 
 ```bash
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
@@ -27,7 +37,7 @@ bash Miniconda3-latest-Linux-x86_64.sh
 source ~/.bashrc
 ```
 
-#### 2. Create and activate a Conda environment for FastVideo
+#### 2. [Optional] Create and activate a Conda environment for FastVideo
 
 ```bash
 conda create -n fastvideo python=3.10 -y
@@ -56,7 +66,7 @@ pip install -e .
 pip install flash-attn==2.7.0.post2 --no-build-isolation
 ```
 
-### Sliding Tile Attention (STA)
+### Sliding Tile Attention (STA) (Requires CUDA 12.4+ and H100)
 
 To try Sliding Tile Attention (optional), please follow the instructions in [csrc/sliding_tile_attention/README.md](#sta-installation) to install STA.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fastvideo"
-version = "0.0.1.dev1"
+version = "0.0.2"
 description = "FastVideo"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fastvideo"
 version = "0.0.2"
 description = "FastVideo"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Tested that FastVideo also works on Python 3.11 and 3.12