### PR TITLE
[V1] Worker improvements/cleanup

### DIFF
--- a/fastvideo/v1/entrypoints/video_generator.py
+++ b/fastvideo/v1/entrypoints/video_generator.py
@@ -241,7 +241,7 @@ class VideoGenerator:
         # Run inference
         start_time = time.time()
         output_batch = self.executor.execute_forward(batch, fastvideo_args)
-        samples = output_batch.output
+        samples = output_batch
 
         gen_time = time.time() - start_time
         logger.info("Generated successfully in %.2f seconds", gen_time)

--- a/fastvideo/v1/worker/gpu_worker.py
+++ b/fastvideo/v1/worker/gpu_worker.py
@@ -136,7 +136,7 @@ class Worker:
                 fastvideo_args = recv_rpc['kwargs']['fastvideo_args']
                 output_batch = self.execute_forward(forward_batch,
                                                     fastvideo_args)
-                self.pipe.send({"output_batch": output_batch})
+                self.pipe.send({"output_batch": output_batch.output.cpu()})
             else:
                 # Handle other methods dynamically if needed
                 args = recv_rpc.get('args', ())

--- a/fastvideo/v1/worker/multiproc_executor.py
+++ b/fastvideo/v1/worker/multiproc_executor.py
@@ -1,12 +1,9 @@
 import atexit
 import contextlib
 import multiprocessing as mp
-import signal
 import time
 from multiprocessing.process import BaseProcess
 from typing import Any, Callable, List, Optional, Union, cast
-
-import psutil
 
 from fastvideo.v1.fastvideo_args import FastVideoArgs
 from fastvideo.v1.logger import init_logger

--- a/fastvideo/v1/worker/multiproc_executor.py
+++ b/fastvideo/v1/worker/multiproc_executor.py
@@ -20,28 +20,6 @@ logger = init_logger(__name__)
 class MultiprocExecutor(Executor):
 
     def _init_executor(self) -> None:
-        # The child processes will send SIGUSR1 when unrecoverable
-        # errors happen.
-        def sigusr1_handler(signum, frame):
-            logger.fatal(
-                "MulitprocExecutor got fatal signal from worker processes, "
-                "shutting down. See stack trace above for root cause issue.")
-            # Propagate error up to parent process.
-            parent_process = psutil.Process().parent()
-            parent_process.send_signal(signal.SIGUSR1)
-            self.shutdown()
-
-        # Handle Ctrl+C and regular termination
-        def sigint_handler(signum, frame):
-            logger.info("Received interrupt signal, shutting down workers...")
-            self.shutdown()
-            # Then re-raise the signal to the parent process
-            signal.default_int_handler(signum, frame)
-
-        signal.signal(signal.SIGUSR1, sigusr1_handler)
-        signal.signal(signal.SIGINT, sigint_handler)
-        signal.signal(signal.SIGTERM, sigint_handler)
-
         self.world_size = self.fastvideo_args.num_gpus
         self.shutting_down = False
 


### PR DESCRIPTION
Issues found while attempting to use the new API in ComfyUI.

GPU worker change ensures CPU memory has access to forward output--fixes `RuntimeError: cudaMallocAsync does not yet support shareIpcHandle`

Removal of signal handlers do not seem to affect current gradio and basic examples, while avoiding `signal only works in main thread of the main interpreter` and the need to propagate signals from worker -> main thread