### PR TITLE
[misc] Improve worker cleanup

### DIFF
--- a/fastvideo/v1/entrypoints/video_generator.py
+++ b/fastvideo/v1/entrypoints/video_generator.py
@@ -6,6 +6,7 @@ This module provides a consolidated interface for generating videos using
 diffusion models.
 """
 
+import gc
 import os
 import time
 from typing import Any, Dict, List, Optional, Union
@@ -245,7 +246,7 @@ class VideoGenerator:
             if save_path:
                 os.makedirs(os.path.dirname(save_path), exist_ok=True)
                 video_path = os.path.join(save_path, f"{prompt[:100]}.mp4")
-                imageio.mimsave(video_path, frames, fps=batch.fps)
+                imageio.mimsave(video_path, frames, fps=batch.fps, format="mp4")
                 logger.info("Saved video to %s", video_path)
             else:
                 logger.warning("No output path provided, video not saved")
@@ -259,3 +260,12 @@ class VideoGenerator:
                 "size": (target_height, target_width, batch.num_frames),
                 "generation_time": gen_time
             }
+
+    def shutdown(self):
+        """
+        Shutdown the video generator.
+        """
+        self.executor.shutdown()
+        del self.executor
+        gc.collect()
+        torch.cuda.empty_cache()

--- a/fastvideo/v1/worker/executor.py
+++ b/fastvideo/v1/worker/executor.py
@@ -76,3 +76,10 @@ class Executor(ABC):
             and set up data-plane communication to pass data.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def shutdown(self) -> None:
+        """
+        Shutdown the executor.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
These changes allow for the early termination and graceful interruption of generations. This is particularly useful when using jupyter notebook where the `VideoGenerator` is kept in memory and the `generate_video()` call can be freely interrupted and restarted with a new batch