### PR TITLE
[Misc] Replace instances of `time.time()` with `time.perf_counter()`

### DIFF
--- a/examples/inference/optimizations/README.md
+++ b/examples/inference/optimizations/README.md
@@ -115,14 +115,14 @@ To benchmark the performance improvement, try generating the same video with and
 
 ```python
 # Without TeaCache
-start_time = time.time()
+start_time = time.perf_counter()
 generator.generate_video(prompt="Your prompt", enable_teacache=False)
-standard_time = time.time() - start_time
+standard_time = time.perf_counter() - start_time
 
 # With TeaCache
-start_time = time.time()
+start_time = time.perf_counter()
 generator.generate_video(prompt="Your prompt", enable_teacache=True)
-teacache_time = time.time() - start_time
+teacache_time = time.perf_counter() - start_time
 
 print(f"Standard generation: {standard_time:.2f} seconds")
 print(f"TeaCache generation: {teacache_time:.2f} seconds")

--- a/examples/inference/optimizations/attention_example.py
+++ b/examples/inference/optimizations/attention_example.py
@@ -7,15 +7,15 @@ def main():
     # set the attention backend 
     os.environ["FASTVIDEO_ATTENTION_BACKEND"] = "FLASH_ATTN"
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     gen = VideoGenerator.from_pretrained(
         model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
         num_gpus=1,
     )
-    load_time = time.time() - start_time
+    load_time = time.perf_counter() - start_time
     print(f"Model loading time: {load_time:.2f} seconds")
 
-    gen_start_time = time.time()
+    gen_start_time = time.perf_counter()
 
     gen.generate_video(
         prompt=
@@ -23,10 +23,10 @@ def main():
         seed=1024,
         output_path="example_outputs/")
     
-    generation_time = time.time() - gen_start_time
+    generation_time = time.perf_counter() - gen_start_time
     print(f"Video generation time: {generation_time:.2f} seconds")
 
-    total_time = time.time() - start_time
+    total_time = time.perf_counter() - start_time
     print(f"Total execution time: {total_time:.2f} seconds")
 
 if __name__ == "__main__":

--- a/examples/inference/optimizations/teacache_example.py
+++ b/examples/inference/optimizations/teacache_example.py
@@ -4,17 +4,17 @@ from fastvideo import VideoGenerator, SamplingParam
 
 
 def main():
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     gen = VideoGenerator.from_pretrained(
         model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
         num_gpus=1,
         use_cpu_offload=False,
     )
-    load_time = time.time() - start_time
+    load_time = time.perf_counter() - start_time
     print(f"Model loading time: {load_time:.2f} seconds")
 
-    gen_start_time = time.time()
+    gen_start_time = time.perf_counter()
 
     params = SamplingParam.from_pretrained(
         model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
@@ -33,10 +33,10 @@ def main():
         seed=1024,
         output_path="example_outputs/")
     
-    generation_time = time.time() - gen_start_time
+    generation_time = time.perf_counter() - gen_start_time
     print(f"Video generation time: {generation_time:.2f} seconds")
 
-    total_time = time.time() - start_time
+    total_time = time.perf_counter() - start_time
     print(f"Total execution time: {total_time:.2f} seconds")
 
 

--- a/fastvideo/distill.py
+++ b/fastvideo/distill.py
@@ -452,7 +452,7 @@ def main(args):
         return phase
 
     for step in range(init_steps + 1, args.max_train_steps + 1):
-        start_time = time.time()
+        start_time = time.perf_counter()
         assert args.multi_phased_distill_schedule is not None
         num_phases = get_num_phases(args.multi_phased_distill_schedule, step)
 
@@ -482,7 +482,7 @@ def main(args):
             args.hunyuan_teacher_disable_cfg,
         )
 
-        step_time = time.time() - start_time
+        step_time = time.perf_counter() - start_time
         step_times.append(step_time)
         avg_step_time = sum(step_times) / len(step_times)
 

--- a/fastvideo/distill_adv.py
+++ b/fastvideo/distill_adv.py
@@ -517,7 +517,7 @@ def main(args):
     for step in range(init_steps + 1, args.max_train_steps + 1):
         assert args.multi_phased_distill_schedule is not None
         num_phases = get_num_phases(args.multi_phased_distill_schedule, step)
-        start_time = time.time()
+        start_time = time.perf_counter()
         (
             generator_loss,
             generator_grad_norm,
@@ -547,7 +547,7 @@ def main(args):
             args.discriminator_head_stride,
         )
 
-        step_time = time.time() - start_time
+        step_time = time.perf_counter() - start_time
         step_times.append(step_time)
         avg_step_time = sum(step_times) / len(step_times)
 

--- a/fastvideo/models/hunyuan/inference.py
+++ b/fastvideo/models/hunyuan/inference.py
@@ -452,7 +452,7 @@ class HunyuanVideoSampler(Inference):
         # ========================================================================
         # Pipeline inference
         # ========================================================================
-        start_time = time.time()
+        start_time = time.perf_counter()
         samples = self.pipeline(
             prompt=prompt,
             height=target_height,
@@ -476,7 +476,7 @@ class HunyuanVideoSampler(Inference):
         out_dict["samples"] = samples
         out_dict["prompts"] = prompt
 
-        gen_time = time.time() - start_time
+        gen_time = time.perf_counter() - start_time
         logger.info(f"Success, time: {gen_time}")
 
         return out_dict

--- a/fastvideo/train.py
+++ b/fastvideo/train.py
@@ -364,7 +364,7 @@ def main(args):
     for i in range(init_steps):
         next(loader)
     for step in range(init_steps + 1, args.max_train_steps + 1):
-        start_time = time.time()
+        start_time = time.perf_counter()
         loss, grad_norm = train_one_step(
             transformer,
             args.model_type,
@@ -383,7 +383,7 @@ def main(args):
             args.mode_scale,
         )
 
-        step_time = time.time() - start_time
+        step_time = time.perf_counter() - start_time
         step_times.append(step_time)
         avg_step_time = sum(step_times) / len(step_times)
 

--- a/fastvideo/v1/distributed/utils.py
+++ b/fastvideo/v1/distributed/utils.py
@@ -94,14 +94,14 @@ class StatelessProcessGroup:
         key = f"send_to/{dst}/{self.send_dst_counter[dst]}"
         self.store.set(key, pickle.dumps(obj))
         self.send_dst_counter[dst] += 1
-        self.entries.append((key, time.time()))
+        self.entries.append((key, time.perf_counter()))
 
     def expire_data(self) -> None:
         """Expire data that is older than `data_expiration_seconds` seconds."""
         while self.entries:
             # check the oldest entry
             key, timestamp = self.entries[0]
-            if time.time() - timestamp > self.data_expiration_seconds:
+            if time.perf_counter() - timestamp > self.data_expiration_seconds:
                 self.store.delete_key(key)
                 self.entries.popleft()
             else:
@@ -125,7 +125,7 @@ class StatelessProcessGroup:
                    f"{self.broadcast_send_counter}")
             self.store.set(key, pickle.dumps(obj))
             self.broadcast_send_counter += 1
-            self.entries.append((key, time.time()))
+            self.entries.append((key, time.perf_counter()))
             return obj
         else:
             key = (f"broadcast_from/{src}/"

--- a/fastvideo/v1/entrypoints/video_generator.py
+++ b/fastvideo/v1/entrypoints/video_generator.py
@@ -225,11 +225,11 @@ class VideoGenerator:
         )
 
         # Run inference
-        start_time = time.time()
+        start_time = time.perf_counter()
         output_batch = self.executor.execute_forward(batch, fastvideo_args)
         samples = output_batch
 
-        gen_time = time.time() - start_time
+        gen_time = time.perf_counter() - start_time
         logger.info("Generated successfully in %.2f seconds", gen_time)
 
         # Process outputs

--- a/fastvideo/v1/inference_engine.py
+++ b/fastvideo/v1/inference_engine.py
@@ -191,7 +191,7 @@ class InferenceEngine:
         # ========================================================================
         # Pipeline inference
         # ========================================================================
-        start_time = time.time()
+        start_time = time.perf_counter()
         samples = self.pipeline.forward(
             batch=batch,
             fastvideo_args=fastvideo_args,
@@ -201,7 +201,7 @@ class InferenceEngine:
         out_dict["samples"] = samples
         out_dict["prompts"] = prompt
 
-        gen_time = time.time() - start_time
+        gen_time = time.perf_counter() - start_time
         logger.info("Success, time: %s", gen_time)
 
         return out_dict

--- a/fastvideo/v1/pipelines/stages/base.py
+++ b/fastvideo/v1/pipelines/stages/base.py
@@ -61,19 +61,19 @@ class PipelineStage(ABC):
         # if envs.ENABLE_STAGE_LOGGING:
         if False:
             self._logger.info("[%s] Starting execution", self._stage_name)
-            start_time = time.time()
+            start_time = time.perf_counter()
 
             try:
                 # Call the actual implementation
                 result = self._call_implementation(batch, fastvideo_args)
 
-                execution_time = time.time() - start_time
+                execution_time = time.perf_counter() - start_time
                 self._logger.info("[%s] Execution completed in %s ms",
                                   self._stage_name, execution_time * 1000)
 
                 return result
             except Exception as e:
-                execution_time = time.time() - start_time
+                execution_time = time.perf_counter() - start_time
                 self._logger.error(
                     "[%s] Error during execution after %s ms: %s",
                     self._stage_name, execution_time * 1000, e)

--- a/fastvideo/v1/worker/multiproc_executor.py
+++ b/fastvideo/v1/worker/multiproc_executor.py
@@ -109,8 +109,8 @@ class MultiprocExecutor(Executor):
                     pipe.send({"method": "shutdown", "args": (), "kwargs": {}})
 
             # Give workers some time to exit gracefully
-            start_time = time.time()
-            while time.time() - start_time < 5.0:  # 5 seconds timeout
+            start_time = time.perf_counter()
+            while time.perf_counter() - start_time < 5.0:  # 5 seconds timeout
                 if all(not worker.is_alive() for worker in self.workers):
                     break
                 time.sleep(0.1)
@@ -121,8 +121,8 @@ class MultiprocExecutor(Executor):
                     worker.terminate()
 
             # Final timeout for terminate
-            start_time = time.time()
-            while time.time() - start_time < 2.0:  # 2 seconds timeout
+            start_time = time.perf_counter()
+            while time.perf_counter() - start_time < 2.0:  # 2 seconds timeout
                 if all(not worker.is_alive() for worker in self.workers):
                     break
                 time.sleep(0.1)

--- a/predict.py
+++ b/predict.py
@@ -22,11 +22,11 @@ MODEL_URL = "https://weights.replicate.delivery/default/FastVideo/FastHunyuan/mo
 
 
 def download_weights(url, dest):
-    start = time.time()
+    start = time.perf_counter()
     print("downloading url: ", url)
     print("downloading to: ", dest)
     subprocess.check_call(["pget", "-xf", url, dest], close_fds=False)
-    print("downloading took: ", time.time() - start)
+    print("downloading took: ", time.perf_counter() - start)
 
 
 class Predictor(BasePredictor):

--- a/scripts/dataset_preparation/resize_videos.py
+++ b/scripts/dataset_preparation/resize_videos.py
@@ -134,9 +134,9 @@ def main():
         logging.error(f"Input directory not found: {args.input_dir}")
         return
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     process_folder(args)
-    duration = time.time() - start_time
+    duration = time.perf_counter() - start_time
     logging.info(f"Batch processing completed in {duration:.2f} seconds")
 
 


### PR DESCRIPTION
For this purpose, `time.time()` should not be used to measure inference code speed, as well as benchmarks, instead we should use `time.perf_counter()`. See: https://peps.python.org/pep-0418/#rationale 👍 