### PR TITLE
[Teacache] allow None for forward_context batch when using teacache

### DIFF
--- a/fastvideo/v1/models/dits/base.py
+++ b/fastvideo/v1/models/dits/base.py
@@ -95,8 +95,6 @@ class CachableDiT(BaseDiT):
         if self.config.prefix == "wan":
             self.use_ret_steps = self.config.cache_config.use_ret_steps
             self.is_even = False
-            self.previous_e0_even: torch.Tensor | None = None
-            self.previous_e0_odd: torch.Tensor | None = None
             self.previous_residual_even: torch.Tensor | None = None
             self.previous_residual_odd: torch.Tensor | None = None
             self.accumulated_rel_l1_distance_even = 0
@@ -106,7 +104,9 @@ class CachableDiT(BaseDiT):
         else:
             self.accumulated_rel_l1_distance = 0
             self.previous_modulated_input = None
-            self.previous_residual = None
+            self.previous_resiual = None
+        self.previous_e0_even: torch.Tensor | None = None
+        self.previous_e0_odd: torch.Tensor | None = None
 
     def maybe_cache_states(self, hidden_states: torch.Tensor,
                            original_hidden_states: torch.Tensor) -> None:

--- a/fastvideo/v1/models/dits/hunyuanvideo.py
+++ b/fastvideo/v1/models/dits/hunyuanvideo.py
@@ -562,8 +562,7 @@ class HunyuanVideoTransformer3DModel(CachableDiT):
         """
         forward_context = get_forward_context()
         forward_batch = forward_context.forward_batch
-        assert forward_batch is not None
-        enable_teacache = forward_batch.enable_teacache
+        enable_teacache = forward_batch is not None and forward_batch.enable_teacache
 
         if guidance is None:
             guidance = torch.tensor([6016.0],
@@ -661,7 +660,8 @@ class HunyuanVideoTransformer3DModel(CachableDiT):
 
         forward_context = get_forward_context()
         forward_batch = forward_context.forward_batch
-        assert forward_batch is not None
+        if forward_batch is None:
+            return False
         current_timestep = forward_context.current_timestep
         enable_teacache = forward_batch.enable_teacache
 

--- a/fastvideo/v1/models/dits/wanvideo.py
+++ b/fastvideo/v1/models/dits/wanvideo.py
@@ -424,8 +424,7 @@ class WanTransformer3DModel(CachableDiT):
                 guidance=None,
                 **kwargs) -> torch.Tensor:
         forward_batch = get_forward_context().forward_batch
-        assert forward_batch is not None
-        enable_teacache = forward_batch.enable_teacache
+        enable_teacache = forward_batch is not None and forward_batch.enable_teacache
 
         orig_dtype = hidden_states.dtype
         if not isinstance(encoder_hidden_states, torch.Tensor):
@@ -525,8 +524,7 @@ class WanTransformer3DModel(CachableDiT):
 
         forward_context = get_forward_context()
         forward_batch = forward_context.forward_batch
-        assert forward_batch is not None
-        if not forward_batch.enable_teacache:
+        if forward_batch is None or not forward_batch.enable_teacache:
             return False
         teacache_params = forward_batch.teacache_params
         assert teacache_params is not None, "teacache_params is not initialized"


### PR DESCRIPTION
More sensible behavior in DiTs when forward_context's batch is None -- especially needed when using DiT for training/distill