### PR TITLE
Fulfill worker response on interrupt

### DIFF
--- a/fastvideo/v1/worker/gpu_worker.py
+++ b/fastvideo/v1/worker/gpu_worker.py
@@ -154,6 +154,14 @@ class Worker:
                 logger.error(
                     "Worker %d in loop received KeyboardInterrupt, aborting forward pass",
                     self.rank)
+                try:
+                    self.pipe.send(
+                        {"error": "Operation aborted by KeyboardInterrupt"})
+                    logger.info("Worker %d sent error response after interrupt",
+                                self.rank)
+                except Exception as e:
+                    logger.error("Worker %d failed to send error response: %s",
+                                 self.rank, str(e))
                 continue
 
 


### PR DESCRIPTION
The multiproc_executor pipe was getting stuck in a faulty state, which can be seen if inference is attempted again after an interrupt, as it's expecting a response from the workers.