### PR TITLE
misc: Add flash-attn to CI dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
     "av==14.3.0",
     "pytorch-msssim==1.0.0",
     "pytest",
+    "flash-attn==2.7.4.post1 --no-cache-dir --no-build-isolation",
 ]
 
 dev = [ "fastvideo[lint]", "fastvideo[test]", ]


### PR DESCRIPTION
Flash attn should be installed because [SSIM tests](https://github.com/hao-ai-lab/FastVideo/blob/12647457a784a41add9a4d93e5f13a052a8938d3/fastvideo/v1/tests/ssim/test_inference_similarity.py#L133) uses it.