### PR TITLE
[bugfix] fix validation pipeline initialization

### DIFF
--- a/fastvideo/v1/fastvideo_args.py
+++ b/fastvideo/v1/fastvideo_args.py
@@ -581,9 +581,6 @@ class TrainingArgs(FastVideoArgs):
     # master_weight_type
     master_weight_type: str = ""
 
-    # For fast checking in LoRA pipeline
-    training_mode: bool = True
-
     @classmethod
     def from_cli_args(cls, args: argparse.Namespace) -> "TrainingArgs":
         # Get all fields from the dataclass
@@ -606,7 +603,8 @@ class TrainingArgs(FastVideoArgs):
             # Use getattr with default value from the dataclass for potentially missing attributes
             else:
                 default_value = getattr(cls, attr, None)
-                kwargs[attr] = getattr(args, attr, default_value)
+                if getattr(args, attr, default_value) is not None:
+                    kwargs[attr] = getattr(args, attr, default_value)
 
         return cls(**kwargs)
 

--- a/fastvideo/v1/pipelines/composed_pipeline_base.py
+++ b/fastvideo/v1/pipelines/composed_pipeline_base.py
@@ -55,6 +55,7 @@ class ComposedPipelineBase(ABC):
         use. The pipeline should be stateless and not hold any batch state.
         """
 
+        assert fastvideo_args.training_mode != fastvideo_args.inference_mode, "training_mode and inference_mode cannot be both True"
         if fastvideo_args.training_mode:
             assert isinstance(fastvideo_args, TrainingArgs)
             self.training_args = fastvideo_args

--- a/fastvideo/v1/training/wan_training_pipeline.py
+++ b/fastvideo/v1/training/wan_training_pipeline.py
@@ -55,10 +55,11 @@ class WanTrainingPipeline(TrainingPipeline):
 
         args_copy.inference_mode = True
         args_copy.vae_config.load_encoder = False
-        validation_pipeline = WanValidationPipeline.from_pretrained(
+        args_copy.log_validation = False
+        # no need to use .from_pretrained here as we already have TrainingArgs
+        validation_pipeline = WanValidationPipeline(
             training_args.model_path,
-            args=None,
-            inference_mode=True,
+            fastvideo_args=args_copy,
             loaded_modules={"transformer": self.get_module("transformer")})
 
         self.validation_pipeline = validation_pipeline


### PR DESCRIPTION
directly call validation pipeline's  `__init__` in wan_training_pipeline since we already have TrainingArgs available