### PR TITLE
Specify cu128 Pytorch installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dependencies = [
     "av",
 ]
 
+[tool.uv]
+extra-index-url = ["https://download.pytorch.org/whl/cu128"]
+
 [project.optional-dependencies]
 
 # flash-attn: pip install flash-attn==2.7.4.post1 --no-cache-dir --no-build-isolation 


### PR DESCRIPTION
Tested on 5090

![image](https://github.com/user-attachments/assets/762531af-b874-49f7-ba55-ef32a8964c4d)
