### PR TITLE
[CI] Fix CI checks

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -158,7 +158,7 @@ jobs:
   encoder-test:
     needs: change-filter
     if: >-
-      (github.event_name != 'workflow_dispatch' && needs.change-filter.outputs.encoder-test == 'true') || 
+      (github.event_name != 'workflow_dispatch' && github.event.pull_request.draft == false && needs.change-filter.outputs.encoder-test == 'true') || 
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run_encoder_test == 'true')
     uses: ./.github/workflows/runpod-test.yml
     with:
@@ -176,7 +176,7 @@ jobs:
   vae-test:
     needs: change-filter
     if: >-
-      (github.event_name != 'workflow_dispatch' && needs.change-filter.outputs.vae-test == 'true') || 
+      (github.event_name != 'workflow_dispatch' && github.event.pull_request.draft == false && needs.change-filter.outputs.vae-test == 'true') || 
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run_vae_test == 'true')
     uses: ./.github/workflows/runpod-test.yml
     with:
@@ -194,7 +194,7 @@ jobs:
   transformer-test:
     needs: change-filter
     if: >-
-      (github.event_name != 'workflow_dispatch' && needs.change-filter.outputs.transformer-test == 'true') || 
+      (github.event_name != 'workflow_dispatch' && github.event.pull_request.draft == false && needs.change-filter.outputs.transformer-test == 'true') || 
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run_transformer_test == 'true')
     uses: ./.github/workflows/runpod-test.yml
     with:
@@ -298,7 +298,7 @@ jobs:
   precision-test-STA:
     needs: change-filter
     if: >-
-      (github.event_name != 'workflow_dispatch' && github.event.pull_request.draft == false) || 
+      (github.event_name != 'workflow_dispatch' && github.event.pull_request.draft == false && needs.change-filter.outputs.precision-test-STA == 'true') || 
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run_precision_test_STA == 'true')
     uses: ./.github/workflows/runpod-test.yml
     with:
@@ -317,7 +317,7 @@ jobs:
   precision-test-VSA:
     needs: change-filter
     if: >-
-      (github.event_name != 'workflow_dispatch' && github.event.pull_request.draft == false) || 
+      (github.event_name != 'workflow_dispatch' && github.event.pull_request.draft == false && needs.change-filter.outputs.precision-test-VSA == 'true') || 
       (github.event_name == 'workflow_dispatch' && github.event.inputs.run_precision_test_VSA == 'true')
     uses: ./.github/workflows/runpod-test.yml
     with:


### PR DESCRIPTION
Now draft PRs won't trigger anything, and correctly restrict precision tests to the paths