### PR TITLE
Fix clip config

### DIFF
--- a/fastvideo/v1/configs/models/encoders/clip.py
+++ b/fastvideo/v1/configs/models/encoders/clip.py
@@ -62,6 +62,13 @@ class CLIPVisionArchConfig(ImageEncoderArchConfig):
     attention_dropout: float = 0.0
     initializer_range: float = 0.02
     initializer_factor: float = 1.0
+    stacked_params_mapping: List[Tuple[str, str,
+                                       str]] = field(default_factory=lambda: [
+                                           # (param_name, shard_name, shard_id)
+                                           ("qkv_proj", "q_proj", "q"),
+                                           ("qkv_proj", "k_proj", "k"),
+                                           ("qkv_proj", "v_proj", "v"),
+                                       ])
 
 
 @dataclass


### PR DESCRIPTION
There seems to be some bugs associated with pytest to cause one worker to always lag behind, and therefore [hangs when loading weights from distributed.](https://github.com/hao-ai-lab/FastVideo/actions/runs/15940892905/job/44968804148) Everything runs fine with `python examples/inference/basic/basic.py`. You can reproduce by inserting a `dist.breakpoint` anywhere in the weight loading code.
With cpu offload only one GPU is sufficient.
