### PR TITLE
Fix VAE precisions

### DIFF
--- a/fastvideo/v1/configs/pipelines/base.py
+++ b/fastvideo/v1/configs/pipelines/base.py
@@ -52,7 +52,7 @@ class PipelineConfig:
 
     # VAE configuration
     vae_config: VAEConfig = field(default_factory=VAEConfig)
-    vae_precision: str = "fp16"
+    vae_precision: str = "fp32"
     vae_tiling: bool = True
     vae_sp: bool = True
 

--- a/fastvideo/v1/configs/pipelines/wan.py
+++ b/fastvideo/v1/configs/pipelines/wan.py
@@ -50,7 +50,7 @@ class WanT2V480PConfig(PipelineConfig):
 
     # Precision for each component
     precision: str = "bf16"
-    vae_precision: str = "fp16"
+    vae_precision: str = "fp32"
     text_encoder_precisions: Tuple[str, ...] = field(
         default_factory=lambda: ("fp32", ))
 

--- a/fastvideo/v1/configs/wan_1.3B_t2v_pipeline.json
+++ b/fastvideo/v1/configs/wan_1.3B_t2v_pipeline.json
@@ -4,7 +4,7 @@
   "use_cpu_offload": true,
   "disable_autocast": false,
   "precision": "bf16",
-  "vae_precision": "fp16",
+  "vae_precision": "fp32",
   "vae_tiling": false,
   "vae_sp": false,
   "vae_config": {

--- a/fastvideo/v1/configs/wan_14B_i2v_480p_pipeline.json
+++ b/fastvideo/v1/configs/wan_14B_i2v_480p_pipeline.json
@@ -4,7 +4,7 @@
   "use_cpu_offload": true,
   "disable_autocast": false,
   "precision": "bf16",
-  "vae_precision": "fp16",
+  "vae_precision": "fp32",
   "vae_tiling": false,
   "vae_sp": false,
   "vae_config": {


### PR DESCRIPTION
Wan precisions from https://github.com/hao-ai-lab/FastVideo/pull/358 were incorrect. Note that even after this PR, if you run the following script, the `prompt_embed` from text encoder is still mismatching huggingface, making it harder to write lora tests.
https://huggingface.co/Wan-AI/Wan2.1-T2V-1.3B-Diffusers
## Official
![image](https://github.com/user-attachments/assets/df829733-cbfe-4a50-9347-f6e71452d588)
## Ours
![image](https://github.com/user-attachments/assets/7c09a80b-6d19-443a-8923-ae60ed8041cd)

```
import torch
from diffusers import AutoencoderKLWan, WanPipeline
from diffusers.schedulers.scheduling_unipc_multistep import (
    UniPCMultistepScheduler)
from diffusers.utils import export_to_video

model_id = "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
vae = AutoencoderKLWan.from_pretrained(model_id,
                                       subfolder="vae",
                                       torch_dtype=torch.float32)
pipe = WanPipeline.from_pretrained(model_id,
                                   vae=vae,
                                   torch_dtype=torch.bfloat16)
pipe.scheduler = UniPCMultistepScheduler.from_config(pipe.scheduler.config,
                                                     flow_shift=3.0)
pipe.text_encoder = pipe.text_encoder.to(torch.float32)
pipe.to("cuda")
# pipe.load_lora_weights("benjamin-paine/steamboat-willie-1.3b", adapter_name="a", weight_name="steamboat-willie.bf16.safetensors")
pipe.load_lora_weights("benjamin-paine/steamboat-willie-1.3b")
prompt = "steamboat willie style, golden era animation, close-up of a short fluffy monster  kneeling beside a melting red candle. the mood is one of wonder and curiosity,  as the monster gazes at the flame with wide eyes and open mouth. Its pose and expression  convey a sense of innocence and playfulness, as if it is exploring the world around it for the first time.  The use of warm colors and dramatic lighting further enhances the cozy atmosphere of the image."
negative_prompt = "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"

# pipe.load_lora_weights("motimalu/wan-flat-color-1.3b-v2")
# prompt = "flat color, no lineart, blending, negative space, artist:[john kafka|ponsuke kaikai|hara id 21|yoneyama mai|fuzichoco],  1girl, sakura miko, pink hair, cowboy shot, white shirt, floral print, off shoulder, outdoors, cherry blossom, tree shade, wariza, looking up, falling petals, half-closed eyes, white sky, clouds,  live2d animation, upper body, high quality cinematic video of a woman sitting under a sakura tree. Dreamy and lonely, the camera close-ups on the face of the woman as she turns towards the viewer. The Camera is steady, This is a cowboy shot. The animation is smooth and fluid."
# negative_prompt = "bad quality video,色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"

output = pipe(prompt=prompt,
              negative_prompt=negative_prompt,
              height=480,
              width=832,
              num_frames=81,
              guidance_scale=5.0,
              num_inference_steps=32,
              generator=torch.Generator(device="cpu").manual_seed(42)).frames[0]

export_to_video(output, "output.mp4", fps=24)
```