### PR TITLE
Remove all unnecessary torch.cuda.empty_cache

### DIFF
--- a/fastvideo/v1/distributed/parallel_state.py
+++ b/fastvideo/v1/distributed/parallel_state.py
@@ -23,7 +23,6 @@ If you only need to use the distributed environment without model parallelism,
  you can skip the model parallel initialization and destruction steps.
 """
 import contextlib
-import gc
 import os
 import pickle
 import weakref
@@ -1016,15 +1015,6 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
     if shutdown_ray:
         import ray  # Lazy import Ray
         ray.shutdown()
-    gc.collect()
-    from fastvideo.v1.platforms import current_platform
-    if not current_platform.is_cpu():
-        torch.cuda.empty_cache()
-    try:
-        torch._C._host_emptyCache()
-    except AttributeError:
-        logger.warning(
-            "torch._C._host_emptyCache() only available in Pytorch >=2.5")
 
 
 def in_the_same_node_as(pg: ProcessGroup | StatelessProcessGroup,

--- a/fastvideo/v1/entrypoints/video_generator.py
+++ b/fastvideo/v1/entrypoints/video_generator.py
@@ -6,7 +6,6 @@ This module provides a consolidated interface for generating videos using
 diffusion models.
 """
 
-import gc
 import math
 import os
 import time
@@ -277,5 +276,3 @@ class VideoGenerator:
         """
         self.executor.shutdown()
         del self.executor
-        gc.collect()
-        torch.cuda.empty_cache()

--- a/fastvideo/v1/models/vaes/common.py
+++ b/fastvideo/v1/models/vaes/common.py
@@ -239,7 +239,6 @@ class ParallelTiledVAE(ABC):
 
         results = torch.cat(local_results, dim=0).contiguous()
         del local_results
-        torch.cuda.empty_cache()
         # first gather size to pad the results
         local_size = torch.tensor([results.size(0)],
                                   device=results.device,
@@ -253,7 +252,7 @@ class ParallelTiledVAE(ABC):
         padded_results = torch.zeros(max_size, device=results.device)
         padded_results[:results.size(0)] = results
         del results
-        torch.cuda.empty_cache()
+
         # Gather all results
         gathered_dim_metadata = [None] * world_size
         gathered_results = torch.zeros_like(padded_results).repeat(

--- a/fastvideo/v1/pipelines/stages/encoding.py
+++ b/fastvideo/v1/pipelines/stages/encoding.py
@@ -136,7 +136,6 @@ class EncodingStage(PipelineStage):
             self.maybe_free_model_hooks()
 
         self.vae.to("cpu")
-        torch.cuda.empty_cache()
 
         return batch
 

--- a/fastvideo/v1/pipelines/stages/image_encoding.py
+++ b/fastvideo/v1/pipelines/stages/image_encoding.py
@@ -5,8 +5,6 @@ Image encoding stages for I2V diffusion pipelines.
 This module contains implementations of image encoding stages for diffusion pipelines.
 """
 
-import torch
-
 from fastvideo.v1.distributed import get_local_torch_device
 from fastvideo.v1.fastvideo_args import FastVideoArgs
 from fastvideo.v1.forward_context import set_forward_context
@@ -68,7 +66,6 @@ class ImageEncodingStage(PipelineStage):
 
         if fastvideo_args.use_cpu_offload:
             self.image_encoder.to('cpu')
-            torch.cuda.empty_cache()
 
         return batch
 

--- a/fastvideo/v1/training/training_pipeline.py
+++ b/fastvideo/v1/training/training_pipeline.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-import gc
 import math
 import os
 import time
@@ -706,5 +705,3 @@ class TrainingPipeline(ComposedPipelineBase, ABC):
         # Re-enable gradients for training
         training_args.inference_mode = False
         transformer.train()
-        gc.collect()
-        torch.cuda.empty_cache()


### PR DESCRIPTION
`empty_cache` is super expensive because it scans all the blocks in torch's cache allocator to defragment small blocks. (See https://discuss.pytorch.org/t/gpu-ram-fragmentation-diagnostics/34073/6) When the allocation pattern is stable with no memory leaks, it's not helpful and slows things down a lot.
The better approach is to write code without memory leaks and use offload/reduce seqlen.