### PR TITLE
[misc] Use FASTVIDEO_STAGE_LOGGING for perf timing of stage

### DIFF
--- a/fastvideo/envs.py
+++ b/fastvideo/envs.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     CMAKE_BUILD_TYPE: str | None = None
     VERBOSE: bool = False
     FASTVIDEO_SERVER_DEV_MODE: bool = False
-    FASTVIDEO_ENABLE_STAGE_LOGGING: bool = False
+    FASTVIDEO_STAGE_LOGGING: bool = False
 
 
 def get_default_cache_root() -> str:
@@ -204,8 +204,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
 
     # If set, fastvideo will enable stage logging, which will print the time
     # taken for each stage
-    "FASTVIDEO_ENABLE_STAGE_LOGGING":
-    lambda: bool(int(os.getenv("FASTVIDEO_ENABLE_STAGE_LOGGING", "0"))),
+    "FASTVIDEO_STAGE_LOGGING":
+    lambda: bool(int(os.getenv("FASTVIDEO_STAGE_LOGGING", "0"))),
 }
 
 # end-env-vars-definition

--- a/fastvideo/envs.py
+++ b/fastvideo/envs.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     CMAKE_BUILD_TYPE: str | None = None
     VERBOSE: bool = False
     FASTVIDEO_SERVER_DEV_MODE: bool = False
+    FASTVIDEO_ENABLE_STAGE_LOGGING: bool = False
 
 
 def get_default_cache_root() -> str:
@@ -172,6 +173,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # - "TORCH_SDPA": use torch.nn.MultiheadAttention
     # - "FLASH_ATTN": use FlashAttention
     # - "SLIDING_TILE_ATTN" : use Sliding Tile Attention
+    # - "VIDEO_SPARSE_ATTN": use Video Sparse Attention
     # - "SAGE_ATTN": use Sage Attention
     "FASTVIDEO_ATTENTION_BACKEND":
     lambda: os.getenv("FASTVIDEO_ATTENTION_BACKEND", None),
@@ -199,6 +201,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # e.g. `/reset_prefix_cache`
     "FASTVIDEO_SERVER_DEV_MODE":
     lambda: bool(int(os.getenv("FASTVIDEO_SERVER_DEV_MODE", "0"))),
+
+    # If set, fastvideo will enable stage logging, which will print the time
+    # taken for each stage
+    "FASTVIDEO_ENABLE_STAGE_LOGGING":
+    lambda: bool(int(os.getenv("FASTVIDEO_ENABLE_STAGE_LOGGING", "0"))),
 }
 
 # end-env-vars-definition

--- a/fastvideo/pipelines/stages/base.py
+++ b/fastvideo/pipelines/stages/base.py
@@ -12,6 +12,7 @@ from abc import ABC, abstractmethod
 
 import torch
 
+import fastvideo.envs as envs
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
@@ -145,8 +146,7 @@ class PipelineStage(ABC):
                 raise
 
         # Execute the actual stage logic
-        # envs.ENABLE_STAGE_LOGGING
-        if False:
+        if envs.FASTVIDEO_ENABLE_STAGE_LOGGING:
             logger.info("[%s] Starting execution", stage_name)
             start_time = time.perf_counter()
 

--- a/fastvideo/pipelines/stages/base.py
+++ b/fastvideo/pipelines/stages/base.py
@@ -146,7 +146,7 @@ class PipelineStage(ABC):
                 raise
 
         # Execute the actual stage logic
-        if envs.FASTVIDEO_ENABLE_STAGE_LOGGING:
+        if envs.FASTVIDEO_STAGE_LOGGING:
             logger.info("[%s] Starting execution", stage_name)
             start_time = time.perf_counter()
 


### PR DESCRIPTION
setting envvar `FASTVIDEO_STAGE_LOGGING=1` will result in the below logging:

```
NFO 07-25 01:23:24 [video_generator.py:224]                   flow_shift: 8
INFO 07-25 01:23:24 [video_generator.py:224]      embedded_guidance_scale: 6.0
INFO 07-25 01:23:24 [video_generator.py:224]                   save_video: True
INFO 07-25 01:23:24 [video_generator.py:224]                   output_path: video_samples_dmd2
INFO 07-25 01:23:24 [video_generator.py:224]         
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [composed_pipeline_base.py:102] Creating pipeline stages...
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [cuda.py:116] Trying FASTVIDEO_ATTENTION_BACKEND=VIDEO_SPARSE_ATTN
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [cuda.py:153] Using Video Sparse Attention backend.
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [composed_pipeline_base.py:311] Running pipeline stages: dict_keys(['input_validation_stage', 'prompt_encoding_stage', 'conditioning_stage', 'timestep_preparation_stage', 'latent_preparation_stage', 'denoising_stage', 'decoding_stage'])
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:150] [InputValidationStage] Starting execution
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:156] [InputValidationStage] Execution completed in 0.03416999970795587 ms
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:150] [TextEncodingStage] Starting execution
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:156] [TextEncodingStage] Execution completed in 466.4717690029647 ms
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:150] [ConditioningStage] Starting execution
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:156] [ConditioningStage] Execution completed in 0.0208609999390319 ms
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:150] [TimestepPreparationStage] Starting execution
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:156] [TimestepPreparationStage] Execution completed in 0.4417329982970841 ms
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:150] [LatentPreparationStage] Starting execution
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:156] [LatentPreparationStage] Execution completed in 8.668422997288872 ms
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:24 [base.py:150] [DmdDenoisingStage] Starting execution
  0%|                                                                                | 0/3 [00:00<?, ?it/s](FVWorkerProc-0 pid=282801) INFO 07-25 01:23:26 [config.py:58] PyTorch version 2.7.1+cu128 available.
100%|████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.05s/it]
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:27 [base.py:156] [DmdDenoisingStage] Execution completed in 3167.356700003438 ms
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:27 [base.py:150] [DecodingStage] Starting execution
(FVWorkerProc-0 pid=282801) INFO 07-25 01:23:29 [base.py:156] [DecodingStage] Execution completed in 2210.2446550052264 ms
```