### PR TITLE
[Feature] Optionally enable torch compile 

### DIFF
--- a/fastvideo/attention/layer.py
+++ b/fastvideo/attention/layer.py
@@ -13,7 +13,6 @@ from fastvideo.platforms import AttentionBackendEnum
 from fastvideo.utils import get_compute_dtype
 
 
-@torch.compiler.disable
 class DistributedAttention(nn.Module):
     """Distributed attention layer.
     """
@@ -56,6 +55,7 @@ class DistributedAttention(nn.Module):
         self.backend = backend_name_to_enum(attn_backend.get_name())
         self.dtype = dtype
 
+    @torch.compiler.disable
     def forward(
         self,
         q: torch.Tensor,

--- a/fastvideo/attention/layer.py
+++ b/fastvideo/attention/layer.py
@@ -13,6 +13,7 @@ from fastvideo.platforms import AttentionBackendEnum
 from fastvideo.utils import get_compute_dtype
 
 
+@torch.compiler.disable
 class DistributedAttention(nn.Module):
     """Distributed attention layer.
     """
@@ -136,6 +137,7 @@ class DistributedAttention_VSA(DistributedAttention):
     """Distributed attention layer with VSA support.
     """
 
+    @torch.compiler.disable
     def forward(
         self,
         q: torch.Tensor,

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -382,9 +382,7 @@ class FastVideoArgs:
             "--enable-torch-compile",
             action=StoreBoolean,
             default=FastVideoArgs.enable_torch_compile,
-            help=
-            "Use torch.compile to speed up DiT (available for both inference and training)."
-            +
+            help="Use torch.compile to speed up DiT inference." +
             "However, will likely cause precision drifts. See (https://github.com/pytorch/pytorch/issues/145213)",
         )
         # Add pipeline configuration arguments

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -383,7 +383,7 @@ class FastVideoArgs:
             action=StoreBoolean,
             default=FastVideoArgs.enable_torch_compile,
             help=
-            "Use torch.compile to speed up DiT (for both inference and training)."
+            "Use torch.compile to speed up DiT (available for both inference and training)."
             +
             "However, will likely cause precision drifts. See (https://github.com/pytorch/pytorch/issues/145213)",
         )

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -308,8 +308,9 @@ class FastVideoArgs:
         parser.add_argument(
             "--enable-torch-compile",
             action=StoreBoolean,
-            help=
-            "Use torch.compile for speeding up STA inference without teacache",
+            default=FastVideoArgs.enable_torch_compile,
+            help="Use torch.compile to speed up DiT inference." +
+            "However, will likely cause precision drifts. See (https://github.com/pytorch/pytorch/issues/145213)",
         )
 
         parser.add_argument(
@@ -377,13 +378,6 @@ class FastVideoArgs:
             action=StoreBoolean,
             default=FastVideoArgs.enable_stage_verification,
             help="Enable input/output verification for pipeline stages",
-        )
-        parser.add_argument(
-            "--enable-torch-compile",
-            action=StoreBoolean,
-            default=FastVideoArgs.enable_torch_compile,
-            help="Use torch.compile to speed up DiT inference." +
-            "However, will likely cause precision drifts. See (https://github.com/pytorch/pytorch/issues/145213)",
         )
         # Add pipeline configuration arguments
         PipelineConfig.add_cli_args(parser)

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -378,7 +378,15 @@ class FastVideoArgs:
             default=FastVideoArgs.enable_stage_verification,
             help="Enable input/output verification for pipeline stages",
         )
-
+        parser.add_argument(
+            "--enable-torch-compile",
+            action=StoreBoolean,
+            default=FastVideoArgs.enable_torch_compile,
+            help=
+            "Use torch.compile to speed up DiT (for both inference and training)."
+            +
+            "However, will likely cause precision drifts. See (https://github.com/pytorch/pytorch/issues/145213)",
+        )
         # Add pipeline configuration arguments
         PipelineConfig.add_cli_args(parser)
 
@@ -496,12 +504,6 @@ class FastVideoArgs:
 
         if self.num_gpus < max(self.tp_size, self.sp_size):
             self.num_gpus = max(self.tp_size, self.sp_size)
-
-        if self.enable_torch_compile and self.num_gpus > 1:
-            logger.warning(
-                "Currently torch compile does not work with multi-gpu. Setting enable_torch_compile to False"
-            )
-            self.enable_torch_compile = False
 
         if self.pipeline_config is None:
             raise ValueError("pipeline_config is not set in FastVideoArgs")

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -459,7 +459,7 @@ class TransformerLoader(ComponentLoader):
             output_dtype=None,
             training_mode=fastvideo_args.training_mode)
         if fastvideo_args.enable_torch_compile:
-            model = torch.compile(model, dynamic=True)
+            model = torch.compile(model)
 
 
         total_params = sum(p.numel() for p in model.parameters())

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -460,6 +460,7 @@ class TransformerLoader(ComponentLoader):
             training_mode=fastvideo_args.training_mode)
         if fastvideo_args.enable_torch_compile:
             model = torch.compile(model)
+            logger.info("Torch Compile enabled for DiT")
 
 
         total_params = sum(p.numel() for p in model.parameters())

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -459,7 +459,7 @@ class TransformerLoader(ComponentLoader):
             output_dtype=None,
             training_mode=fastvideo_args.training_mode)
         if fastvideo_args.enable_torch_compile:
-            model = torch.compile(model)
+            model = torch.compile(model, dynamic=True)
 
 
         total_params = sum(p.numel() for p in model.parameters())

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -459,24 +459,8 @@ class TransformerLoader(ComponentLoader):
             output_dtype=None,
             training_mode=fastvideo_args.training_mode)
         if fastvideo_args.enable_torch_compile:
-            logger.info("Torch Compile enabled for DiT")
-            for n, m in reversed(list(model.named_modules())):
-                if any([
-                        compile_condition(n, m)
-                        for compile_condition in model._compile_conditions
-                ]):
-                    parts = n.split(".")
-                    parent = model
-                    attr = parts[-1]
-                    for part in parts[:-1]:
-                        if part.isdigit():
-                            parent = parent[int(part)]
-                        else:
-                            parent = getattr(parent, part)
-                    if attr.isdigit():
-                        parent[int(attr)] = torch.compile(m)
-                    else:
-                        setattr(parent, attr, torch.compile(m))
+            model = torch.compile(model)
+
 
         total_params = sum(p.numel() for p in model.parameters())
         logger.info("Loaded model with %.2fB parameters", total_params / 1e9)

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -458,9 +458,6 @@ class TransformerLoader(ComponentLoader):
             reduce_dtype=torch.float32,
             output_dtype=None,
             training_mode=fastvideo_args.training_mode)
-        if fastvideo_args.enable_torch_compile:
-            model = torch.compile(model)
-            logger.info("Torch Compile enabled for DiT")
 
 
         total_params = sum(p.numel() for p in model.parameters())

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -97,6 +97,10 @@ class ComposedPipelineBase(ABC):
                 self.initialize_validation_pipeline(self.training_args)
 
         self.initialize_pipeline(self.fastvideo_args)
+        if self.fastvideo_args.enable_torch_compile:
+            self.modules["transformer"] = torch.compile(
+                self.modules["transformer"])
+            logger.info("Torch Compile enabled for DiT")
 
         if not self.fastvideo_args.training_mode:
             logger.info("Creating pipeline stages...")

--- a/fastvideo/platforms/__init__.py
+++ b/fastvideo/platforms/__init__.py
@@ -83,7 +83,7 @@ def rocm_platform_plugin() -> str | None:
         finally:
             amdsmi.amdsmi_shut_down()
     except Exception as e:
-        logger.info("ROCm detection failed: %s", e)
+        logger.info("ROCm platform is unavailable: %s", e)
 
     return "fastvideo.platforms.rocm.RocmPlatform" if is_rocm else None
 


### PR DESCRIPTION
`python examples/inference/basic/basic.py`
## One GPU
### With compile 
<img width="782" height="42" alt="image" src="https://github.com/user-attachments/assets/e5bd568a-a3cc-430c-9c7c-e1a257cbd208" />

### Without compile 
<img width="630" height="48" alt="image" src="https://github.com/user-attachments/assets/1f565522-cf4b-47d3-9969-ba873fce12d2" />

## Two-GPU
### With compile
<img width="751" height="64" alt="image" src="https://github.com/user-attachments/assets/355d5d11-cd32-4401-972e-c22524bd0796" />

### Without compile 
<img width="618" height="94" alt="image" src="https://github.com/user-attachments/assets/4980f7e7-f0d3-4397-9cf0-4022d94e4448" />

