### PR TITLE
[bugfix] fix install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dependencies = [
 
 [tool.uv]
 extra-index-url = ["https://download.pytorch.org/whl/cu128"]
+index-strategy = "unsafe-best-match"
 
 [project.optional-dependencies]
 


### PR DESCRIPTION
Currently a clean install using `uv pip install -e .` will fail as we are using experimental dataset==4.0.0 