### PR TITLE
[Bugfix] Fix VMoba requirements

### DIFF
--- a/csrc/attn/vmoba_attn/setup.py
+++ b/csrc/attn/vmoba_attn/setup.py
@@ -20,5 +20,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
     ],
     python_requires='>=3.12',
-    install_requires=[]
+    install_requires=[
+        "flash-attn >= 2.7.1",
+    ]
 )

--- a/csrc/attn/vmoba_attn/vmoba/vmoba.py
+++ b/csrc/attn/vmoba_attn/vmoba/vmoba.py
@@ -6,8 +6,14 @@ import time
 import os
 import torch
 from typing import Tuple
-from flash_attn import flash_attn_varlen_func  # Use the new flash attention function
-from flash_attn.flash_attn_interface import _flash_attn_varlen_forward, _flash_attn_varlen_backward
+try:
+    from flash_attn import flash_attn_varlen_func  # Use the new flash attention function
+    from flash_attn.flash_attn_interface import _flash_attn_varlen_forward, _flash_attn_varlen_backward
+except ImportError:
+    _flash_attn_varlen_forward = None
+    _flash_attn_varlen_backward = None
+    flash_attn_varlen_func = None
+    
 from functools import lru_cache
 from einops import rearrange
 


### PR DESCRIPTION
https://github.com/hao-ai-lab/FastVideo/pull/778 directly imports flash-attn, and running any training script will cause error if you don't install that. This PR circumvents the error.
