### PR TITLE
fix: incorrect dv in vsa Triton kernel causing test_vsa error

### DIFF
--- a/csrc/attn/video_sparse_attn/vsa/block_sparse_attn_triton.py
+++ b/csrc/attn/video_sparse_attn/vsa/block_sparse_attn_triton.py
@@ -247,11 +247,11 @@ def _attn_bwd_dq(dq, q, K, V,  #
 
     kv_blocks = tl.load(q2k_num  + meta_base)                 # int32
     kv_ptr    = q2k_index + meta_base * max_kv_blks           # ptr to list
+    block_size = tl.load(variable_block_sizes + q_blk)
     
     
     for blk_idx in range(kv_blocks*2):
         block_sparse_offset = (tl.load(kv_ptr + blk_idx//2).to(tl.int32)*2 + blk_idx%2) *step_n * stride_tok
-        block_size = tl.load(variable_block_sizes + blk_idx//2) - (blk_idx%2) * step_n
         kT = tl.load(kT_ptrs + block_sparse_offset)
         vT = tl.load(vT_ptrs + block_sparse_offset)
         qk = tl.dot(q, kT)


### PR DESCRIPTION
The original VSA Triton kernel shows some mismatches in the `vsa_test`.
<img width="1455" height="215" alt="original triton vsa test" src="https://github.com/user-attachments/assets/3bd1abfd-34c9-40b9-a93d-a7509c00039e" />

With the changes in this PR, the issue should be addressed.
<img width="1452" height="218" alt="fixed triton vsa test" src="https://github.com/user-attachments/assets/90040091-f81e-4fa4-aa16-be2912634aa3" />
