### PR TITLE
Fix mp worker busy loop to handle all string RPC methods

### DIFF
--- a/fastvideo/worker/multiproc_executor.py
+++ b/fastvideo/worker/multiproc_executor.py
@@ -467,6 +467,10 @@ class WorkerMultiprocProc:
                             "output_batch": output_batch.output.cpu(),
                             "logging_info": logging_info
                         })
+                    else:
+                        result = self.worker.execute_method(
+                            method, *args, **kwargs)
+                        self.pipe.send(result)
                 else:
                     result = self.worker.execute_method(method, *args, **kwargs)
                     self.pipe.send(result)


### PR DESCRIPTION
When we load in loras using generator.set_lora_adapter instead of loading it in from the VideoGenerator.from_pretrained, the workers get stuck and hangs. This is because in worker_busy_loop in multiproc_executor.py , the merge_lora_weights method is passed in as a string, but the code that handles the string part is missing an else statement. This means that all loras using the mp backend that loads the set_lora_adapter hangs, which includes the CI tests. Adding an else statement just like the outer one fixes this problem.