### PR TITLE
[bigfix] [distillation] Fix DMD inference pipeline noise initialization shape

### DIFF
--- a/fastvideo/pipelines/basic/wan/wan_dmd_pipeline.py
+++ b/fastvideo/pipelines/basic/wan/wan_dmd_pipeline.py
@@ -59,7 +59,8 @@ class WanDMDPipeline(LoRAPipeline, ComposedPipelineBase):
         self.add_stage(stage_name="latent_preparation_stage",
                        stage=LatentPreparationStage(
                            scheduler=self.get_module("scheduler"),
-                           transformer=self.get_module("transformer", None)))
+                           transformer=self.get_module("transformer", None),
+                           use_btchw_layout=True))
 
         self.add_stage(stage_name="denoising_stage",
                        stage=DmdDenoisingStage(

--- a/fastvideo/pipelines/basic/wan/wan_i2v_dmd_pipeline.py
+++ b/fastvideo/pipelines/basic/wan/wan_i2v_dmd_pipeline.py
@@ -62,7 +62,8 @@ class WanImageToVideoDmdPipeline(LoRAPipeline, ComposedPipelineBase):
         self.add_stage(stage_name="latent_preparation_stage",
                        stage=LatentPreparationStage(
                            scheduler=self.get_module("scheduler"),
-                           transformer=self.get_module("transformer")))
+                           transformer=self.get_module("transformer"),
+                           use_btchw_layout=True))
 
         self.add_stage(stage_name="image_latent_preparation_stage",
                        stage=ImageVAEEncodingStage(vae=self.get_module("vae")))

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -1085,7 +1085,6 @@ class DmdDenoisingStage(DenoisingStage):
         # Get latents and embeddings
         assert batch.latents is not None, "latents must be provided"
         latents = batch.latents
-        latents = latents.permute(0, 2, 1, 3, 4)
 
         video_raw_latent_shape = latents.shape
         prompt_embeds = batch.prompt_embeds

--- a/fastvideo/pipelines/stages/latent_preparation.py
+++ b/fastvideo/pipelines/stages/latent_preparation.py
@@ -28,10 +28,14 @@ class LatentPreparationStage(PipelineStage):
     denoised during the diffusion process.
     """
 
-    def __init__(self, scheduler, transformer) -> None:
+    def __init__(self,
+                 scheduler,
+                 transformer,
+                 use_btchw_layout: bool = False) -> None:
         super().__init__()
         self.scheduler = scheduler
         self.transformer = transformer
+        self.use_btchw_layout = use_btchw_layout
 
     def forward(
         self,
@@ -78,15 +82,26 @@ class LatentPreparationStage(PipelineStage):
             raise ValueError("Height and width must be provided")
 
         # Calculate latent shape
-        shape = (
-            batch_size,
-            self.transformer.num_channels_latents,
-            num_frames,
-            height // fastvideo_args.pipeline_config.vae_config.arch_config.
-            spatial_compression_ratio,
-            width // fastvideo_args.pipeline_config.vae_config.arch_config.
-            spatial_compression_ratio,
-        )
+        if self.use_btchw_layout:
+            shape = (
+                batch_size,
+                num_frames,
+                self.transformer.num_channels_latents,
+                height // fastvideo_args.pipeline_config.vae_config.arch_config.
+                spatial_compression_ratio,
+                width // fastvideo_args.pipeline_config.vae_config.arch_config.
+                spatial_compression_ratio,
+            )
+        else:
+            shape = (
+                batch_size,
+                self.transformer.num_channels_latents,
+                num_frames,
+                height // fastvideo_args.pipeline_config.vae_config.arch_config.
+                spatial_compression_ratio,
+                width // fastvideo_args.pipeline_config.vae_config.arch_config.
+                spatial_compression_ratio,
+            )
 
         # Validate generator if it's a list
         if isinstance(generator, list) and len(generator) != batch_size:


### PR DESCRIPTION
For some reason permuting time and channel dims after sampling the noise (as opposed to permuting the shape before sampling) causes weird color issues.

Below are examples from 1.3B DMD distill @ step 100
BEFORE

https://github.com/user-attachments/assets/85431fb8-f9f2-40a9-9286-bb50f1079ac6



AFTER

https://github.com/user-attachments/assets/4e98ae34-d9d8-4c27-896a-19e1496fa5cd

