### PR TITLE
[bugfix] [VSA] Fix block_size computation in backward kernel

### DIFF
--- a/csrc/attn/video_sparse_attn/vsa/block_sparse_attn_triton.py
+++ b/csrc/attn/video_sparse_attn/vsa/block_sparse_attn_triton.py
@@ -247,11 +247,12 @@ def _attn_bwd_dq(dq, q, K, V,  #
 
     kv_blocks = tl.load(q2k_num  + meta_base)                 # int32
     kv_ptr    = q2k_index + meta_base * max_kv_blks           # ptr to list
-    block_size = tl.load(variable_block_sizes + q_blk)
     
     
     for blk_idx in range(kv_blocks*2):
-        block_sparse_offset = (tl.load(kv_ptr + blk_idx//2).to(tl.int32)*2 + blk_idx%2) *step_n * stride_tok
+        kv_idx = tl.load(kv_ptr + blk_idx//2).to(tl.int32)
+        block_size = tl.load(variable_block_sizes + kv_idx) -  (blk_idx % 2) * step_n
+        block_sparse_offset = (kv_idx*2 + blk_idx%2) * step_n * stride_tok
         kT = tl.load(kT_ptrs + block_sparse_offset)
         vT = tl.load(vT_ptrs + block_sparse_offset)
         qk = tl.dot(q, kT)


### PR DESCRIPTION
fix(sparse-attn): correct block_size masking in backward kernel

The backward kernel used an incorrect block_size when applying the mask, causing padding positions to be treated as valid tokens. As a result, p = tl.math.exp2(qk - m) was computed on invalid entries, leading to Inf and NaN values during gradient accumulation (especially in dQ).

This patch fixes the block_size computation for split blocks so that the mask correctly excludes padded regions in all cases.