### PR TITLE
[misc] Allow manual override of Pipeline class through override_pipeline_cls_name

### DIFF
--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -174,6 +174,8 @@ class FastVideoArgs:
     init_weights_from_safetensors: str = ""  # path to safetensors file for initial weight loading
     init_weights_from_safetensors_2: str = ""  # path to safetensors file for initial weight loading for transformer_2
 
+    override_pipeline_cls_name: str | None = None
+
     # # DMD parameters
     # dmd_denoising_steps: List[int] | None = field(default=None)
 
@@ -423,6 +425,12 @@ class FastVideoArgs:
             type=str,
             default=FastVideoArgs.override_transformer_cls_name,
             help="Override transformer cls name",
+        )
+        parser.add_argument(
+            "--override-pipeline-cls-name",
+            type=str,
+            default=FastVideoArgs.override_pipeline_cls_name,
+            help="Override pipeline cls name",
         )
         parser.add_argument(
             "--init-weights-from-safetensors",

--- a/fastvideo/pipelines/__init__.py
+++ b/fastvideo/pipelines/__init__.py
@@ -44,6 +44,12 @@ def build_pipeline(
 
     config = verify_model_config_and_directory(model_path)
     pipeline_name = config.get("_class_name")
+
+    if fastvideo_args.override_pipeline_cls_name:
+        logger.info("Overriding pipeline class name from %s to %s",
+                    pipeline_name, fastvideo_args.override_pipeline_cls_name)
+        pipeline_name = fastvideo_args.override_pipeline_cls_name
+
     if pipeline_name is None:
         raise ValueError(
             "Model config does not contain a _class_name attribute. "


### PR DESCRIPTION


Example:
```
    generator = VideoGenerator.from_pretrained(
        model_name,
        # FastVideo will automatically handle distributed setup
        num_gpus=8,
        use_fsdp_inference=True,
        # Adjust these offload parameters if you have < 32GB of VRAM
        text_encoder_cpu_offload=True,
        pin_cpu_memory=True, # set to false if low CPU RAM or hit obscure "CUDA error: Invalid argument"
        dit_cpu_offload=False,
        vae_cpu_offload=False,
        VSA_sparsity=0.8,
        override_pipeline_cls_name="WanDMDPipeline"
)
```