### PR TITLE
[fix]: fix sliding_tile_attn with sdpa(without flash_attn)

### DIFF
--- a/fastvideo/attention/backends/sdpa.py
+++ b/fastvideo/attention/backends/sdpa.py
@@ -82,7 +82,9 @@ class SDPAImpl(AttentionImpl):
         key = key.transpose(1, 2)
         value = value.transpose(1, 2)
 
-        attn_mask = attn_metadata.attn_mask if (attn_metadata is not None and hasattr(attn_metadata, "attn_mask")) else None
+        attn_mask = attn_metadata.attn_mask if (
+            attn_metadata is not None
+            and hasattr(attn_metadata, "attn_mask")) else None
         attn_kwargs = {
             "attn_mask": attn_mask,
             "dropout_p": self.dropout,

--- a/fastvideo/attention/backends/sdpa.py
+++ b/fastvideo/attention/backends/sdpa.py
@@ -82,7 +82,7 @@ class SDPAImpl(AttentionImpl):
         key = key.transpose(1, 2)
         value = value.transpose(1, 2)
 
-        attn_mask = attn_metadata.attn_mask if attn_metadata is not None else None
+        attn_mask = attn_metadata.attn_mask if (attn_metadata is not None and hasattr(attn_metadata, "attn_mask")) else None
         attn_kwargs = {
             "attn_mask": attn_mask,
             "dropout_p": self.dropout,


### PR DESCRIPTION
After this PR, run ```scripts/inference/v1_inference_hunyuan_STA.sh``` will failed with:
```
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384] WorkerMultiprocProc failed.
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384] Traceback (most recent call last):
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/worker/multiproc_executor.py", line 378, in worker_main
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     worker.worker_busy_loop()
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/worker/multiproc_executor.py", line 461, in worker_busy_loop
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     output_batch = self.worker.execute_forward(
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/worker/gpu_worker.py", line 80, in execute_forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     output_batch = self.pipeline.forward(forward_batch, self.fastvideo_args)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     return func(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/pipelines/composed_pipeline_base.py", line 421, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     batch = stage(batch, fastvideo_args)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/pipelines/stages/base.py", line 169, in __call__
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     result = self.forward(batch, fastvideo_args)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/pipelines/stages/denoising.py", line 383, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     noise_pred = current_model(
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     return self._call_impl(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1881, in _call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     return inner()
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1829, in inner
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     result = forward_call(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/models/dits/hunyuanvideo.py", line 599, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     txt = self.txt_in(txt, t)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     return self._call_impl(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     return forward_call(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/models/dits/hunyuanvideo.py", line 805, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     x = block(x, c)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     return self._call_impl(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1881, in _call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     return inner()
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1829, in inner
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     result = forward_call(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/models/dits/hunyuanvideo.py", line 887, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     attn_output = self.attn(q, k, v)  # [B, L, H, D]
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     return self._call_impl(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     return forward_call(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/attention/layer.py", line 324, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     output = self.attn_impl.forward(q, k, v, ctx_attn_metadata)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]   File "/home/roywan/FastVideo/fastvideo/attention/backends/sdpa.py", line 85, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384]     attn_mask = attn_metadata.attn_mask if attn_metadata is not None else None
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:384] AttributeError: 'SlidingTileAttentionMetadata' object has no attribute 'attn_mask'
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391] Worker 3 hit an exception: Traceback (most recent call last):
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/worker/multiproc_executor.py", line 378, in worker_main
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     worker.worker_busy_loop()
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/worker/multiproc_executor.py", line 461, in worker_busy_loop
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     output_batch = self.worker.execute_forward(
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/worker/gpu_worker.py", line 80, in execute_forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     output_batch = self.pipeline.forward(forward_batch, self.fastvideo_args)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     return func(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/pipelines/composed_pipeline_base.py", line 421, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     batch = stage(batch, fastvideo_args)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/pipelines/stages/base.py", line 169, in __call__
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     result = self.forward(batch, fastvideo_args)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/pipelines/stages/denoising.py", line 383, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     noise_pred = current_model(
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     return self._call_impl(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1881, in _call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     return inner()
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1829, in inner
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     result = forward_call(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/models/dits/hunyuanvideo.py", line 599, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     txt = self.txt_in(txt, t)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     return self._call_impl(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     return forward_call(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/models/dits/hunyuanvideo.py", line 805, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     x = block(x, c)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     return self._call_impl(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1881, in _call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     return inner()
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1829, in inner
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     result = forward_call(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/models/dits/hunyuanvideo.py", line 887, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     attn_output = self.attn(q, k, v)  # [B, L, H, D]
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     return self._call_impl(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/opt/venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     return forward_call(*args, **kwargs)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/attention/layer.py", line 324, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     output = self.attn_impl.forward(q, k, v, ctx_attn_metadata)
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]   File "/home/roywan/FastVideo/fastvideo/attention/backends/sdpa.py", line 85, in forward
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]     attn_mask = attn_metadata.attn_mask if attn_metadata is not None else None
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391] AttributeError: 'SlidingTileAttentionMetadata' object has no attribute 'attn_mask'
(Worker pid=4505) ERROR 12-29 07:02:29 [multiproc_executor.py:391]
```

because ```SlidingTileAttentionMetadata``` has no attribute ```attn_mask```, Therefore, foolproof checks must be added.