### PR TITLE
[fix]: fix fastvideo-kernel Rocm build and Dockerfile for Rocm

### DIFF
--- a/docker/rocm7_1.Dockerfile
+++ b/docker/rocm7_1.Dockerfile
@@ -36,7 +36,7 @@ RUN echo "# Placeholder" > README.md
 RUN source $HOME/.local/bin/env && \
     uv venv --python 3.10 --seed /opt/venv && \
     source /opt/venv/bin/activate && \
-    uv pip install --no-cache-dir --upgrade pip 
+    uv pip install --no-cache-dir --upgrade pip
 
 COPY . .
 
@@ -53,6 +53,6 @@ RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
     cd fastvideo-kernel && \
     git submodule update --init --recursive && \
-    ./build.sh --release
+    ./build.sh --rocm
 
 EXPOSE 22

--- a/fastvideo-kernel/CMakeLists.txt
+++ b/fastvideo-kernel/CMakeLists.txt
@@ -1,5 +1,16 @@
 cmake_minimum_required(VERSION 3.26 FATAL_ERROR)
-project(fastvideo-kernel LANGUAGES CXX CUDA)
+project(fastvideo-kernel LANGUAGES CXX)
+
+# Prefer environment variable (used by CI or pip install git+repo_addr) if CMake var is not explicitly set.
+if(NOT DEFINED GPU_BACKEND AND DEFINED ENV{GPU_BACKEND})
+    set(GPU_BACKEND "$ENV{GPU_BACKEND}")
+endif()
+
+if(GPU_BACKEND STREQUAL "ROCM")
+    enable_language(HIP)
+else()
+    enable_language(CUDA)
+endif()
 
 # Import common utils if needed, but we keep it simple for now
 
@@ -59,7 +70,7 @@ else()
     else()
         # Best-effort local detection (works when a CUDA device is visible).
         execute_process(
-            COMMAND "${Python_EXECUTABLE}" -c "import torch; import sys; \nprint('1' if (torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9) else '0')"
+            COMMAND "${Python_EXECUTABLE}" -c "import torch; import sys; \nprint('1' if (torch.cuda.is_available() and torch.version.cuda and torch.cuda.get_device_capability()[0] >= 9) else '0')"
             OUTPUT_VARIABLE _LOCAL_HAS_HOPPER
             OUTPUT_STRIP_TRAILING_WHITESPACE
             ERROR_QUIET
@@ -107,10 +118,10 @@ endif()
 if(BUILD_CXX_KERNELS)
     # Source files
     set(EXTENSION_SOURCES csrc/common_extension.cpp)
-    
+
     # Conditionally add TK kernels
     if(ENABLE_TK_KERNELS)
-        list(APPEND EXTENSION_SOURCES 
+        list(APPEND EXTENSION_SOURCES
             csrc/attention/st_attn_h100.cu
             csrc/attention/block_sparse_h100.cu
         )
@@ -121,7 +132,7 @@ if(BUILD_CXX_KERNELS)
     Python_add_library(fastvideo_kernel_ops MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI
         ${EXTENSION_SOURCES}
     )
-    
+
     # Build compile definitions list
     set(COMPILE_DEFS TORCH_EXTENSION_NAME=fastvideo_kernel_ops)
     if(ENABLE_TK_KERNELS)
@@ -130,10 +141,10 @@ if(BUILD_CXX_KERNELS)
 
     target_compile_definitions(fastvideo_kernel_ops PRIVATE ${COMPILE_DEFS})
 
-    target_compile_options(fastvideo_kernel_ops PRIVATE 
+    target_compile_options(fastvideo_kernel_ops PRIVATE
         $<$<COMPILE_LANGUAGE:CUDA>:${CUDA_FLAGS}>
     )
-    
+
     # We install it to fastvideo_kernel/_C so we can load it to register the ops
     install(TARGETS fastvideo_kernel_ops LIBRARY DESTINATION fastvideo_kernel/_C)
 endif()

--- a/fastvideo-kernel/README.md
+++ b/fastvideo-kernel/README.md
@@ -22,6 +22,14 @@ cd fastvideo-kernel
 ```
 *Note: The resulting wheel will contain kernels that require an H100 GPU to run, but can be built on any machine with CUDA 12.3+ toolchain.*
 
+### Rocm Build
+If you are in a rocm environment without the compilation toolchaine of CUDA.
+
+```bash
+cd fastvideo-kernel
+./build.sh --rocm
+```
+
 ## Usage
 
 ```python

--- a/fastvideo-kernel/build.sh
+++ b/fastvideo-kernel/build.sh
@@ -21,8 +21,6 @@ for arg in "$@"; do
         --release|-r)
             RELEASE=1
             ;;
-    esac
-    case "$arg" in
         --rocm)
             GPU_BACKEND=ROCM
             ;;

--- a/fastvideo-kernel/build.sh
+++ b/fastvideo-kernel/build.sh
@@ -15,9 +15,19 @@ git submodule update --init --recursive
 pip install scikit-build-core cmake ninja
 
 RELEASE=0
-if [ "${1:-}" = "--release" ] || [ "${1:-}" = "-r" ]; then
-    RELEASE=1
-fi
+GPU_BACKEND=CUDA
+for arg in "$@"; do
+    case "$arg" in
+        --release|-r)
+            RELEASE=1
+            ;;
+    esac
+    case "$arg" in
+        --rocm)
+            GPU_BACKEND=ROCM
+            ;;
+    esac
+done
 
 if [ "$RELEASE" -eq 1 ]; then
     # Force-enable ThunderKittens kernels and compile for Hopper.
@@ -26,8 +36,11 @@ if [ "$RELEASE" -eq 1 ]; then
     export CMAKE_ARGS="${CMAKE_ARGS:-} -DFASTVIDEO_KERNEL_BUILD_TK=ON -DCMAKE_CUDA_ARCHITECTURES=90a"
 fi
 
+export CMAKE_ARGS="${CMAKE_ARGS:-} -DGPU_BACKEND=${GPU_BACKEND}"
+
 echo "TORCH_CUDA_ARCH_LIST: ${TORCH_CUDA_ARCH_LIST:-<unset>}"
 echo "CMAKE_ARGS: ${CMAKE_ARGS:-<unset>}"
+echo "GPU_BACKEND: ${GPU_BACKEND:-<unset>}"
 # Build and install
 # Use -v for verbose output
 pip install . -v --no-build-isolation


### PR DESCRIPTION
- fix fastvideo-kernel build in a rocm environment without the compilation toolchaine of CUDA
before this PR:
```
14.10   Building wheel for fastvideo-kernel (pyproject.toml): started
14.10   Running command Building wheel for fastvideo-kernel (pyproject.toml)
14.33   *** scikit-build-core 0.11.6 using CMake 4.0.0 (wheel)
14.34   *** Configuring CMake...
14.44   loading initial cache file /tmp/tmpjg1no2d5/build/CMakeInit.txt
14.91   -- The CXX compiler identification is GNU 11.4.0
14.92   -- Detecting CXX compiler ABI info
15.41   -- Detecting CXX compiler ABI info - done
15.43   -- Check for working CXX compiler: /usr/bin/x86_64-linux-gnu-g++ - skipped
15.43   -- Detecting CXX compile features
15.43   -- Detecting CXX compile features - done
15.45   CMake Error at /opt/venv/lib/python3.10/site-packages/cmake/data/share/cmake-4.0/Modules/Internal/CMakeCUDAFindToolkit.cmake:104 (message):
15.45     Failed to find nvcc.
15.45 
15.45     Compiler requires the CUDA toolkit.  Please set the CUDAToolkit_ROOT
15.45     variable.
15.45   Call Stack (most recent call first):
15.45     /opt/venv/lib/python3.10/site-packages/cmake/data/share/cmake-4.0/Modules/CMakeDetermineCUDACompiler.cmake:85 (cmake_cuda_find_toolkit)
15.45     CMakeLists.txt:7 (enable_language)
15.45 
15.45 
15.45   -- Configuring incomplete, errors occurred!
15.46 
15.46   *** CMake configuration failed
15.73   error: subprocess-exited-with-error
15.73   
15.73   × Building wheel for fastvideo-kernel (pyproject.toml) did not run successfully.
15.73   │ exit code: 1
15.73   ╰─> No available output.
15.73   
15.73   note: This error originates from a subprocess, and is likely not a problem with pip.
15.73   full command: /opt/venv/bin/python /opt/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py build_wheel /tmp/tmpsllaimsu
15.73   cwd: /FastVideo/fastvideo-kernel
15.73   Building wheel for fastvideo-kernel (pyproject.toml): finished with status 'error'
15.73   ERROR: Failed building wheel for fastvideo-kernel
15.73 Failed to build fastvideo-kernel
15.74 error: failed-wheel-build-for-install
15.74 
15.74 × Failed to build installable wheels for some pyproject.toml based projects
15.74 ╰─> fastvideo-kernel
```

after this PR
```
cd fastvideo-kernel
./build.sh --rocm
```

- fix fastvideo Rocm Dockerfile
before this PR:
```
14.10   Building wheel for fastvideo-kernel (pyproject.toml): started
14.10   Running command Building wheel for fastvideo-kernel (pyproject.toml)
14.33   *** scikit-build-core 0.11.6 using CMake 4.0.0 (wheel)
14.34   *** Configuring CMake...
14.44   loading initial cache file /tmp/tmpjg1no2d5/build/CMakeInit.txt
14.91   -- The CXX compiler identification is GNU 11.4.0
14.92   -- Detecting CXX compiler ABI info
15.41   -- Detecting CXX compiler ABI info - done
15.43   -- Check for working CXX compiler: /usr/bin/x86_64-linux-gnu-g++ - skipped
15.43   -- Detecting CXX compile features
15.43   -- Detecting CXX compile features - done
15.45   CMake Error at /opt/venv/lib/python3.10/site-packages/cmake/data/share/cmake-4.0/Modules/Internal/CMakeCUDAFindToolkit.cmake:104 (message):
15.45     Failed to find nvcc.
15.45 
15.45     Compiler requires the CUDA toolkit.  Please set the CUDAToolkit_ROOT
15.45     variable.
15.45   Call Stack (most recent call first):
15.45     /opt/venv/lib/python3.10/site-packages/cmake/data/share/cmake-4.0/Modules/CMakeDetermineCUDACompiler.cmake:85 (cmake_cuda_find_toolkit)
15.45     CMakeLists.txt:7 (enable_language)
15.45 
15.45 
15.45   -- Configuring incomplete, errors occurred!
15.46 
15.46   *** CMake configuration failed
15.73   error: subprocess-exited-with-error
15.73   
15.73   × Building wheel for fastvideo-kernel (pyproject.toml) did not run successfully.
15.73   │ exit code: 1
15.73   ╰─> No available output.
15.73   
15.73   note: This error originates from a subprocess, and is likely not a problem with pip.
15.73   full command: /opt/venv/bin/python /opt/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py build_wheel /tmp/tmpsllaimsu
15.73   cwd: /FastVideo/fastvideo-kernel
15.73   Building wheel for fastvideo-kernel (pyproject.toml): finished with status 'error'
15.73   ERROR: Failed building wheel for fastvideo-kernel
15.73 Failed to build fastvideo-kernel
15.74 error: failed-wheel-build-for-install
15.74 
15.74 × Failed to build installable wheels for some pyproject.toml based projects
15.74 ╰─> fastvideo-kernel
```

after this PR
```
[+] Building 43.8s (16/16) FINISHED                                                                                                                                                   docker:default
 => [internal] load build definition from rocm7_1.Dockerfile                                                                                                                                    0.0s
 => => transferring dockerfile: 1.89kB                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/rocm/pytorch:rocm7.1_ubuntu22.04_py3.10_pytorch_release_2.9.1                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                               0.0s
 => => transferring context: 2B                                                                                                                                                                 0.0s
 => [ 1/11] FROM docker.io/rocm/pytorch:rocm7.1_ubuntu22.04_py3.10_pytorch_release_2.9.1                                                                                                        0.0s
 => [internal] load build context                                                                                                                                                               0.1s
 => => transferring context: 232.14kB                                                                                                                                                           0.1s
 => CACHED [ 2/11] WORKDIR /FastVideo                                                                                                                                                           0.0s
 => CACHED [ 3/11] RUN apt-get update && apt-get install -y --no-install-recommends     wget     git     ca-certificates     openssh-server     zsh     vim     curl     gcc-11     g++-11      0.0s
 => CACHED [ 4/11] RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11                                                              0.0s
 => CACHED [ 5/11] RUN curl -LsSf https://astral.sh/uv/install.sh | sh &&     echo 'source $HOME/.local/bin/env' >> /root/.bashrc                                                               0.0s
 => CACHED [ 6/11] COPY pyproject_other.toml ./pyproject.toml                                                                                                                                   0.0s
 => CACHED [ 7/11] RUN echo "# Placeholder" > README.md                                                                                                                                         0.0s
 => CACHED [ 8/11] RUN source $HOME/.local/bin/env &&     uv venv --python 3.10 --seed /opt/venv &&     source /opt/venv/bin/activate &&     uv pip install --no-cache-dir --upgrade pip        0.0s
 => [ 9/11] COPY . .                                                                                                                                                                            0.8s
 => [10/11] RUN source $HOME/.local/bin/env &&     source /opt/venv/bin/activate &&     uv pip install --no-cache-dir -e .[rocm] &&     git config --unset-all http.https://github.com/.extrah  8.6s
 => [11/11] RUN source $HOME/.local/bin/env &&     source /opt/venv/bin/activate &&     cd fastvideo-kernel &&     git submodule update --init --recursive &&     ./build.sh --rocm            30.0s 
 => exporting to image                                                                                                                                                                          4.3s 
 => => exporting layers                                                                                                                                                                         4.3s 
 => => writing image sha256:ac4004a617935dc16a223381707a25734543f98d97662ff0a18152bc6a1f9e0a                                                                                                    0.0s 
 => => naming to docker.io/library/fastvideo:rocm-test                                                                                                                                          0.0s 
```
