### PR TITLE
[misc] [bugfix] unpin 'av' in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ lint = [
 ]
 
 test = [
-    "av==14.3.0",
+    "av",
     "pytorch-msssim==1.0.0",
     "pytest",
 ]

--- a/pyproject_other.toml
+++ b/pyproject_other.toml
@@ -90,7 +90,7 @@ lint = [
 ]
 
 test = [
-    "av==14.3.0",
+    "av",
     "pytorch-msssim==1.0.0",
     "pytest",
 ]


### PR DESCRIPTION
fixes:

```bash
(fv) ray@g-72afdc91fd82e0001:/mnt/user_storage/dev/FastVideo$ uv pip install -e .[dev]
Using Python 3.12.12 environment at: /home/ray/anaconda3/envs/fv
  × No solution found when resolving dependencies:
  ╰─▶ Because fastvideo[dev]==0.1.7 depends on av==14.3.0 and there is no version of av==14.3.0, we
      can conclude that fastvideo[dev]==0.1.7 cannot be used.
      And because only fastvideo[dev]==0.1.7 is available and you require fastvideo[dev], we can
      conclude that your requirements are unsatisfiable.