### PR TITLE
[bugfix] Allow update timesteps for hy1.5 model.

### DIFF
--- a/fastvideo/configs/sample/hunyuan15.py
+++ b/fastvideo/configs/sample/hunyuan15.py
@@ -21,12 +21,12 @@ class Hunyuan15_480P_SamplingParam(SamplingParam):
         default_factory=lambda: list(np.linspace(1.0, 0.0, 50 + 1)[:-1]))
 
     negative_prompt: str = ""
-    
+
     def __post_init__(self):
         super().__post_init__()
         self.sigmas = list(
-            np.linspace(1.0, 0.0, self.num_inference_steps + 1)[:-1]
-        )
+            np.linspace(1.0, 0.0, self.num_inference_steps + 1)[:-1])
+
 
 @dataclass
 class Hunyuan15_720P_SamplingParam(Hunyuan15_480P_SamplingParam):


### PR DESCRIPTION
- Previously, the timesteps of HY1.5 is fixed to length=50. It was using sigmas in samplingparam to control the timesteps. That means when the user override num_inference_steps, they don't actually change the number of denoising steps.

- The fix add a post init method to update sigmas based on the num_inference_steps. So when samplingparams.update is called, the `timesteps` is updated to the user intended length.