### PR TITLE
[bugfix] Fix NCCL all_gather contiguity + correct ParallelTiledVAE decode tiling threshold

### DIFF
--- a/fastvideo/distributed/device_communicators/base_device_communicator.py
+++ b/fastvideo/distributed/device_communicators/base_device_communicator.py
@@ -57,6 +57,9 @@ class DistributedAutograd:
             ctx.dim = dim
             ctx.input_shape = input_.shape
 
+            # NCCL all_gather_into_tensor requires contiguous tensors.
+            if not input_.is_contiguous():
+                input_ = input_.contiguous()
             input_size = input_.size()
             output_size = (input_size[0] * world_size, ) + input_size[1:]
             output_tensor = torch.empty(output_size,

--- a/fastvideo/models/vaes/common.py
+++ b/fastvideo/models/vaes/common.py
@@ -79,7 +79,7 @@ class ParallelTiledVAE(ABC):
     def decode(self, z: torch.Tensor) -> torch.Tensor:
         batch_size, num_channels, num_frames, height, width = z.shape
         tile_latent_min_height = self.tile_sample_min_height // self.spatial_compression_ratio
-        tile_latent_min_width = self.tile_sample_stride_width // self.spatial_compression_ratio
+        tile_latent_min_width = self.tile_sample_min_width // self.spatial_compression_ratio
         tile_latent_min_num_frames = self.tile_sample_min_num_frames // self.temporal_compression_ratio
         num_sample_frames = (num_frames -
                              1) * self.temporal_compression_ratio + 1


### PR DESCRIPTION
- Ensure input tensor is contiguous for NCCL all_gather_into_tensor in DistributedAutograd
- Fix variable name in ParallelTiledVAE decode method