### PR TITLE
[bugfix] Double Normalization in Preprocessing Dataset

### DIFF
--- a/fastvideo/dataset/preprocessing_datasets.py
+++ b/fastvideo/dataset/preprocessing_datasets.py
@@ -366,9 +366,11 @@ class ImageTransformStage(DatasetStage):
             image = self.transform_topcrop(image)
         elif self.transform is not None:
             image = self.transform(image)
+            image = image.float() / 127.5 - 1.0
+        else:
+            image = image.float() / 127.5 - 1.0
 
         image = image.transpose(0, 1)  # [1 C H W] -> [C 1 H W]
-        image = image.float() / 127.5 - 1.0
         batch.pixel_values = image
         return batch
 


### PR DESCRIPTION
[__init__.py#L29](https://github.com/hao-ai-lab/FastVideo/blob/38a6bd93d3b0b3ed0d9941e8a0198eca412e7289/fastvideo/dataset/__init__.py#L29)

```
    transform_topcrop = transforms.Compose([
        Normalize255(),
        *resize_topcrop,
        norm_fun,
    ])
```

the `transform_topcrop` already has normalization
and [preprocessing_datasets.py#L36](https://github.com/hao-ai-lab/FastVideo/blob/38a6bd93d3b0b3ed0d9941e8a0198eca412e7289/fastvideo/dataset/preprocessing_datasets.py#L365) `ImageTransform` will double normalize the image, causing the image to all black.

```
class ImageTransformStage(DatasetStage):
    """Stage for image data transformation."""

    def __init__(self, transform, transform_topcrop) -> None:
        self.transform = transform
        self.transform_topcrop = transform_topcrop

    def process(self, batch: PreprocessBatch, **kwargs) -> PreprocessBatch:
        """
        Transform image data.
        
        Args:
            batch: Dataset batch with image information
            
        Returns:
            Batch with transformed image tensor
        """
        if not batch.is_image:
            return batch

        image = Image.open(batch.path).convert("RGB")
        image = torch.from_numpy(np.array(image))
        image = rearrange(image, "h w c -> c h w").unsqueeze(0)

        if self.transform_topcrop is not None:
            image = self.transform_topcrop(image)
        elif self.transform is not None:
            image = self.transform(image)

        image = image.transpose(0, 1)  # [1 C H W] -> [C 1 H W]
        image = image.float() / 127.5 - 1.0
        batch.pixel_values = image
        return batch
```
