### PR TITLE
[chore]: use higher precision timestamp in logging

### DIFF
--- a/fastvideo/logger.py
+++ b/fastvideo/logger.py
@@ -27,7 +27,7 @@ RESET = '\033[0;0m'
 _warned_local_main_process = False
 _warned_main_process = False
 
-_FORMAT = (f"{FASTVIDEO_LOGGING_PREFIX}%(levelname)s %(asctime)s "
+_FORMAT = (f"{FASTVIDEO_LOGGING_PREFIX}%(levelname)s %(asctime)s.%(msecs)03d "
            "[%(filename)s:%(lineno)d] %(message)s")
 _DATE_FORMAT = "%m-%d %H:%M:%S"
 


### PR DESCRIPTION
Show millisecond in timestamps for understanding performance issue in realtime inference/world model