### PR TITLE
[feat] Add activation offloading to training pipelines

### DIFF
--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -855,9 +855,10 @@ class TrainingArgs(FastVideoArgs):
     checkpoints_total_limit: int = 0
     resume_from_checkpoint: str = ""  # specify the checkpoint folder to resume from
     activation_offloading: bool = field(
-        default=False, 
-        metadata={"help": "Offload activations to CPU to save VRAM during training."}
-    )
+        default=False,
+        metadata={
+            "help": "Offload activations to CPU to save VRAM during training."
+        })
 
     # optimizer & scheduler
     num_train_epochs: int = 0
@@ -1124,6 +1125,12 @@ class TrainingArgs(FastVideoArgs):
                             help="Directory for logging")
 
         # Training configuration
+        parser.add_argument(
+            "--activation-offloading",
+            action=StoreBoolean,
+            default=False,
+            help="Offload activations to CPU to save VRAM."
+        )
         parser.add_argument("--num-train-epochs",
                             type=int,
                             help="Number of training epochs")

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -854,6 +854,10 @@ class TrainingArgs(FastVideoArgs):
     output_dir: str = ""
     checkpoints_total_limit: int = 0
     resume_from_checkpoint: str = ""  # specify the checkpoint folder to resume from
+    activation_offloading: bool = field(
+        default=False, 
+        metadata={"help": "Offload activations to CPU to save VRAM during training."}
+    )
 
     # optimizer & scheduler
     num_train_epochs: int = 0

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -1125,12 +1125,10 @@ class TrainingArgs(FastVideoArgs):
                             help="Directory for logging")
 
         # Training configuration
-        parser.add_argument(
-            "--activation-offloading",
-            action=StoreBoolean,
-            default=False,
-            help="Offload activations to CPU to save VRAM."
-        )
+        parser.add_argument("--activation-offloading",
+                            action=StoreBoolean,
+                            default=False,
+                            help="Offload activations to CPU to save VRAM.")
         parser.add_argument("--num-train-epochs",
                             type=int,
                             help="Number of training epochs")

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -31,14 +31,23 @@ from fastvideo.utils import (maybe_download_model,
 logger = init_logger(__name__)
 
 def pack_hook(tensor: torch.Tensor):
+    """
+    Moves activations from GPU to CPU memory during the forward pass.
+    """
     return tensor.to("cpu", non_blocking=True)
 
 def unpack_hook(packed_tensor):
+    """
+    Fetches activations back to the GPU from CPU memory during the backward pass.
+    """
     return packed_tensor.to("cuda", non_blocking=True)
 
 def offloaded_forward(module, *args, **kwargs):
-        with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
-            return module(*args, **kwargs)
+    """
+    A wrapper for a module's forward pass that enables activation offloading.
+    """
+    with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
+        return module(*args, **kwargs)
 
 class ComposedPipelineBase(ABC):
     """

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -128,16 +128,21 @@ class ComposedPipelineBase(ABC):
 
                 if self.fastvideo_args.activation_offloading:
                     for name, module in self.named_modules():
-                        for attr_name in ["blocks", "layers", "transformer_blocks"]:
+                        for attr_name in [
+                                "blocks", "layers", "transformer_blocks"
+                        ]:
                             blocks = getattr(module, attr_name, None)
                             if isinstance(blocks, torch.nn.ModuleList):
                                 for layer in blocks:
                                     # Original forward method
                                     original_forward = layer.forward
                                     # Patch with the function
-                                    layer.forward = functools.partial(offloaded_forward, original_forward)
-                                
-                                logger.info(f"Successfully enabled activation offloading for {len(blocks)} layers in {name}.")
+                                    layer.forward = functools.partial(
+                                        offloaded_forward, original_forward)
+
+                                logger.info(
+                                    f"Successfully enabled activation offloading for {len(blocks)} layers in {name}."
+                                )
                                 return
 
     @staticmethod

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -9,6 +9,7 @@ import argparse
 import os
 from abc import ABC, abstractmethod
 from typing import Any, cast
+import functools
 
 import torch
 
@@ -29,6 +30,15 @@ from fastvideo.utils import (maybe_download_model,
 
 logger = init_logger(__name__)
 
+def pack_hook(tensor: torch.Tensor):
+    return tensor.to("cpu", non_blocking=True)
+
+def unpack_hook(packed_tensor):
+    return packed_tensor.to("cuda", non_blocking=True)
+
+def offloaded_forward(module, *args, **kwargs):
+        with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
+            return module(*args, **kwargs)
 
 class ComposedPipelineBase(ABC):
     """
@@ -88,7 +98,7 @@ class ComposedPipelineBase(ABC):
         logger.info("Loading pipeline modules...")
         with self.profiler_controller.region("profiler_region_model_loading"):
             self.modules = self.load_modules(fastvideo_args, loaded_modules)
-
+        
     def set_trainable(self) -> None:
         # Only train DiT
         if getattr(self.fastvideo_args, "training_mode", False):
@@ -100,6 +110,22 @@ class ComposedPipelineBase(ABC):
                     continue
                 module.requires_grad_(True)
                 module.train()
+
+                if getattr(self.fastvideo_args, "activation_offloading", False):
+                    blocks = None
+                    for attr in ["layers", "blocks", "transformer_blocks"]:
+                        if hasattr(module, attr):
+                            blocks = getattr(module, attr)
+                            logger.info(f"Found transformer blocks in attribute: {attr}")
+                            break
+                    
+                    if blocks is not None:
+                        for i, layer in enumerate(blocks):
+                            # Apply the monkeypatch
+                            layer.forward = functools.partial(offloaded_forward, layer)
+                        logger.info(f"Successfully wrapped {len(blocks)} blocks for offloading.")
+                    else:
+                        logger.warning(f"Could not find layers to offload in {name}!")
 
     @staticmethod
     def _compile_with_conditions(


### PR DESCRIPTION
This PR implements asynchronous activation offloading to reduce VRAM consumption during training. By leveraging PyTorch’s saved_tensors_hooks, intermediate activations are moved to CPU memory during the forward pass and fetched back just-in-time for the backward pass 