### PR TITLE
[bugfix] fix import PreTrainedModel in stepllm.py

### DIFF
--- a/fastvideo/models/encoders/stepllm.py
+++ b/fastvideo/models/encoders/stepllm.py
@@ -19,8 +19,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
-from transformers import PretrainedConfig
-from transformers.modeling_utils import PreTrainedModel
+from transformers import PretrainedConfig, PreTrainedModel
 
 from fastvideo.models.dits.stepvideo import StepVideoRMSNorm
 


### PR DESCRIPTION
In `transformers==4.57.3` (per `pyproject.toml`), `PreTrainedModel` should directory be imported from `transformers` module. Previously we were importing from `transformers.modeling_utils`, which was causing a crash.