### PR TITLE
[Misc] Fix memory leakage in VideoGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ def main():
     # Generate the video
     video = generator.generate_video(
         prompt,
-        return_frames=True,  # Also return frames from this call (defaults to False)
         output_path="my_videos/",  # Controls where videos are saved
         save_video=True
     )

--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -41,7 +41,6 @@ def main():
     # Generate the video
     video = generator.generate_video(
         prompt,
-        return_frames=True,  # Also return frames from this call (defaults to False)
         output_path="my_videos/",  # Controls where videos are saved
         save_video=True
     )

--- a/docs/inference/configuration.md
+++ b/docs/inference/configuration.md
@@ -61,12 +61,11 @@ def main():
         prompt, 
         sampling_param=sampling_param, 
         output_path="my_videos/",  # Controls where videos are saved
-        return_frames=True,  # Also return frames from this call (defaults to False)
         save_video=True
     )
 
-    # If return_frames=True, video contains the generated frames as a NumPy array
-    print(f"Generated {len(video)} frames")
+    # If return_frames=True, frames are available in video["frames"]
+    print(f"Generated {len(video['frames'])} frames")
 
 if __name__ == '__main__':
     main()
@@ -76,6 +75,8 @@ if __name__ == '__main__':
 
 The CLI supports `--config` with JSON or YAML. Command-line arguments override
 config file values.
+By default, `fastvideo generate` uses `return_frames=false` unless you set
+`--return-frames` (or `return_frames: true` in config).
 
 ```bash
 fastvideo generate --config config.yaml

--- a/docs/inference/inference_quick_start.md
+++ b/docs/inference/inference_quick_start.md
@@ -44,7 +44,6 @@ def main():
     # Generate the video
     video = generator.generate_video(
         prompt,
-        return_frames=True,  # Also return frames from this call (defaults to False)
         output_path="my_videos/",  # Controls where videos are saved
         save_video=True
     )

--- a/examples/inference/gradio/serving/ray_serve_backend.py
+++ b/examples/inference/gradio/serving/ray_serve_backend.py
@@ -168,7 +168,7 @@ def prepare_sampling_params(video_request: VideoGenerationRequest, default_param
     params.height = video_request.height
     params.width = video_request.width
     params.save_video = False
-    params.return_frames = False
+    params.return_frames = True
     
     return params
 
@@ -229,7 +229,7 @@ class BaseModelDeployment:
             sampling_param=params,
             image_path=image_path,
             save_video=False,
-            return_frames=False,
+            return_frames=True,
         )
         inference_time = time.time() - inference_start_time
 

--- a/fastvideo/configs/sample/base.py
+++ b/fastvideo/configs/sample/base.py
@@ -75,7 +75,7 @@ class SamplingParam:
 
     # Misc
     save_video: bool = True
-    return_frames: bool = False
+    return_frames: bool = True
     return_trajectory_latents: bool = False  # returns all latents for each timestep
     return_trajectory_decoded: bool = False  # returns decoded latents for each timestep
 
@@ -218,7 +218,7 @@ class SamplingParam:
         parser.add_argument(
             "--return-frames",
             action="store_true",
-            default=SamplingParam.return_frames,
+            default=False,
             help="Whether to return the raw frames",
         )
         parser.add_argument(

--- a/fastvideo/entrypoints/cli/generate.py
+++ b/fastvideo/entrypoints/cli/generate.py
@@ -80,6 +80,7 @@ class GenerateSubcommand(CLISubcommand):
             k: v
             for k, v in merged_args.items() if k in self.generation_arg_names
         }
+        generation_args.setdefault("return_frames", False)
 
         model_path = init_args.pop('model_path')
         prompt = generation_args.pop('prompt', None)

--- a/tests/local_tests/pipelines/test_gamecraft_pipeline_parity.py
+++ b/tests/local_tests/pipelines/test_gamecraft_pipeline_parity.py
@@ -340,9 +340,8 @@ def test_gamecraft_pipeline_latent_parity():
         camera_states=plucker_embedding,
     )
     
-    fastvideo_latents = result.get("latents")
-    if fastvideo_latents is None:
-        fastvideo_latents = result.get("samples")
+
+    fastvideo_latents = result.get("samples")
     
     _log_tensor_stats("FastVideo latents", fastvideo_latents)
     


### PR DESCRIPTION

  ## Summary
  Fix #860 
  This PR standardizes generation return behavior and clarifies `return_frames` semantics across API, CLI, serving, docs, and tests.

  ## What Changed
  - `VideoGenerator.generate_video()` now consistently returns metadata dictionaries.
  - Raw outputs (`samples`, `frames`, `audio`) are only populated when `return_frames=True`.
  - Added `video_path` to generation results when video saving is enabled.
  - Set API default `return_frames=True` via `SamplingParam`, while keeping CLI default `return_frames=False` unless explicitly requested.
  - Updated Ray Serve backend to always request frames for response encoding.
  - Synced docs and quick-start examples with the new return format.
  - Updated local parity test to use `result["samples"]`.
