### PR TITLE
Port GGUF quantization layer from vLLM to FastVideo

### DIFF
--- a/examples/inference/optimizations/README.md
+++ b/examples/inference/optimizations/README.md
@@ -1,5 +1,24 @@
 # Optimization Examples
 
+## Attention backend
 ```bash
 python examples/inference/optimizations/attention_example.py
+```
+
+## Text encoder quantization (AbsMaxFP8)
+```bash
+python examples/inference/optimizations/text_encoder_quant_example.py \
+    --text_encoder_path /path/to/umt5_xxl_fp8_e4m3fn_scaled.safetensors
+```
+
+## Text encoder quantization (GGUF)
+
+GGUF quantization uses low-precision weight types (Q4_0, Q4_K, Q8_0, etc.) to
+reduce the text encoder memory footprint while keeping quality close to the
+original. Requires [vLLM](https://github.com/vllm-project/vllm) for the GGML
+CUDA dequantization kernels.
+
+```bash
+python examples/inference/optimizations/gguf_quant_example.py \
+    --text_encoder_path /path/to/text_encoder_gguf.safetensors
 ```

--- a/examples/inference/optimizations/gguf_quant_example.py
+++ b/examples/inference/optimizations/gguf_quant_example.py
@@ -1,0 +1,76 @@
+"""Example: running inference with a GGUF-quantized text encoder.
+
+GGUF quantization reduces the memory footprint of the text encoder by using
+lower-precision weight types (Q4_0, Q4_K, Q8_0, etc.) while keeping model
+quality close to the original. This is especially useful when running large
+models on GPUs with limited VRAM.
+
+Prerequisites:
+    - A GGUF-quantized text encoder stored as a safetensors file.
+    - vLLM installed (provides the GGML CUDA kernels needed for dequantization).
+
+Usage:
+    python examples/inference/optimizations/gguf_quant_example.py \
+        --text_encoder_path /path/to/text_encoder_gguf.safetensors
+
+    # With a custom model:
+    python examples/inference/optimizations/gguf_quant_example.py \
+        --text_encoder_path /path/to/text_encoder_gguf.safetensors \
+        --model_path Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+"""
+
+import argparse
+
+from fastvideo import VideoGenerator
+
+OUTPUT_PATH = "video_samples_gguf_quant"
+
+
+def main(model_path: str, text_encoder_path: str):
+    generator = VideoGenerator.from_pretrained(
+        model_path,
+        num_gpus=1,
+        use_fsdp_inference=False,
+        dit_cpu_offload=False,
+        vae_cpu_offload=False,
+        text_encoder_cpu_offload=True,
+        override_text_encoder_quant="gguf",
+        override_text_encoder_safetensors=text_encoder_path,
+        pin_cpu_memory=True,
+    )
+
+    prompt = (
+        "A curious raccoon peers through a vibrant field of yellow sunflowers, "
+        "its eyes wide with interest. The playful yet serene atmosphere is "
+        "complemented by soft natural light filtering through the petals. "
+        "Mid-shot, warm and cheerful tones."
+    )
+    generator.generate_video(prompt, output_path=OUTPUT_PATH, save_video=True)
+
+    prompt2 = (
+        "A majestic lion strides across the golden savanna, its powerful frame "
+        "glistening under the warm afternoon sun. The tall grass ripples gently "
+        "in the breeze, enhancing the lion's commanding presence. Low angle, "
+        "steady tracking shot, cinematic."
+    )
+    generator.generate_video(prompt2, output_path=OUTPUT_PATH, save_video=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate video with a GGUF-quantized text encoder."
+    )
+    parser.add_argument(
+        "--text_encoder_path",
+        type=str,
+        required=True,
+        help="Path to the GGUF-quantized text encoder safetensors file.",
+    )
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        help="HuggingFace model ID or local path to the diffusion model.",
+    )
+    args = parser.parse_args()
+    main(args.model_path, args.text_encoder_path)

--- a/fastvideo/layers/quantization/__init__.py
+++ b/fastvideo/layers/quantization/__init__.py
@@ -2,7 +2,7 @@ from typing import Literal, get_args
 
 from fastvideo.layers.quantization.base_config import QuantizationConfig
 
-QuantizationMethods = Literal[None, "AbsMaxFP8"]
+QuantizationMethods = Literal[None, "AbsMaxFP8", "gguf"]
 
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))
 
@@ -52,9 +52,11 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
 
     # lazy import to avoid triggering `torch.compile` too early
     from .absmax_fp8 import AbsMaxFP8Config
+    from .gguf import GGUFConfig
 
     method_to_config: dict[str, type[QuantizationConfig]] = {
         "AbsMaxFP8": AbsMaxFP8Config,
+        "gguf": GGUFConfig,
     }
     # Update the `method_to_config` with customized quantization methods.
     method_to_config.update(_CUSTOMIZED_METHOD_TO_QUANT_CONFIG)

--- a/fastvideo/layers/quantization/gguf.py
+++ b/fastvideo/layers/quantization/gguf.py
@@ -1,0 +1,462 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from vllm: https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/quantization/gguf.py
+
+from collections.abc import Callable, Mapping
+from types import MappingProxyType
+from typing import Any
+
+import gguf
+import torch
+from gguf import GGMLQuantizationType as WeightType
+from torch.library import Library, infer_schema
+from torch.nn.parameter import Parameter, UninitializedParameter
+
+from vllm import _custom_ops as ops
+
+from fastvideo.layers.linear import (
+    LinearBase,
+    LinearMethodBase,
+    UnquantizedLinearMethod,
+)
+from fastvideo.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from fastvideo.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
+    VocabParallelEmbedding,
+)
+from fastvideo.logger import init_logger
+from fastvideo.models.utils import set_weight_attrs
+from fastvideo.platforms import current_platform
+
+logger = init_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Torch custom op registration utilities
+# ---------------------------------------------------------------------------
+
+_fastvideo_lib = Library("fastvideo", "FRAGMENT")
+
+
+def _direct_register_custom_op(
+    op_name: str,
+    op_func: Callable,
+    mutates_args: list[str] | None = None,
+    fake_impl: Callable | None = None,
+    dispatch_key: str | None = None,
+):
+    if mutates_args is None:
+        mutates_args = []
+    if dispatch_key is None:
+        dispatch_key = current_platform.dispatch_key
+
+    schema_str = infer_schema(op_func, mutates_args=mutates_args)
+    _fastvideo_lib.define(op_name + schema_str)
+    _fastvideo_lib.impl(op_name, op_func, dispatch_key=dispatch_key)
+    if fake_impl is not None:
+        _fastvideo_lib._register_fake(op_name, fake_impl)
+
+
+# ---------------------------------------------------------------------------
+# GGUFConfig
+# ---------------------------------------------------------------------------
+
+
+class GGUFConfig(QuantizationConfig):
+    """Config class for GGUF."""
+
+    def __init__(self, unquantized_modules: list[str] | None = None) -> None:
+        super().__init__()
+        self.unquantized_modules = unquantized_modules or []
+
+    def __repr__(self) -> str:
+        return "GGUFConfig()"
+
+    def get_name(self) -> str:
+        return "gguf"
+
+    def get_supported_act_dtypes(self) -> list[torch.dtype]:
+        if current_platform.has_device_capability(100):
+            logger.warning_once(
+                "GGUF has precision issues with bfloat16 on Blackwell."
+            )
+            return [torch.half, torch.float32]
+        return [torch.half, torch.bfloat16, torch.float32]
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 60
+
+    @classmethod
+    def get_config_filenames(cls) -> list[str]:
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "GGUFConfig":
+        return cls()
+
+    def get_quant_method(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> "QuantizeMethodBase | None":
+        if isinstance(layer, LinearBase):
+            if is_layer_skipped_gguf(
+                prefix, self.unquantized_modules, self.packed_modules_mapping
+            ):
+                return UnquantizedLinearMethod()
+            return GGUFLinearMethod(self)
+        elif isinstance(layer, VocabParallelEmbedding):
+            if is_layer_skipped_gguf(
+                prefix, self.unquantized_modules, self.packed_modules_mapping
+            ):
+                return UnquantizedEmbeddingMethod()
+            return GGUFEmbeddingMethod(self)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Layer-skipping logic
+# ---------------------------------------------------------------------------
+
+
+def is_layer_skipped_gguf(
+    prefix: str,
+    unquantized_modules: list[str],
+    fused_mapping: Mapping[str, list[str]] = MappingProxyType({}),
+):
+    proj_name = prefix.split(".")[-1]
+    if proj_name in fused_mapping:
+        shard_prefixes = [
+            prefix.replace(proj_name, shard_proj_name)
+            for shard_proj_name in fused_mapping[proj_name]
+        ]
+        is_skipped = None
+        for shard_prefix in shard_prefixes:
+            is_shard_skipped = any(
+                shard_prefix in module_name
+                for module_name in unquantized_modules
+            )
+            if is_skipped is None:
+                is_skipped = is_shard_skipped
+            elif is_shard_skipped != is_skipped:
+                raise ValueError(
+                    f"Detected some but not all shards of {prefix} "
+                    "are quantized. All shards of fused layers "
+                    "to have the same precision."
+                )
+    else:
+        is_skipped = any(
+            module_name in prefix for module_name in unquantized_modules
+        )
+    assert is_skipped is not None
+    return is_skipped
+
+
+# ---------------------------------------------------------------------------
+# Quantization type sets
+# ---------------------------------------------------------------------------
+
+UNQUANTIZED_TYPES = {WeightType.F32, WeightType.F16, WeightType.BF16}
+STANDARD_QUANT_TYPES = {
+    WeightType.Q4_0,
+    WeightType.Q4_1,
+    WeightType.Q5_0,
+    WeightType.Q5_1,
+    WeightType.Q8_0,
+    WeightType.Q8_1,
+}
+KQUANT_TYPES = {
+    WeightType.Q2_K,
+    WeightType.Q3_K,
+    WeightType.Q4_K,
+    WeightType.Q5_K,
+    WeightType.Q6_K,
+}
+IMATRIX_QUANT_TYPES = {
+    WeightType.IQ1_M,
+    WeightType.IQ1_S,
+    WeightType.IQ2_XXS,
+    WeightType.IQ2_XS,
+    WeightType.IQ2_S,
+    WeightType.IQ3_XXS,
+    WeightType.IQ3_S,
+    WeightType.IQ4_XS,
+    WeightType.IQ4_NL,
+}
+DEQUANT_TYPES = STANDARD_QUANT_TYPES | KQUANT_TYPES | IMATRIX_QUANT_TYPES
+MMVQ_QUANT_TYPES = STANDARD_QUANT_TYPES | KQUANT_TYPES | IMATRIX_QUANT_TYPES
+MMQ_QUANT_TYPES = STANDARD_QUANT_TYPES | KQUANT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Custom ops: fused_mul_mat_gguf
+# ---------------------------------------------------------------------------
+
+
+def _fused_mul_mat_gguf(
+    x: torch.Tensor, qweight: torch.Tensor, qweight_type: int
+) -> torch.Tensor:
+    if qweight_type in IMATRIX_QUANT_TYPES:
+        mmvq_safe = 8 if qweight.shape[0] > 5120 else 16
+    else:
+        mmvq_safe = 2 if qweight.shape[0] > 5120 else 6
+
+    if x.shape[0] == 0:
+        return torch.empty(
+            x.shape[0], qweight.shape[0], dtype=x.dtype, device=x.device
+        )
+
+    if qweight_type in UNQUANTIZED_TYPES:
+        return x @ qweight.T
+
+    if x.shape[0] <= mmvq_safe and qweight_type in MMVQ_QUANT_TYPES:
+        y = ops.ggml_mul_mat_vec_a8(qweight, x, qweight_type, qweight.shape[0])
+    elif qweight_type in MMQ_QUANT_TYPES:
+        y = ops.ggml_mul_mat_a8(qweight, x, qweight_type, qweight.shape[0])
+    elif qweight_type in DEQUANT_TYPES:
+        block_size, type_size = gguf.GGML_QUANT_SIZES[qweight_type]
+        shape = (qweight.shape[0], qweight.shape[1] // type_size * block_size)
+        weight = ops.ggml_dequantize(qweight, qweight_type, *shape, x.dtype)
+        y = x @ weight.T
+    else:
+        qweight_type = WeightType(qweight_type)
+        raise NotImplementedError(
+            f"Unsupported GGUF quantization type: {qweight_type}"
+        )
+    return y
+
+
+def _fused_mul_mat_gguf_fake(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    qweight_type: int,
+) -> torch.Tensor:
+    return torch.empty(
+        x.shape[0], qweight.shape[0], dtype=x.dtype, device=x.device
+    )
+
+
+_direct_register_custom_op(
+    op_name="_fused_mul_mat_gguf",
+    op_func=_fused_mul_mat_gguf,
+    fake_impl=_fused_mul_mat_gguf_fake,
+)
+fused_mul_mat_gguf = torch.ops.fastvideo._fused_mul_mat_gguf
+
+
+# ---------------------------------------------------------------------------
+# Custom ops: apply_gguf_embedding
+# ---------------------------------------------------------------------------
+
+
+def _apply_gguf_embedding(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    qweight_type: int,
+    hidden_size: int,
+    dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    if qweight_type in UNQUANTIZED_TYPES:
+        return torch.embedding(qweight, x)
+    elif qweight_type in DEQUANT_TYPES:
+        block_size, type_size = gguf.GGML_QUANT_SIZES[qweight_type]
+        x_flat = x.flatten()
+        assert hidden_size == qweight.shape[1] // type_size * block_size
+        quant = torch.index_select(qweight, dim=0, index=x_flat)
+        dequant = ops.ggml_dequantize(
+            quant, qweight_type, hidden_size, x_flat.shape[0], dtype
+        )
+        return dequant.view(*x.shape, hidden_size)
+    else:
+        qweight_type = WeightType(qweight_type)
+        raise NotImplementedError(
+            f"Unsupported GGUF quantization type: {qweight_type}"
+        )
+
+
+def _apply_gguf_embedding_fake(
+    x: torch.Tensor,
+    qweight: torch.Tensor,
+    qweight_type: int,
+    hidden_size: int,
+    dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    return torch.empty(x.shape[0], hidden_size, dtype=dtype, device=x.device)
+
+
+_direct_register_custom_op(
+    op_name="_apply_gguf_embedding",
+    op_func=_apply_gguf_embedding,
+    fake_impl=_apply_gguf_embedding_fake,
+)
+apply_gguf_embedding = torch.ops.fastvideo._apply_gguf_embedding
+
+
+# ---------------------------------------------------------------------------
+# GGUFLinearMethod
+# ---------------------------------------------------------------------------
+
+
+class GGUFLinearMethod(LinearMethodBase):
+    """Linear method for GGUF.
+
+    Args:
+        quant_config: The GGUF quantization config.
+    """
+
+    def __init__(self, quant_config: GGUFConfig):
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        self.params_dtype = params_dtype
+        output_size_per_partition = sum(output_partition_sizes)
+
+        tensor_shape = (output_size_per_partition, input_size_per_partition)
+        qweight = GGUFUninitializedParameter(requires_grad=False)
+        set_weight_attrs(
+            qweight,
+            {
+                "input_dim": 1,
+                "output_dim": 0,
+                "tensor_shape": tensor_shape,
+                "is_gguf_weight": True,
+                "data_container": [],
+                "shard_id": [],
+                "shard_id_map": {},
+            },
+        )
+        set_weight_attrs(qweight, extra_weight_attrs)
+        layer.register_parameter("qweight", qweight)
+
+        qweight_type = Parameter(
+            torch.empty(len(output_partition_sizes), dtype=torch.uint8),
+            requires_grad=False,
+        )
+        set_weight_attrs(
+            qweight_type,
+            {
+                "is_gguf_weight_type": True,
+                "weight_type": 0,
+                "shard_weight_type": {},
+                "ignore_warning": True,
+            },
+        )
+        set_weight_attrs(qweight_type, extra_weight_attrs)
+        layer.register_parameter("qweight_type", qweight_type)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module):
+        qweight_type = layer.qweight_type.weight_type
+        if not (qweight_type in UNQUANTIZED_TYPES or qweight_type in DEQUANT_TYPES):
+            qweight_type = WeightType(qweight_type)
+            raise ValueError(
+                f"Unsupported GGUF quantization type {qweight_type} "
+                f"in layer {layer}."
+            )
+        self._create_padded_weight_param(layer)
+
+    def _create_padded_weight_param(self, layer: torch.nn.Module):
+        """Create padded weight parameter for GGUF MergedLinear layer."""
+        qweight = layer.qweight
+        shard_id_map = qweight.shard_id_map
+        shard_id = qweight.shard_id
+        if len(data_container := qweight.data_container) > 1:
+            dtype = {data.dtype for data in data_container}
+            assert len(dtype) == 1, ValueError(
+                f"Data container has mixed dtypes: {dtype}"
+            )
+            dtype = next(iter(dtype))
+            padded_side = max(x.size(1) for x in data_container)
+            concat_side = sum(x.size(0) for x in data_container)
+            padded_data = torch.zeros(
+                (concat_side, padded_side),
+                dtype=dtype,
+                device=qweight.device,
+            )
+            shard_offset_map = dict[str, tuple[int, int, int]]()
+            for idx in shard_id:
+                id_in_container = shard_id_map[idx]
+                start = sum(
+                    x.size(0) for x in data_container[:id_in_container]
+                )
+                end = start + data_container[id_in_container].size(0)
+                size = data_container[id_in_container].size(1)
+                padded_data[start:end, :size] = data_container[id_in_container]
+                shard_offset_map[idx] = (start, end, size)
+            qweight.data_container.clear()
+            padded_param = Parameter(padded_data, requires_grad=False)
+            set_weight_attrs(padded_param, vars(qweight))
+            set_weight_attrs(padded_param, {"shard_offset_map": shard_offset_map})
+            layer.register_parameter("qweight", padded_param)
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        shard_id = layer.qweight.shard_id
+
+        if shard_id:
+            shard_id = ["q", "k", "v"] if "q" in shard_id else shard_id
+            qweight = layer.qweight
+            result = []
+            for idx in shard_id:
+                start, end, offset = layer.qweight.shard_offset_map[idx]
+                qweight_type = layer.qweight_type.shard_weight_type[idx]
+                result.append(
+                    fused_mul_mat_gguf(
+                        x,
+                        qweight[start:end, :offset].contiguous(),
+                        qweight_type,
+                    )
+                )
+            out = torch.cat(result, axis=1)
+        else:
+            qweight = layer.qweight
+            qweight_type = layer.qweight_type.weight_type
+            out = fused_mul_mat_gguf(x, qweight, qweight_type)
+
+        if bias is not None:
+            out.add_(bias)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# GGUFEmbeddingMethod
+# ---------------------------------------------------------------------------
+
+
+class GGUFEmbeddingMethod(GGUFLinearMethod):
+    """Embedding method for GGUF.
+
+    Args:
+        quant_config: The GGUF quantization config.
+    """
+
+    def embedding(self, layer: torch.nn.Module, x: torch.Tensor) -> torch.Tensor:
+        qweight = layer.qweight
+        qweight_type = layer.qweight_type.weight_type
+        hidden_size = qweight.tensor_shape[1]
+
+        return apply_gguf_embedding(
+            x, qweight, qweight_type, hidden_size, dtype=self.params_dtype
+        )
+
+
+# ---------------------------------------------------------------------------
+# GGUFUninitializedParameter
+# ---------------------------------------------------------------------------
+
+
+class GGUFUninitializedParameter(UninitializedParameter):
+    cls_to_become = Parameter
+    data_container: list[torch.Tensor]


### PR DESCRIPTION
Add GGUF quantization support (GGUFConfig, GGUFLinearMethod, GGUFEmbeddingMethod) adapted from vLLM, using vLLM's GGML CUDA kernels for dequantization. MoE support excluded as FastVideo does not use mixture-of-experts layers.