### PR TITLE
[bugfix]: fix CFG formula using cond instead of uncond as base term

### DIFF
--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -829,7 +829,7 @@ class CosmosDenoisingStage(DenoisingStage):
                                 1 - batch.uncond_indicator) * uncond_pred
 
                         guidance_diff = cond_pred - uncond_pred
-                        final_pred = uncond_pred + guidance_scale * guidance_diff
+                        final_pred = cond_pred + guidance_scale * guidance_diff
                     else:
                         final_pred = cond_pred
 
@@ -1074,7 +1074,7 @@ class Cosmos25DenoisingStage(CosmosDenoisingStage):
                             return_dict=False,
                         )[0]
                         if is_conditioned:
-                            v = uncond_v + guidance_scale * (cond_v - uncond_v)
+                            v = cond_v + guidance_scale * (cond_v - uncond_v)
                         else:
                             v = uncond_v + guidance_scale * (cond_v - uncond_v)
                     else:


### PR DESCRIPTION
Problem                                                                                                                                                                          
                                                            
  Three places in the codebase use the wrong CFG formula:                                                                                                                          
  - Wrong: cond + scale * (cond - uncond)                                                                                                                                          
  - Correct: uncond + scale * (cond - uncond)                                                                                                                                      
  
Using cond as the base term over-weights the conditional prediction by effectively applying (1 + scale) * cond - scale * uncond instead of the intended uncond + scale * (cond - 
  uncond).                                                  
                                                                                                                                                                                   
  Changes                                                   

  - fastvideo/training/distillation_pipeline.py:801 — DMD distillation real score prediction
  
  It's still worth investiagting about whether we should change cosmos denoising path(fastvideo/pipelines/stages/denoising.py:832,1077). That requires additional work on numerical alignments.