### PR TITLE
[Feat] Add causal Wan pipeline with multi-step denoising   

### DIFF
--- a/fastvideo/pipelines/basic/wan/wan_causal_pipeline.py
+++ b/fastvideo/pipelines/basic/wan/wan_causal_pipeline.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Wan causal pipeline with standard multi-step denoising.
+
+Block-by-block causal inference with KV caching, using the full
+scheduler timestep schedule (40-50 steps) rather than DMD few-step.
+"""
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.logger import init_logger
+from fastvideo.models.schedulers.scheduling_flow_unipc_multistep import (
+    FlowUniPCMultistepScheduler)
+from fastvideo.pipelines import ComposedPipelineBase, LoRAPipeline
+
+# isort: off
+from fastvideo.pipelines.stages import (
+    CausalDenoisingStage,
+    ConditioningStage,
+    DecodingStage,
+    InputValidationStage,
+    LatentPreparationStage,
+    TextEncodingStage,
+    TimestepPreparationStage,
+)
+# isort: on
+
+logger = init_logger(__name__)
+
+
+class WanCausalPipeline(LoRAPipeline, ComposedPipelineBase):
+    """Wan causal pipeline with standard multi-step denoising."""
+
+    _required_config_modules = [
+        "text_encoder", "tokenizer", "vae",
+        "transformer", "scheduler",
+    ]
+
+    def initialize_pipeline(
+        self, fastvideo_args: FastVideoArgs,
+    ):
+        self.modules["scheduler"] = (
+            FlowUniPCMultistepScheduler(
+                shift=fastvideo_args.pipeline_config.flow_shift,
+            )
+        )
+
+    def create_pipeline_stages(
+        self, fastvideo_args: FastVideoArgs,
+    ) -> None:
+        self.add_stage(
+            stage_name="input_validation_stage",
+            stage=InputValidationStage(),
+        )
+
+        self.add_stage(
+            stage_name="prompt_encoding_stage",
+            stage=TextEncodingStage(
+                text_encoders=[
+                    self.get_module("text_encoder")],
+                tokenizers=[
+                    self.get_module("tokenizer")],
+            ),
+        )
+
+        self.add_stage(
+            stage_name="conditioning_stage",
+            stage=ConditioningStage(),
+        )
+
+        self.add_stage(
+            stage_name="timestep_preparation_stage",
+            stage=TimestepPreparationStage(
+                scheduler=self.get_module("scheduler"),
+            ),
+        )
+
+        self.add_stage(
+            stage_name="latent_preparation_stage",
+            stage=LatentPreparationStage(
+                scheduler=self.get_module("scheduler"),
+                transformer=self.get_module(
+                    "transformer", None),
+            ),
+        )
+
+        self.add_stage(
+            stage_name="denoising_stage",
+            stage=CausalDenoisingStage(
+                transformer=self.get_module("transformer"),
+                scheduler=self.get_module("scheduler"),
+            ),
+        )
+
+        self.add_stage(
+            stage_name="decoding_stage",
+            stage=DecodingStage(
+                vae=self.get_module("vae")),
+        )
+
+
+EntryClass = WanCausalPipeline

--- a/fastvideo/pipelines/stages/__init__.py
+++ b/fastvideo/pipelines/stages/__init__.py
@@ -7,7 +7,8 @@ complete diffusion pipelines.
 """
 
 from fastvideo.pipelines.stages.base import PipelineStage
-from fastvideo.pipelines.stages.causal_denoising import CausalDMDDenosingStage
+from fastvideo.pipelines.stages.causal_denoising import (
+    CausalDMDDenosingStage, CausalDenoisingStage)
 from fastvideo.pipelines.stages.conditioning import ConditioningStage
 from fastvideo.pipelines.stages.decoding import DecodingStage
 from fastvideo.pipelines.stages.denoising import (
@@ -63,6 +64,7 @@ __all__ = [
     "DenoisingStage",
     "DmdDenoisingStage",
     "CausalDMDDenosingStage",
+    "CausalDenoisingStage",
     "MatrixGameCausalDenoisingStage",
     "HYWorldDenoisingStage",
     "GameCraftDenoisingStage",

--- a/fastvideo/pipelines/stages/causal_denoising.py
+++ b/fastvideo/pipelines/stages/causal_denoising.py
@@ -482,3 +482,215 @@ class CausalDMDDenosingStage(DenoisingStage):
             "negative_prompt_embeds", batch.negative_prompt_embeds, lambda x:
             not batch.do_classifier_free_guidance or V.list_not_empty(x))
         return result
+
+
+class CausalDenoisingStage(CausalDMDDenosingStage):
+    """Causal block-by-block denoising with standard multi-step
+    flow matching (scheduler.step), not DMD few-step.
+
+    Each block is fully denoised through all scheduler timesteps
+    before moving to the next block.  After each block is denoised,
+    the KV cache is updated with clean context so subsequent blocks
+    can attend to prior clean frames.
+    """
+
+    def forward(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> ForwardBatch:
+        target_dtype = torch.bfloat16
+        autocast_enabled = (
+            target_dtype != torch.float32
+            and not fastvideo_args.disable_autocast
+        )
+
+        latent_seq_length = (
+            batch.latents.shape[-1] * batch.latents.shape[-2]
+        )
+        patch_ratio = (
+            self.transformer.config.arch_config.patch_size[-1]
+            * self.transformer.config.arch_config.patch_size[-2]
+        )
+        self.frame_seq_length = latent_seq_length // patch_ratio
+
+        pos_cond_kwargs = self.prepare_extra_func_kwargs(
+            self.transformer.forward,
+            {
+                "encoder_attention_mask":
+                    batch.prompt_attention_mask,
+            },
+        )
+
+        assert batch.latents is not None, (
+            "latents must be provided"
+        )
+        latents = batch.latents  # [B, C, T, H, W]
+        b, c, t, h, w = latents.shape
+        prompt_embeds = batch.prompt_embeds
+        assert torch.isnan(prompt_embeds[0]).sum() == 0
+
+        num_inference_steps = batch.num_inference_steps
+
+        # Initialize caches
+        kv_cache = self._initialize_kv_cache(
+            batch_size=b,
+            dtype=target_dtype,
+            device=latents.device,
+        )
+        crossattn_cache = self._initialize_crossattn_cache(
+            batch_size=b,
+            max_text_len=(
+                fastvideo_args.pipeline_config
+                .text_encoder_configs[0]
+                .arch_config.text_len
+            ),
+            dtype=target_dtype,
+            device=latents.device,
+        )
+
+        # Determine block sizes
+        if t % self.num_frames_per_block != 0:
+            raise ValueError(
+                "num_frames must be divisible by "
+                "num_frames_per_block"
+            )
+        num_blocks = t // self.num_frames_per_block
+        block_sizes = [self.num_frames_per_block] * num_blocks
+        start_index = 0
+        pos_start_base = 0
+
+        context_noise = getattr(
+            fastvideo_args.pipeline_config,
+            "context_noise", 0,
+        )
+
+        with self.progress_bar(
+            total=len(block_sizes) * num_inference_steps
+        ) as progress_bar:
+            for current_num_frames in block_sizes:
+                current_latents = latents[
+                    :, :,
+                    start_index:start_index + current_num_frames,
+                    :, :,
+                ]
+
+                # Reset scheduler per block so its multi-step
+                # history starts fresh.
+                self.scheduler.set_timesteps(
+                    num_inference_steps,
+                    device=latents.device,
+                )
+                timesteps = self.scheduler.timesteps
+
+                for i, t_cur in enumerate(timesteps):
+                    latent_model_input = current_latents.to(
+                        target_dtype
+                    )
+                    t_expanded = t_cur * torch.ones(
+                        (b, 1),
+                        device=latents.device,
+                        dtype=torch.long,
+                    )
+
+                    with (
+                        torch.autocast(
+                            device_type="cuda",
+                            dtype=target_dtype,
+                            enabled=autocast_enabled,
+                        ),
+                        set_forward_context(
+                            current_timestep=i,
+                            attn_metadata=None,
+                            forward_batch=batch,
+                        ),
+                    ):
+                        # Transformer returns [B, C, T, H, W],
+                        # permute to [B, T, C, H, W] then flatten
+                        # B*T for the scheduler.
+                        noise_pred = self.transformer(
+                            latent_model_input,
+                            prompt_embeds,
+                            t_expanded,
+                            kv_cache=kv_cache,
+                            crossattn_cache=crossattn_cache,
+                            current_start=(
+                                (pos_start_base + start_index)
+                                * self.frame_seq_length
+                            ),
+                            start_frame=start_index,
+                            **pos_cond_kwargs,
+                        )
+
+                    # Flatten [B,C,T,H,W] -> [B*T,C,H,W] for
+                    # scheduler, then unflatten back.
+                    nf = current_num_frames
+                    noise_pred_flat = (
+                        noise_pred
+                        .permute(0, 2, 1, 3, 4)
+                        .flatten(0, 1)
+                    )
+                    latents_flat = (
+                        current_latents
+                        .permute(0, 2, 1, 3, 4)
+                        .flatten(0, 1)
+                    )
+                    updated_flat = self.scheduler.step(
+                        noise_pred_flat,
+                        t_cur,
+                        latents_flat,
+                        return_dict=False,
+                    )[0]
+                    current_latents = (
+                        updated_flat
+                        .unflatten(0, (b, nf))
+                        .permute(0, 2, 1, 3, 4)
+                    )
+
+                    if progress_bar is not None:
+                        progress_bar.update()
+
+                # Write denoised block back
+                latents[
+                    :, :,
+                    start_index:start_index + current_num_frames,
+                    :, :,
+                ] = current_latents
+
+                # Update KV cache with clean context
+                t_context = torch.ones(
+                    [b],
+                    device=latents.device,
+                    dtype=torch.long,
+                ) * int(context_noise)
+                context_bcthw = current_latents.to(target_dtype)
+                with (
+                    torch.autocast(
+                        device_type="cuda",
+                        dtype=target_dtype,
+                        enabled=autocast_enabled,
+                    ),
+                    set_forward_context(
+                        current_timestep=0,
+                        attn_metadata=None,
+                        forward_batch=batch,
+                    ),
+                ):
+                    self.transformer(
+                        context_bcthw,
+                        prompt_embeds,
+                        t_context.unsqueeze(1),
+                        kv_cache=kv_cache,
+                        crossattn_cache=crossattn_cache,
+                        current_start=(
+                            (pos_start_base + start_index)
+                            * self.frame_seq_length
+                        ),
+                        start_frame=start_index,
+                        **pos_cond_kwargs,
+                    )
+
+                start_index += current_num_frames
+
+        batch.latents = latents
+        return batch


### PR DESCRIPTION
  ## Summary                                                                                                                                                    
  - Add `CausalDenoisingStage` that performs block-by-block causal denoising using the full scheduler timestep schedule (UniPC multi-step) with KV caching, as  opposed to the existing DMD few-step approach                                                                                                                 
  - Add `WanCausalPipeline` that composes the standard pipeline stages with the new causal denoising stage                                                      
  - Export `CausalDenoisingStage` from the stages module                                                                                                        
                                                                                                                                                                