### PR TITLE
[bugfix] self-forcing train/validation step mismatch

### DIFF
--- a/fastvideo/train/callbacks/validation.py
+++ b/fastvideo/train/callbacks/validation.py
@@ -297,6 +297,13 @@ class ValidationCallback(Callback):
             tc.model_path,
             **kwargs,
         )
+
+        scheduler = self._pipeline.get_module("scheduler")
+        if (scheduler is not None and type(scheduler).__name__ == "SelfForcingFlowMatchScheduler"):
+            scheduler.sigma_min = 0.0
+            scheduler.extra_one_step = True
+            scheduler.set_timesteps(num_inference_steps=1000, training=True)
+
         self._pipeline_key = key
         return self._pipeline
 


### PR DESCRIPTION
## Purpose

In the new training framework, the validation pipeline rebuilds the pipeline from `from_pretrained(...)`, but it does not re-apply the Self-Forcing scheduler settings used during training.

Training explicitly constructs `SelfForcingFlowMatchScheduler` with:
```
  self._sf_scheduler = SelfForcingFlowMatchScheduler(
      num_inference_steps=1000,
      num_train_timesteps=int(self.student.num_train_timesteps),
      shift=shift,
      sigma_min=0.0,
      extra_one_step=True,
      training=True,
  )
```
- [`fastvideo/train/methods/distribution_matching/self_forcing.py:147-154`](https://github.com/hao-ai-lab/FastVideo/blob/4105094fa5bc321bf9c9f92fb8c9558070da2b0d/fastvideo/train/methods/distribution_matching/self_forcing.py#L147)

However, validation previously reused the loaded scheduler without restoring self-forcing settings. As a result, validation could interpret the denoising step `[1000, 750, 500, 250]` to `[1000.0, 937.5, 833.33, 625.0]`.


## Checklist

- [X] I ran `pre-commit run --all-files` and fixed all issues
- [X] I added or updated tests for my changes
- [X] I updated documentation if needed
- [X] I considered GPU memory impact of my changes
