### PR TITLE
[ci] Post pre-commit status to PR commit SHA

### DIFF
--- a/.github/workflows/ci-slash-commands.yml
+++ b/.github/workflows/ci-slash-commands.yml
@@ -149,6 +149,27 @@ jobs:
       && needs.parse-command.outputs.test_scope == 'precommit'
     uses: ./.github/workflows/ci-precommit.yml
 
+  post-precommit-status:
+    needs: [parse-command, pre-commit]
+    if: always() && needs.parse-command.outputs.test_scope == 'precommit'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          PR_SHA: ${{ needs.parse-command.outputs.pr_sha }}
+          RESULT: ${{ needs.pre-commit.result }}
+        with:
+          script: |
+            const state = process.env.RESULT === 'success' ? 'success' : 'failure';
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.PR_SHA,
+              state,
+              context: 'pre-commit',
+              description: `Triggered via /test pre-commit (${state})`,
+            });
+
   trigger-buildkite:
     needs: parse-command
     if: >-


### PR DESCRIPTION
## Summary

`/test pre-commit` runs but the check doesn't appear on the PR page because `issue_comment` workflows run in the default branch context, not the PR's commit.

Fix: after pre-commit completes, post a commit status to the PR's head SHA via the GitHub API. This makes the check visible on the PR page and satisfies Mergify's `check-success~=pre-commit` condition.