### PR TITLE
[ci] Add statuses:write permission for /test pre-commit

### DIFF
--- a/.github/workflows/ci-slash-commands.yml
+++ b/.github/workflows/ci-slash-commands.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
 
 jobs:
   handle-merge:


### PR DESCRIPTION
Fixes 403 on createCommitStatus — the workflow needs statuses:write to post pre-commit results to the PR commit SHA.