### PR TITLE
[ci] Remove Mergify ready-label race condition

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -283,14 +283,6 @@ pull_request_rules:
     actions:
       rebase: {}
 
-  - name: remove ready label on Full Suite failure
-    conditions:
-      - label=ready
-      - check-failure=full-suite-passed
-    actions:
-      label:
-        remove: [ready]
-
   # ============================================================
   # PR title format help
   # ============================================================


### PR DESCRIPTION
Removes the rule that strips `ready` on full-suite failure. It races with `/merge` — Mergify sees the old failed status and removes `ready` before the new build starts. Safe to remove because auto-merge requires `check-success=full-suite-passed` anyway.