### PR TITLE
[ci] Fix /merge to directly trigger Full Suite + simplify rebase conditions

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -272,11 +272,10 @@ pull_request_rules:
       merge:
         method: squash
 
-  - name: auto-rebase when ready and Full Suite passed
+  - name: auto-rebase when ready
     conditions:
       - label=ready
       - "#approved-reviews-by>=1"
-      - check-success=full-suite-passed
       - -conflict
       - -closed
       - -draft

--- a/.github/workflows/ci-slash-commands.yml
+++ b/.github/workflows/ci-slash-commands.yml
@@ -33,6 +33,7 @@ jobs:
             core.setOutput('has_write', String(hasWrite));
 
       - name: Add ready label and react
+        id: label
         if: steps.perm.outputs.has_write == 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -40,7 +41,6 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const prNumber = context.payload.issue.number;
-            // Remove ready first to allow re-trigger (labeled event fires on add, not if already present)
             try { await github.rest.issues.removeLabel({ owner, repo, issue_number: prNumber, name: 'ready' }); } catch {}
             await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['ready'] });
             await github.rest.reactions.createForIssueComment({
@@ -48,6 +48,44 @@ jobs:
               comment_id: context.payload.comment.id,
               content: 'rocket',
             });
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            core.setOutput('pr_sha', pr.head.sha);
+            core.setOutput('pr_branch', pr.head.ref);
+            core.setOutput('pr_number', String(prNumber));
+
+      - name: Trigger Full Suite
+        if: steps.perm.outputs.has_write == 'true'
+        env:
+          BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}
+          PR_SHA: ${{ steps.label.outputs.pr_sha }}
+          PR_BRANCH: ${{ steps.label.outputs.pr_branch }}
+          PR_NUMBER: ${{ steps.label.outputs.pr_number }}
+          BK_ORG: ${{ vars.BUILDKITE_ORG_SLUG }}
+          BK_PIPELINE: ${{ vars.BUILDKITE_PIPELINE_SLUG }}
+        run: |
+          curl -sS --fail-with-body -X POST \
+            "https://api.buildkite.com/v2/organizations/${BK_ORG}/pipelines/${BK_PIPELINE}/builds" \
+            -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-raw "$(jq -n \
+              --arg commit "$PR_SHA" \
+              --arg branch "$PR_BRANCH" \
+              --arg message "Full Suite for PR #${PR_NUMBER} (via /merge)" \
+              --argjson pr_id "$PR_NUMBER" \
+              '{
+                commit: $commit,
+                branch: $branch,
+                message: $message,
+                ignore_pipeline_branch_filters: true,
+                pull_request_id: $pr_id,
+                pull_request_base_branch: "main",
+                env: {
+                  TEST_SCOPE: "full",
+                  FULL_SUITE: "true",
+                  PR_NUMBER: ($pr_id | tostring)
+                }
+              }')"
+
   parse-command:
     if: >-
       github.event.issue.pull_request != null
@@ -143,6 +181,18 @@ jobs:
             core.setOutput('sha', pr.head.sha);
             core.setOutput('branch', pr.head.ref);
 
+      - name: React to comment
+        if: steps.perm.outputs.has_write == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
   pre-commit:
     needs: parse-command
     if: >-
@@ -178,17 +228,6 @@ jobs:
       && needs.parse-command.outputs.test_type != ''
     runs-on: ubuntu-latest
     steps:
-      - name: React to comment
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            await github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket',
-            });
-
       - name: Trigger Buildkite
         env:
           BUILDKITE_API_TOKEN: ${{ secrets.BUILDKITE_API_TOKEN }}

--- a/.github/workflows/ci-trigger-full-suite.yml
+++ b/.github/workflows/ci-trigger-full-suite.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: full-suite-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   trigger:


### PR DESCRIPTION
## Summary

- `/merge` now directly triggers Buildkite Full Suite via API (bypasses GITHUB_TOKEN event limitation)
- Simplify Mergify auto-rebase: remove `check-success=full-suite-passed` requirement, rebase as soon as `ready` + approved + no conflicts

## Problem

`/merge` adds `ready` label using `GITHUB_TOKEN`, which doesn't trigger other workflows. So `ci-trigger-full-suite.yml` never fires, and Full Suite never starts.

## Fix

`handle-merge` now:
1. Adds `ready` label (for Mergify auto-merge conditions)
2. Directly calls Buildkite API to start Full Suite (no event chain dependency)

Two paths to Full Suite, both work:
- `/merge` → direct API call from handle-merge
- Manual `ready` label → `ci-trigger-full-suite.yml` (pull_request: labeled)