### PR TITLE
[ci] Ignore legacy reference videos when checking for HF download

### DIFF
--- a/fastvideo/tests/ssim/reference_videos_cli.py
+++ b/fastvideo/tests/ssim/reference_videos_cli.py
@@ -134,12 +134,11 @@ def _discover_reference_dirs_for_tier(
 
 
 def _has_local_reference_videos(base_dir: Path, quality_tier: str) -> bool:
-    # Check for completion marker file first
     marker_path = base_dir / REFERENCE_VIDEOS_DIRNAME / quality_tier / f".download_complete_{quality_tier}"
     if not marker_path.exists():
         return False
-    # Also verify at least one .mp4 exists
-    for ref_dir in _discover_reference_dirs_for_tier(base_dir, quality_tier):
+    tier_root = _reference_tier_root(base_dir, quality_tier)
+    for ref_dir in _discover_reference_dirs(tier_root):
         for _ in _iter_video_files(ref_dir):
             return True
     return False


### PR DESCRIPTION
## Summary

`_has_local_reference_videos()` no longer falls back to legacy `*_reference_videos/` dirs when deciding whether to download from HF.

## Problem

PRs that commit legacy-layout reference videos (e.g. `L40S_reference_videos/GEN3C-Cosmos-7B/`) cause conftest to think references are already available, skipping the HF download entirely. Models that only exist on HF (like `SFWan2.1-T2V-1.3B-Diffusers`) are never downloaded, and their tests fail with `FileNotFoundError`.

## Fix

`_has_local_reference_videos()` now only checks the new tiered layout (`reference_videos/<tier>/`) and marker file. Legacy dirs no longer prevent HF downloads.

Runtime path resolution (`build_reference_folder_path`) still falls back to legacy dirs, so committed references remain usable as fallback during test execution.