### PR TITLE
[ci] Use pull_request_target for Full Suite trigger

### DIFF
--- a/.github/workflows/ci-trigger-full-suite.yml
+++ b/.github/workflows/ci-trigger-full-suite.yml
@@ -1,7 +1,7 @@
 name: Trigger Full Suite
 
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled, synchronize]
 
 permissions:


### PR DESCRIPTION
Fork PRs have no access to secrets under pull_request events. Changing to pull_request_target runs the workflow from main with full secret access. Safe because this workflow only calls APIs, no PR code checkout.