### PR TITLE
[ci] Add direct test retry with check overwrite and aggregate status refresh

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,11 +9,183 @@ notify:
   - github_commit_status:
       context: "full-suite-passed"
     if: build.env("TEST_SCOPE") == "full"
+  - github_commit_status:
+      context: "direct-test-completed"
+    if: build.env("TEST_SCOPE") == "direct"
 
 steps:
   # ============================================================
-    - label: ":dart: Direct Test (${TEST_TYPE})"
-      if: build.env("TEST_SCOPE") == "direct"
+  # Direct test: triggered by /test <name> slash command.
+  # Labels match fastcheck/full-suite counterparts so the GitHub
+  # check status overwrites the original failed check.
+  # Only ONE step executes per build (gated by TEST_TYPE).
+  # ============================================================
+
+  # --- Fastcheck-scope direct tests ---
+    - label: ":microscope: Encoder Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "encoder"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":microscope: VAE Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "vae"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":microscope: Transformer Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "transformer"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":microscope: Kernel Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "kernel_tests"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":microscope: Unit Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "unit_test"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+
+  # --- Full-suite-scope direct tests ---
+    - label: ":bar_chart: SSIM Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "ssim"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+          - exit_status: 1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":test_tube: LoRA Inference Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "inference_lora"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":test_tube: Training Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "training"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":test_tube: Distillation DMD Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "distillation_dmd"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":test_tube: Self-Forcing Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "self_forcing"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":test_tube: LoRA Training Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "training_lora"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+          - exit_status: 1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":test_tube: Training Tests VSA"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "training_vsa"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+          - exit_status: 1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":test_tube: Inference Tests VMoBA"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "inference_vmoba"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":test_tube: Performance Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "performance"
+      command: "timeout 90m .buildkite/scripts/pr_test.sh"
+      retry:
+        automatic:
+          - exit_status: 128
+            limit: 3
+          - exit_status: -1
+            limit: 2
+      agents:
+        queue: "default"
+    - label: ":test_tube: API Server Tests"
+      if: build.env("TEST_SCOPE") == "direct" && build.env("TEST_TYPE") == "api_server"
       command: "timeout 90m .buildkite/scripts/pr_test.sh"
       retry:
         automatic:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,8 +4,10 @@ merge_protections:
       - base = main
     success_conditions:
       - "title~=(?i)^\\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model)\\]"
+      - "#approved-reviews-by>=1"
       - check-success~=pre-commit
       - check-success=fastcheck-passed
+      - check-success=full-suite-passed
 
 pull_request_rules:
 

--- a/.github/workflows/ci-aggregate-status.yml
+++ b/.github/workflows/ci-aggregate-status.yml
@@ -1,0 +1,80 @@
+name: Aggregate Test Status
+
+on:
+  status:
+
+permissions:
+  statuses: write
+
+jobs:
+  aggregate:
+    if: >-
+      github.event.context == 'direct-test-completed'
+      && github.event.state == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check and update aggregate status
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const sha = context.payload.sha;
+
+            const { data } = await github.rest.repos.getCombinedStatusForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              per_page: 100,
+            });
+
+            const bkStatuses = data.statuses.filter(
+              s => s.context.startsWith('buildkite/ci/')
+            );
+
+            const FASTCHECK_PREFIX = 'buildkite/ci/microscope-';
+            const FULL_SUITE_PREFIXES = [
+              'buildkite/ci/test-tube-',
+              'buildkite/ci/bar-chart-',
+            ];
+
+            const fastcheck = bkStatuses.filter(
+              s => s.context.startsWith(FASTCHECK_PREFIX)
+            );
+            const fullSuite = bkStatuses.filter(
+              s => FULL_SUITE_PREFIXES.some(p => s.context.startsWith(p))
+            );
+
+            if (
+              fastcheck.length > 0
+              && fastcheck.every(s => s.state === 'success')
+            ) {
+              core.info(
+                `All ${fastcheck.length} fastcheck tests passed — updating fastcheck-passed`
+              );
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'success',
+                context: 'fastcheck-passed',
+                description:
+                  `All ${fastcheck.length} fastcheck tests passed`,
+              });
+            }
+
+            if (
+              fullSuite.length > 0
+              && fullSuite.every(s => s.state === 'success')
+            ) {
+              core.info(
+                `All ${fullSuite.length} full suite tests passed — updating full-suite-passed`
+              );
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: 'success',
+                context: 'full-suite-passed',
+                description:
+                  `All ${fullSuite.length} full suite tests passed`,
+              });
+            }

--- a/.github/workflows/ci-precommit.yml
+++ b/.github/workflows/ci-precommit.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     branches: [main]
   workflow_call:
-
-concurrency:
-  group: pre-commit-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+    inputs:
+      ref:
+        description: 'Git ref to checkout (defaults to github.ref)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -18,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref || '' }}
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"

--- a/.github/workflows/ci-slash-commands.yml
+++ b/.github/workflows/ci-slash-commands.yml
@@ -199,6 +199,8 @@ jobs:
       needs.parse-command.outputs.has_write == 'true'
       && needs.parse-command.outputs.test_scope == 'precommit'
     uses: ./.github/workflows/ci-precommit.yml
+    with:
+      ref: refs/pull/${{ github.event.issue.number }}/merge
 
   post-precommit-status:
     needs: [parse-command, pre-commit]

--- a/docs/contributing/ci_architecture.md
+++ b/docs/contributing/ci_architecture.md
@@ -24,7 +24,7 @@ PR push
           Runs on the PR branch directly
               │
           pass ──► Mergify auto-squash-merges to main, branch deleted
-          fail ──► Mergify removes 'ready' label; fix and /merge again
+          fail ──► fix the regression, push, and /merge again
 ```
 
 ---
@@ -102,8 +102,8 @@ failing test's output.
 | Performance Tests | `performance` | 30 min |
 | API Server Tests | `api_server` | 30 min |
 
-A Full Suite failure removes the `ready` label automatically. A Mergify comment links to
-the Buildkite build. Fix the regression, push, and comment `/merge` again.
+If a Full Suite test fails, check the Buildkite build log for the failing step's output.
+Fix the regression, push, and comment `/merge` again to re-trigger.
 
 ---
 
@@ -129,8 +129,8 @@ Suite passing directly on the PR branch.
    - No merge conflicts
 5. If all conditions pass, Mergify squash-merges to `main` automatically. The branch is
    deleted after merge.
-6. If the Full Suite fails, Mergify removes the `ready` label and posts a comment linking to
-   the Buildkite build. The developer fixes the issue, pushes, and comments `/merge` again.
+6. If the Full Suite fails, the developer fixes the issue, pushes, and comments `/merge`
+   again to re-trigger.
 
 **Merge conditions summary:**
 
@@ -279,6 +279,30 @@ Triggers a specific Buildkite test or suite on the current PR branch.
 | `/test api` | API server integration tests | `api_server` |
 | `/test full` | Entire Full Suite | all (with `TEST_SCOPE=full`) |
 | `/test fastcheck` | Entire Fastcheck suite | fastcheck (with `TEST_SCOPE=fastcheck`) |
+| `/test pre-commit` | Pre-commit checks on PR code | — (runs `ci-precommit.yml` via `workflow_call`) |
+
+**Re-running failed tests:** When you use `/test <name>` to re-run a specific failed test,
+the resulting Buildkite check uses the same name as the original (e.g., `/test encoder`
+creates `buildkite/ci/microscope-encoder-tests`). This overwrites the failed check status.
+Once all tests in a tier pass, the aggregate status (`fastcheck-passed` or
+`full-suite-passed`) is automatically updated to `success` by the `ci-aggregate-status.yml`
+workflow.
+
+**How aggregate status refresh works:**
+
+1. `/test <name>` triggers a Buildkite build with `TEST_SCOPE=direct`. The test step uses
+   the same label as its fastcheck/full-suite counterpart, so the resulting GitHub check
+   overwrites the original.
+2. When the build completes, Buildkite's `notify` posts a `direct-test-completed` commit
+   status. This is the only signal that triggers the aggregate workflow — intermediate step
+   status updates do not trigger it.
+3. `ci-aggregate-status.yml` fires, calls `getCombinedStatusForRef` to fetch the latest
+   status for every context on that commit (each context returns only its most recent
+   state), groups them by prefix (`microscope-*` → fastcheck, `test-tube-*`/`bar-chart-*`
+   → full suite), and posts `fastcheck-passed: success` or `full-suite-passed: success` if
+   all entries in the group are `success`.
+4. Tests that were never triggered (skipped by monorepo-diff) have no status entry and do
+   not block the aggregate.
 
 ---
 
@@ -296,6 +320,7 @@ Protected branches (`main`, `master`, `release/*`) are never deleted.
 | `ci-precommit.yml` | Every push / PR against `main` | Runs pre-commit hooks (yapf, ruff, mypy, codespell, pymarkdown, actionlint, check-filenames) |
 | `ci-trigger-full-suite.yml` | `ready` label added to a PR | Calls Buildkite API to run Full Suite on the PR branch |
 | `ci-slash-commands.yml` | PR comment starting with `/merge` or `/test` | Handles slash commands; adds `ready` label or triggers Buildkite |
+| `ci-aggregate-status.yml` | Any Buildkite commit status update | Checks if all tests in a tier passed; updates `fastcheck-passed` or `full-suite-passed` |
 | `community-issue-labeler.yml` | Issue opened or edited | Auto-labels issues by keyword matching against title and body |
 | `community-welcome.yml` | First contribution | Posts a welcome comment for first-time contributors |
 | `community-stale.yml` | Scheduled | Marks and closes stale issues and PRs |

--- a/docs/contributing/pull_requests.md
+++ b/docs/contributing/pull_requests.md
@@ -104,8 +104,9 @@ distillation, self-forcing, VSA, VMoBA, performance benchmarks, and API server t
 8. If all Full Suite tests pass and all merge conditions are met (approval, valid title,
    pre-commit green, fastcheck green, no draft, no conflicts), Mergify squash-merges to
    `main` automatically. Your branch is deleted.
-9. If a Full Suite test fails, Mergify removes the `ready` label and posts a comment with a
-   link to the Buildkite build. Fix the issue, push, and comment `/merge` again.
+9. If a Full Suite test fails, check the Buildkite build log for the failing step. Fix the
+   issue, push, and comment `/merge` again. You can also re-run individual failed tests
+   with `/test <name>` — see below.
 
 !!! note
     Only contributors with write permission to the repository can trigger slash commands.
@@ -149,9 +150,14 @@ Comment on your PR to trigger specific tests independently of the auto-merge flo
 /test vmoba            # VMoBA inference tests
 /test performance      # Performance benchmarks
 /test api              # API server integration tests
+/test pre-commit       # Pre-commit checks on PR code
 ```
 
 The workflow reacts with a 🚀 emoji to confirm the command was received.
+
+When you re-run an individual test with `/test <name>`, the new result overwrites the
+original failed check (same Buildkite check name). Once all tests in a tier pass, the
+`fastcheck-passed` or `full-suite-passed` status is automatically updated.
 
 ---
 
@@ -199,9 +205,8 @@ Mergify removes the `needs-rebase` label automatically once conflicts are resolv
 
 ### Full Suite failed after `/merge`
 
-The Full Suite found a regression. Mergify removes the `ready` label and posts a comment
-linking to the Buildkite build. Check the failing step's output for assertion errors or
-tracebacks.
+The Full Suite found a regression. Check the failing Buildkite step's output for assertion
+errors or tracebacks.
 
 Common causes:
 


### PR DESCRIPTION
## Summary

- `/test <name>` now overwrites the original failed check instead of creating a separate one with a different name
- When all tests in a tier (fastcheck or full suite) pass after individual re-runs, the aggregate status (`fastcheck-passed` / `full-suite-passed`) is automatically refreshed
- `/test pre-commit` now checks out the PR merge ref instead of main
- Merge protection conditions aligned with auto-merge (added reviewer and full-suite requirements)

## Changes

### `.buildkite/pipeline.yml`
- Replace generic `:dart: Direct Test (${TEST_TYPE})` step with 15 individual steps, each using the same label as its fastcheck/full-suite counterpart (e.g., `:microscope: Encoder Tests`). Same Buildkite label → same GitHub check name → re-run overwrites the failed check.
- Add `direct-test-completed` notify for direct test builds to signal the aggregate workflow.

### `.github/workflows/ci-aggregate-status.yml` (new)
- Triggered by `direct-test-completed` status event (once per direct test build completion, not on every intermediate step update).
- Calls `getCombinedStatusForRef` to get the latest status per context, groups by prefix (`microscope-*` → fastcheck, `test-tube-*`/`bar-chart-*` → full suite), and posts `fastcheck-passed: success` or `full-suite-passed: success` if all entries in the group are success.
- Permissions: `statuses: write` only (minimum required).

### `.github/workflows/ci-precommit.yml` + `ci-slash-commands.yml`
- `/test pre-commit` now passes `refs/pull/<number>/merge` as the checkout ref, matching the auto-triggered `pull_request` behavior. Previously it checked out main because `issue_comment` events have `github.ref = refs/heads/main`.

### `.github/mergify.yml`
- Added `#approved-reviews-by>=1` and `check-success=full-suite-passed` to merge protection, aligning with auto-merge conditions.

### Docs
- Updated `ci_architecture.md` and `pull_requests.md`: removed outdated "Mergify removes ready label on failure" references, added `/test pre-commit`, added aggregate status refresh documentation, added `ci-aggregate-status.yml` to workflow reference table.