### PR TITLE
[ci] Use update instead of rebase for auto branch sync

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -274,7 +274,7 @@ pull_request_rules:
       merge:
         method: squash
 
-  - name: auto-rebase when ready
+  - name: auto-update when ready
     conditions:
       - label=ready
       - "#approved-reviews-by>=1"
@@ -282,7 +282,7 @@ pull_request_rules:
       - -closed
       - -draft
     actions:
-      rebase: {}
+      update: {}
 
   # ============================================================
   # PR title format help


### PR DESCRIPTION
## Summary

- Switch Mergify auto-rebase rule from `rebase: {}` to `update: {}`
- Fixes fork PR auto-update failing with "Unable to rebase: Mergify can't impersonate" error

## Why

`rebase` requires force-pushing to the PR branch, which needs the PR author's Mergify dashboard authorization. Fork contributors typically haven't done this, so auto-rebase fails silently.

`update` uses GitHub's `update-branch` API which only needs base repo permissions — works for all PRs including forks, no additional setup required.

The PR branch gets a merge commit instead of a rebase, but since all merges to main are squash merges, this has no effect on main's history.