### PR TITLE
[feat] Cosmos 2.5 training support in fastvideo.train

### DIFF
--- a/examples/train/configs/fine_tuning/cosmos/t2v.yaml
+++ b/examples/train/configs/fine_tuning/cosmos/t2v.yaml
@@ -1,0 +1,73 @@
+# Cosmos Predict2 2B T2V finetune config.
+#
+# Data must be preprocessed with Cosmos VAE + T5 text encoder
+# into parquet format before training.
+
+models:
+  student:
+    _target_: fastvideo.train.models.cosmos.CosmosModel
+    init_from: nvidia/Cosmos-Predict2-2B-Video2World
+    trainable: true
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    num_gpus: 8
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 8
+    hsdp_shard_dim: 1
+
+  data:
+    data_path: data/cosmos_preprocessed
+    dataloader_num_workers: 4
+    train_batch_size: 1
+    training_cfg_rate: 0.0
+    seed: 1000
+    # Cosmos VAE: 4x temporal, 8x spatial compression.
+    # 93 frames -> 24 latent frames, 480x832 -> 60x104
+    num_latent_t: 24
+    num_height: 480
+    num_width: 832
+    num_frames: 93
+
+  optimizer:
+    learning_rate: 1.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.01
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    max_train_steps: 5000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/cosmos_finetune
+    training_state_checkpointing_steps: 500
+    checkpoints_total_limit: 3
+    resume_from_checkpoint: latest
+
+  tracker:
+    project_name: fastvideo_cosmos
+    run_name: cosmos_finetune
+
+  model:
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.cosmos.cosmos_pipeline.Cosmos2VideoToWorldPipeline
+    dataset_file: data/cosmos_preprocessed/validation_prompts.json
+    every_steps: 100
+    sampling_steps: [50]
+    guidance_scale: 6.0
+
+pipeline:
+  flow_shift: 1.0

--- a/examples/train/configs/overfit_cosmos25_t2w.yaml
+++ b/examples/train/configs/overfit_cosmos25_t2w.yaml
@@ -1,0 +1,79 @@
+# Cosmos-Predict2.5-2B Text-to-World overfitting test config.
+#
+# Overfits on a few short videos (480x832, 93 frames) to verify the
+# Cosmos 2.5 training plugin works end-to-end.
+#
+# Preprocess data first:
+#   CUDA_VISIBLE_DEVICES=0 python fastvideo/pipelines/preprocess/preprocess_cosmos25_overfit.py
+#
+# Run:
+#   bash examples/train/run.sh examples/train/configs/overfit_cosmos25_t2w.yaml
+
+models:
+  student:
+    _target_: fastvideo.train.models.cosmos.CosmosModel
+    init_from: KyleShao/Cosmos-Predict2.5-2B-Diffusers
+    trainable: true
+    enable_gradient_checkpointing_type: full
+    flow_shift: 1.0
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    num_gpus: 1
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 1
+
+  data:
+    data_path: data/cosmos25_overfit_preprocessed
+    dataloader_num_workers: 0
+    train_batch_size: 1
+    training_cfg_rate: 0.0
+    seed: 42
+    num_latent_t: 24
+    num_height: 480
+    num_width: 832
+    num_frames: 93
+
+  optimizer:
+    learning_rate: 5.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    max_train_steps: 300
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/cosmos25_overfit
+    training_state_checkpointing_steps: 50
+    checkpoints_total_limit: 2
+
+  tracker:
+    project_name: fastvideo_cosmos25
+    run_name: cosmos25_overfit
+
+  model:
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.cosmos.cosmos2_5_pipeline.Cosmos2_5Pipeline
+    dataset_file: data/cosmos25_overfit_preprocessed/validation_prompts.json
+    every_steps: 150
+    sampling_steps: [35]
+    guidance_scale: 7.0
+
+pipeline:
+  flow_shift: 1.0

--- a/fastvideo/configs/models/base.py
+++ b/fastvideo/configs/models/base.py
@@ -48,8 +48,6 @@ class ModelConfig:
         for key, value in source_model_dict.items():
             if key in valid_fields:
                 setattr(arch_config, key, value)
-            else:
-                raise AttributeError(f"{type(arch_config).__name__} has no field '{key}'")
 
         if hasattr(arch_config, "__post_init__"):
             arch_config.__post_init__()

--- a/fastvideo/configs/models/dits/cosmos.py
+++ b/fastvideo/configs/models/dits/cosmos.py
@@ -50,7 +50,8 @@ class CosmosArchConfig(DiTArchConfig):
         })
 
     # Cosmos-specific config parameters based on transformer_cosmos.py
-    in_channels: int = 16
+    # in_channels includes the condition_mask channel (16 latent + 1 cond = 17)
+    in_channels: int = 17
     out_channels: int = 16
     num_attention_heads: int = 16
     attention_head_dim: int = 128

--- a/fastvideo/models/dits/cosmos.py
+++ b/fastvideo/models/dits/cosmos.py
@@ -556,7 +556,10 @@ class CosmosTransformer3DModel(BaseDiT):
         self.extra_pos_embed_type = config.extra_pos_embed_type
 
         # 1. Patch Embedding
-        patch_embed_in_channels = config.in_channels + 1 if config.concat_padding_mask else config.in_channels
+        # config.in_channels already includes the condition_mask channel
+        # (HF config: in_channels=17 = 16 latent + 1 condition_mask).
+        # Only add +1 for the padding_mask when concat_padding_mask=True.
+        patch_embed_in_channels = config.in_channels + (1 if config.concat_padding_mask else 0)
         self.patch_embed = CosmosPatchEmbed(patch_embed_in_channels,
                                             inner_dim,
                                             config.patch_size,
@@ -617,6 +620,28 @@ class CosmosTransformer3DModel(BaseDiT):
 
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
 
+        # Defensive dtype alignment: the Cosmos checkpoint is bf16 but
+        # FSDP-wrapped training copies may report fp32 via
+        # `next(parameters()).dtype`, which disables autocast in the
+        # shared denoising stage and feeds fp32 tensors into bf16
+        # weights. Cast every external input to the patch_embed weight
+        # dtype so the model forward is robust regardless of caller.
+        _target_dtype = self.patch_embed.proj.weight.dtype
+        if hidden_states.dtype != _target_dtype:
+            hidden_states = hidden_states.to(_target_dtype)
+        if condition_mask is not None and condition_mask.dtype != _target_dtype:
+            condition_mask = condition_mask.to(_target_dtype)
+        if padding_mask is not None and padding_mask.dtype != _target_dtype:
+            padding_mask = padding_mask.to(_target_dtype)
+        if isinstance(encoder_hidden_states, torch.Tensor):
+            if encoder_hidden_states.dtype != _target_dtype:
+                encoder_hidden_states = encoder_hidden_states.to(_target_dtype)
+        else:
+            encoder_hidden_states = [
+                t.to(_target_dtype) if t.dtype != _target_dtype else t
+                for t in encoder_hidden_states
+            ]
+
         # 1. Concatenate padding mask if needed & prepare attention mask
         if condition_mask is not None:
             hidden_states = torch.cat([hidden_states, condition_mask], dim=1)
@@ -626,6 +651,10 @@ class CosmosTransformer3DModel(BaseDiT):
             padding_mask = transforms.functional.resize(
                 padding_mask, list(hidden_states.shape[-2:]), interpolation=transforms.InterpolationMode.NEAREST
             )
+            # torchvision.resize may upcast bf16/fp16 → fp32; restore
+            # hidden_states' dtype so the subsequent cat doesn't promote
+            # everything and break patch_embed (bf16 weights).
+            padding_mask = padding_mask.to(hidden_states.dtype)
             hidden_states = torch.cat(
                 [hidden_states, padding_mask.unsqueeze(2).repeat(batch_size, 1, num_frames, 1, 1)], dim=1
             )
@@ -703,6 +732,11 @@ class CosmosTransformer3DModel(BaseDiT):
         hidden_states = hidden_states.permute(0, 7, 1, 6, 2, 4, 3, 5)
         hidden_states = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
 
+        # Return as tuple for compatibility with callers that
+        # do `transformer(..., return_dict=False)[0]` (diffusers
+        # convention used by CosmosDenoisingStage).
+        if not kwargs.get("return_dict", True):
+            return (hidden_states,)
         return hidden_states
 
 # Entry point for model registry

--- a/fastvideo/pipelines/basic/cosmos/cosmos_pipeline.py
+++ b/fastvideo/pipelines/basic/cosmos/cosmos_pipeline.py
@@ -22,23 +22,18 @@ class Cosmos2VideoToWorldPipeline(ComposedPipelineBase):
     _required_config_modules = ["text_encoder", "tokenizer", "vae", "transformer", "scheduler", "safety_checker"]
 
     def initialize_pipeline(self, fastvideo_args: FastVideoArgs):
-        self.modules["scheduler"] = FlowMatchEulerDiscreteScheduler(shift=fastvideo_args.pipeline_config.flow_shift,
-                                                                    use_karras_sigmas=True)
-
-        sigma_max = 80.0
-        sigma_min = 0.002
-        sigma_data = 1.0
-        final_sigmas_type = "sigma_min"
-
-        if self.modules["scheduler"] is not None:
-            scheduler = self.modules["scheduler"]
-            scheduler.config.sigma_max = sigma_max
-            scheduler.config.sigma_min = sigma_min
-            scheduler.config.sigma_data = sigma_data
-            scheduler.config.final_sigmas_type = final_sigmas_type
-            scheduler.sigma_max = sigma_max
-            scheduler.sigma_min = sigma_min
-            scheduler.sigma_data = sigma_data
+        scheduler = FlowMatchEulerDiscreteScheduler(
+            shift=fastvideo_args.pipeline_config.flow_shift,
+            use_karras_sigmas=True,
+        )
+        scheduler.config.sigma_max = 80.0
+        scheduler.config.sigma_min = 0.002
+        scheduler.config.sigma_data = 1.0
+        scheduler.config.final_sigmas_type = "sigma_min"
+        scheduler.sigma_max = 80.0
+        scheduler.sigma_min = 0.002
+        scheduler.sigma_data = 1.0
+        self.modules["scheduler"] = scheduler
 
     def create_pipeline_stages(self, fastvideo_args: FastVideoArgs):
         """Set up pipeline stages with proper dependency injection."""

--- a/fastvideo/pipelines/preprocess/preprocess_cosmos25_overfit.py
+++ b/fastvideo/pipelines/preprocess/preprocess_cosmos25_overfit.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Preprocess Cosmos 2.5 overfit data into parquet format.
+
+Encodes videos with the Cosmos (Wan-style) VAE and captions with the
+Reason1 (Qwen2.5-VL) text encoder into the t2v parquet schema.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=0 python fastvideo/pipelines/preprocess/preprocess_cosmos25_overfit.py
+"""
+
+import json
+import os
+
+import cv2
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import torch
+
+from fastvideo.dataset.dataloader.schema import pyarrow_schema_t2v
+from fastvideo.utils import maybe_download_model
+
+# --- Config ---
+NUM_FRAMES = 93  # 4*23+1 → 24 latent frames
+MAX_HEIGHT = 480
+MAX_WIDTH = 832
+TRAIN_FPS = 16.0
+
+DATA_DIR = "data/cosmos_overfit"
+OUTPUT_DIR = "data/cosmos25_overfit_preprocessed"
+MODEL_REPO = "KyleShao/Cosmos-Predict2.5-2B-Diffusers"
+# The VAE is architecturally identical to Cosmos Predict2;
+# use the Predict2 model for VAE since its weights are in
+# standard diffusers format.
+VAE_REPO = "nvidia/Cosmos-Predict2-2B-Video2World"
+
+
+def load_video(path: str, num_frames: int) -> torch.Tensor:
+    """Load video as [1, C, T, H, W] in [-1, 1]."""
+    cap = cv2.VideoCapture(path)
+    frames: list[np.ndarray] = []
+    while len(frames) < num_frames:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        frames.append(frame)
+    cap.release()
+
+    if len(frames) < num_frames:
+        while len(frames) < num_frames:
+            frames.append(frames[-1])
+
+    frames = frames[:num_frames]
+    video = np.stack(frames, axis=0)
+    video = torch.from_numpy(video).float()
+    video = video / 127.5 - 1.0  # [0,255] -> [-1,1]
+    video = video.permute(3, 0, 1, 2).unsqueeze(0)  # [1,C,T,H,W]
+    return video
+
+
+def main() -> None:
+    device = torch.device("cuda:0")
+    model_path = maybe_download_model(MODEL_REPO)
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    # Load captions
+    with open(os.path.join(DATA_DIR, "videos2caption.json")) as f:
+        caption_data = json.load(f)
+
+    # --- Load VAE (Wan-style, same arch for Cosmos 2 and 2.5) ---
+    print("Loading Cosmos VAE (AutoencoderKLWan)...")
+    vae_path = maybe_download_model(VAE_REPO)
+    from diffusers import AutoencoderKLWan
+    vae = AutoencoderKLWan.from_pretrained(
+        vae_path,
+        subfolder="vae",
+        torch_dtype=torch.float16,
+    ).to(device).eval()
+    print(
+        f"VAE loaded "
+        f"({sum(p.numel() for p in vae.parameters())/1e6:.0f}M)"
+    )
+
+    # --- Load Reason1 (Qwen2.5-VL) text encoder ---
+    print("Loading Reason1 text encoder...")
+    from fastvideo.configs.pipelines.cosmos2_5 import (
+        Cosmos25Config,
+    )
+    from fastvideo.models.encoders.reason1 import (
+        Reason1TextEncoder,
+    )
+    pipeline_cfg = Cosmos25Config()
+    text_enc_cfg = pipeline_cfg.text_encoder_configs[0]
+    text_enc_path = os.path.join(model_path, "text_encoder")
+
+    # Instantiate Reason1TextEncoder with config and checkpoint
+    text_encoder = Reason1TextEncoder(
+        text_enc_cfg,
+        checkpoint_path=text_enc_path,
+    )
+    # Load weights from safetensors into the meta-device model.
+    # Materialize empty tensors in bf16 on the target device,
+    # then overwrite with checkpoint weights.
+    text_encoder = text_encoder.to_empty(device=device)
+    text_encoder = text_encoder.to(torch.bfloat16)
+    import glob
+    from safetensors.torch import load_file
+    sd: dict[str, torch.Tensor] = {}
+    for sf in sorted(
+        glob.glob(os.path.join(text_enc_path, "*.safetensors"))
+    ):
+        sd.update(load_file(sf, device=str(device)))
+    sd = {k: v.to(torch.bfloat16) for k, v in sd.items()}
+    text_encoder.load_state_dict(sd, strict=False, assign=True)
+    del sd
+    torch.cuda.empty_cache()
+    text_encoder = text_encoder.eval()
+    print("Reason1 text encoder loaded")
+
+    # --- Process each video ---
+    records = []
+    for idx, item in enumerate(caption_data):
+        video_name = item["path"]
+        record_id = f"{idx:04d}_{video_name}"
+        caption = item["cap"][0]
+        video_path = os.path.join(DATA_DIR, "videos", video_name)
+
+        print(f"\nProcessing: {video_name}")
+        print(f"  Caption: {caption[:80]}...")
+
+        # Encode video
+        video = load_video(
+            video_path, NUM_FRAMES
+        ).to(device=device, dtype=torch.float16)
+        print(f"  Video shape: {video.shape}")
+
+        with torch.no_grad():
+            latent_dist = vae.encode(video).latent_dist
+            latent = latent_dist.mean.squeeze(0).float().cpu()
+        print(f"  Latent shape: {latent.shape}")
+
+        # Encode text with Reason1 (Qwen2.5-VL)
+        with torch.no_grad():
+            text_embedding = text_encoder.compute_text_embeddings(
+                [caption], device=device,
+            )
+            text_embedding = text_embedding.squeeze(0).float().cpu()
+        print(f"  Text embedding shape: {text_embedding.shape}")
+
+        record = {
+            "id": record_id,
+            "vae_latent_bytes": latent.numpy().tobytes(),
+            "vae_latent_shape": list(latent.shape),
+            "vae_latent_dtype": str(latent.dtype).replace(
+                "torch.", ""
+            ),
+            "text_embedding_bytes": (
+                text_embedding.numpy().tobytes()
+            ),
+            "text_embedding_shape": list(text_embedding.shape),
+            "text_embedding_dtype": str(
+                text_embedding.dtype
+            ).replace("torch.", ""),
+            "file_name": video_name,
+            "caption": caption,
+            "media_type": "video",
+            "width": MAX_WIDTH,
+            "height": MAX_HEIGHT,
+            "num_frames": NUM_FRAMES,
+            "duration_sec": NUM_FRAMES / TRAIN_FPS,
+            "fps": TRAIN_FPS,
+        }
+        records.append(record)
+
+    # Clean up
+    del text_encoder, vae
+    torch.cuda.empty_cache()
+
+    # Write parquet
+    table = pa.table(
+        {k: [r[k] for r in records] for k in records[0]},
+        schema=pyarrow_schema_t2v,
+    )
+    output_path = os.path.join(OUTPUT_DIR, "data_00000.parquet")
+    pq.write_table(table, output_path)
+    print(f"\nWrote {len(records)} records to {output_path}")
+
+    # Write T2W validation prompts (no image_path for T2W)
+    val_prompts = {
+        "data": [{
+            "caption": item["cap"][0],
+        } for item in caption_data],
+    }
+    val_path = os.path.join(OUTPUT_DIR, "validation_prompts.json")
+    with open(val_path, "w") as f:
+        json.dump(val_prompts, f, indent=2)
+    print(f"Wrote validation prompts to {val_path}")
+
+    print(
+        "\nDone! Use data_path: "
+        + OUTPUT_DIR
+        + " in training config."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/fastvideo/pipelines/preprocess/preprocess_cosmos25_overfit.py
+++ b/fastvideo/pipelines/preprocess/preprocess_cosmos25_overfit.py
@@ -78,19 +78,15 @@ def main() -> None:
         subfolder="vae",
         torch_dtype=torch.float16,
     ).to(device).eval()
-    print(
-        f"VAE loaded "
-        f"({sum(p.numel() for p in vae.parameters())/1e6:.0f}M)"
-    )
+    print(f"VAE loaded "
+          f"({sum(p.numel() for p in vae.parameters())/1e6:.0f}M)")
 
     # --- Load Reason1 (Qwen2.5-VL) text encoder ---
     print("Loading Reason1 text encoder...")
     from fastvideo.configs.pipelines.cosmos2_5 import (
-        Cosmos25Config,
-    )
+        Cosmos25Config, )
     from fastvideo.models.encoders.reason1 import (
-        Reason1TextEncoder,
-    )
+        Reason1TextEncoder, )
     pipeline_cfg = Cosmos25Config()
     text_enc_cfg = pipeline_cfg.text_encoder_configs[0]
     text_enc_path = os.path.join(model_path, "text_encoder")
@@ -108,9 +104,7 @@ def main() -> None:
     import glob
     from safetensors.torch import load_file
     sd: dict[str, torch.Tensor] = {}
-    for sf in sorted(
-        glob.glob(os.path.join(text_enc_path, "*.safetensors"))
-    ):
+    for sf in sorted(glob.glob(os.path.join(text_enc_path, "*.safetensors"))):
         sd.update(load_file(sf, device=str(device)))
     sd = {k: v.to(torch.bfloat16) for k, v in sd.items()}
     text_encoder.load_state_dict(sd, strict=False, assign=True)
@@ -131,9 +125,7 @@ def main() -> None:
         print(f"  Caption: {caption[:80]}...")
 
         # Encode video
-        video = load_video(
-            video_path, NUM_FRAMES
-        ).to(device=device, dtype=torch.float16)
+        video = load_video(video_path, NUM_FRAMES).to(device=device, dtype=torch.float16)
         print(f"  Video shape: {video.shape}")
 
         with torch.no_grad():
@@ -144,7 +136,8 @@ def main() -> None:
         # Encode text with Reason1 (Qwen2.5-VL)
         with torch.no_grad():
             text_embedding = text_encoder.compute_text_embeddings(
-                [caption], device=device,
+                [caption],
+                device=device,
             )
             text_embedding = text_embedding.squeeze(0).float().cpu()
         print(f"  Text embedding shape: {text_embedding.shape}")
@@ -153,16 +146,10 @@ def main() -> None:
             "id": record_id,
             "vae_latent_bytes": latent.numpy().tobytes(),
             "vae_latent_shape": list(latent.shape),
-            "vae_latent_dtype": str(latent.dtype).replace(
-                "torch.", ""
-            ),
-            "text_embedding_bytes": (
-                text_embedding.numpy().tobytes()
-            ),
+            "vae_latent_dtype": str(latent.dtype).replace("torch.", ""),
+            "text_embedding_bytes": (text_embedding.numpy().tobytes()),
             "text_embedding_shape": list(text_embedding.shape),
-            "text_embedding_dtype": str(
-                text_embedding.dtype
-            ).replace("torch.", ""),
+            "text_embedding_dtype": str(text_embedding.dtype).replace("torch.", ""),
             "file_name": video_name,
             "caption": caption,
             "media_type": "video",
@@ -180,7 +167,8 @@ def main() -> None:
 
     # Write parquet
     table = pa.table(
-        {k: [r[k] for r in records] for k in records[0]},
+        {k: [r[k] for r in records]
+         for k in records[0]},
         schema=pyarrow_schema_t2v,
     )
     output_path = os.path.join(OUTPUT_DIR, "data_00000.parquet")
@@ -198,11 +186,7 @@ def main() -> None:
         json.dump(val_prompts, f, indent=2)
     print(f"Wrote validation prompts to {val_path}")
 
-    print(
-        "\nDone! Use data_path: "
-        + OUTPUT_DIR
-        + " in training config."
-    )
+    print("\nDone! Use data_path: " + OUTPUT_DIR + " in training config.")
 
 
 if __name__ == "__main__":

--- a/fastvideo/pipelines/preprocess/preprocess_cosmos_overfit.py
+++ b/fastvideo/pipelines/preprocess/preprocess_cosmos_overfit.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Preprocess Cosmos-Predict2 overfit data into parquet format.
+
+Encodes videos with the Cosmos (Wan-style) VAE and captions with the
+single T5 Large text encoder into the t2v parquet schema expected by
+the training framework.
+
+Usage:
+    CUDA_VISIBLE_DEVICES=0 python fastvideo/pipelines/preprocess/preprocess_cosmos_overfit.py
+"""
+
+import json
+import os
+
+import cv2
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import torch
+
+from fastvideo.configs.models.encoders import T5LargeConfig
+from fastvideo.configs.models.encoders.base import BaseEncoderOutput
+from fastvideo.configs.pipelines.cosmos import t5_large_postprocess_text
+from fastvideo.dataset.dataloader.schema import pyarrow_schema_t2v
+from fastvideo.utils import maybe_download_model
+
+# --- Config ---
+NUM_FRAMES = 93  # 4*23+1 for temporal compression ratio 4 -> 24 latent frames
+MAX_HEIGHT = 480
+MAX_WIDTH = 832
+TRAIN_FPS = 16.0
+
+DATA_DIR = "data/cosmos_overfit"
+OUTPUT_DIR = "data/cosmos_overfit_preprocessed"
+MODEL_REPO = "nvidia/Cosmos-Predict2-2B-Video2World"
+
+
+def load_video(path: str, num_frames: int) -> torch.Tensor:
+    """Load video as [1, C, T, H, W] in [-1, 1]."""
+    cap = cv2.VideoCapture(path)
+    frames: list[np.ndarray] = []
+    while len(frames) < num_frames:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        frames.append(frame)
+    cap.release()
+
+    if len(frames) < num_frames:
+        # Repeat last frame to fill
+        while len(frames) < num_frames:
+            frames.append(frames[-1])
+
+    frames = frames[:num_frames]
+    video = np.stack(frames, axis=0)
+    video = torch.from_numpy(video).float()
+    video = video / 127.5 - 1.0  # [0,255] -> [-1,1]
+    video = video.permute(3, 0, 1, 2).unsqueeze(0)  # [1,C,T,H,W]
+    return video
+
+
+def main() -> None:
+    device = torch.device("cuda:0")
+    model_path = maybe_download_model(MODEL_REPO)
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    # Load captions
+    with open(os.path.join(DATA_DIR, "videos2caption.json")) as f:
+        caption_data = json.load(f)
+
+    # --- Load VAE ---
+    # Cosmos-Predict2-2B ships a Wan-style VAE; vae/config.json declares
+    # `_class_name: AutoencoderKLWan`, so diffusers can load it directly.
+    print("Loading Cosmos VAE (AutoencoderKLWan)...")
+    from diffusers import AutoencoderKLWan
+    vae = AutoencoderKLWan.from_pretrained(
+        model_path,
+        subfolder="vae",
+        torch_dtype=torch.float16,
+    ).to(device).eval()
+    print(f"VAE loaded ({sum(p.numel() for p in vae.parameters())/1e6:.0f}M)")
+
+    # --- Load T5 Large text encoder ---
+    print("Loading T5 Large text encoder...")
+    from transformers import AutoTokenizer, T5EncoderModel
+
+    t5_cfg = T5LargeConfig()
+    tok_kwargs = dict(t5_cfg.tokenizer_kwargs)
+    tokenizer = AutoTokenizer.from_pretrained(
+        os.path.join(model_path, "tokenizer"))
+    text_encoder = T5EncoderModel.from_pretrained(
+        os.path.join(model_path, "text_encoder"),
+        torch_dtype=torch.bfloat16,
+    ).to(device).eval()
+
+    # --- Process each video ---
+    records = []
+    for idx, item in enumerate(caption_data):
+        video_name = item["path"]
+        record_id = f"{idx:04d}_{video_name}"
+        caption = item["cap"][0]
+        video_path = os.path.join(DATA_DIR, "videos", video_name)
+
+        print(f"\nProcessing: {video_name}")
+        print(f"  Caption: {caption[:80]}...")
+
+        # Encode video
+        video = load_video(video_path,
+                           NUM_FRAMES).to(device=device, dtype=torch.float16)
+        print(f"  Video shape: {video.shape}")
+
+        with torch.no_grad():
+            latent_dist = vae.encode(video).latent_dist
+            # Cast to fp32 — dataloader hardcodes np.float32
+            latent = latent_dist.mean.squeeze(0).float().cpu()
+        print(f"  Latent shape: {latent.shape}")
+
+        # Encode text with T5
+        with torch.no_grad():
+            inputs = tokenizer(caption, **tok_kwargs).to(device)
+            outputs = text_encoder(**inputs)
+            enc_out = BaseEncoderOutput(
+                last_hidden_state=outputs.last_hidden_state,
+                attention_mask=inputs["attention_mask"],
+            )
+            # [1, max_len, 1024], zeros beyond real length
+            t5_embed = t5_large_postprocess_text(enc_out).squeeze(0)
+            # Trim to real sequence length so dataloader's pad() builds
+            # the correct attention mask.
+            real_len = int(inputs["attention_mask"].sum().item())
+            text_embedding = t5_embed[:real_len].float().cpu()  # [seq, 1024]
+        print(f"  Text embedding shape: {text_embedding.shape}")
+
+        record = {
+            "id": record_id,
+            "vae_latent_bytes": latent.numpy().tobytes(),
+            "vae_latent_shape": list(latent.shape),
+            "vae_latent_dtype": str(latent.dtype).replace("torch.", ""),
+            "text_embedding_bytes": text_embedding.numpy().tobytes(),
+            "text_embedding_shape": list(text_embedding.shape),
+            "text_embedding_dtype": str(text_embedding.dtype).replace(
+                "torch.", ""),
+            "file_name": video_name,
+            "caption": caption,
+            "media_type": "video",
+            "width": MAX_WIDTH,
+            "height": MAX_HEIGHT,
+            "num_frames": NUM_FRAMES,
+            "duration_sec": NUM_FRAMES / TRAIN_FPS,
+            "fps": TRAIN_FPS,
+        }
+        records.append(record)
+
+    # Clean up encoders
+    del text_encoder, tokenizer, vae
+
+    # Write parquet
+    table = pa.table(
+        {k: [r[k] for r in records]
+         for k in records[0]},
+        schema=pyarrow_schema_t2v,
+    )
+    output_path = os.path.join(OUTPUT_DIR, "data_00000.parquet")
+    pq.write_table(table, output_path)
+    print(f"\nWrote {len(records)} records to {output_path}")
+
+    # Extract first frame from first video as V2W conditioning image
+    import cv2
+    first_video = os.path.join(
+        DATA_DIR, "videos", caption_data[0]["path"])
+    cap = cv2.VideoCapture(first_video)
+    ret, frame = cap.read()
+    cap.release()
+    cond_frame_path = os.path.join(OUTPUT_DIR, "cond_frame.png")
+    if ret:
+        cv2.imwrite(cond_frame_path, frame)
+        print(f"Saved conditioning frame to {cond_frame_path}")
+
+    # Write validation prompts for callback
+    # Wrap in "data" key — ValidationDataset expects field="data"
+    # Use "caption" field — ValidationDataset aliases it to "prompt"
+    # Include image_path for V2W conditioning during validation
+    val_prompts = {
+        "data": [{
+            "caption": item["cap"][0],
+            "image_path": "cond_frame.png",
+        } for item in caption_data]
+    }
+    val_path = os.path.join(OUTPUT_DIR, "validation_prompts.json")
+    with open(val_path, "w") as f:
+        json.dump(val_prompts, f, indent=2)
+    print(f"Wrote validation prompts to {val_path}")
+
+    print("\nDone! Use data_path: " + OUTPUT_DIR + " in training config.")
+
+
+if __name__ == "__main__":
+    main()

--- a/fastvideo/pipelines/preprocess/preprocess_cosmos_overfit.py
+++ b/fastvideo/pipelines/preprocess/preprocess_cosmos_overfit.py
@@ -88,8 +88,7 @@ def main() -> None:
 
     t5_cfg = T5LargeConfig()
     tok_kwargs = dict(t5_cfg.tokenizer_kwargs)
-    tokenizer = AutoTokenizer.from_pretrained(
-        os.path.join(model_path, "tokenizer"))
+    tokenizer = AutoTokenizer.from_pretrained(os.path.join(model_path, "tokenizer"))
     text_encoder = T5EncoderModel.from_pretrained(
         os.path.join(model_path, "text_encoder"),
         torch_dtype=torch.bfloat16,
@@ -107,8 +106,7 @@ def main() -> None:
         print(f"  Caption: {caption[:80]}...")
 
         # Encode video
-        video = load_video(video_path,
-                           NUM_FRAMES).to(device=device, dtype=torch.float16)
+        video = load_video(video_path, NUM_FRAMES).to(device=device, dtype=torch.float16)
         print(f"  Video shape: {video.shape}")
 
         with torch.no_grad():
@@ -140,8 +138,7 @@ def main() -> None:
             "vae_latent_dtype": str(latent.dtype).replace("torch.", ""),
             "text_embedding_bytes": text_embedding.numpy().tobytes(),
             "text_embedding_shape": list(text_embedding.shape),
-            "text_embedding_dtype": str(text_embedding.dtype).replace(
-                "torch.", ""),
+            "text_embedding_dtype": str(text_embedding.dtype).replace("torch.", ""),
             "file_name": video_name,
             "caption": caption,
             "media_type": "video",
@@ -168,8 +165,7 @@ def main() -> None:
 
     # Extract first frame from first video as V2W conditioning image
     import cv2
-    first_video = os.path.join(
-        DATA_DIR, "videos", caption_data[0]["path"])
+    first_video = os.path.join(DATA_DIR, "videos", caption_data[0]["path"])
     cap = cv2.VideoCapture(first_video)
     ret, frame = cap.read()
     cap.release()

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -540,16 +540,14 @@ class CosmosDenoisingStage(DenoisingStage):
         batch: ForwardBatch,
     ) -> torch.Tensor:
         with set_forward_context(
-            current_timestep=step_index,
-            attn_metadata=None,
-            forward_batch=batch,
+                current_timestep=step_index,
+                attn_metadata=None,
+                forward_batch=batch,
         ):
             return self.transformer(
                 hidden_states=hidden_states.to(target_dtype),
                 timestep=timestep.to(target_dtype),
-                encoder_hidden_states=encoder_hidden_states.to(
-                    target_dtype
-                ),
+                encoder_hidden_states=encoder_hidden_states.to(target_dtype),
                 fps=24,
                 condition_mask=condition_mask,
                 padding_mask=padding_mask,
@@ -573,149 +571,109 @@ class CosmosDenoisingStage(DenoisingStage):
             fastvideo_args.model_loaded["transformer"] = True
 
         if hasattr(self.transformer, "module"):
-            transformer_dtype = next(
-                self.transformer.module.parameters()
-            ).dtype
+            transformer_dtype = next(self.transformer.module.parameters()).dtype
         else:
-            transformer_dtype = next(
-                self.transformer.parameters()
-            ).dtype
+            transformer_dtype = next(self.transformer.parameters()).dtype
         target_dtype = transformer_dtype
-        autocast_enabled = (
-            target_dtype != torch.float32
-            and not fastvideo_args.disable_autocast
-        )
+        autocast_enabled = (target_dtype != torch.float32 and not fastvideo_args.disable_autocast)
 
         latents = batch.latents
         num_inference_steps = batch.num_inference_steps
         guidance_scale = batch.guidance_scale
-        do_cfg = (
-            batch.do_classifier_free_guidance
-            and batch.negative_prompt_embeds is not None
-        )
+        do_cfg = (batch.do_classifier_free_guidance and batch.negative_prompt_embeds is not None)
 
-        sigma_data = float(
-            getattr(self.scheduler.config, "sigma_data", 1.0)
-        )
+        sigma_data = float(getattr(self.scheduler.config, "sigma_data", 1.0))
 
         self.scheduler.set_timesteps(
-            num_inference_steps, device=latents.device,
+            num_inference_steps,
+            device=latents.device,
         )
         timesteps = self.scheduler.timesteps
 
         # Clamp terminal sigma to sigma_min (avoid zero).
-        if (
-            hasattr(self.scheduler.config, "final_sigmas_type")
-            and self.scheduler.config.final_sigmas_type
-            == "sigma_min"
-            and len(self.scheduler.sigmas) > 1
-        ):
+        if (hasattr(self.scheduler.config, "final_sigmas_type")
+                and self.scheduler.config.final_sigmas_type == "sigma_min" and len(self.scheduler.sigmas) > 1):
             self.scheduler.sigmas[-1] = self.scheduler.sigmas[-2]
 
         conditioning_latents = getattr(
-            batch, "conditioning_latents", None,
+            batch,
+            "conditioning_latents",
+            None,
         )
         cond_indicator = getattr(batch, "cond_indicator", None)
         uncond_indicator = getattr(
-            batch, "uncond_indicator", None,
+            batch,
+            "uncond_indicator",
+            None,
         )
 
         augment_sigma = torch.tensor(
-            [0.001], device=latents.device, dtype=torch.float32,
+            [0.001],
+            device=latents.device,
+            dtype=torch.float32,
         )
 
         padding_mask = torch.zeros(
-            1, 1, batch.height, batch.width,
-            device=latents.device, dtype=target_dtype,
+            1,
+            1,
+            batch.height,
+            batch.width,
+            device=latents.device,
+            dtype=target_dtype,
         )
 
-        condition_mask = (
-            batch.cond_mask.to(target_dtype)
-            if hasattr(batch, "cond_mask")
-            and batch.cond_mask is not None
-            else None
-        )
-        uncond_condition_mask = (
-            batch.uncond_mask.to(target_dtype)
-            if hasattr(batch, "uncond_mask")
-            and batch.uncond_mask is not None
-            else condition_mask
-        )
+        condition_mask = (batch.cond_mask.to(target_dtype)
+                          if hasattr(batch, "cond_mask") and batch.cond_mask is not None else None)
+        uncond_condition_mask = (batch.uncond_mask.to(target_dtype)
+                                 if hasattr(batch, "uncond_mask") and batch.uncond_mask is not None else condition_mask)
         if condition_mask is None:
             b, c, tf, h, w = latents.shape
             condition_mask = torch.zeros(
-                b, 1, tf, h, w,
-                device=latents.device, dtype=target_dtype,
+                b,
+                1,
+                tf,
+                h,
+                w,
+                device=latents.device,
+                dtype=target_dtype,
             )
             uncond_condition_mask = condition_mask
 
-        with self.progress_bar(
-            total=num_inference_steps,
-        ) as progress_bar:
+        with self.progress_bar(total=num_inference_steps, ) as progress_bar:
             for i, t in enumerate(timesteps):
                 if hasattr(self, "interrupt") and self.interrupt:
                     continue
 
                 sigma = self.scheduler.sigmas[i]
-                is_aug_greater = bool(
-                    augment_sigma >= sigma
-                )
+                is_aug_greater = bool(augment_sigma >= sigma)
 
                 # EDM preconditioning coefficients.
-                c_in = 1.0 / (
-                    sigma**2 + sigma_data**2
-                ) ** 0.5
-                c_in_aug = 1.0 / (
-                    augment_sigma**2 + sigma_data**2
-                ) ** 0.5
-                c_skip = sigma_data**2 / (
-                    sigma**2 + sigma_data**2
-                )
-                c_out = (
-                    sigma
-                    * sigma_data
-                    / (sigma**2 + sigma_data**2) ** 0.5
-                )
+                c_in = 1.0 / (sigma**2 + sigma_data**2)**0.5
+                c_in_aug = 1.0 / (augment_sigma**2 + sigma_data**2)**0.5
+                c_skip = sigma_data**2 / (sigma**2 + sigma_data**2)
+                c_out = (sigma * sigma_data / (sigma**2 + sigma_data**2)**0.5)
 
                 # The model expects timestep = sigma * 1000
                 # (FlowMatchEulerDiscreteScheduler convention).
-                timestep_expanded = t.expand(
-                    latents.shape[0],
-                ).to(target_dtype)
+                timestep_expanded = t.expand(latents.shape[0], ).to(target_dtype)
 
                 with torch.autocast(
-                    device_type="cuda",
-                    dtype=target_dtype,
-                    enabled=autocast_enabled,
+                        device_type="cuda",
+                        dtype=target_dtype,
+                        enabled=autocast_enabled,
                 ):
                     # --- Conditioning frame injection ---
-                    cur_ci = (
-                        cond_indicator * 0
-                        if cond_indicator is not None
-                        and is_aug_greater
-                        else cond_indicator
-                    )
+                    cur_ci = (cond_indicator * 0 if cond_indicator is not None and is_aug_greater else cond_indicator)
 
                     cond_latent = latents.clone()
-                    if (
-                        cur_ci is not None
-                        and conditioning_latents is not None
-                    ):
+                    if (cur_ci is not None and conditioning_latents is not None):
                         cn = torch.randn_like(
-                            latents, dtype=torch.float32,
+                            latents,
+                            dtype=torch.float32,
                         )
-                        cf = (
-                            conditioning_latents
-                            + cn
-                            * augment_sigma[
-                                :, None, None, None, None
-                            ]
-                        )
+                        cf = (conditioning_latents + cn * augment_sigma[:, None, None, None, None])
                         cf = cf * c_in_aug / c_in
-                        cond_latent = (
-                            cur_ci * cf
-                            + (1 - cur_ci) * cond_latent
-                        )
+                        cond_latent = (cur_ci * cf + (1 - cur_ci) * cond_latent)
 
                     # Manual EDM input scaling.
                     model_input = cond_latent * c_in
@@ -732,93 +690,54 @@ class CosmosDenoisingStage(DenoisingStage):
                     )
 
                     # EDM output → x0 prediction.
-                    cond_x0 = (
-                        c_skip * latents
-                        + c_out * noise_pred_cond.float()
-                    )
-                    if (
-                        cur_ci is not None
-                        and conditioning_latents is not None
-                    ):
-                        cond_x0 = (
-                            cur_ci * conditioning_latents
-                            + (1 - cur_ci) * cond_x0
-                        )
+                    cond_x0 = (c_skip * latents + c_out * noise_pred_cond.float())
+                    if (cur_ci is not None and conditioning_latents is not None):
+                        cond_x0 = (cur_ci * conditioning_latents + (1 - cur_ci) * cond_x0)
 
                     # --- CFG: unconditional pass ---
                     if do_cfg:
-                        cur_ui = (
-                            uncond_indicator * 0
-                            if uncond_indicator is not None
-                            and is_aug_greater
-                            else uncond_indicator
-                        )
+                        cur_ui = (uncond_indicator *
+                                  0 if uncond_indicator is not None and is_aug_greater else uncond_indicator)
 
                         uncond_latent = latents.clone()
-                        if (
-                            cur_ui is not None
-                            and conditioning_latents is not None
-                        ):
+                        if (cur_ui is not None and conditioning_latents is not None):
                             un = torch.randn_like(
-                                latents, dtype=torch.float32,
+                                latents,
+                                dtype=torch.float32,
                             )
-                            uf = (
-                                conditioning_latents
-                                + un
-                                * augment_sigma[
-                                    :, None, None, None, None
-                                ]
-                            )
+                            uf = (conditioning_latents + un * augment_sigma[:, None, None, None, None])
                             uf = uf * c_in_aug / c_in
-                            uncond_latent = (
-                                cur_ui * uf
-                                + (1 - cur_ui) * uncond_latent
-                            )
+                            uncond_latent = (cur_ui * uf + (1 - cur_ui) * uncond_latent)
 
                         uncond_input = uncond_latent * c_in
 
-                        noise_pred_uncond = (
-                            self._run_transformer(
-                                uncond_input,
-                                timestep_expanded,
-                                batch.negative_prompt_embeds[0],
-                                uncond_condition_mask,
-                                padding_mask,
-                                target_dtype,
-                                i,
-                                batch,
-                            )
-                        )
+                        noise_pred_uncond = (self._run_transformer(
+                            uncond_input,
+                            timestep_expanded,
+                            batch.negative_prompt_embeds[0],
+                            uncond_condition_mask,
+                            padding_mask,
+                            target_dtype,
+                            i,
+                            batch,
+                        ))
 
-                        uncond_x0 = (
-                            c_skip * latents
-                            + c_out * noise_pred_uncond.float()
-                        )
-                        if (
-                            cur_ui is not None
-                            and conditioning_latents is not None
-                        ):
-                            uncond_x0 = (
-                                cur_ui * conditioning_latents
-                                + (1 - cur_ui) * uncond_x0
-                            )
+                        uncond_x0 = (c_skip * latents + c_out * noise_pred_uncond.float())
+                        if (cur_ui is not None and conditioning_latents is not None):
+                            uncond_x0 = (cur_ui * conditioning_latents + (1 - cur_ui) * uncond_x0)
 
-                        final_x0 = (
-                            cond_x0
-                            + guidance_scale
-                            * (cond_x0 - uncond_x0)
-                        )
+                        final_x0 = (cond_x0 + guidance_scale * (cond_x0 - uncond_x0))
                     else:
                         final_x0 = cond_x0
 
                 # Convert x0 to velocity for
                 # FlowMatchEulerDiscreteScheduler.
-                velocity = (
-                    latents - final_x0
-                ) / sigma.clamp(min=1e-6)
+                velocity = (latents - final_x0) / sigma.clamp(min=1e-6)
 
                 latents = self.scheduler.step(
-                    velocity, t, latents,
+                    velocity,
+                    t,
+                    latents,
                     return_dict=False,
                 )[0]
 
@@ -879,16 +798,12 @@ class Cosmos25DenoisingStage(CosmosDenoisingStage):
             if p.dtype != torch.float32:
                 target_dtype = p.dtype
                 break
-        autocast_enabled = (
-            target_dtype != torch.float32
-        ) and not fastvideo_args.disable_autocast
+        autocast_enabled = (target_dtype != torch.float32) and not fastvideo_args.disable_autocast
 
         latents = batch.latents
         if latents is None:
-            raise ValueError(
-                "latents must be provided for "
-                "Cosmos25DenoisingStage"
-            )
+            raise ValueError("latents must be provided for "
+                             "Cosmos25DenoisingStage")
         guidance_scale = batch.guidance_scale
 
         if batch.timesteps is None:

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -518,12 +518,43 @@ class DenoisingStage(PipelineStage):
 
 
 class CosmosDenoisingStage(DenoisingStage):
-    """
-    Denoising stage for Cosmos models using FlowMatchEulerDiscreteScheduler.
+    """Denoising stage for Cosmos models.
+
+    Uses FlowMatchEulerDiscreteScheduler with manual EDM
+    preconditioning (c_in, c_skip, c_out) to match the
+    pretrained Cosmos model's training convention.
     """
 
     def __init__(self, transformer, scheduler, pipeline=None) -> None:
         super().__init__(transformer, scheduler, pipeline)
+
+    def _run_transformer(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        condition_mask: torch.Tensor,
+        padding_mask: torch.Tensor,
+        target_dtype: torch.dtype,
+        step_index: int,
+        batch: ForwardBatch,
+    ) -> torch.Tensor:
+        with set_forward_context(
+            current_timestep=step_index,
+            attn_metadata=None,
+            forward_batch=batch,
+        ):
+            return self.transformer(
+                hidden_states=hidden_states.to(target_dtype),
+                timestep=timestep.to(target_dtype),
+                encoder_hidden_states=encoder_hidden_states.to(
+                    target_dtype
+                ),
+                fps=24,
+                condition_mask=condition_mask,
+                padding_mask=padding_mask,
+                return_dict=False,
+            )[0]
 
     def forward(
         self,
@@ -533,199 +564,267 @@ class CosmosDenoisingStage(DenoisingStage):
         pipeline = self.pipeline() if self.pipeline else None
         if not fastvideo_args.model_loaded["transformer"]:
             loader = TransformerLoader()
-            self.transformer = loader.load(fastvideo_args.model_paths["transformer"], fastvideo_args)
+            self.transformer = loader.load(
+                fastvideo_args.model_paths["transformer"],
+                fastvideo_args,
+            )
             if pipeline:
                 pipeline.add_module("transformer", self.transformer)
             fastvideo_args.model_loaded["transformer"] = True
 
-        extra_step_kwargs = self.prepare_extra_func_kwargs(
-            self.scheduler.step,
-            {
-                "generator": batch.generator,
-                "eta": batch.eta
-            },
-        )
-
-        if hasattr(self.transformer, 'module'):
-            transformer_dtype = next(self.transformer.module.parameters()).dtype
+        if hasattr(self.transformer, "module"):
+            transformer_dtype = next(
+                self.transformer.module.parameters()
+            ).dtype
         else:
-            transformer_dtype = next(self.transformer.parameters()).dtype
+            transformer_dtype = next(
+                self.transformer.parameters()
+            ).dtype
         target_dtype = transformer_dtype
-        autocast_enabled = (target_dtype != torch.float32) and not fastvideo_args.disable_autocast
+        autocast_enabled = (
+            target_dtype != torch.float32
+            and not fastvideo_args.disable_autocast
+        )
 
         latents = batch.latents
         num_inference_steps = batch.num_inference_steps
         guidance_scale = batch.guidance_scale
+        do_cfg = (
+            batch.do_classifier_free_guidance
+            and batch.negative_prompt_embeds is not None
+        )
 
-        sigma_max = 80.0
-        sigma_min = 0.002
-        sigma_data = 1.0
-        final_sigmas_type = "sigma_min"
+        sigma_data = float(
+            getattr(self.scheduler.config, "sigma_data", 1.0)
+        )
 
-        if self.scheduler is not None:
-            self.scheduler.register_to_config(
-                sigma_max=sigma_max,
-                sigma_min=sigma_min,
-                sigma_data=sigma_data,
-                final_sigmas_type=final_sigmas_type,
-            )
-
-        self.scheduler.set_timesteps(num_inference_steps, device=latents.device)
+        self.scheduler.set_timesteps(
+            num_inference_steps, device=latents.device,
+        )
         timesteps = self.scheduler.timesteps
 
-        if (hasattr(self.scheduler.config, 'final_sigmas_type')
-                and self.scheduler.config.final_sigmas_type == "sigma_min" and len(self.scheduler.sigmas) > 1):
+        # Clamp terminal sigma to sigma_min (avoid zero).
+        if (
+            hasattr(self.scheduler.config, "final_sigmas_type")
+            and self.scheduler.config.final_sigmas_type
+            == "sigma_min"
+            and len(self.scheduler.sigmas) > 1
+        ):
             self.scheduler.sigmas[-1] = self.scheduler.sigmas[-2]
 
-        conditioning_latents = getattr(batch, 'conditioning_latents', None)
-        unconditioning_latents = conditioning_latents
+        conditioning_latents = getattr(
+            batch, "conditioning_latents", None,
+        )
+        cond_indicator = getattr(batch, "cond_indicator", None)
+        uncond_indicator = getattr(
+            batch, "uncond_indicator", None,
+        )
 
-        with self.progress_bar(total=num_inference_steps) as progress_bar:
+        augment_sigma = torch.tensor(
+            [0.001], device=latents.device, dtype=torch.float32,
+        )
+
+        padding_mask = torch.zeros(
+            1, 1, batch.height, batch.width,
+            device=latents.device, dtype=target_dtype,
+        )
+
+        condition_mask = (
+            batch.cond_mask.to(target_dtype)
+            if hasattr(batch, "cond_mask")
+            and batch.cond_mask is not None
+            else None
+        )
+        uncond_condition_mask = (
+            batch.uncond_mask.to(target_dtype)
+            if hasattr(batch, "uncond_mask")
+            and batch.uncond_mask is not None
+            else condition_mask
+        )
+        if condition_mask is None:
+            b, c, tf, h, w = latents.shape
+            condition_mask = torch.zeros(
+                b, 1, tf, h, w,
+                device=latents.device, dtype=target_dtype,
+            )
+            uncond_condition_mask = condition_mask
+
+        with self.progress_bar(
+            total=num_inference_steps,
+        ) as progress_bar:
             for i, t in enumerate(timesteps):
-                if hasattr(self, 'interrupt') and self.interrupt:
+                if hasattr(self, "interrupt") and self.interrupt:
                     continue
 
-                current_sigma = self.scheduler.sigmas[i]
-                current_t = current_sigma / (current_sigma + 1)
-                c_in = 1 - current_t
-                c_skip = 1 - current_t
-                c_out = -current_t
+                sigma = self.scheduler.sigmas[i]
+                is_aug_greater = bool(
+                    augment_sigma >= sigma
+                )
 
-                timestep = current_t.view(1, 1, 1, 1, 1).expand(latents.size(0), -1, latents.size(2), -1,
-                                                                -1)  # [B, 1, T, 1, 1]
+                # EDM preconditioning coefficients.
+                c_in = 1.0 / (
+                    sigma**2 + sigma_data**2
+                ) ** 0.5
+                c_in_aug = 1.0 / (
+                    augment_sigma**2 + sigma_data**2
+                ) ** 0.5
+                c_skip = sigma_data**2 / (
+                    sigma**2 + sigma_data**2
+                )
+                c_out = (
+                    sigma
+                    * sigma_data
+                    / (sigma**2 + sigma_data**2) ** 0.5
+                )
 
-                with torch.autocast(device_type="cuda", dtype=target_dtype, enabled=autocast_enabled):
+                # The model expects timestep = sigma * 1000
+                # (FlowMatchEulerDiscreteScheduler convention).
+                timestep_expanded = t.expand(
+                    latents.shape[0],
+                ).to(target_dtype)
 
-                    cond_latent = latents * c_in
+                with torch.autocast(
+                    device_type="cuda",
+                    dtype=target_dtype,
+                    enabled=autocast_enabled,
+                ):
+                    # --- Conditioning frame injection ---
+                    cur_ci = (
+                        cond_indicator * 0
+                        if cond_indicator is not None
+                        and is_aug_greater
+                        else cond_indicator
+                    )
 
-                    if hasattr(
-                            batch,
-                            'cond_indicator') and batch.cond_indicator is not None and conditioning_latents is not None:
-                        cond_latent = batch.cond_indicator * conditioning_latents + (1 -
-                                                                                     batch.cond_indicator) * cond_latent
-                    else:
-                        logger.warning(
-                            "Step %s: Missing conditioning data - cond_indicator: %s, conditioning_latents: %s", i,
-                            hasattr(batch, 'cond_indicator'), conditioning_latents is not None)
-
-                    cond_latent = cond_latent.to(target_dtype)
-
-                    cond_timestep = timestep
-                    if hasattr(batch, 'cond_indicator') and batch.cond_indicator is not None:
-                        sigma_conditioning = 0.0001
-                        t_conditioning = sigma_conditioning / (sigma_conditioning + 1)
-                        cond_timestep = batch.cond_indicator * t_conditioning + (1 - batch.cond_indicator) * timestep
-                        cond_timestep = cond_timestep.to(target_dtype)
-
-                    with set_forward_context(
-                            current_timestep=i,
-                            attn_metadata=None,
-                            forward_batch=batch,
+                    cond_latent = latents.clone()
+                    if (
+                        cur_ci is not None
+                        and conditioning_latents is not None
                     ):
-                        # Use conditioning masks from CosmosLatentPreparationStage
-                        condition_mask = batch.cond_mask.to(target_dtype) if hasattr(batch, 'cond_mask') else None
-                        padding_mask = torch.zeros(1,
-                                                   1,
-                                                   batch.height,
-                                                   batch.width,
-                                                   device=cond_latent.device,
-                                                   dtype=target_dtype)
+                        cn = torch.randn_like(
+                            latents, dtype=torch.float32,
+                        )
+                        cf = (
+                            conditioning_latents
+                            + cn
+                            * augment_sigma[
+                                :, None, None, None, None
+                            ]
+                        )
+                        cf = cf * c_in_aug / c_in
+                        cond_latent = (
+                            cur_ci * cf
+                            + (1 - cur_ci) * cond_latent
+                        )
 
-                        # Fallback if masks not available
-                        if condition_mask is None:
-                            batch_size, num_channels, num_frames, height, width = cond_latent.shape
-                            condition_mask = torch.zeros(batch_size,
-                                                         1,
-                                                         num_frames,
-                                                         height,
-                                                         width,
-                                                         device=cond_latent.device,
-                                                         dtype=target_dtype)
+                    # Manual EDM input scaling.
+                    model_input = cond_latent * c_in
 
-                        noise_pred = self.transformer(
-                            hidden_states=cond_latent,
-                            timestep=cond_timestep.to(target_dtype),
-                            encoder_hidden_states=batch.prompt_embeds[0].to(target_dtype),
-                            fps=24,  # TODO: get fps from batch or config
-                            condition_mask=condition_mask,
-                            padding_mask=padding_mask,
-                            return_dict=False,
-                        )[0]
+                    noise_pred_cond = self._run_transformer(
+                        model_input,
+                        timestep_expanded,
+                        batch.prompt_embeds[0],
+                        condition_mask,
+                        padding_mask,
+                        target_dtype,
+                        i,
+                        batch,
+                    )
 
-                    cond_pred = (c_skip * latents + c_out * noise_pred.float()).to(target_dtype)
+                    # EDM output → x0 prediction.
+                    cond_x0 = (
+                        c_skip * latents
+                        + c_out * noise_pred_cond.float()
+                    )
+                    if (
+                        cur_ci is not None
+                        and conditioning_latents is not None
+                    ):
+                        cond_x0 = (
+                            cur_ci * conditioning_latents
+                            + (1 - cur_ci) * cond_x0
+                        )
 
-                    if hasattr(
-                            batch,
-                            'cond_indicator') and batch.cond_indicator is not None and conditioning_latents is not None:
-                        cond_pred = batch.cond_indicator * conditioning_latents + (1 - batch.cond_indicator) * cond_pred
+                    # --- CFG: unconditional pass ---
+                    if do_cfg:
+                        cur_ui = (
+                            uncond_indicator * 0
+                            if uncond_indicator is not None
+                            and is_aug_greater
+                            else uncond_indicator
+                        )
 
-                    if batch.do_classifier_free_guidance and batch.negative_prompt_embeds is not None:
-                        uncond_latent = latents * c_in
-
-                        if hasattr(batch, 'uncond_indicator'
-                                   ) and batch.uncond_indicator is not None and unconditioning_latents is not None:
-                            uncond_latent = batch.uncond_indicator * unconditioning_latents + (
-                                1 - batch.uncond_indicator) * uncond_latent
-
-                        with set_forward_context(
-                                current_timestep=i,
-                                attn_metadata=None,
-                                forward_batch=batch,
+                        uncond_latent = latents.clone()
+                        if (
+                            cur_ui is not None
+                            and conditioning_latents is not None
                         ):
-                            uncond_condition_mask = batch.uncond_mask.to(target_dtype) if hasattr(
-                                batch, 'uncond_mask') and batch.uncond_mask is not None else condition_mask
+                            un = torch.randn_like(
+                                latents, dtype=torch.float32,
+                            )
+                            uf = (
+                                conditioning_latents
+                                + un
+                                * augment_sigma[
+                                    :, None, None, None, None
+                                ]
+                            )
+                            uf = uf * c_in_aug / c_in
+                            uncond_latent = (
+                                cur_ui * uf
+                                + (1 - cur_ui) * uncond_latent
+                            )
 
-                            uncond_timestep = timestep
-                            if hasattr(batch, 'uncond_indicator') and batch.uncond_indicator is not None:
-                                sigma_conditioning = 0.0001
-                                t_conditioning = sigma_conditioning / (sigma_conditioning + 1)
-                                uncond_timestep = batch.uncond_indicator * t_conditioning + (
-                                    1 - batch.uncond_indicator) * timestep
-                                uncond_timestep = uncond_timestep.to(target_dtype)
+                        uncond_input = uncond_latent * c_in
 
-                            noise_pred_uncond = self.transformer(
-                                hidden_states=uncond_latent.to(target_dtype),
-                                timestep=uncond_timestep.to(target_dtype),
-                                encoder_hidden_states=batch.negative_prompt_embeds[0].to(target_dtype),
-                                fps=24,  # TODO: get fps from batch or config
-                                condition_mask=uncond_condition_mask,
-                                padding_mask=padding_mask,
-                                return_dict=False,
-                            )[0]
+                        noise_pred_uncond = (
+                            self._run_transformer(
+                                uncond_input,
+                                timestep_expanded,
+                                batch.negative_prompt_embeds[0],
+                                uncond_condition_mask,
+                                padding_mask,
+                                target_dtype,
+                                i,
+                                batch,
+                            )
+                        )
 
-                        uncond_pred = (c_skip * latents + c_out * noise_pred_uncond.float()).to(target_dtype)
+                        uncond_x0 = (
+                            c_skip * latents
+                            + c_out * noise_pred_uncond.float()
+                        )
+                        if (
+                            cur_ui is not None
+                            and conditioning_latents is not None
+                        ):
+                            uncond_x0 = (
+                                cur_ui * conditioning_latents
+                                + (1 - cur_ui) * uncond_x0
+                            )
 
-                        if hasattr(batch, 'uncond_indicator'
-                                   ) and batch.uncond_indicator is not None and unconditioning_latents is not None:
-                            uncond_pred = batch.uncond_indicator * unconditioning_latents + (
-                                1 - batch.uncond_indicator) * uncond_pred
-
-                        guidance_diff = cond_pred - uncond_pred
-                        final_pred = cond_pred + guidance_scale * guidance_diff
+                        final_x0 = (
+                            cond_x0
+                            + guidance_scale
+                            * (cond_x0 - uncond_x0)
+                        )
                     else:
-                        final_pred = cond_pred
+                        final_x0 = cond_x0
 
-                # Convert to noise for scheduler step
-                if current_sigma > 1e-8:
-                    noise_for_scheduler = (latents - final_pred) / current_sigma
-                else:
-                    logger.warning("Step %s: current_sigma too small (%s), using final_pred directly", i, current_sigma)
-                    noise_for_scheduler = final_pred
+                # Convert x0 to velocity for
+                # FlowMatchEulerDiscreteScheduler.
+                velocity = (
+                    latents - final_x0
+                ) / sigma.clamp(min=1e-6)
 
-                if torch.isnan(noise_for_scheduler).sum() > 0:
-                    logger.error("Step %s: NaN detected in noise_for_scheduler, sum: %s", i,
-                                 noise_for_scheduler.float().sum().item())
-                    logger.error("Step %s: latents sum: %s, final_pred sum: %s, current_sigma: %s", i,
-                                 latents.float().sum().item(),
-                                 final_pred.float().sum().item(), current_sigma)
-
-                latents = self.scheduler.step(noise_for_scheduler, t, latents, **extra_step_kwargs,
-                                              return_dict=False)[0]
+                latents = self.scheduler.step(
+                    velocity, t, latents,
+                    return_dict=False,
+                )[0]
 
                 progress_bar.update()
 
         batch.latents = latents
-
         return batch
 
     def verify_input(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> VerificationResult:
@@ -771,16 +870,25 @@ class Cosmos25DenoisingStage(CosmosDenoisingStage):
             },
         )
 
-        if hasattr(self.transformer, 'module'):
-            transformer_dtype = next(self.transformer.module.parameters()).dtype
-        else:
-            transformer_dtype = next(self.transformer.parameters()).dtype
-        target_dtype = transformer_dtype
-        autocast_enabled = (target_dtype != torch.float32) and not fastvideo_args.disable_autocast
+        # Detect the actual weight dtype.  FSDP-wrapped models may
+        # report fp32 via next(parameters()) even when the physical
+        # weights are bf16.  Walk through parameters to find one
+        # that is NOT fp32 (the real checkpoint dtype).
+        target_dtype = torch.bfloat16  # safe default for Cosmos 2.5
+        for p in self.transformer.parameters():
+            if p.dtype != torch.float32:
+                target_dtype = p.dtype
+                break
+        autocast_enabled = (
+            target_dtype != torch.float32
+        ) and not fastvideo_args.disable_autocast
 
         latents = batch.latents
         if latents is None:
-            raise ValueError("latents must be provided for Cosmos25DenoisingStage")
+            raise ValueError(
+                "latents must be provided for "
+                "Cosmos25DenoisingStage"
+            )
         guidance_scale = batch.guidance_scale
 
         if batch.timesteps is None:

--- a/fastvideo/train/callbacks/validation.py
+++ b/fastvideo/train/callbacks/validation.py
@@ -288,7 +288,8 @@ class ValidationCallback(Callback):
             "sp_size": tc.distributed.sp_size,
             "num_gpus": tc.distributed.num_gpus,
             "pin_cpu_memory": (tc.distributed.pin_cpu_memory),
-            "dit_cpu_offload": True,
+            "dit_cpu_offload": False,
+            "dit_layerwise_offload": False,
         }
         if flow_shift is not None:
             kwargs["flow_shift"] = float(flow_shift)

--- a/fastvideo/train/models/cosmos/__init__.py
+++ b/fastvideo/train/models/cosmos/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cosmos model plugin package."""
+
+from fastvideo.train.models.cosmos.cosmos import (
+    CosmosModel as CosmosModel, )

--- a/fastvideo/train/models/cosmos/cosmos.py
+++ b/fastvideo/train/models/cosmos/cosmos.py
@@ -1,0 +1,341 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cosmos model plugin (per-role instance).
+
+Subclasses WanModel since Cosmos uses the same
+FlowMatchEulerDiscreteScheduler.  Differences:
+  - transformer class name: CosmosTransformer3DModel
+  - normalize_dit_input("cosmos", ...) instead of ("wan", ...)
+  - forward kwargs: no encoder_attention_mask, needs
+    condition_mask + padding_mask + fps
+  - hidden_states in (B,C,T,H,W) — no permute needed
+  - default flow_shift = 1.0
+  - single T5 text encoder (not dual like Hunyuan)
+"""
+
+from __future__ import annotations
+
+import copy
+import gc
+from typing import Any, Literal, TYPE_CHECKING
+
+import torch
+
+from fastvideo.forward_context import set_forward_context
+from fastvideo.pipelines import TrainingBatch
+from fastvideo.training.training_utils import (
+    normalize_dit_input, )
+
+from fastvideo.train.models.wan.wan import WanModel
+
+if TYPE_CHECKING:
+    from fastvideo.train.utils.training_config import (
+        TrainingConfig, )
+
+
+class CosmosModel(WanModel):
+    """Cosmos 2.5 per-role model.
+
+    Inherits most behaviour from WanModel (noise scheduler,
+    timestep sampling, attention metadata, backward).  Overrides
+    only the pieces that differ for Cosmos 2.5.
+
+    Cosmos 2.5 uses:
+    - Cosmos25Transformer3DModel (velocity prediction)
+    - EDM noise schedule: x_t = x_0 + sigma * eps
+    - No input/output preconditioning (raw latents)
+    - Timestep = raw sigma value
+    - Model output = velocity ≈ noise
+    """
+
+    _transformer_cls_name: str = "Cosmos25Transformer3DModel"
+
+    def __init__(
+        self,
+        *,
+        init_from: str,
+        training_config: TrainingConfig,
+        trainable: bool = True,
+        disable_custom_init_weights: bool = False,
+        flow_shift: float = 1.0,
+        enable_gradient_checkpointing_type: str
+        | None = None,
+        transformer_override_safetensor: str
+        | None = None,
+    ) -> None:
+        super().__init__(
+            init_from=init_from,
+            training_config=training_config,
+            trainable=trainable,
+            disable_custom_init_weights=(disable_custom_init_weights),
+            flow_shift=flow_shift,
+            enable_gradient_checkpointing_type=(enable_gradient_checkpointing_type),
+            transformer_override_safetensor=(transformer_override_safetensor),
+        )
+
+    # ------------------------------------------------------------------
+    # Overrides
+    # ------------------------------------------------------------------
+
+    def prepare_batch(
+        self,
+        raw_batch: dict[str, Any],
+        *,
+        generator: torch.Generator,
+        latents_source: Literal["data", "zeros"] = "data",
+    ) -> TrainingBatch:
+        """Same flow as Wan, but uses Cosmos VAE
+        normalisation."""
+        self.ensure_negative_conditioning()
+        assert self.training_config is not None
+        tc = self.training_config
+
+        dtype = self._get_training_dtype()
+        device = self.device
+
+        training_batch = TrainingBatch()
+        encoder_hidden_states = raw_batch["text_embedding"]
+        encoder_attention_mask = raw_batch["text_attention_mask"]
+        infos = raw_batch.get("info_list")
+
+        if latents_source == "zeros":
+            batch_size = encoder_hidden_states.shape[0]
+            vae_config = (
+                tc.pipeline_config.vae_config  # type: ignore[union-attr]
+                .arch_config)
+            num_channels = getattr(
+                vae_config,
+                "z_dim",
+                getattr(vae_config, "latent_channels", 16),
+            )
+            spatial_compression_ratio = (vae_config.spatial_compression_ratio)
+            latent_height = (tc.data.num_height // spatial_compression_ratio)
+            latent_width = (tc.data.num_width // spatial_compression_ratio)
+            latents = torch.zeros(
+                batch_size,
+                num_channels,
+                tc.data.num_latent_t,
+                latent_height,
+                latent_width,
+                device=device,
+                dtype=dtype,
+            )
+        elif latents_source == "data":
+            if "vae_latent" not in raw_batch:
+                raise ValueError("vae_latent not found in batch "
+                                 "and latents_source='data'")
+            latents = raw_batch["vae_latent"]
+            latents = latents[:, :, :tc.data.num_latent_t]
+            latents = latents.to(device, dtype=dtype)
+        else:
+            raise ValueError(f"Unknown latents_source: "
+                             f"{latents_source!r}")
+
+        training_batch.latents = latents
+        training_batch.encoder_hidden_states = (encoder_hidden_states.to(device, dtype=dtype))
+        training_batch.encoder_attention_mask = (encoder_attention_mask.to(device, dtype=dtype))
+        training_batch.infos = infos
+
+        # KEY DIFFERENCE: "cosmos" normalisation
+        training_batch.latents = normalize_dit_input(
+            "cosmos",
+            training_batch.latents,
+            self.vae,
+        )
+        training_batch = self._prepare_dit_inputs(training_batch, generator)
+        training_batch = self._build_attention_metadata(training_batch)
+
+        training_batch.attn_metadata_vsa = copy.deepcopy(training_batch.attn_metadata)
+        if training_batch.attn_metadata is not None:
+            training_batch.attn_metadata.VSA_sparsity = 0.0  # type: ignore[attr-defined]
+
+        return training_batch
+
+    def predict_noise(
+        self,
+        noisy_latents: torch.Tensor,
+        timestep: torch.Tensor,
+        batch: TrainingBatch,
+        *,
+        conditional: bool,
+        cfg_uncond: dict[str, Any] | None = None,
+        attn_kind: Literal["dense", "vsa"] = "dense",
+    ) -> torch.Tensor:
+        device_type = self.device.type
+        dtype = noisy_latents.dtype
+        if conditional:
+            text_dict = batch.conditional_dict
+            if text_dict is None:
+                raise RuntimeError(
+                    "Missing conditional_dict in TrainingBatch"
+                )
+        else:
+            text_dict = self._get_uncond_text_dict(
+                batch, cfg_uncond=cfg_uncond,
+            )
+
+        if attn_kind == "dense":
+            attn_metadata = batch.attn_metadata
+        elif attn_kind == "vsa":
+            attn_metadata = batch.attn_metadata_vsa
+        else:
+            raise ValueError(f"Unknown attn_kind: {attn_kind!r}")
+
+        # finetune.py hands us `noisy_latents` in (B, T, C, H, W)
+        # (Wan canonical). Un-permute back to the (B, C, T, H, W)
+        # layout Cosmos's transformer expects.
+        noisy_latents = noisy_latents.permute(0, 2, 1, 3, 4)
+
+        # ----------------------------------------------------------
+        # Cosmos 2.5: velocity prediction, no preconditioning.
+        #
+        # Noise schedule (EDM):  x_t = x_0 + sigma * eps
+        # Model input:   raw x_t (no c_in scaling)
+        # Timestep:      raw sigma value
+        # Model output:  velocity v ≈ noise
+        #
+        # finetune.py (precondition_outputs=True) computes:
+        #   pred_x0 = x_t - pred * sigma
+        # Since v ≈ noise, this gives:
+        #   pred_x0 = (x_0 + sigma*eps) - eps*sigma = x_0  ✓
+        # ----------------------------------------------------------
+        assert batch.sigmas is not None
+        sigma_1d = batch.sigmas.flatten()[:noisy_latents.shape[0]]
+
+        # Cosmos 2.5 timestep = raw sigma (matching inference
+        # convention where scheduler timestep * 0.001 = sigma).
+        cosmos_timestep = sigma_1d
+
+        with (
+            torch.autocast(device_type, dtype=dtype),
+            set_forward_context(
+                current_timestep=batch.timesteps,
+                attn_metadata=attn_metadata,
+            ),
+        ):
+            input_kwargs = self._build_distill_input_kwargs(
+                noisy_latents, cosmos_timestep, text_dict,
+            )
+            transformer = self._get_transformer(timestep)
+            model_output = transformer(**input_kwargs)
+
+        # Raw velocity output (≈ noise).
+        # Re-permute (B, C, T, H, W) → (B, T, C, H, W)
+        pred = model_output.permute(0, 2, 1, 3, 4)
+        return pred
+
+    def _build_distill_input_kwargs(
+        self,
+        noise_input: torch.Tensor,
+        timestep: torch.Tensor,
+        text_dict: dict[str, torch.Tensor] | None,
+    ) -> dict[str, Any]:
+        """Build transformer forward kwargs for Cosmos 2.5.
+
+        Cosmos 2.5 transformer expects:
+        - hidden_states in (B, C, T, H, W)
+        - timestep as (B, 1) for T2W (scalar per sample)
+        - condition_mask and padding_mask
+        - fps tensor
+        """
+        if text_dict is None:
+            raise ValueError(
+                "text_dict cannot be None for Cosmos forward"
+            )
+
+        b, c, t, h, w = noise_input.shape
+
+        # For T2W fine-tuning: no conditioning frames.
+        condition_mask = torch.zeros(
+            b, 1, t, h, w,
+            device=noise_input.device,
+            dtype=noise_input.dtype,
+        )
+
+        # Padding mask: zeros (no padding).
+        padding_mask = torch.zeros(
+            1, 1, h, w,
+            device=noise_input.device,
+            dtype=noise_input.dtype,
+        )
+
+        # Cosmos 2.5 expects timestep as (B, 1) for T2W.
+        if timestep.ndim == 1:
+            timestep = timestep.unsqueeze(1)
+
+        return {
+            "hidden_states": noise_input,
+            "encoder_hidden_states": (
+                text_dict["encoder_hidden_states"]
+            ),
+            "timestep": timestep,
+            "condition_mask": condition_mask,
+            "padding_mask": padding_mask,
+            "fps": 16,
+        }
+
+    def _prepare_dit_inputs(
+        self,
+        training_batch: TrainingBatch,
+        generator: torch.Generator,
+    ) -> TrainingBatch:
+        """Prepare DiT inputs for Cosmos 2.5.
+
+        Uses the same flow-matching noise schedule as the parent
+        WanModel but with the Karras sigma schedule from the
+        Cosmos scheduler.  The noisy input is:
+
+            x_t = (1 - sigma) * x_0 + sigma * noise
+
+        where sigma comes from the scheduler's Karras schedule.
+        The model predicts the flow-matching velocity
+        ``v = noise - x_0``.
+        """
+        # Delegate entirely to the parent WanModel implementation.
+        # This uses the noise scheduler's sigmas (Karras, [0..80])
+        # with standard flow-matching interpolation:
+        #   x_t = (1 - sigma) * x_0 + sigma * noise
+        training_batch = super()._prepare_dit_inputs(
+            training_batch, generator,
+        )
+        return training_batch
+
+    def ensure_negative_conditioning(self) -> None:
+        """Create negative (unconditional) prompt embeddings.
+
+        Cosmos 2.5 uses Reason1 (Qwen2.5-VL) which is expensive
+        to load.  For training with ``training_cfg_rate=0`` (no
+        classifier-free guidance dropout), the negative embedding
+        is never used.  We create a zero-valued placeholder that
+        matches the text embedding dimension from the dataset.
+        """
+        if self.negative_prompt_embeds is not None:  # type: ignore[has-type]
+            return
+
+        device = self.device
+        dtype = self._get_training_dtype()
+
+        # Infer embedding dimension from the pipeline config's
+        # text encoder settings, or fall back to a reasonable
+        # default for Cosmos 2.5 (Reason1 full_concat: 100352).
+        assert self.training_config is not None
+        tc = self.training_config
+        text_enc_cfgs = tc.pipeline_config.text_encoder_configs
+        if text_enc_cfgs:
+            arch = text_enc_cfgs[0].arch_config
+            embed_dim = getattr(arch, "hidden_size", 100352)
+        else:
+            embed_dim = 100352
+
+        num_tokens = 512  # Reason1 default padding length
+
+        neg_embeds = torch.zeros(
+            1, num_tokens, embed_dim,
+            device=device, dtype=dtype,
+        )
+        neg_mask = torch.ones(
+            1, num_tokens,
+            device=device, dtype=dtype,
+        )
+
+        self.negative_prompt_embeds = neg_embeds
+        self.negative_prompt_attention_mask = neg_mask

--- a/fastvideo/train/models/cosmos/cosmos.py
+++ b/fastvideo/train/models/cosmos/cosmos.py
@@ -15,7 +15,6 @@ FlowMatchEulerDiscreteScheduler.  Differences:
 from __future__ import annotations
 
 import copy
-import gc
 from typing import Any, Literal, TYPE_CHECKING
 
 import torch
@@ -165,12 +164,11 @@ class CosmosModel(WanModel):
         if conditional:
             text_dict = batch.conditional_dict
             if text_dict is None:
-                raise RuntimeError(
-                    "Missing conditional_dict in TrainingBatch"
-                )
+                raise RuntimeError("Missing conditional_dict in TrainingBatch")
         else:
             text_dict = self._get_uncond_text_dict(
-                batch, cfg_uncond=cfg_uncond,
+                batch,
+                cfg_uncond=cfg_uncond,
             )
 
         if attn_kind == "dense":
@@ -206,14 +204,16 @@ class CosmosModel(WanModel):
         cosmos_timestep = sigma_1d
 
         with (
-            torch.autocast(device_type, dtype=dtype),
-            set_forward_context(
-                current_timestep=batch.timesteps,
-                attn_metadata=attn_metadata,
-            ),
+                torch.autocast(device_type, dtype=dtype),
+                set_forward_context(
+                    current_timestep=batch.timesteps,
+                    attn_metadata=attn_metadata,
+                ),
         ):
             input_kwargs = self._build_distill_input_kwargs(
-                noisy_latents, cosmos_timestep, text_dict,
+                noisy_latents,
+                cosmos_timestep,
+                text_dict,
             )
             transformer = self._get_transformer(timestep)
             model_output = transformer(**input_kwargs)
@@ -238,22 +238,27 @@ class CosmosModel(WanModel):
         - fps tensor
         """
         if text_dict is None:
-            raise ValueError(
-                "text_dict cannot be None for Cosmos forward"
-            )
+            raise ValueError("text_dict cannot be None for Cosmos forward")
 
         b, c, t, h, w = noise_input.shape
 
         # For T2W fine-tuning: no conditioning frames.
         condition_mask = torch.zeros(
-            b, 1, t, h, w,
+            b,
+            1,
+            t,
+            h,
+            w,
             device=noise_input.device,
             dtype=noise_input.dtype,
         )
 
         # Padding mask: zeros (no padding).
         padding_mask = torch.zeros(
-            1, 1, h, w,
+            1,
+            1,
+            h,
+            w,
             device=noise_input.device,
             dtype=noise_input.dtype,
         )
@@ -264,9 +269,7 @@ class CosmosModel(WanModel):
 
         return {
             "hidden_states": noise_input,
-            "encoder_hidden_states": (
-                text_dict["encoder_hidden_states"]
-            ),
+            "encoder_hidden_states": (text_dict["encoder_hidden_states"]),
             "timestep": timestep,
             "condition_mask": condition_mask,
             "padding_mask": padding_mask,
@@ -295,7 +298,8 @@ class CosmosModel(WanModel):
         # with standard flow-matching interpolation:
         #   x_t = (1 - sigma) * x_0 + sigma * noise
         training_batch = super()._prepare_dit_inputs(
-            training_batch, generator,
+            training_batch,
+            generator,
         )
         return training_batch
 
@@ -329,12 +333,17 @@ class CosmosModel(WanModel):
         num_tokens = 512  # Reason1 default padding length
 
         neg_embeds = torch.zeros(
-            1, num_tokens, embed_dim,
-            device=device, dtype=dtype,
+            1,
+            num_tokens,
+            embed_dim,
+            device=device,
+            dtype=dtype,
         )
         neg_mask = torch.ones(
-            1, num_tokens,
-            device=device, dtype=dtype,
+            1,
+            num_tokens,
+            device=device,
+            dtype=dtype,
         )
 
         self.negative_prompt_embeds = neg_embeds

--- a/fastvideo/train/models/cosmos/cosmos.py
+++ b/fastvideo/train/models/cosmos/cosmos.py
@@ -307,13 +307,29 @@ class CosmosModel(WanModel):
         """Create negative (unconditional) prompt embeddings.
 
         Cosmos 2.5 uses Reason1 (Qwen2.5-VL) which is expensive
-        to load.  For training with ``training_cfg_rate=0`` (no
-        classifier-free guidance dropout), the negative embedding
-        is never used.  We create a zero-valued placeholder that
-        matches the text embedding dimension from the dataset.
+        to load.  This method only supports ``training_cfg_rate=0``
+        (no classifier-free guidance dropout), in which case the
+        negative embedding is never used and a zero placeholder
+        sized to match the text embedding dimension is sufficient.
+        ``training_cfg_rate>0`` would require real Reason1 negative
+        embeddings and is rejected here to avoid silently training
+        with zero-vector "unconditional" inputs.
         """
         if self.negative_prompt_embeds is not None:  # type: ignore[has-type]
             return
+
+        assert self.training_config is not None
+        tc = self.training_config
+
+        cfg_rate = float(tc.data.training_cfg_rate or 0.0)
+        if cfg_rate > 0.0:
+            raise NotImplementedError("Cosmos 2.5 currently only supports training_cfg_rate=0; "
+                                      f"got training_cfg_rate={cfg_rate}. Real negative-prompt "
+                                      "embeddings via Reason1 (Qwen2.5-VL) are not implemented "
+                                      "yet — using the zero placeholder with CFG dropout would "
+                                      "train against zero-vector \"unconditional\" inputs and "
+                                      "produce wrong gradients. Set "
+                                      "training.data.training_cfg_rate=0.")
 
         device = self.device
         dtype = self._get_training_dtype()
@@ -321,8 +337,6 @@ class CosmosModel(WanModel):
         # Infer embedding dimension from the pipeline config's
         # text encoder settings, or fall back to a reasonable
         # default for Cosmos 2.5 (Reason1 full_concat: 100352).
-        assert self.training_config is not None
-        tc = self.training_config
         text_enc_cfgs = tc.pipeline_config.text_encoder_configs
         if text_enc_cfgs:
             arch = text_enc_cfgs[0].arch_config

--- a/fastvideo/training/training_utils.py
+++ b/fastvideo/training/training_utils.py
@@ -820,9 +820,7 @@ def normalize_dit_input(model_type, latents, vae) -> torch.Tensor:
             lm = torch.tensor(vae.latents_mean)
             ls = torch.tensor(vae.latents_std)
         else:
-            raise ValueError(
-                "Cannot find latents_mean/latents_std on VAE"
-            )
+            raise ValueError("Cannot find latents_mean/latents_std on VAE")
         latents_mean = lm.view(1, -1, 1, 1, 1).to(device=latents.device)
         latents_std = ls.view(1, -1, 1, 1, 1).to(device=latents.device)
         latents = ((latents.float() - latents_mean) / latents_std).to(latents)

--- a/fastvideo/training/training_utils.py
+++ b/fastvideo/training/training_utils.py
@@ -806,6 +806,27 @@ def normalize_dit_input(model_type, latents, vae) -> torch.Tensor:
         latents_std = latents_std.view(1, -1, 1, 1, 1).to(device=latents.device)
         latents = ((latents.float() - latents_mean) * latents_std).to(latents)
         return latents
+    elif model_type == "cosmos":
+        # Support both diffusers VAE (vae.config.latents_mean)
+        # and Cosmos25WanVAE/Adapter (vae._latents_mean buffer).
+        cfg = getattr(vae, "config", None)
+        if cfg is not None and hasattr(cfg, "latents_mean"):
+            lm = torch.tensor(cfg.latents_mean)
+            ls = torch.tensor(cfg.latents_std)
+        elif hasattr(vae, "_latents_mean"):
+            lm = vae._latents_mean.flatten()
+            ls = vae._latents_std.flatten()
+        elif hasattr(vae, "latents_mean"):
+            lm = torch.tensor(vae.latents_mean)
+            ls = torch.tensor(vae.latents_std)
+        else:
+            raise ValueError(
+                "Cannot find latents_mean/latents_std on VAE"
+            )
+        latents_mean = lm.view(1, -1, 1, 1, 1).to(device=latents.device)
+        latents_std = ls.view(1, -1, 1, 1, 1).to(device=latents.device)
+        latents = ((latents.float() - latents_mean) / latents_std).to(latents)
+        return latents
     else:
         raise NotImplementedError(f"model_type {model_type} not supported")
 


### PR DESCRIPTION
## Summary
Add Cosmos 2.5 (Predict2.5-2B) model plugin for fastvideo/train framework
Add preprocessing pipeline and overfit config for Cosmos 2.5
Fix flow-matching noise schedule, FSDP dtype handling, and VAE normalization'
## Test
Overfit test: 1 GPU, 480×832, 93 frames, 1000 steps
Loss: 0.075 → 0.057, grad norm stable ~0.43
Validation videos verified clean at steps 0, 150, 300, 500, 1000