### PR TITLE
[new-model] Port FLUX.1-dev T2I to FastVideo

### DIFF
--- a/examples/inference/basic/basic_flux_dev.py
+++ b/examples/inference/basic/basic_flux_dev.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import re
+
+DEFAULT_PROMPTS = [
+    "a photo of a cat",
+    (
+        "a cinematic photo of a red panda wearing a tiny backpack, standing on a "
+        "rainy neon-lit street at night, shallow depth of field, sharp focus, "
+        "35mm, bokeh"
+    ),
+]
+
+
+def _safe_filename(text: str, max_len: int = 100) -> str:
+    """Make a stable, filesystem-friendly filename base."""
+    s = text[:max_len].strip()
+    s = s.replace(os.sep, "_")
+    if os.altsep:
+        s = s.replace(os.altsep, "_")
+    s = re.sub(r"\s+", " ", s)
+    s = re.sub(r"[^A-Za-z0-9 .,_-]", "_", s)
+    s = s.strip(" .")
+    return s or "prompt"
+
+
+def _remove_existing_outputs(out_dir: str, filename_base: str) -> None:
+    """Delete prior outputs so reruns do not get _1, _2 suffixes."""
+    if not os.path.isdir(out_dir):
+        return
+
+    pattern = re.compile(rf"^{re.escape(filename_base)}(_\d+)?\.(mp4|png)$")
+    for fn in os.listdir(out_dir):
+        if pattern.match(fn):
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(os.path.join(out_dir, fn))
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Run FLUX.1-dev text-to-image with FastVideo VideoGenerator.",
+    )
+    p.add_argument(
+        "--model-path",
+        default="official_weights/FLUX.1-dev",
+        help="Local Diffusers checkpoint dir or HF repo id.",
+    )
+    p.add_argument(
+        "--out-dir",
+        "--outdir",
+        default="outputs/flux_dev/samples",
+        help="Directory for saved PNG outputs.",
+    )
+    p.add_argument(
+        "--prompt",
+        action="append",
+        default=None,
+        help="Prompt. Repeat for multiple images.",
+    )
+    p.add_argument(
+        "--backend",
+        default=None,
+        help="Set FASTVIDEO_ATTENTION_BACKEND (e.g. TORCH_SDPA).",
+    )
+    p.add_argument("--seed", type=int, default=42, help="Base seed; each prompt uses seed + index.")
+    p.add_argument("--height", type=int, default=1024, help="Output height.")
+    p.add_argument("--width", type=int, default=1024, help="Output width.")
+    p.add_argument("--steps", type=int, default=28, help="Number of inference steps.")
+    p.add_argument("--guidance", type=float, default=3.5, help="Guidance scale.")
+    p.add_argument("--num-gpus", type=int, default=1, help="GPU count.")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    prompts: list[str] = args.prompt if args.prompt else DEFAULT_PROMPTS
+
+    if args.backend:
+        os.environ["FASTVIDEO_ATTENTION_BACKEND"] = args.backend
+
+    from fastvideo import VideoGenerator
+
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    init_kwargs = {
+        "num_gpus": args.num_gpus,
+        "workload_type": "t2i",
+        "sp_size": 1,
+        "tp_size": 1,
+        "dit_cpu_offload": False,
+        "dit_layerwise_offload": False,
+        "text_encoder_cpu_offload": False,
+        "vae_cpu_offload": False,
+        "image_encoder_cpu_offload": False,
+        "pin_cpu_memory": False,
+        "use_fsdp_inference": False,
+    }
+
+    generator = VideoGenerator.from_pretrained(
+        model_path=args.model_path,
+        **init_kwargs,
+    )
+    try:
+        for i, prompt in enumerate(prompts):
+            seed = args.seed + i
+            filename_base = (
+                f"flux_dev_{i:02d}_seed{seed}_{_safe_filename(prompt, max_len=80)}"
+            )
+            _remove_existing_outputs(args.out_dir, filename_base)
+            output_path = os.path.join(args.out_dir, f"{filename_base}.png")
+            print(f"[flux] prompt_idx={i} seed={seed} output_path={output_path}")
+
+            generation_kwargs = {
+                "output_path": output_path,
+                "height": args.height,
+                "width": args.width,
+                "num_frames": 1,
+                "fps": 1,
+                "num_inference_steps": args.steps,
+                "guidance_scale": args.guidance,
+                "use_embedded_guidance": True,
+                "true_cfg_scale": 1.0,
+                "seed": seed,
+                "save_video": True,
+            }
+
+            generator.generate_video(prompt, **generation_kwargs)
+
+        print(f"[flux] done. outputs written to: {args.out_dir}")
+    finally:
+        generator.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/fastvideo/configs/models/dits/flux.py
+++ b/fastvideo/configs/models/dits/flux.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass, field
+
+from fastvideo.configs.models.dits.base import DiTArchConfig, DiTConfig
+
+
+@dataclass
+class FluxTransformer2DArchConfig(DiTArchConfig):
+
+    patch_size: int = 1
+    in_channels: int = 64
+    out_channels: int | None = None
+    num_layers: int = 19
+    num_single_layers: int = 38
+    attention_head_dim: int = 128
+    num_attention_heads: int = 24
+    joint_attention_dim: int = 4096
+    pooled_projection_dim: int = 768
+    guidance_embeds: bool = True
+    axes_dims_rope: tuple[int, int, int] = (16, 56, 56)
+
+
+@dataclass
+class FluxDiTConfig(DiTConfig):
+    arch_config: DiTArchConfig = field(default_factory=FluxTransformer2DArchConfig)
+    prefix: str = "flux"

--- a/fastvideo/configs/pipelines/flux.py
+++ b/fastvideo/configs/pipelines/flux.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import torch
+
+from fastvideo.configs.models import EncoderConfig
+from fastvideo.configs.models.dits.flux import FluxDiTConfig
+from fastvideo.configs.models.encoders import (
+    BaseEncoderOutput,
+    CLIPTextConfig,
+    T5LargeConfig,
+)
+from fastvideo.configs.models.vaes.autoencoder_kl import AutoencoderKLVAEConfig
+from fastvideo.configs.pipelines.base import PipelineConfig, preprocess_text
+
+
+def _flux_clip_pooled_postprocess(outputs: BaseEncoderOutput) -> torch.Tensor:
+    """CLIP branch for FLUX: Diffusers uses pooled prompt embeddings only."""
+    if outputs.pooler_output is None:
+        raise RuntimeError(
+            "FLUX CLIP conditioning requires pooler_output. Ensure the CLIP text encoder returns pooled features."
+        )
+    return outputs.pooler_output
+
+
+def _flux_t5_sequence_postprocess(outputs: BaseEncoderOutput) -> torch.Tensor:
+    if outputs.last_hidden_state is None:
+        raise RuntimeError("FLUX T5 conditioning requires last_hidden_state.")
+    return outputs.last_hidden_state
+
+
+@dataclass
+class FluxPipelineConfig(PipelineConfig):
+    """Pipeline layout for Diffusers FLUX.1-dev (CLIP + T5 + packed DiT + FlowMatch)."""
+
+    scheduler_arch: str = "FlowMatchEulerDiscreteScheduler"
+    transformer_arch: str = "FluxTransformer2DModel"
+    vae_arch: str = "AutoencoderKL"
+    text_encoder_archs: tuple[str, ...] = ("CLIPTextModel", "T5EncoderModel")
+    tokenizer_archs: tuple[str, ...] = ("CLIPTokenizer", "T5TokenizerFast")
+
+    dit_config: FluxDiTConfig = field(default_factory=FluxDiTConfig)
+    vae_config: AutoencoderKLVAEConfig = field(default_factory=AutoencoderKLVAEConfig)
+
+    embedded_cfg_scale: float = 3.5
+    flow_shift: float | None = None
+
+    text_encoder_configs: tuple[EncoderConfig, ...] = field(default_factory=lambda: (CLIPTextConfig(), T5LargeConfig()))
+    preprocess_text_funcs: tuple[Callable[[str], str], ...] = field(
+        default_factory=lambda: (preprocess_text, preprocess_text)
+    )
+    postprocess_text_funcs: tuple[Callable[[BaseEncoderOutput], torch.Tensor], ...] = field(
+        default_factory=lambda: (_flux_clip_pooled_postprocess, _flux_t5_sequence_postprocess)
+    )
+
+    dit_precision: str = "bf16"
+    vae_precision: str = "fp32"
+    text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("fp32", "bf16"))
+
+    def __post_init__(self) -> None:
+        te_cfgs = list(self.text_encoder_configs)
+        if len(te_cfgs) >= 1:
+            te_cfgs[0].tokenizer_kwargs.setdefault("padding", "max_length")
+            te_cfgs[0].tokenizer_kwargs.setdefault("max_length", 77)
+            te_cfgs[0].tokenizer_kwargs.setdefault("truncation", True)
+            te_cfgs[0].tokenizer_kwargs.setdefault("return_tensors", "pt")
+        if len(te_cfgs) >= 2:
+            cap = 512
+            te_cfgs[1].tokenizer_kwargs["max_length"] = min(
+                int(te_cfgs[1].tokenizer_kwargs.get("max_length", cap)), cap
+            )
+            te_cfgs[1].tokenizer_kwargs.setdefault("padding", "max_length")
+            te_cfgs[1].tokenizer_kwargs.setdefault("truncation", True)
+            te_cfgs[1].tokenizer_kwargs.setdefault("return_tensors", "pt")

--- a/fastvideo/configs/pipelines/flux.py
+++ b/fastvideo/configs/pipelines/flux.py
@@ -22,8 +22,7 @@ def _flux_clip_pooled_postprocess(outputs: BaseEncoderOutput) -> torch.Tensor:
     """CLIP branch for FLUX: Diffusers uses pooled prompt embeddings only."""
     if outputs.pooler_output is None:
         raise RuntimeError(
-            "FLUX CLIP conditioning requires pooler_output. Ensure the CLIP text encoder returns pooled features."
-        )
+            "FLUX CLIP conditioning requires pooler_output. Ensure the CLIP text encoder returns pooled features.")
     return outputs.pooler_output
 
 
@@ -50,12 +49,10 @@ class FluxPipelineConfig(PipelineConfig):
     flow_shift: float | None = None
 
     text_encoder_configs: tuple[EncoderConfig, ...] = field(default_factory=lambda: (CLIPTextConfig(), T5LargeConfig()))
-    preprocess_text_funcs: tuple[Callable[[str], str], ...] = field(
-        default_factory=lambda: (preprocess_text, preprocess_text)
-    )
+    preprocess_text_funcs: tuple[Callable[[str], str],
+                                 ...] = field(default_factory=lambda: (preprocess_text, preprocess_text))
     postprocess_text_funcs: tuple[Callable[[BaseEncoderOutput], torch.Tensor], ...] = field(
-        default_factory=lambda: (_flux_clip_pooled_postprocess, _flux_t5_sequence_postprocess)
-    )
+        default_factory=lambda: (_flux_clip_pooled_postprocess, _flux_t5_sequence_postprocess))
 
     dit_precision: str = "bf16"
     vae_precision: str = "fp32"
@@ -70,9 +67,8 @@ class FluxPipelineConfig(PipelineConfig):
             te_cfgs[0].tokenizer_kwargs.setdefault("return_tensors", "pt")
         if len(te_cfgs) >= 2:
             cap = 512
-            te_cfgs[1].tokenizer_kwargs["max_length"] = min(
-                int(te_cfgs[1].tokenizer_kwargs.get("max_length", cap)), cap
-            )
+            te_cfgs[1].tokenizer_kwargs["max_length"] = min(int(te_cfgs[1].tokenizer_kwargs.get("max_length", cap)),
+                                                            cap)
             te_cfgs[1].tokenizer_kwargs.setdefault("padding", "max_length")
             te_cfgs[1].tokenizer_kwargs.setdefault("truncation", True)
             te_cfgs[1].tokenizer_kwargs.setdefault("return_tensors", "pt")

--- a/fastvideo/configs/sample/base.py
+++ b/fastvideo/configs/sample/base.py
@@ -68,6 +68,10 @@ class SamplingParam:
     num_inference_steps: int = 50
     num_inference_steps_sr: int = 50
     guidance_scale: float = 1.0
+    # Embedded guidance (FLUX): do not treat ``guidance_scale > 1`` as classic CFG.
+    use_embedded_guidance: bool = False
+    # Diffusers-style true CFG for FLUX when > 1 (requires negative prompt encoding).
+    true_cfg_scale: float = 1.0
     guidance_rescale: float = 0.0
     boundary_ratio: float | None = None
     sigmas: list[float] | None = None

--- a/fastvideo/configs/sample/flux.py
+++ b/fastvideo/configs/sample/flux.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastvideo.configs.sample.base import SamplingParam
+
+
+@dataclass
+class FluxSamplingParam(SamplingParam):
+
+    prompt: str | None = "a photo of a cat"
+    negative_prompt: str = ""
+
+    num_videos_per_prompt: int = 1
+    seed: int = 0
+
+    num_frames: int = 1
+    height: int = 1024
+    width: int = 1024
+    fps: int = 1
+
+    num_inference_steps: int = 28
+    guidance_scale: float = 3.5
+    use_embedded_guidance: bool = True
+    true_cfg_scale: float = 1.0

--- a/fastvideo/models/dits/flux.py
+++ b/fastvideo/models/dits/flux.py
@@ -1,0 +1,574 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from dataclasses import dataclass
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from diffusers.models.embeddings import apply_rotary_emb, get_1d_rotary_pos_embed
+
+from fastvideo.attention import DistributedAttention
+from fastvideo.configs.models import DiTConfig
+from fastvideo.forward_context import get_forward_context, set_forward_context
+from fastvideo.layers.linear import ReplicatedLinear
+from fastvideo.layers.visual_embedding import Timesteps
+from fastvideo.models.dits.base import BaseDiT
+from fastvideo.models.dits.sd3 import (
+    CombinedTimestepTextProjEmbeddings,
+    SD3AdaLayerNormContinuous,
+    SD3AdaLayerNormZero,
+    SD3FeedForward,
+    SD3TextProjection,
+    SD3TimestepEmbedding,
+)
+from fastvideo.platforms import AttentionBackendEnum
+
+
+@dataclass
+class FluxTransformer2DModelOutput:
+    sample: torch.Tensor
+
+
+class FluxPosEmbed(nn.Module):
+    """1D RoPE axes concatenated per Diffusers `FluxPosEmbed`."""
+
+    def __init__(self, theta: int, axes_dim: list[int]) -> None:
+        super().__init__()
+        self.theta = theta
+        self.axes_dim = axes_dim
+
+    def forward(self, ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        n_axes = ids.shape[-1]
+        cos_out: list[torch.Tensor] = []
+        sin_out: list[torch.Tensor] = []
+        pos = ids.float()
+        is_mps = ids.device.type == "mps"
+        is_npu = ids.device.type == "npu"
+        freqs_dtype = torch.float32 if (is_mps or is_npu) else torch.float64
+        for i in range(n_axes):
+            cos, sin = get_1d_rotary_pos_embed(
+                self.axes_dim[i],
+                pos[:, i],
+                theta=self.theta,
+                repeat_interleave_real=True,
+                use_real=True,
+                freqs_dtype=freqs_dtype,
+            )
+            cos_out.append(cos)
+            sin_out.append(sin)
+        freqs_cos = torch.cat(cos_out, dim=-1).to(ids.device)
+        freqs_sin = torch.cat(sin_out, dim=-1).to(ids.device)
+        return freqs_cos, freqs_sin
+
+
+class FluxCombinedTimestepGuidanceTextProjEmbeddings(nn.Module):
+    def __init__(self, embedding_dim: int, pooled_projection_dim: int) -> None:
+        super().__init__()
+        self.time_proj = Timesteps(
+            num_channels=256,
+            flip_sin_to_cos=True,
+            downscale_freq_shift=0,
+        )
+        self.timestep_embedder = SD3TimestepEmbedding(
+            in_channels=256,
+            time_embed_dim=embedding_dim,
+            act_fn="silu",
+        )
+        self.guidance_embedder = SD3TimestepEmbedding(
+            in_channels=256,
+            time_embed_dim=embedding_dim,
+            act_fn="silu",
+        )
+        self.text_embedder = SD3TextProjection(
+            pooled_projection_dim,
+            embedding_dim,
+            act_fn="silu",
+        )
+
+    def forward(
+        self,
+        timestep: torch.Tensor,
+        guidance: torch.Tensor,
+        pooled_projection: torch.Tensor,
+    ) -> torch.Tensor:
+        timesteps_proj = self.time_proj(timestep)
+        timesteps_emb = self.timestep_embedder(timesteps_proj.to(dtype=pooled_projection.dtype))
+        guidance_proj = self.time_proj(guidance)
+        guidance_emb = self.guidance_embedder(guidance_proj.to(dtype=pooled_projection.dtype))
+        time_guidance_emb = timesteps_emb + guidance_emb
+        pooled_projections = self.text_embedder(pooled_projection)
+        return time_guidance_emb + pooled_projections
+
+
+class FluxAdaLayerNormZeroSingle(nn.Module):
+    def __init__(self, embedding_dim: int, bias: bool = True) -> None:
+        super().__init__()
+        self.silu = nn.SiLU()
+        self.linear = ReplicatedLinear(embedding_dim, 3 * embedding_dim, bias=bias)
+        self.norm = nn.LayerNorm(embedding_dim, elementwise_affine=False, eps=1e-6)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        emb: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        emb, _ = self.linear(self.silu(emb))
+        shift_msa, scale_msa, gate_msa = emb.chunk(3, dim=1)
+        x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
+        return x, gate_msa
+
+
+class FluxJointAttention(nn.Module):
+    """Joint attention: text tokens precede image tokens (Diffusers order)."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        supported_attention_backends: tuple[AttentionBackendEnum, ...] | None = None,
+    ) -> None:
+        super().__init__()
+        self.heads = num_attention_heads
+        self.head_dim = attention_head_dim
+        self.inner_dim = num_attention_heads * attention_head_dim
+
+        self.norm_q = nn.RMSNorm(attention_head_dim, eps=1e-6)
+        self.norm_k = nn.RMSNorm(attention_head_dim, eps=1e-6)
+        self.norm_added_q = nn.RMSNorm(attention_head_dim, eps=1e-6)
+        self.norm_added_k = nn.RMSNorm(attention_head_dim, eps=1e-6)
+
+        self.to_q = ReplicatedLinear(dim, self.inner_dim, bias=True)
+        self.to_k = ReplicatedLinear(dim, self.inner_dim, bias=True)
+        self.to_v = ReplicatedLinear(dim, self.inner_dim, bias=True)
+        self.add_q_proj = ReplicatedLinear(dim, self.inner_dim, bias=True)
+        self.add_k_proj = ReplicatedLinear(dim, self.inner_dim, bias=True)
+        self.add_v_proj = ReplicatedLinear(dim, self.inner_dim, bias=True)
+
+        self.to_out = nn.ModuleList(
+            [
+                ReplicatedLinear(self.inner_dim, dim, bias=True),
+                nn.Dropout(0.0),
+            ]
+        )
+        self.to_add_out = ReplicatedLinear(self.inner_dim, dim, bias=True)
+
+        self.attn = DistributedAttention(
+            num_heads=num_attention_heads,
+            head_size=attention_head_dim,
+            causal=False,
+            supported_attention_backends=supported_attention_backends,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        batch_size = hidden_states.shape[0]
+        text_seq_len = encoder_hidden_states.shape[1]
+        img_seq_len = hidden_states.shape[1]
+
+        q, _ = self.to_q(hidden_states)
+        k, _ = self.to_k(hidden_states)
+        v, _ = self.to_v(hidden_states)
+        q = q.view(batch_size, img_seq_len, self.heads, self.head_dim)
+        k = k.view(batch_size, img_seq_len, self.heads, self.head_dim)
+        v = v.view(batch_size, img_seq_len, self.heads, self.head_dim)
+        q = self.norm_q(q)
+        k = self.norm_k(k)
+
+        enc_q, _ = self.add_q_proj(encoder_hidden_states)
+        enc_k, _ = self.add_k_proj(encoder_hidden_states)
+        enc_v, _ = self.add_v_proj(encoder_hidden_states)
+        enc_q = enc_q.view(batch_size, text_seq_len, self.heads, self.head_dim)
+        enc_k = enc_k.view(batch_size, text_seq_len, self.heads, self.head_dim)
+        enc_v = enc_v.view(batch_size, text_seq_len, self.heads, self.head_dim)
+        enc_q = self.norm_added_q(enc_q)
+        enc_k = self.norm_added_k(enc_k)
+
+        q = torch.cat([enc_q, q], dim=1)
+        k = torch.cat([enc_k, k], dim=1)
+        v = torch.cat([enc_v, v], dim=1)
+
+        q = apply_rotary_emb(q, image_rotary_emb, sequence_dim=1)
+        k = apply_rotary_emb(k, image_rotary_emb, sequence_dim=1)
+
+        joint_out, _ = self.attn(q, k, v)
+        joint_out = joint_out.reshape(batch_size, text_seq_len + img_seq_len, self.inner_dim)
+
+        enc_out = joint_out[:, :text_seq_len]
+        img_out = joint_out[:, text_seq_len:]
+
+        img_out, _ = self.to_out[0](img_out)
+        img_out = self.to_out[1](img_out)
+        enc_out, _ = self.to_add_out(enc_out)
+        return img_out, enc_out
+
+
+class FluxSingleStreamAttention(nn.Module):
+    """Self-attention on concatenated text+image sequence (single blocks)."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        supported_attention_backends: tuple[AttentionBackendEnum, ...] | None = None,
+    ) -> None:
+        super().__init__()
+        self.heads = num_attention_heads
+        self.head_dim = attention_head_dim
+        self.inner_dim = num_attention_heads * attention_head_dim
+
+        self.norm_q = nn.RMSNorm(attention_head_dim, eps=1e-6)
+        self.norm_k = nn.RMSNorm(attention_head_dim, eps=1e-6)
+        self.to_q = ReplicatedLinear(dim, self.inner_dim, bias=True)
+        self.to_k = ReplicatedLinear(dim, self.inner_dim, bias=True)
+        self.to_v = ReplicatedLinear(dim, self.inner_dim, bias=True)
+        self.attn = DistributedAttention(
+            num_heads=num_attention_heads,
+            head_size=attention_head_dim,
+            causal=False,
+            supported_attention_backends=supported_attention_backends,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        q, _ = self.to_q(hidden_states)
+        k, _ = self.to_k(hidden_states)
+        v, _ = self.to_v(hidden_states)
+        q = q.view(batch_size, seq_len, self.heads, self.head_dim)
+        k = k.view(batch_size, seq_len, self.heads, self.head_dim)
+        v = v.view(batch_size, seq_len, self.heads, self.head_dim)
+        q = self.norm_q(q)
+        k = self.norm_k(k)
+        q = apply_rotary_emb(q, image_rotary_emb, sequence_dim=1)
+        k = apply_rotary_emb(k, image_rotary_emb, sequence_dim=1)
+        out, _ = self.attn(q, k, v)
+        return out.reshape(batch_size, seq_len, self.inner_dim)
+
+
+class FluxTransformerBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        supported_attention_backends: tuple[AttentionBackendEnum, ...] | None = None,
+    ) -> None:
+        super().__init__()
+        self.norm1 = SD3AdaLayerNormZero(dim)
+        self.norm1_context = SD3AdaLayerNormZero(dim)
+        self.attn = FluxJointAttention(
+            dim=dim,
+            num_attention_heads=num_attention_heads,
+            attention_head_dim=attention_head_dim,
+            supported_attention_backends=supported_attention_backends,
+        )
+        self.norm2 = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        self.ff = SD3FeedForward(
+            dim=dim,
+            dim_out=dim,
+            activation_fn="gelu-approximate",
+        )
+        self.norm2_context = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        self.ff_context = SD3FeedForward(
+            dim=dim,
+            dim_out=dim,
+            activation_fn="gelu-approximate",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        joint_attention_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        del joint_attention_kwargs
+        norm_hidden_states, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.norm1(hidden_states, emb=temb)
+        (norm_encoder_hidden_states, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp) = self.norm1_context(
+            encoder_hidden_states, emb=temb
+        )
+
+        attn_output, context_attn_output = self.attn(
+            hidden_states=norm_hidden_states,
+            encoder_hidden_states=norm_encoder_hidden_states,
+            image_rotary_emb=image_rotary_emb,
+        )
+
+        attn_output = gate_msa.unsqueeze(1) * attn_output
+        hidden_states = hidden_states + attn_output
+
+        norm_hidden_states = self.norm2(hidden_states)
+        norm_hidden_states = norm_hidden_states * (1 + scale_mlp[:, None]) + shift_mlp[:, None]
+        ff_output = self.ff(norm_hidden_states)
+        hidden_states = hidden_states + gate_mlp.unsqueeze(1) * ff_output
+
+        context_attn_output = c_gate_msa.unsqueeze(1) * context_attn_output
+        encoder_hidden_states = encoder_hidden_states + context_attn_output
+
+        norm_encoder_hidden_states = self.norm2_context(encoder_hidden_states)
+        norm_encoder_hidden_states = norm_encoder_hidden_states * (1 + c_scale_mlp[:, None]) + c_shift_mlp[:, None]
+        context_ff_output = self.ff_context(norm_encoder_hidden_states)
+        encoder_hidden_states = encoder_hidden_states + (c_gate_mlp.unsqueeze(1) * context_ff_output)
+        if encoder_hidden_states.dtype == torch.float16:
+            encoder_hidden_states = encoder_hidden_states.clip(-65504, 65504)
+
+        return encoder_hidden_states, hidden_states
+
+
+class FluxSingleTransformerBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        mlp_ratio: float = 4.0,
+        supported_attention_backends: tuple[AttentionBackendEnum, ...] | None = None,
+    ) -> None:
+        super().__init__()
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.norm = FluxAdaLayerNormZeroSingle(dim)
+        self.proj_mlp = ReplicatedLinear(dim, mlp_hidden_dim, bias=True)
+        self.act_mlp = nn.GELU(approximate="tanh")
+        self.proj_out = ReplicatedLinear(dim + mlp_hidden_dim, dim, bias=True)
+        self.attn = FluxSingleStreamAttention(
+            dim=dim,
+            num_attention_heads=num_attention_heads,
+            attention_head_dim=attention_head_dim,
+            supported_attention_backends=supported_attention_backends,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        image_rotary_emb: tuple[torch.Tensor, torch.Tensor],
+        joint_attention_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        del joint_attention_kwargs
+        text_seq_len = encoder_hidden_states.shape[1]
+        hidden_states = torch.cat([encoder_hidden_states, hidden_states], dim=1)
+        residual = hidden_states
+        norm_hidden_states, gate = self.norm(hidden_states, emb=temb)
+        mlp_hidden_states = self.act_mlp(self.proj_mlp(norm_hidden_states)[0])
+        attn_output = self.attn(
+            hidden_states=norm_hidden_states,
+            image_rotary_emb=image_rotary_emb,
+        )
+        hidden_states = torch.cat([attn_output, mlp_hidden_states], dim=2)
+        gate = gate.unsqueeze(1)
+        hidden_states = gate * self.proj_out(hidden_states)[0]
+        hidden_states = residual + hidden_states
+        if hidden_states.dtype == torch.float16:
+            hidden_states = hidden_states.clip(-65504, 65504)
+        encoder_hidden_states = hidden_states[:, :text_seq_len]
+        hidden_states = hidden_states[:, text_seq_len:]
+        return encoder_hidden_states, hidden_states
+
+
+class FluxTransformer2DModel(BaseDiT):
+    """FastVideo FLUX transformer; load Diffusers FLUX safetensors 1:1."""
+
+    _fsdp_shard_conditions = [
+        lambda n, m: (n.startswith("transformer_blocks.") or n.startswith("single_transformer_blocks."))
+        and n.split(".")[-1].isdigit(),
+    ]
+    _compile_conditions = _fsdp_shard_conditions
+    # HF weight names already match this module layout (cf. SGLang regex maps).
+    param_names_mapping: dict[str, Any] = {}
+    reverse_param_names_mapping: dict[str, Any] = {}
+    lora_param_names_mapping: dict[str, Any] = {}
+    _supported_attention_backends = (
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.TORCH_SDPA,
+    )
+
+    def __init__(self, config: DiTConfig, hf_config: dict[str, Any], **kwargs) -> None:
+        del kwargs
+        super().__init__(config=config, hf_config=hf_config)
+        self.fastvideo_config = config
+        self.hf_config = hf_config
+        arch = config.arch_config
+
+        out_ch = arch.out_channels
+        self.out_channels = out_ch if out_ch is not None else arch.in_channels
+        self.inner_dim = arch.num_attention_heads * arch.attention_head_dim
+        self.hidden_size = self.inner_dim
+        self.num_attention_heads = arch.num_attention_heads
+        self.num_channels_latents = arch.in_channels
+
+        axes_list = list(arch.axes_dims_rope)
+        self.pos_embed = FluxPosEmbed(theta=10000, axes_dim=axes_list)
+        if arch.guidance_embeds:
+            self.time_text_embed = FluxCombinedTimestepGuidanceTextProjEmbeddings(
+                embedding_dim=self.inner_dim,
+                pooled_projection_dim=arch.pooled_projection_dim,
+            )
+        else:
+            self.time_text_embed = CombinedTimestepTextProjEmbeddings(
+                embedding_dim=self.inner_dim,
+                pooled_projection_dim=arch.pooled_projection_dim,
+            )
+        self.context_embedder = ReplicatedLinear(arch.joint_attention_dim, self.inner_dim)
+        self.x_embedder = ReplicatedLinear(arch.in_channels, self.inner_dim)
+
+        self.transformer_blocks = nn.ModuleList(
+            [
+                FluxTransformerBlock(
+                    dim=self.inner_dim,
+                    num_attention_heads=arch.num_attention_heads,
+                    attention_head_dim=arch.attention_head_dim,
+                    supported_attention_backends=self._supported_attention_backends,
+                )
+                for _ in range(arch.num_layers)
+            ]
+        )
+        self.single_transformer_blocks = nn.ModuleList(
+            [
+                FluxSingleTransformerBlock(
+                    dim=self.inner_dim,
+                    num_attention_heads=arch.num_attention_heads,
+                    attention_head_dim=arch.attention_head_dim,
+                    supported_attention_backends=self._supported_attention_backends,
+                )
+                for _ in range(arch.num_single_layers)
+            ]
+        )
+
+        self.norm_out = SD3AdaLayerNormContinuous(
+            self.inner_dim,
+            self.inner_dim,
+            elementwise_affine=False,
+            eps=1e-6,
+            bias=True,
+            norm_type="layer_norm",
+        )
+        self.proj_out = ReplicatedLinear(
+            self.inner_dim,
+            arch.patch_size * arch.patch_size * self.out_channels,
+            bias=True,
+        )
+        self.gradient_checkpointing = False
+        self.__post_init__()
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor | None = None,
+        pooled_projections: torch.Tensor | None = None,
+        timestep: torch.LongTensor | torch.Tensor | None = None,
+        img_ids: torch.Tensor | None = None,
+        txt_ids: torch.Tensor | None = None,
+        guidance: torch.Tensor | None = None,
+        joint_attention_kwargs: dict[str, Any] | None = None,
+        return_dict: bool = True,
+        controlnet_block_samples: Any | None = None,
+        controlnet_single_block_samples: Any | None = None,
+        controlnet_blocks_repeat: bool = False,
+        **kwargs: Any,
+    ) -> FluxTransformer2DModelOutput | tuple[torch.Tensor, ...]:
+        del kwargs
+        if encoder_hidden_states is None:
+            raise ValueError("encoder_hidden_states must be provided")
+        if pooled_projections is None:
+            raise ValueError("pooled_projections must be provided")
+        if timestep is None:
+            raise ValueError("timestep must be provided")
+        if img_ids is None or txt_ids is None:
+            raise ValueError("img_ids and txt_ids must be provided")
+
+        arch = self.fastvideo_config.arch_config
+        if arch.guidance_embeds and guidance is None:
+            raise ValueError("guidance must be provided when guidance_embeds=True")
+
+        if timestep.dim() == 0:
+            timestep = timestep[None]
+        if timestep.dim() > 1:
+            timestep = timestep.reshape(-1)
+        if timestep.shape[0] == 1 and hidden_states.shape[0] > 1:
+            timestep = timestep.expand(hidden_states.shape[0])
+
+        try:
+            get_forward_context()
+            forward_context = nullcontext()
+        except AssertionError:
+            ts0 = int(timestep[0].item()) if timestep.numel() > 0 else 0
+            forward_context = set_forward_context(current_timestep=ts0, attn_metadata=None)
+
+        with forward_context:
+            hidden_states, _ = self.x_embedder(hidden_states)
+
+            ts = timestep.to(hidden_states.dtype) * 1000
+            g = None if guidance is None else guidance.to(hidden_states.dtype) * 1000
+
+            if arch.guidance_embeds:
+                assert g is not None
+                temb = self.time_text_embed(ts, g, pooled_projections)
+            else:
+                temb = self.time_text_embed(timestep=ts, pooled_projection=pooled_projections)
+
+            encoder_hidden_states, _ = self.context_embedder(encoder_hidden_states)
+
+            if txt_ids.ndim == 3:
+                txt_ids = txt_ids[0]
+            if img_ids.ndim == 3:
+                img_ids = img_ids[0]
+
+            ids = torch.cat((txt_ids, img_ids), dim=0)
+            image_rotary_emb = self.pos_embed(ids)
+
+            jkwargs = joint_attention_kwargs or {}
+
+            for idx, block in enumerate(self.transformer_blocks):
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    image_rotary_emb=image_rotary_emb,
+                    joint_attention_kwargs=jkwargs,
+                )
+                if controlnet_block_samples is not None:
+                    interval = len(self.transformer_blocks) / len(controlnet_block_samples)
+                    interval = int(math.ceil(interval))
+                    if controlnet_blocks_repeat:
+                        hidden_states = hidden_states + controlnet_block_samples[idx % len(controlnet_block_samples)]
+                    else:
+                        hidden_states = hidden_states + controlnet_block_samples[idx // interval]
+
+            for idx, block in enumerate(self.single_transformer_blocks):
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    image_rotary_emb=image_rotary_emb,
+                    joint_attention_kwargs=jkwargs,
+                )
+                if controlnet_single_block_samples is not None:
+                    interval = len(self.single_transformer_blocks) / len(controlnet_single_block_samples)
+                    interval = int(math.ceil(interval))
+                    hidden_states = hidden_states + controlnet_single_block_samples[idx // interval]
+
+            hidden_states = self.norm_out(hidden_states, temb)
+            output, _ = self.proj_out(hidden_states)
+
+            if not return_dict:
+                return (output,)
+            return FluxTransformer2DModelOutput(sample=output)
+
+
+EntryClass = FluxTransformer2DModel

--- a/fastvideo/pipelines/basic/flux/__init__.py
+++ b/fastvideo/pipelines/basic/flux/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/fastvideo/pipelines/basic/flux/flux_pipeline.py
+++ b/fastvideo/pipelines/basic/flux/flux_pipeline.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.pipelines.stages.flux_stages import (
+    FluxConditioningStage,
+    FluxDecodingStage,
+    FluxDenoisingStage,
+    FluxInputValidationStage,
+    FluxLatentPreparationStage,
+    FluxTimestepPreparationStage,
+)
+from fastvideo.pipelines.stages.text_encoding import TextEncodingStage
+
+
+class FluxPipeline(ComposedPipelineBase):
+    """FLUX.1-dev T2I (Diffusers module layout, packed latents, embedded guidance)."""
+
+    _required_config_modules = [
+        "scheduler",
+        "transformer",
+        "vae",
+        "text_encoder",
+        "text_encoder_2",
+        "tokenizer",
+        "tokenizer_2",
+    ]
+
+    def create_pipeline_stages(self, fastvideo_args: FastVideoArgs) -> None:
+        self.add_stage(stage_name="input_validation_stage", stage=FluxInputValidationStage())
+
+        self.add_stage(
+            stage_name="text_encoding_stage",
+            stage=TextEncodingStage(
+                text_encoders=[
+                    self.get_module("text_encoder"),
+                    self.get_module("text_encoder_2"),
+                ],
+                tokenizers=[
+                    self.get_module("tokenizer"),
+                    self.get_module("tokenizer_2"),
+                ],
+            ),
+        )
+
+        self.add_stage(stage_name="flux_conditioning_stage", stage=FluxConditioningStage())
+
+        self.add_stage(
+            stage_name="timestep_preparation_stage",
+            stage=FluxTimestepPreparationStage(scheduler=self.get_module("scheduler")),
+        )
+
+        self.add_stage(
+            stage_name="latent_preparation_stage",
+            stage=FluxLatentPreparationStage(scheduler=self.get_module("scheduler")),
+        )
+
+        self.add_stage(
+            stage_name="denoising_stage",
+            stage=FluxDenoisingStage(
+                transformer=self.get_module("transformer"),
+                scheduler=self.get_module("scheduler"),
+            ),
+        )
+
+        self.add_stage(
+            stage_name="decoding_stage",
+            stage=FluxDecodingStage(vae=self.get_module("vae")),
+        )
+
+
+EntryClass = FluxPipeline

--- a/fastvideo/pipelines/pipeline_batch_info.py
+++ b/fastvideo/pipelines/pipeline_batch_info.py
@@ -108,6 +108,10 @@ class ForwardBatch:
     max_sequence_length: int | None = None
     prompt_template: dict[str, Any] | None = None
     do_classifier_free_guidance: bool = False
+    # When True, ``guidance_scale`` is passed into models that use embedded guidance (e.g. FLUX)
+    # and must not imply classic dual-forward CFG. Use ``true_cfg_scale > 1`` for true CFG.
+    use_embedded_guidance: bool = False
+    true_cfg_scale: float = 1.0
 
     # Batch info
     batch_size: int | None = None
@@ -224,9 +228,12 @@ class ForwardBatch:
     def __post_init__(self):
         """Initialize dependent fields after dataclass initialization."""
 
-        # Enable CFG for standard guidance_scale and LTX-2 text CFG scales.
+        # LTX-2 text CFG scales; FLUX uses ``use_embedded_guidance`` so ``guidance_scale > 1`` alone
+        # does not enable classifier-free guidance.
         ltx2_text_cfg_enabled = (self.ltx2_cfg_scale_video != 1.0 or self.ltx2_cfg_scale_audio != 1.0)
-        if self.guidance_scale > 1.0 or ltx2_text_cfg_enabled:
+        if self.use_embedded_guidance:
+            self.do_classifier_free_guidance = (self.true_cfg_scale > 1.0) or ltx2_text_cfg_enabled
+        elif self.guidance_scale > 1.0 or ltx2_text_cfg_enabled:
             self.do_classifier_free_guidance = True
         if self.negative_prompt_embeds is None:
             self.negative_prompt_embeds = []

--- a/fastvideo/pipelines/stages/flux_stages.py
+++ b/fastvideo/pipelines/stages/flux_stages.py
@@ -66,12 +66,9 @@ class FluxInputValidationStage(InputValidationStage):
         batch: ForwardBatch,
         fastvideo_args: FastVideoArgs,
     ) -> ForwardBatch:
-        if (batch.height is not None and batch.width is not None
-                and (batch.height % 16 != 0 or batch.width % 16 != 0)):
-            raise ValueError(
-                "FLUX expects height and width divisible by 16 "
-                f"(VAE latent grid × 2× packing); got {batch.height}×{batch.width}."
-            )
+        if (batch.height is not None and batch.width is not None and (batch.height % 16 != 0 or batch.width % 16 != 0)):
+            raise ValueError("FLUX expects height and width divisible by 16 "
+                             f"(VAE latent grid × 2× packing); got {batch.height}×{batch.width}.")
         return super().forward(batch, fastvideo_args)
 
 
@@ -81,10 +78,8 @@ class FluxConditioningStage(PipelineStage):
     @torch.no_grad()
     def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
         if len(batch.prompt_embeds) < 2:
-            raise ValueError(
-                "FluxConditioningStage expects 2 prompt_embeds (CLIP pooled, T5 sequence), "
-                f"got {len(batch.prompt_embeds)}"
-            )
+            raise ValueError("FluxConditioningStage expects 2 prompt_embeds (CLIP pooled, T5 sequence), "
+                             f"got {len(batch.prompt_embeds)}")
 
         device = get_local_torch_device()
         target_dtype = PRECISION_TO_TYPE[fastvideo_args.pipeline_config.dit_precision]
@@ -188,9 +183,7 @@ class FluxLatentPreparationStage(PipelineStage):
         batch_size *= batch.num_videos_per_prompt
 
         if isinstance(batch.generator, list) and len(batch.generator) != batch_size:
-            raise ValueError(
-                f"generator list length {len(batch.generator)} does not match batch_size {batch_size}"
-            )
+            raise ValueError(f"generator list length {len(batch.generator)} does not match batch_size {batch_size}")
 
         arch = fastvideo_args.pipeline_config.dit_config.arch_config
         in_channels = int(getattr(arch, "in_channels", 64))
@@ -280,7 +273,7 @@ class FluxDenoisingStage(PipelineStage):
 
         bs = packed.shape[0]
         if guidance_embeds:
-            guidance = torch.full((bs,), float(batch.guidance_scale), device=device, dtype=torch.float32)
+            guidance = torch.full((bs, ), float(batch.guidance_scale), device=device, dtype=torch.float32)
         else:
             guidance = None
 
@@ -297,16 +290,16 @@ class FluxDenoisingStage(PipelineStage):
 
             ts_ctx = int(t_scalar.reshape(-1)[0].item())
             with (
-                torch.autocast(
-                    device_type="cuda",
-                    dtype=target_dtype,
-                    enabled=autocast_enabled and device.type == "cuda",
-                ),
-                set_forward_context(
-                    current_timestep=ts_ctx,
-                    attn_metadata=None,
-                    forward_batch=batch,
-                ),
+                    torch.autocast(
+                        device_type="cuda",
+                        dtype=target_dtype,
+                        enabled=autocast_enabled and device.type == "cuda",
+                    ),
+                    set_forward_context(
+                        current_timestep=ts_ctx,
+                        attn_metadata=None,
+                        forward_batch=batch,
+                    ),
             ):
                 if use_true_cfg:
                     assert neg_enc is not None and neg_pooled is not None
@@ -405,9 +398,9 @@ class FluxDecodingStage(PipelineStage):
         use_cuda_autocast = autocast_enabled and vae_device.type == "cuda"
 
         with torch.autocast(
-            device_type="cuda",
-            dtype=vae_dtype,
-            enabled=use_cuda_autocast,
+                device_type="cuda",
+                dtype=vae_dtype,
+                enabled=use_cuda_autocast,
         ):
             if not autocast_enabled:
                 latents_4d = latents_4d.to(dtype=vae_dtype)

--- a/fastvideo/pipelines/stages/flux_stages.py
+++ b/fastvideo/pipelines/stages/flux_stages.py
@@ -1,0 +1,419 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import torch
+from diffusers.utils.torch_utils import randn_tensor
+
+from fastvideo.distributed import get_local_torch_device
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.forward_context import set_forward_context
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.stages.input_validation import InputValidationStage
+from fastvideo.pipelines.stages.timestep_preparation import TimestepPreparationStage
+from fastvideo.utils import PRECISION_TO_TYPE
+
+
+def _pack_latents(
+    latents: torch.Tensor,
+    batch_size: int,
+    num_channels_latents: int,
+    height: int,
+    width: int,
+) -> torch.Tensor:
+    """Diffusers ``_pack_latents`` for FLUX (2×2 spatial pack in latent space)."""
+    latents = latents.view(batch_size, num_channels_latents, height // 2, 2, width // 2, 2)
+    latents = latents.permute(0, 2, 4, 1, 3, 5)
+    return latents.reshape(batch_size, (height // 2) * (width // 2), num_channels_latents * 4)
+
+
+def _unpack_latents(
+    latents: torch.Tensor,
+    batch_size: int,
+    num_channels_latents: int,
+    height: int,
+    width: int,
+) -> torch.Tensor:
+    """Inverse of ``_pack_latents``."""
+    latents = latents.reshape(batch_size, height // 2, width // 2, num_channels_latents, 2, 2)
+    latents = latents.permute(0, 3, 1, 4, 2, 5)
+    return latents.reshape(batch_size, num_channels_latents, height, width)
+
+
+def _prepare_latent_image_ids(
+    patch_height: int,
+    patch_width: int,
+    device: torch.device,
+    dtype: torch.dtype = torch.long,
+) -> torch.Tensor:
+    """Match Diffusers ``FluxPipeline._prepare_latent_image_ids`` (no batch dim)."""
+    latent_image_ids = torch.zeros(patch_height, patch_width, 3, device=device, dtype=torch.float32)
+    latent_image_ids[..., 1] = latent_image_ids[..., 1] + torch.arange(patch_height, device=device)[:, None]
+    latent_image_ids[..., 2] = latent_image_ids[..., 2] + torch.arange(patch_width, device=device)[None, :]
+    h, w, c = latent_image_ids.shape
+    return latent_image_ids.reshape(h * w, c).to(dtype=dtype)
+
+
+class FluxInputValidationStage(InputValidationStage):
+    """Require height/width divisible by 16 (VAE scale × 2 for FLUX packing)."""
+
+    def forward(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> ForwardBatch:
+        if (batch.height is not None and batch.width is not None
+                and (batch.height % 16 != 0 or batch.width % 16 != 0)):
+            raise ValueError(
+                "FLUX expects height and width divisible by 16 "
+                f"(VAE latent grid × 2× packing); got {batch.height}×{batch.width}."
+            )
+        return super().forward(batch, fastvideo_args)
+
+
+class FluxConditioningStage(PipelineStage):
+    """Build CLIP pooled + T5 sequence + ``text_ids`` (and optional negative for true CFG)."""
+
+    @torch.no_grad()
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        if len(batch.prompt_embeds) < 2:
+            raise ValueError(
+                "FluxConditioningStage expects 2 prompt_embeds (CLIP pooled, T5 sequence), "
+                f"got {len(batch.prompt_embeds)}"
+            )
+
+        device = get_local_torch_device()
+        target_dtype = PRECISION_TO_TYPE[fastvideo_args.pipeline_config.dit_precision]
+
+        pooled = batch.prompt_embeds[0].to(device=device, dtype=target_dtype)
+        enc = batch.prompt_embeds[1].to(device=device, dtype=target_dtype)
+        seq_len = enc.shape[1]
+        text_ids = torch.zeros(seq_len, 3, device=device, dtype=torch.long)
+
+        batch.extra["flux_pooled_projections"] = pooled
+        batch.extra["flux_encoder_hidden_states"] = enc
+        batch.extra["flux_text_ids"] = text_ids
+
+        if batch.do_classifier_free_guidance:
+            if not batch.negative_prompt_embeds or len(batch.negative_prompt_embeds) < 2:
+                raise ValueError("True CFG requires two negative_prompt_embeds (CLIP, T5).")
+            neg_pooled = batch.negative_prompt_embeds[0].to(device=device, dtype=target_dtype)
+            neg_enc = batch.negative_prompt_embeds[1].to(device=device, dtype=target_dtype)
+            batch.extra["flux_negative_pooled_projections"] = neg_pooled
+            batch.extra["flux_negative_encoder_hidden_states"] = neg_enc
+
+        return batch
+
+
+class FluxTimestepPreparationStage(TimestepPreparationStage):
+    """Flow Match with resolution-dependent ``mu`` from packed image sequence length."""
+
+    @staticmethod
+    def _calculate_mu(
+        image_seq_len: int,
+        base_seq_len: int = 256,
+        max_seq_len: int = 4096,
+        base_shift: float = 0.5,
+        max_shift: float = 1.15,
+    ) -> float:
+        m = (max_shift - base_shift) / (max_seq_len - base_seq_len)
+        b = base_shift - m * base_seq_len
+        return float(image_seq_len) * m + b
+
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        sig = inspect.signature(self.scheduler.set_timesteps)
+        if "mu" not in sig.parameters:
+            return super().forward(batch, fastvideo_args)
+
+        cfg = getattr(self.scheduler, "config", None)
+        use_dynamic = bool(getattr(cfg, "use_dynamic_shifting", False)) if cfg is not None else False
+        if not use_dynamic:
+            return super().forward(batch, fastvideo_args)
+
+        if batch.height is None or batch.width is None:
+            raise ValueError("height/width must be set before FluxTimestepPreparationStage")
+
+        vae_arch = fastvideo_args.pipeline_config.vae_config.arch_config
+        spatial_ratio = int(getattr(vae_arch, "spatial_compression_ratio", 8))
+        h_lat = batch.height // spatial_ratio
+        w_lat = batch.width // spatial_ratio
+        if h_lat % 2 != 0 or w_lat % 2 != 0:
+            raise ValueError(
+                f"Latent spatial dims must be even for FLUX packing; got {h_lat}×{w_lat} from {batch.height}×{batch.width}."
+            )
+        image_seq_len = (h_lat // 2) * (w_lat // 2)
+
+        base_seq_len = int(getattr(cfg, "base_image_seq_len", 256))
+        max_seq_len = int(getattr(cfg, "max_image_seq_len", 4096))
+        base_shift = float(getattr(cfg, "base_shift", 0.5))
+        max_shift = float(getattr(cfg, "max_shift", 1.15))
+
+        device = get_local_torch_device()
+        mu = self._calculate_mu(
+            image_seq_len=image_seq_len,
+            base_seq_len=base_seq_len,
+            max_seq_len=max_seq_len,
+            base_shift=base_shift,
+            max_shift=max_shift,
+        )
+        self.scheduler.set_timesteps(batch.num_inference_steps, device=device, mu=mu)
+        batch.timesteps = self.scheduler.timesteps
+        return batch
+
+
+class FluxLatentPreparationStage(PipelineStage):
+
+    def __init__(self, scheduler) -> None:
+        super().__init__()
+        self.scheduler = scheduler
+
+    @torch.no_grad()
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        if batch.height is None or batch.width is None:
+            raise ValueError("height/width required for FluxLatentPreparationStage")
+
+        if isinstance(batch.prompt, list):
+            batch_size = len(batch.prompt)
+        elif batch.prompt is not None:
+            batch_size = 1
+        else:
+            if not batch.prompt_embeds:
+                raise ValueError("prompt or prompt_embeds must be provided")
+            batch_size = batch.prompt_embeds[0].shape[0]
+
+        batch_size *= batch.num_videos_per_prompt
+
+        if isinstance(batch.generator, list) and len(batch.generator) != batch_size:
+            raise ValueError(
+                f"generator list length {len(batch.generator)} does not match batch_size {batch_size}"
+            )
+
+        arch = fastvideo_args.pipeline_config.dit_config.arch_config
+        in_channels = int(getattr(arch, "in_channels", 64))
+        num_channels_latents = in_channels // 4
+
+        vae_arch = fastvideo_args.pipeline_config.vae_config.arch_config
+        spatial_ratio = int(getattr(vae_arch, "spatial_compression_ratio", 8))
+
+        h_lat = batch.height // spatial_ratio
+        w_lat = batch.width // spatial_ratio
+
+        dtype = PRECISION_TO_TYPE[fastvideo_args.pipeline_config.dit_precision]
+        device = get_local_torch_device()
+
+        shape = (batch_size, num_channels_latents, h_lat, w_lat)
+        latents = batch.latents
+        if latents is None:
+            latents = randn_tensor(shape, generator=batch.generator, device=device, dtype=dtype)
+            if hasattr(self.scheduler, "init_noise_sigma"):
+                latents = latents * self.scheduler.init_noise_sigma
+        else:
+            latents = latents.to(device=device, dtype=dtype)
+            if latents.shape != shape:
+                raise ValueError(f"Expected latents shape {shape}, got {tuple(latents.shape)}")
+            if hasattr(self.scheduler, "init_noise_sigma"):
+                latents = latents * self.scheduler.init_noise_sigma
+
+        packed = _pack_latents(latents, batch_size, num_channels_latents, h_lat, w_lat)
+
+        patch_h, patch_w = h_lat // 2, w_lat // 2
+        img_ids = _prepare_latent_image_ids(patch_h, patch_w, device, dtype=torch.long)
+
+        batch.latents = packed
+        batch.raw_latent_shape = shape
+        batch.extra["flux_h_lat"] = h_lat
+        batch.extra["flux_w_lat"] = w_lat
+        batch.extra["flux_num_channels_latents"] = num_channels_latents
+        batch.extra["flux_latent_image_ids"] = img_ids
+
+        return batch
+
+
+class FluxDenoisingStage(PipelineStage):
+
+    def __init__(self, transformer, scheduler) -> None:
+        super().__init__()
+        self.transformer = transformer
+        self.scheduler = scheduler
+
+    @staticmethod
+    def _step_kwargs(scheduler_step, batch: ForwardBatch) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
+        sig = inspect.signature(scheduler_step)
+        if "generator" in sig.parameters:
+            gen = batch.generator[0] if isinstance(batch.generator, list) else batch.generator
+            kwargs["generator"] = gen
+        return kwargs
+
+    @torch.no_grad()
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        if batch.timesteps is None:
+            raise ValueError("timesteps must be set before FluxDenoisingStage")
+        if batch.latents is None:
+            raise ValueError("latents must be set before FluxDenoisingStage")
+
+        packed = batch.latents
+        timesteps = batch.timesteps
+
+        pooled = batch.extra["flux_pooled_projections"]
+        enc = batch.extra["flux_encoder_hidden_states"]
+        txt_ids = batch.extra["flux_text_ids"]
+        img_ids = batch.extra["flux_latent_image_ids"]
+
+        neg_pooled = batch.extra.get("flux_negative_pooled_projections")
+        neg_enc = batch.extra.get("flux_negative_encoder_hidden_states")
+
+        true_cfg_scale = float(batch.true_cfg_scale)
+        use_true_cfg = batch.do_classifier_free_guidance and true_cfg_scale > 1.0
+
+        # Prefer the loaded transformer's arch (HF ``guidance_embeds``), not static pipeline defaults.
+        tr_arch = self.transformer.fastvideo_config.arch_config
+        guidance_embeds = bool(getattr(tr_arch, "guidance_embeds", False))
+
+        device = get_local_torch_device()
+        target_dtype = PRECISION_TO_TYPE[fastvideo_args.pipeline_config.dit_precision]
+        autocast_enabled = (target_dtype != torch.float32) and not fastvideo_args.disable_autocast
+
+        bs = packed.shape[0]
+        if guidance_embeds:
+            guidance = torch.full((bs,), float(batch.guidance_scale), device=device, dtype=torch.float32)
+        else:
+            guidance = None
+
+        step_extras = self._step_kwargs(self.scheduler.step, batch)
+
+        for t in timesteps:
+            t_scalar = t
+            if not isinstance(t_scalar, torch.Tensor):
+                t_scalar = torch.tensor([t_scalar], device=device, dtype=torch.float32)
+            t_scalar = t_scalar.to(device=device, dtype=torch.float32)
+
+            timestep_model = t_scalar.expand(bs).float() / 1000.0
+            timestep_model = timestep_model.to(dtype=target_dtype)
+
+            ts_ctx = int(t_scalar.reshape(-1)[0].item())
+            with (
+                torch.autocast(
+                    device_type="cuda",
+                    dtype=target_dtype,
+                    enabled=autocast_enabled and device.type == "cuda",
+                ),
+                set_forward_context(
+                    current_timestep=ts_ctx,
+                    attn_metadata=None,
+                    forward_batch=batch,
+                ),
+            ):
+                if use_true_cfg:
+                    assert neg_enc is not None and neg_pooled is not None
+                    n_neg = self.transformer(
+                        hidden_states=packed,
+                        encoder_hidden_states=neg_enc,
+                        pooled_projections=neg_pooled,
+                        timestep=timestep_model,
+                        guidance=guidance,
+                        txt_ids=txt_ids,
+                        img_ids=img_ids,
+                        return_dict=False,
+                    )[0]
+                    n_pos = self.transformer(
+                        hidden_states=packed,
+                        encoder_hidden_states=enc,
+                        pooled_projections=pooled,
+                        timestep=timestep_model,
+                        guidance=guidance,
+                        txt_ids=txt_ids,
+                        img_ids=img_ids,
+                        return_dict=False,
+                    )[0]
+                    noise_pred = n_neg + true_cfg_scale * (n_pos - n_neg)
+                else:
+                    noise_pred = self.transformer(
+                        hidden_states=packed,
+                        encoder_hidden_states=enc,
+                        pooled_projections=pooled,
+                        timestep=timestep_model,
+                        guidance=guidance,
+                        txt_ids=txt_ids,
+                        img_ids=img_ids,
+                        return_dict=False,
+                    )[0]
+
+            packed = self.scheduler.step(
+                noise_pred,
+                t_scalar,
+                packed,
+                return_dict=False,
+                **step_extras,
+            )[0]
+
+        batch.latents = packed
+        return batch
+
+
+class FluxDecodingStage(PipelineStage):
+    """Unpack latents, apply VAE scaling/shift, decode to pixels (5D output ``B×3×1×H×W``)."""
+
+    def __init__(self, vae) -> None:
+        super().__init__()
+        self.vae = vae
+
+    @staticmethod
+    def _denormalize_latents(latents: torch.Tensor, vae: Any) -> torch.Tensor:
+        cfg = getattr(vae, "config", None)
+        sf = getattr(cfg, "scaling_factor", None) if cfg is not None else None
+        sh = getattr(cfg, "shift_factor", None) if cfg is not None else None
+        if sf is None and hasattr(vae, "scaling_factor"):
+            sf = vae.scaling_factor
+        if sh is None and hasattr(vae, "shift_factor"):
+            sh = vae.shift_factor
+        if sf is not None:
+            latents = latents / (sf.to(latents.device, latents.dtype) if isinstance(sf, torch.Tensor) else sf)
+            if sh is not None:
+                latents = latents + (sh.to(latents.device, latents.dtype) if isinstance(sh, torch.Tensor) else sh)
+        return latents
+
+    @torch.no_grad()
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        packed = batch.latents
+        if packed is None:
+            raise ValueError("latents must be set before FluxDecodingStage")
+
+        h_lat = int(batch.extra["flux_h_lat"])
+        w_lat = int(batch.extra["flux_w_lat"])
+        num_ch = int(batch.extra["flux_num_channels_latents"])
+        raw_shape = batch.raw_latent_shape
+        if raw_shape is None:
+            raise ValueError("raw_latent_shape missing; FluxLatentPreparationStage must run first.")
+        batch_size = int(raw_shape[0])
+
+        infer_device = get_local_torch_device()
+        packed = packed.to(infer_device)
+
+        latents_4d = _unpack_latents(packed, batch_size, num_ch, h_lat, w_lat)
+        latents_4d = self._denormalize_latents(latents_4d, self.vae)
+
+        vae_device = next(self.vae.parameters()).device
+        latents_4d = latents_4d.to(device=vae_device)
+
+        vae_dtype = PRECISION_TO_TYPE[fastvideo_args.pipeline_config.vae_precision]
+        autocast_enabled = (vae_dtype != torch.float32) and not fastvideo_args.disable_autocast
+        use_cuda_autocast = autocast_enabled and vae_device.type == "cuda"
+
+        with torch.autocast(
+            device_type="cuda",
+            dtype=vae_dtype,
+            enabled=use_cuda_autocast,
+        ):
+            if not autocast_enabled:
+                latents_4d = latents_4d.to(dtype=vae_dtype)
+            dec = self.vae.decode(latents_4d)
+            image = dec.sample if hasattr(dec, "sample") else dec[0]
+
+        image = (image / 2 + 0.5).clamp(0, 1)
+        batch.output = image.unsqueeze(2).detach().float().cpu()
+        return batch

--- a/fastvideo/registry.py
+++ b/fastvideo/registry.py
@@ -47,8 +47,10 @@ from fastvideo.configs.pipelines.wan import (
     WanT2V480PConfig,
     WanT2V720PConfig,
 )
+from fastvideo.configs.pipelines.flux import FluxPipelineConfig
 from fastvideo.configs.pipelines.sd35 import SD35Config
 from fastvideo.configs.sample.base import SamplingParam
+from fastvideo.configs.sample.flux import FluxSamplingParam
 from fastvideo.configs.sample.cosmos import (
     Cosmos_Predict2_2B_Video2World_SamplingParam, )
 from fastvideo.configs.sample.cosmos2_5 import Cosmos25SamplingParamBase
@@ -240,6 +242,8 @@ def _get_config_info(
 
 
 def _register_configs() -> None:
+    if _CONFIG_REGISTRY:
+        return
     # LTX-2 (base)
     register_configs(
         sampling_param_cls=LTX2BaseSamplingParam,
@@ -637,6 +641,21 @@ def _register_configs() -> None:
                 "stablediffusion3",
                 "stabilityai__stable-diffusion-3.5-medium",
             )),
+        ],
+    )
+
+    # FLUX.1-dev (Diffusers)
+    register_configs(
+        sampling_param_cls=FluxSamplingParam,
+        pipeline_config_cls=FluxPipelineConfig,
+        workload_types=(WorkloadType.T2I, ),
+        hf_model_paths=[
+            "black-forest-labs/FLUX.1-dev",
+        ],
+        model_detectors=[
+            lambda path: "fluxpipeline" in path,
+            lambda path: "flux.1-dev" in path or "flux_1_dev" in path,
+            lambda path: "/flux/" in path or path.endswith("/flux"),
         ],
     )
 

--- a/fastvideo/tests/ssim/inference_similarity_utils.py
+++ b/fastvideo/tests/ssim/inference_similarity_utils.py
@@ -58,25 +58,43 @@ def resolve_inference_device_reference_folder(logger: Logger) -> str:
     return device_reference_folder
 
 
-def _find_reference_video(reference_folder: str, prompt: str) -> str:
+def _find_reference_media(
+    reference_folder: str,
+    prompt: str,
+    *,
+    media_extension: str,
+) -> str:
+    """Pick a reference file whose basename contains the prompt prefix."""
     prompt_prefix = prompt[:100].strip()
+    allowed = (media_extension.lower(), ".mp4", ".png", ".jpg", ".jpeg")
+    matches: list[str] = []
     for filename in os.listdir(reference_folder):
-        if filename.endswith(".mp4") and prompt_prefix in filename:
-            return os.path.join(reference_folder, filename)
-    raise FileNotFoundError("Reference video missing")
+        low = filename.lower()
+        if not any(low.endswith(ext) for ext in allowed):
+            continue
+        if prompt_prefix in filename:
+            matches.append(filename)
+    if not matches:
+        raise FileNotFoundError("Reference media missing")
+    preferred = media_extension.lower().lstrip(".")
+    for name in matches:
+        if name.lower().endswith(f".{preferred}"):
+            return os.path.join(reference_folder, name)
+    return os.path.join(reference_folder, matches[0])
 
 
 def _assert_similarity(
     *,
     logger: Logger,
     output_dir: str,
-    output_video_name: str,
+    output_media_name: str,
     reference_folder: str,
     prompt: str,
     num_inference_steps: int,
     min_acceptable_ssim: float,
     model_id: str,
     attention_backend_name: str,
+    media_extension: str,
 ) -> None:
     if not os.path.exists(reference_folder):
         logger.error("Reference folder missing: %s", reference_folder)
@@ -88,25 +106,29 @@ def _assert_similarity(
         raise FileNotFoundError(error_msg)
 
     try:
-        reference_video_path = _find_reference_video(reference_folder, prompt)
+        reference_media_path = _find_reference_media(
+            reference_folder,
+            prompt,
+            media_extension=media_extension,
+        )
     except FileNotFoundError as error:
         logger.error(
-            "Reference video not found for prompt: %s with backend: %s",
+            "Reference media not found for prompt: %s with backend: %s",
             prompt,
             attention_backend_name,
         )
         raise error
 
-    generated_video_path = os.path.join(output_dir, output_video_name)
+    generated_media_path = os.path.join(output_dir, output_media_name)
 
     logger.info(
         "Computing SSIM between %s and %s",
-        reference_video_path,
-        generated_video_path,
+        reference_media_path,
+        generated_media_path,
     )
     ssim_values = compute_video_ssim_torchvision(
-        reference_video_path,
-        generated_video_path,
+        reference_media_path,
+        generated_media_path,
         use_ms_ssim=True,
     )
 
@@ -117,8 +139,8 @@ def _assert_similarity(
     success = write_ssim_results(
         output_dir,
         ssim_values,
-        reference_video_path,
-        generated_video_path,
+        reference_media_path,
+        generated_media_path,
         num_inference_steps,
         prompt,
     )
@@ -203,6 +225,7 @@ def run_text_to_video_similarity_test(
     min_acceptable_ssim: float,
     init_kwargs_override: dict[str, object] | None = None,
     generation_kwargs_override: dict[str, object] | None = None,
+    media_extension: str = ".mp4",
 ) -> None:
     with attention_backend(attention_backend_name):
         output_dir = build_generated_output_dir(
@@ -211,7 +234,7 @@ def run_text_to_video_similarity_test(
             model_id,
             attention_backend_name,
         )
-        output_video_name = f"{prompt[:100].strip()}.mp4"
+        output_media_name = f"{prompt[:100].strip()}{media_extension}"
         os.makedirs(output_dir, exist_ok=True)
 
         params_map = select_ssim_params(
@@ -254,13 +277,14 @@ def run_text_to_video_similarity_test(
     _assert_similarity(
         logger=logger,
         output_dir=output_dir,
-        output_video_name=output_video_name,
+        output_media_name=output_media_name,
         reference_folder=reference_folder,
         prompt=prompt,
         num_inference_steps=num_inference_steps,
         min_acceptable_ssim=min_acceptable_ssim,
         model_id=model_id,
         attention_backend_name=attention_backend_name,
+        media_extension=media_extension,
     )
 
 
@@ -286,7 +310,7 @@ def run_image_to_video_similarity_test(
             model_id,
             attention_backend_name,
         )
-        output_video_name = f"{prompt[:100].strip()}.mp4"
+        output_media_name = f"{prompt[:100].strip()}.mp4"
         os.makedirs(output_dir, exist_ok=True)
 
         params_map = select_ssim_params(
@@ -330,11 +354,12 @@ def run_image_to_video_similarity_test(
     _assert_similarity(
         logger=logger,
         output_dir=output_dir,
-        output_video_name=output_video_name,
+        output_media_name=output_media_name,
         reference_folder=reference_folder,
         prompt=prompt,
         num_inference_steps=num_inference_steps,
         min_acceptable_ssim=min_acceptable_ssim,
         model_id=model_id,
         attention_backend_name=attention_backend_name,
+        media_extension=".mp4",
     )

--- a/fastvideo/tests/ssim/test_flux_t2i_similarity.py
+++ b/fastvideo/tests/ssim/test_flux_t2i_similarity.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+
+from fastvideo.configs.sample.flux import FluxSamplingParam
+from fastvideo.logger import init_logger
+from fastvideo.tests.ssim.inference_similarity_utils import (
+    run_text_to_video_similarity_test,
+)
+from fastvideo.tests.ssim.reference_utils import (
+    get_cuda_device_name,
+    resolve_device_reference_folder,
+)
+
+logger = init_logger(__name__)
+
+REQUIRED_GPUS = 1
+
+# MS-SSIM gate (see module docstring).
+FLUX_T2I_MIN_SSIM = 0.98
+
+FLUX_MODEL_PATH = os.getenv(
+    "FLUX_T2I_MODEL_DIR",
+    "black-forest-labs/FLUX.1-dev",
+)
+
+device_reference_folder = resolve_device_reference_folder(
+    (
+        ("A40", "A40"),
+        ("L40S", "L40S"),
+        ("H100", "H100"),
+        ("H200", "H200"),
+        ("RTX 4090", "RTX4090"),
+        ("4090", "RTX4090"),
+    ),
+    device_name=get_cuda_device_name(),
+    fallback_device_prefix="L40S",
+    logger=logger,
+)
+
+# Folder token must match Hub path with slashes → double underscore (SD3.5
+# pattern in ``test_sd35_similarity.py``).
+MODEL_ID = "black-forest-labs__FLUX.1-dev"
+
+TEST_PROMPTS = [
+    "a photo of a cat",
+]
+
+FLUX_DEFAULT_PARAMS: dict[str, object] = {
+    "num_gpus": 1,
+    "model_path": FLUX_MODEL_PATH,
+    "sp_size": 1,
+    "tp_size": 1,
+    "height": 256,
+    "width": 256,
+    "num_frames": 1,
+    "fps": 1,
+    "num_inference_steps": 8,
+    "guidance_scale": 3.5,
+    "seed": 0,
+}
+
+_flux_full_defaults = FluxSamplingParam()
+FLUX_FULL_QUALITY_PARAMS: dict[str, object] = {
+    "num_gpus": 1,
+    "model_path": FLUX_MODEL_PATH,
+    "sp_size": 1,
+    "tp_size": 1,
+    "height": _flux_full_defaults.height,
+    "width": _flux_full_defaults.width,
+    "num_frames": 1,
+    "fps": _flux_full_defaults.fps,
+    "num_inference_steps": _flux_full_defaults.num_inference_steps,
+    "guidance_scale": _flux_full_defaults.guidance_scale,
+    "seed": _flux_full_defaults.seed,
+}
+
+FLUX_MODEL_TO_PARAMS = {
+    MODEL_ID: FLUX_DEFAULT_PARAMS,
+}
+FLUX_FULL_QUALITY_MODEL_TO_PARAMS = {
+    MODEL_ID: FLUX_FULL_QUALITY_PARAMS,
+}
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="FLUX T2I SSIM test requires CUDA",
+)
+@pytest.mark.parametrize("prompt", TEST_PROMPTS)
+@pytest.mark.parametrize("attention_backend_name", ["TORCH_SDPA", "FLASH_ATTN"])
+@pytest.mark.parametrize("model_id", list(FLUX_MODEL_TO_PARAMS.keys()))
+def test_flux_t2i_similarity(
+    prompt: str,
+    attention_backend_name: str,
+    model_id: str,
+) -> None:
+    is_hf_repo = "/" in FLUX_MODEL_PATH and not FLUX_MODEL_PATH.startswith("/")
+    if not is_hf_repo and not os.path.isdir(FLUX_MODEL_PATH):
+        pytest.skip(
+            f"FLUX weights not found at {FLUX_MODEL_PATH} "
+            f"(set FLUX_T2I_MODEL_DIR to override)"
+        )
+
+    run_text_to_video_similarity_test(
+        logger=logger,
+        script_dir=os.path.dirname(os.path.abspath(__file__)),
+        device_reference_folder=device_reference_folder,
+        prompt=prompt,
+        attention_backend_name=attention_backend_name,
+        model_id=model_id,
+        default_params_map=FLUX_MODEL_TO_PARAMS,
+        full_quality_params_map=FLUX_FULL_QUALITY_MODEL_TO_PARAMS,
+        min_acceptable_ssim=FLUX_T2I_MIN_SSIM,
+        media_extension=".png",
+        init_kwargs_override={
+            "workload_type": "t2i",
+            "use_fsdp_inference": False,
+            "text_encoder_cpu_offload": False,
+            "vae_cpu_offload": False,
+            "image_encoder_cpu_offload": False,
+            "pin_cpu_memory": False,
+        },
+        generation_kwargs_override={
+            "save_video": True,
+            "use_embedded_guidance": True,
+            "true_cfg_scale": 1.0,
+        },
+    )

--- a/fastvideo/tests/transformers/test_flux.py
+++ b/fastvideo/tests/transformers/test_flux.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import glob
+import os
+
+import pytest
+import torch
+from diffusers import FluxTransformer2DModel as HFFluxTransformer2DModel
+from torch.testing import assert_close
+
+from fastvideo.configs.models.dits.flux import FluxDiTConfig
+from fastvideo.configs.pipelines.base import PipelineConfig
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.forward_context import set_forward_context
+from fastvideo.models.loader.component_loader import TransformerLoader
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29517")
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+_DEFAULT_FLUX_TRANSFORMER = os.path.join(
+    _REPO_ROOT,
+    "official_weights",
+    "FLUX.1-dev",
+    "transformer",
+)
+
+
+def _flux_transformer_path() -> str:
+    return os.environ.get("FLUX_TRANSFORMER_PATH", _DEFAULT_FLUX_TRANSFORMER)
+
+
+def _prepare_latent_image_ids(
+    height: int,
+    width: int,
+    device: torch.device,
+    dtype: torch.dtype = torch.long,
+) -> torch.Tensor:
+    """Match Diffusers ``FluxPipeline._prepare_latent_image_ids`` (batch omitted)."""
+    latent_image_ids = torch.zeros(height, width, 3)
+    latent_image_ids[..., 1] = latent_image_ids[..., 1] + torch.arange(height)[:, None]
+    latent_image_ids[..., 2] = latent_image_ids[..., 2] + torch.arange(width)[None, :]
+    h, w, c = latent_image_ids.shape
+    latent_image_ids = latent_image_ids.reshape(h * w, c)
+    return latent_image_ids.to(device=device, dtype=dtype)
+
+
+@pytest.fixture
+def torch_sdpa_attention_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "TORCH_SDPA")
+
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="FLUX DiT parity test requires CUDA",
+)
+
+requires_weights = pytest.mark.skipif(
+    not glob.glob(os.path.join(_flux_transformer_path(), "*.safetensors")),
+    reason=(
+        f"No safetensors under {_flux_transformer_path()} — download FLUX.1-dev "
+        "transformer or set FLUX_TRANSFORMER_PATH"
+    ),
+)
+
+
+@requires_cuda
+@requires_weights
+@pytest.mark.usefixtures("distributed_setup", "torch_sdpa_attention_backend")
+def test_flux_transformer_parity_vs_diffusers() -> None:
+    """Single forward: FastVideo DiT vs Diffusers ``FluxTransformer2DModel``."""
+    device = torch.device("cuda:0")
+    precision = torch.bfloat16
+    transformer_path = _flux_transformer_path()
+
+    args = FastVideoArgs(
+        model_path=transformer_path,
+        dit_cpu_offload=False,
+        dit_layerwise_offload=False,
+        pipeline_config=PipelineConfig(dit_config=FluxDiTConfig(), dit_precision="bf16"),
+    )
+    args.device = device
+
+    generator = torch.Generator(device=device).manual_seed(0)
+    torch.manual_seed(0)
+
+    batch_size = 1
+    latent_h, latent_w = 4, 4
+    img_seq = latent_h * latent_w
+    text_len = 32
+
+    hidden_states = torch.randn(
+        batch_size,
+        img_seq,
+        64,
+        device=device,
+        dtype=precision,
+        generator=generator,
+    )
+    encoder_hidden_states = torch.randn(
+        batch_size,
+        text_len,
+        4096,
+        device=device,
+        dtype=precision,
+        generator=generator,
+    )
+    pooled_projections = torch.randn(
+        batch_size,
+        768,
+        device=device,
+        dtype=precision,
+        generator=generator,
+    )
+
+    # Diffusers pipeline passes scheduler timesteps / 1000 (float, same dtype as latents).
+    timestep = torch.tensor([512.0], device=device, dtype=precision) / 1000.0
+    guidance = torch.full((batch_size,), 3.5, device=device, dtype=torch.float32)
+
+    txt_ids = torch.zeros(text_len, 3, device=device, dtype=torch.long)
+    img_ids = _prepare_latent_image_ids(latent_h, latent_w, device, dtype=torch.long)
+
+    forward_batch = ForwardBatch(data_type="dummy")
+
+    # One ~12B model at a time avoids peak VRAM from holding both checkpoints.
+    loader = TransformerLoader()
+    fv_model = loader.load(transformer_path, args).to(device=device, dtype=precision)
+    fv_model.eval()
+    with (
+        torch.no_grad(),
+        torch.amp.autocast("cuda", dtype=precision),
+        set_forward_context(
+            current_timestep=512,
+            attn_metadata=None,
+            forward_batch=forward_batch,
+        ),
+    ):
+        fv_out = fv_model(
+            hidden_states=hidden_states.clone(),
+            encoder_hidden_states=encoder_hidden_states.clone(),
+            pooled_projections=pooled_projections.clone(),
+            timestep=timestep.clone(),
+            guidance=guidance.clone(),
+            txt_ids=txt_ids,
+            img_ids=img_ids,
+            return_dict=False,
+        )[0]
+    fv_out_cpu = fv_out.detach().float().cpu()
+    del fv_model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    hf_model = (
+        HFFluxTransformer2DModel.from_pretrained(
+            transformer_path,
+            torch_dtype=precision,
+        )
+        .to(device)
+        .eval()
+    )
+    with torch.no_grad(), torch.amp.autocast("cuda", dtype=precision):
+        hf_out = hf_model(
+            hidden_states=hidden_states.clone(),
+            encoder_hidden_states=encoder_hidden_states.clone(),
+            pooled_projections=pooled_projections.clone(),
+            timestep=timestep.clone(),
+            guidance=guidance.clone(),
+            txt_ids=txt_ids,
+            img_ids=img_ids,
+            return_dict=False,
+        )[0]
+
+    assert hf_out.shape == fv_out_cpu.shape
+    assert_close(hf_out.float().cpu(), fv_out_cpu, atol=1e-4, rtol=1e-4)

--- a/fastvideo/tests/utils.py
+++ b/fastvideo/tests/utils.py
@@ -43,13 +43,32 @@ def _read_video_frames(path: str) -> torch.Tensor:
     return torch.stack(frames)
 
 
+def _read_image_as_single_frame_video(path: str) -> torch.Tensor:
+    """Read one image as a single-frame ``(1, C, H, W)`` uint8 tensor."""
+    from torchvision.io import read_image
+
+    img = read_image(path)
+    return img.unsqueeze(0)
+
+
+def _read_visual_frames(path: str) -> torch.Tensor:
+    """Read a video or a single image as ``(T, C, H, W)`` uint8."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext in {".png", ".jpg", ".jpeg", ".webp"}:
+        return _read_image_as_single_frame_video(path)
+    return _read_video_frames(path)
+
+
 def compute_video_ssim_torchvision(video1_path, video2_path, use_ms_ssim=True):
     """
-    Compute SSIM between two videos.
+    Compute SSIM between two videos or single-frame image files.
+
+    Image paths (``.png``, ``.jpg``, ``.jpeg``, ``.webp``) are treated as
+    one-frame clips so T2I SSIM can share the same MS-SSIM path as video.
 
     Args:
-        video1_path: Path to the first video.
-        video2_path: Path to the second video.
+        video1_path: Path to the first video or image.
+        video2_path: Path to the second video or image.
         use_ms_ssim: Whether to use Multi-Scale Structural Similarity(MS-SSIM) instead of SSIM.
     """
     print(f"Computing SSIM between {video1_path} and {video2_path}...")
@@ -58,8 +77,8 @@ def compute_video_ssim_torchvision(video1_path, video2_path, use_ms_ssim=True):
     if not os.path.exists(video2_path):
         raise FileNotFoundError(f"Video2 not found: {video2_path}")
 
-    frames1 = _read_video_frames(video1_path)
-    frames2 = _read_video_frames(video2_path)
+    frames1 = _read_visual_frames(video1_path)
+    frames2 = _read_visual_frames(video2_path)
 
     # Ensure same number of frames
     min_frames = min(frames1.shape[0], frames2.shape[0])

--- a/tests/local_tests/flux/test_flux_dev_component_loaders.py
+++ b/tests/local_tests/flux/test_flux_dev_component_loaders.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Loader smoke tests for FLUX.1-dev component loading from a local checkpoint.
+
+Verifies that tokenizers, CLIP/T5 text encoders, VAE, and FlowMatch scheduler
+all load correctly from a Diffusers-layout ``FLUX.1-dev`` directory.
+
+Requires ``official_weights/FLUX.1-dev`` (or set ``FLUX_DEV_ROOT``) and CUDA.
+
+Run from repo root::
+
+    pytest tests/local_tests/flux/test_flux_dev_component_loaders.py -vs
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import torch
+
+from fastvideo.configs.models.encoders import (
+    BaseEncoderOutput,
+    CLIPTextConfig,
+    T5Config,
+)
+from fastvideo.configs.models.vaes.autoencoder_kl import AutoencoderKLVAEConfig
+from fastvideo.configs.pipelines.base import PipelineConfig, preprocess_text
+
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29517")
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_FLUX_DEV_ROOT = os.environ.get(
+    "FLUX_DEV_ROOT",
+    str(_REPO_ROOT / "official_weights" / "FLUX.1-dev"),
+)
+
+
+def _flux_clip_post(outputs: BaseEncoderOutput) -> torch.Tensor:
+    if outputs.pooler_output is None:
+        raise RuntimeError("CLIP pooled output required")
+    return outputs.pooler_output
+
+
+def _flux_t5_post(outputs: BaseEncoderOutput) -> torch.Tensor:
+    if outputs.last_hidden_state is None:
+        raise RuntimeError("T5 last_hidden_state required")
+    return outputs.last_hidden_state
+
+
+@dataclass
+class _FluxDevLoaderPipelineConfig(PipelineConfig):
+    """Two text encoders (CLIP + T5) matching FLUX.1-dev model_index.json."""
+
+    vae_config: AutoencoderKLVAEConfig = field(
+        default_factory=AutoencoderKLVAEConfig
+    )
+    text_encoder_configs: tuple[CLIPTextConfig, T5Config] = field(
+        default_factory=lambda: (CLIPTextConfig(), T5Config())
+    )
+    text_encoder_precisions: tuple[str, ...] = ("fp32", "bf16")
+    preprocess_text_funcs: tuple = field(
+        default_factory=lambda: (preprocess_text, preprocess_text)
+    )
+    postprocess_text_funcs: tuple = field(
+        default_factory=lambda: (_flux_clip_post, _flux_t5_post)
+    )
+
+
+def test_flux_dev_model_index_components_load() -> None:
+    """CLIP/T5 encoders, tokenizers, VAE, and FlowMatch scheduler load."""
+    if not torch.cuda.is_available():
+        pytest.skip("FLUX component loader test requires CUDA")
+    if not Path(_FLUX_DEV_ROOT, "model_index.json").is_file():
+        pytest.skip(
+            "official_weights/FLUX.1-dev missing "
+            "(set FLUX_DEV_ROOT or download black-forest-labs/FLUX.1-dev)"
+        )
+
+    from fastvideo.distributed import (
+        cleanup_dist_env_and_memory,
+        maybe_init_distributed_environment_and_model_parallel,
+    )
+    from fastvideo.fastvideo_args import FastVideoArgs
+    from fastvideo.models.loader.component_loader import (
+        SchedulerLoader,
+        TextEncoderLoader,
+        TokenizerLoader,
+        VAELoader,
+    )
+
+    maybe_init_distributed_environment_and_model_parallel(1, 1)
+    try:
+        args = FastVideoArgs(
+            model_path=_FLUX_DEV_ROOT,
+            pipeline_config=_FluxDevLoaderPipelineConfig(),
+            hsdp_shard_dim=1,
+            pin_cpu_memory=False,
+        )
+
+        tok_clip = TokenizerLoader().load(
+            os.path.join(_FLUX_DEV_ROOT, "tokenizer"), args
+        )
+        tok_t5 = TokenizerLoader().load(
+            os.path.join(_FLUX_DEV_ROOT, "tokenizer_2"), args
+        )
+        assert "CLIP" in tok_clip.__class__.__name__
+        assert "T5" in tok_t5.__class__.__name__
+
+        te_clip = TextEncoderLoader().load(
+            os.path.join(_FLUX_DEV_ROOT, "text_encoder"), args
+        )
+        te_t5 = TextEncoderLoader().load(
+            os.path.join(_FLUX_DEV_ROOT, "text_encoder_2"), args
+        )
+        # Distributed init may wrap encoders in an FSDP shell.
+        assert te_clip.__class__.__name__.endswith("CLIPTextModel")
+        assert te_t5.__class__.__name__.endswith("T5EncoderModel")
+
+        vae = VAELoader().load(os.path.join(_FLUX_DEV_ROOT, "vae"), args)
+        assert vae.__class__.__name__ == "AutoencoderKL"
+
+        scheduler = SchedulerLoader().load(
+            os.path.join(_FLUX_DEV_ROOT, "scheduler"), args
+        )
+        assert scheduler.__class__.__name__ == "FlowMatchEulerDiscreteScheduler"
+        scheduler.set_timesteps(4, mu=0.7)
+        assert len(scheduler.timesteps) == 4
+    finally:
+        cleanup_dist_env_and_memory()

--- a/tests/local_tests/pipelines/test_flux_dev_pipeline_smoke.py
+++ b/tests/local_tests/pipelines/test_flux_dev_pipeline_smoke.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end FLUX T2I smoke: short denoise + decode from local checkpoint.
+
+Requires ``official_weights/FLUX.1-dev`` (or set ``FLUX_DEV_ROOT``) and CUDA.
+
+Run from repo root::
+
+    pytest tests/local_tests/pipelines/test_flux_dev_pipeline_smoke.py -vs
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_FLUX_DEV_ROOT = os.environ.get(
+    "FLUX_DEV_ROOT",
+    str(_REPO_ROOT / "official_weights" / "FLUX.1-dev"),
+)
+
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29519")
+
+
+def test_flux_dev_pipeline_short_run_finite_output(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("FLUX pipeline smoke requires CUDA")
+    if not Path(_FLUX_DEV_ROOT, "model_index.json").is_file():
+        pytest.skip(
+            "official_weights/FLUX.1-dev missing (set FLUX_DEV_ROOT or download "
+            "black-forest-labs/FLUX.1-dev)")
+
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "TORCH_SDPA")
+
+    from fastvideo.configs.pipelines.flux import FluxPipelineConfig
+    from fastvideo.distributed import (
+        cleanup_dist_env_and_memory,
+        maybe_init_distributed_environment_and_model_parallel,
+    )
+    from fastvideo.fastvideo_args import FastVideoArgs, WorkloadType
+    from fastvideo.pipelines.basic.flux.flux_pipeline import FluxPipeline
+    from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+
+    torch.manual_seed(0)
+    maybe_init_distributed_environment_and_model_parallel(1, 1)
+    try:
+        args = FastVideoArgs(
+            model_path=_FLUX_DEV_ROOT,
+            pipeline_config=FluxPipelineConfig(),
+            workload_type=WorkloadType.T2I,
+            hsdp_shard_dim=1,
+            pin_cpu_memory=False,
+            distributed_executor_backend="mp",
+        )
+        pipeline = FluxPipeline(_FLUX_DEV_ROOT, args)
+
+        batch = ForwardBatch(
+            data_type="image",
+            prompt="a red circle on white",
+            height=256,
+            width=256,
+            seed=0,
+            num_inference_steps=2,
+            guidance_scale=3.5,
+            use_embedded_guidance=True,
+            true_cfg_scale=1.0,
+            num_videos_per_prompt=1,
+            save_video=False,
+        )
+
+        out = pipeline.forward(batch, args)
+        assert out.output is not None
+        assert out.output.shape[0] >= 1
+        assert out.output.shape[1] == 3
+        assert torch.isfinite(out.output).all()
+    finally:
+        cleanup_dist_env_and_memory()


### PR DESCRIPTION
## Summary

Adds **FLUX.1-dev text-to-image** support to FastVideo: Diffusers-aligned **packed latents**, **FlowMatch `mu`**, **CLIP pooled + T5 sequence** conditioning, **embedded guidance** and optional **true CFG** via `true_cfg_scale`, plus registry wiring for `black-forest-labs/FLUX.1-dev`. Includes **parity**, **loader**, **pipeline smoke**, and **SSIM** test hooks, a minimal **example** script, and contributor-oriented **test layout** (pipeline smoke and checkpoint loader tests under `tests/local_tests/`).

## What changed

- **Model:** `FluxTransformer2DModel` and `FluxDiTConfig` with Diffusers-compatible forward (`txt_ids` / `img_ids`, timestep scaling, guidance when `guidance_embeds`).
- **Pipeline:** `FluxPipeline` and FLUX stages (pack/unpack, latent image ids, scheduler `mu`, denoise loop, VAE denormalize, 5D image output).
- **Config / sampling:** `FluxPipelineConfig`, `FluxSamplingParam` (defaults aligned with FLUX.1-dev).
- **Registry:** T2I registration and path detectors for FLUX checkpoints.
- **Example:** `examples/inference/basic/flux_dev_t2i.py`.
- **Tests:** DiT parity (`fastvideo/tests/transformers/test_flux.py`), SSIM (`fastvideo/tests/ssim/test_flux_t2i_similarity.py`), local **pipeline smoke** (`tests/local_tests/pipelines/test_flux_dev_pipeline_smoke.py`), local **component loaders** (`tests/local_tests/flux/test_flux_dev_component_loaders.py`).

## How to test

From repo root (requires **CUDA** and **`official_weights/FLUX.1-dev`** or `FLUX_DEV_ROOT` / `FLUX_TRANSFORMER_PATH` where noted):

```bash
FASTVIDEO_ATTENTION_BACKEND=TORCH_SDPA pytest \
  fastvideo/tests/transformers/test_flux.py \
  tests/local_tests/flux/test_flux_dev_component_loaders.py \
  tests/local_tests/pipelines/test_flux_dev_pipeline_smoke.py \
  -v