### PR TITLE
[feat] Migrate Hunyuan SamplingParam subclasses to profile-based defaults

### DIFF
--- a/fastvideo/configs/sample/base.py
+++ b/fastvideo/configs/sample/base.py
@@ -103,17 +103,55 @@ class SamplingParam:
         self.__post_init__()
 
     @classmethod
-    def from_pretrained(cls, model_path: str) -> "SamplingParam":
-        from fastvideo.registry import get_sampling_param_cls_for_name
-        sampling_cls = get_sampling_param_cls_for_name(model_path)
-        if sampling_cls is not None:
-            sampling_param: SamplingParam = sampling_cls()
-        else:
-            logger.warning("Couldn't find an optimal sampling param for %s. Using the default sampling param.",
-                           model_path)
-            sampling_param = cls()
+    def _from_profile(
+        cls,
+        profile_name: str,
+    ) -> "SamplingParam":
+        """Create a ``SamplingParam`` with profile defaults applied.
 
-        return sampling_param
+        Looks up *profile_name* in the registered profile tables,
+        creates a base ``SamplingParam()``, then delegates to
+        :meth:`update` so that ``__post_init__`` is called and
+        derived fields stay consistent.
+        """
+        from fastvideo.pipelines.basic.hunyuan.profiles import (
+            PROFILES as _hunyuan_profiles, )
+
+        # Merged lazily; extend this dict as more model families
+        # migrate to profile-based defaults.
+        all_profiles = _hunyuan_profiles
+
+        if profile_name not in all_profiles:
+            raise ValueError(f"Unknown profile '{profile_name}'. "
+                             f"Available: {sorted(all_profiles)}")
+
+        instance = cls()
+        instance.update(all_profiles[profile_name].defaults)
+        return instance
+
+    @classmethod
+    def from_pretrained(cls, model_path: str) -> "SamplingParam":
+        from fastvideo.registry import _get_config_info
+
+        config_info = _get_config_info(model_path, raise_on_missing=False)
+
+        if config_info is None:
+            logger.warning(
+                "Couldn't find an optimal sampling param "
+                "for %s. Using the default sampling param.",
+                model_path,
+            )
+            return cls()
+
+        # Profile-based path (preferred for new migrations).
+        if config_info.default_profile is not None:
+            return cls._from_profile(config_info.default_profile)
+
+        # Legacy path: use the registered subclass directly.
+        if config_info.sampling_param_cls is not None:
+            return config_info.sampling_param_cls()
+
+        return cls()
 
     @staticmethod
     def add_cli_args(parser: Any) -> Any:

--- a/fastvideo/configs/sample/hunyuan.py
+++ b/fastvideo/configs/sample/hunyuan.py
@@ -1,21 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-from dataclasses import dataclass
+"""Hunyuan sampling parameter classes.
 
-from fastvideo.configs.sample.base import SamplingParam
-
-
-@dataclass
-class HunyuanSamplingParam(SamplingParam):
-    num_inference_steps: int = 50
-
-    num_frames: int = 125
-    height: int = 720
-    width: int = 1280
-    fps: int = 24
-
-    guidance_scale: float = 1.0
-
-
-@dataclass
-class FastHunyuanSamplingParam(HunyuanSamplingParam):
-    num_inference_steps: int = 6
+Hunyuan model-specific SamplingParam subclasses have been removed.
+Defaults are now provided by pipeline profiles in
+``fastvideo/pipelines/basic/hunyuan/profiles.py``.
+"""

--- a/fastvideo/pipelines/basic/hunyuan/profiles.py
+++ b/fastvideo/pipelines/basic/hunyuan/profiles.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pipeline profiles for Hunyuan model family.
+
+Each profile defines default sampling parameters that differ from the
+base ``SamplingParam`` defaults.  The registry points a model to its
+``default_profile`` name, and ``SamplingParam._from_profile`` applies
+the profile's ``defaults`` dict onto a freshly-constructed base
+instance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ProfileEntry:
+    """Immutable description of a pipeline profile."""
+
+    defaults: dict[str, Any]
+
+
+# Hunyuan base: all fields match SamplingParam defaults, so the
+# defaults dict is empty.  The profile still exists so that the
+# registry can reference it.
+HUNYUAN_T2V = ProfileEntry(defaults={})
+
+# FastHunyuan: only num_inference_steps differs from base.
+FAST_HUNYUAN_T2V = ProfileEntry(defaults={
+    "num_inference_steps": 6,
+})
+
+# Name -> ProfileEntry lookup used by SamplingParam._from_profile.
+PROFILES: dict[str, ProfileEntry] = {
+    "hunyuan_t2v": HUNYUAN_T2V,
+    "fast_hunyuan_t2v": FAST_HUNYUAN_T2V,
+}

--- a/fastvideo/registry.py
+++ b/fastvideo/registry.py
@@ -53,7 +53,6 @@ from fastvideo.configs.sample.cosmos import (
     Cosmos_Predict2_2B_Video2World_SamplingParam, )
 from fastvideo.configs.sample.cosmos2_5 import Cosmos25SamplingParamBase
 from fastvideo.configs.sample.gen3c import Gen3C_Cosmos_7B_SamplingParam
-from fastvideo.configs.sample.hunyuan import (FastHunyuanSamplingParam, HunyuanSamplingParam)
 from fastvideo.configs.sample.hunyuan15 import (Hunyuan15_480P_SamplingParam,
                                                 Hunyuan15_480P_StepDistilled_I2V_SamplingParam,
                                                 Hunyuan15_720P_SamplingParam,
@@ -138,6 +137,7 @@ class ConfigInfo:
     sampling_param_cls: type[SamplingParam] | None
     pipeline_config_cls: type[PipelineConfig]
     workload_types: tuple[WorkloadType, ...]
+    default_profile: str | None = None
 
 
 # The central registry mapping a model name to its configuration information
@@ -156,6 +156,7 @@ def register_configs(
     workload_types: tuple[WorkloadType, ...],
     hf_model_paths: list[str] | None = None,
     model_detectors: list[Callable[[str], bool]] | None = None,
+    default_profile: str | None = None,
 ) -> None:
     """Register config classes for a model family.
 
@@ -168,6 +169,7 @@ def register_configs(
         sampling_param_cls=sampling_param_cls,
         pipeline_config_cls=pipeline_config_cls,
         workload_types=workload_types,
+        default_profile=default_profile,
     )
 
     if hf_model_paths:
@@ -317,7 +319,7 @@ def _register_configs() -> None:
 
     # Hunyuan (excludes gamecraft, hyworld, and versioned models)
     register_configs(
-        sampling_param_cls=HunyuanSamplingParam,
+        sampling_param_cls=None,
         pipeline_config_cls=HunyuanConfig,
         workload_types=(WorkloadType.T2V, ),
         hf_model_paths=[
@@ -327,14 +329,16 @@ def _register_configs() -> None:
             lambda path: "hunyuan" in path.lower() and "gamecraft" not in path.lower() and "hyworld" not in path.lower(
             ) and "1.5" not in path.lower() and "1-5" not in path.lower()
         ],
+        default_profile="hunyuan_t2v",
     )
     register_configs(
-        sampling_param_cls=FastHunyuanSamplingParam,
+        sampling_param_cls=None,
         pipeline_config_cls=FastHunyuanConfig,
         workload_types=(WorkloadType.T2V, ),
         hf_model_paths=[
             "FastVideo/FastHunyuan-diffusers",
         ],
+        default_profile="fast_hunyuan_t2v",
     )
 
     # HYWorld


### PR DESCRIPTION
## Summary
- Adds profile-based defaults infrastructure: `ConfigInfo.default_profile` field, `SamplingParam._from_profile()` classmethod, and `ProfileEntry` dataclass
- Migrates `HunyuanSamplingParam` and `FastHunyuanSamplingParam` from subclass overrides to declarative profile entries in `fastvideo/pipelines/basic/hunyuan/profiles.py`
- Updates `SamplingParam.from_pretrained()` to prefer profile-based defaults when configured, falling back to legacy subclass path for unmigrated models

## Test plan
- [x] E2E: `SamplingParam.from_pretrained('hunyuanvideo-community/HunyuanVideo')` returns correct defaults (720x1280, 50 steps, guidance_scale=1.0)
- [x] E2E: `SamplingParam.from_pretrained('FastVideo/FastHunyuan-diffusers')` returns correct defaults (720x1280, 6 steps)
- [x] `pytest fastvideo/tests/api/ -v` -- all 46 tests pass
- [x] Pre-commit hooks pass (yapf, ruff, codespell); mypy skipped due to known worktree naming limitation

🤖 Generated with [Claude Code](https://claude.com/claude-code)