### PR TITLE
[new-model] Port Z-Image T2I to FastVideo

### DIFF
--- a/fastvideo/configs/models/encoders/__init__.py
+++ b/fastvideo/configs/models/encoders/__init__.py
@@ -4,6 +4,7 @@ from fastvideo.configs.models.encoders.clip import (CLIPTextConfig, CLIPVisionCo
 from fastvideo.configs.models.encoders.llama import LlamaConfig
 from fastvideo.configs.models.encoders.t5 import T5Config, T5LargeConfig
 from fastvideo.configs.models.encoders.qwen2_5 import Qwen2_5_VLConfig
+from fastvideo.configs.models.encoders.qwen3 import Qwen3Config
 from fastvideo.configs.models.encoders.siglip import SiglipVisionConfig
 from fastvideo.configs.models.encoders.reason1 import Reason1ArchConfig, Reason1Config
 from fastvideo.configs.models.encoders.gemma import LTX2GemmaConfig
@@ -11,5 +12,5 @@ from fastvideo.configs.models.encoders.gemma import LTX2GemmaConfig
 __all__ = [
     "EncoderConfig", "TextEncoderConfig", "ImageEncoderConfig", "BaseEncoderOutput", "CLIPTextConfig",
     "CLIPVisionConfig", "WAN2_1ControlCLIPVisionConfig", "LlamaConfig", "T5Config", "T5LargeConfig", "Qwen2_5_VLConfig",
-    "Reason1ArchConfig", "Reason1Config", "LTX2GemmaConfig", "SiglipVisionConfig"
+    "Reason1ArchConfig", "Reason1Config", "LTX2GemmaConfig", "SiglipVisionConfig", "Qwen3Config",
 ]

--- a/fastvideo/configs/models/encoders/qwen3.py
+++ b/fastvideo/configs/models/encoders/qwen3.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass, field, fields
+from typing import Any
+
+from fastvideo.configs.models.encoders.base import TextEncoderArchConfig, TextEncoderConfig
+
+
+def _is_transformer_layer(n: str, m) -> bool:
+    return "layers" in n and str.isdigit(n.split(".")[-1])
+
+
+def _is_embeddings(n: str, m) -> bool:
+    return n.endswith("embed_tokens")
+
+
+def _is_final_norm(n: str, m) -> bool:
+    return n.endswith("norm")
+
+
+@dataclass
+class Qwen3ArchConfig(TextEncoderArchConfig):
+    architectures: list[str] = field(default_factory=lambda: ["Qwen3Model"])
+    model_type: str = "qwen3"
+
+    vocab_size: int = 151936
+    hidden_size: int = 2048
+    intermediate_size: int = 6144
+    num_hidden_layers: int = 24
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    head_dim: int | None = None
+    hidden_act: str = "silu"
+    max_position_embeddings: int = 32768
+    initializer_range: float = 0.02
+    rms_norm_eps: float = 1e-6
+    use_cache: bool = True
+    tie_word_embeddings: bool = False
+    rope_theta: float = 1000000.0
+    rope_scaling: dict[str, Any] | None = None
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    mlp_bias: bool = False
+
+    pad_token_id: int | None = None
+    bos_token_id: int | None = None
+    eos_token_id: int | None = None
+
+    hidden_state_skip_layer: int = 2
+    text_len: int = 512
+    output_hidden_states: bool = True
+    stacked_params_mapping: list[tuple[str, str, str | int]] = field(default_factory=lambda: [
+        (".qkv_proj", ".q_proj", "q"),
+        (".qkv_proj", ".k_proj", "k"),
+        (".qkv_proj", ".v_proj", "v"),
+        (".gate_up_proj", ".gate_proj", 0),
+        (".gate_up_proj", ".up_proj", 1),
+    ])
+    _fsdp_shard_conditions: list = field(default_factory=lambda: [_is_transformer_layer, _is_embeddings, _is_final_norm])
+
+
+@dataclass
+class Qwen3Config(TextEncoderConfig):
+    arch_config: TextEncoderArchConfig = field(default_factory=Qwen3ArchConfig)
+    prefix: str = "qwen3"
+    is_chat_model: bool = False
+
+    def update_model_arch(self, source_model_dict: dict[str, Any]) -> None:
+        """Lenient arch update for HF Qwen3 configs.
+
+        Qwen3 checkpoints may carry auxiliary config keys that are not required
+        by FastVideo runtime. We only copy known arch fields.
+        """
+        arch_config = self.arch_config
+        valid_fields = {f.name for f in fields(arch_config)}
+
+        for key, value in source_model_dict.items():
+            if key in valid_fields:
+                setattr(arch_config, key, value)
+
+        if hasattr(arch_config, "__post_init__"):
+            arch_config.__post_init__()

--- a/fastvideo/models/encoders/qwen3.py
+++ b/fastvideo/models/encoders/qwen3.py
@@ -1,0 +1,433 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from torch import nn
+
+from fastvideo.configs.models.encoders import BaseEncoderOutput, Qwen3Config
+from fastvideo.distributed import get_tp_world_size
+from fastvideo.layers.activation import SiluAndMul
+from fastvideo.layers.layernorm import RMSNorm
+from fastvideo.layers.linear import MergedColumnParallelLinear, QKVParallelLinear, RowParallelLinear
+from fastvideo.layers.quantization import QuantizationConfig
+from fastvideo.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from fastvideo.models.encoders.base import TextEncoder
+from fastvideo.models.loader.weight_utils import default_weight_loader, maybe_remap_kv_scale_name
+from fastvideo.models.mask_utils import sdpa_mask
+
+
+class Qwen3MLP(nn.Module):
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str,
+        quant_config: QuantizationConfig | None = None,
+        bias: bool = False,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=hidden_size,
+            output_sizes=[intermediate_size] * 2,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            input_size=intermediate_size,
+            output_size=hidden_size,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.down_proj",
+        )
+        if hidden_act != "silu":
+            raise ValueError(f"Unsupported activation: {hidden_act}. Only silu is supported for now.")
+        self.act_fn = SiluAndMul()
+
+    def forward(self, x):
+        x, _ = self.gate_up_proj(x)
+        x = self.act_fn(x)
+        x, _ = self.down_proj(x)
+        return x
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def sdpa_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    dropout: float = 0.0,
+    scaling: float | None = None,
+    is_causal: bool = False,
+) -> torch.Tensor:
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    if attention_mask is not None and attention_mask.ndim == 4:
+        attention_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+    if attention_mask is not None and attention_mask.dtype != torch.bool:
+        attention_mask = attention_mask.bool()
+
+    attn_output = torch.nn.functional.scaled_dot_product_attention(
+        query,
+        key_states,
+        value_states,
+        attn_mask=attention_mask,
+        dropout_p=dropout,
+        scale=scaling,
+        is_causal=is_causal,
+    )
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output
+
+
+def rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    unsqueeze_dim: int = 1,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class Qwen3RotaryEmbedding(nn.Module):
+
+    inv_freq: torch.Tensor
+
+    def __init__(self, config: Qwen3Config, device=None):
+        super().__init__()
+        self.config = config
+        base = getattr(config, "rope_theta", 1000000.0)
+        dim = getattr(config, "head_dim", None) or (config.hidden_size // config.num_attention_heads)
+
+        inv_freq = 1.0 / (base**(torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.attention_scaling = 1.0
+
+    @torch.no_grad()
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class Qwen3Attention(nn.Module):
+
+    def __init__(
+        self,
+        config: Qwen3Config,
+        hidden_size: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_theta: float = 10000,
+        rope_scaling: dict[str, Any] | None = None,
+        max_position_embeddings: int = 8192,
+        quant_config: QuantizationConfig | None = None,
+        bias: bool = False,
+        bias_o_proj: bool = False,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.layer_idx = getattr(config, "layer_idx", 0)
+        tp_size = get_tp_world_size()
+        self.total_num_heads = num_heads
+        assert self.total_num_heads % tp_size == 0
+        self.num_heads = self.total_num_heads // tp_size
+
+        self.total_num_kv_heads = num_kv_heads
+        if self.total_num_kv_heads >= tp_size:
+            assert self.total_num_kv_heads % tp_size == 0
+        else:
+            assert tp_size % self.total_num_kv_heads == 0
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+
+        self.head_dim = getattr(config, "head_dim", self.hidden_size // self.total_num_heads)
+        self.num_key_value_groups = self.total_num_heads // self.total_num_kv_heads
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = getattr(config, "attention_dropout", 0.0)
+
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size=hidden_size,
+            head_size=self.head_dim,
+            total_num_heads=self.total_num_heads,
+            total_num_kv_heads=self.total_num_kv_heads,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
+
+        self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+        self.o_proj = RowParallelLinear(
+            input_size=self.total_num_heads * self.head_dim,
+            output_size=hidden_size,
+            bias=bias_o_proj,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        qkv_states, _ = self.qkv_proj(hidden_states)
+        query_states, key_states, value_states = qkv_states.split(
+            [self.q_size, self.kv_size, self.kv_size],
+            dim=-1,
+        )
+
+        query_states = self.q_norm(query_states.view(hidden_shape)).transpose(1, 2)
+        key_states = self.k_norm(key_states.view(hidden_shape)).transpose(1, 2)
+        value_states = value_states.view(hidden_shape).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        attn_output = sdpa_attention_forward(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=self.attention_dropout if self.training else 0.0,
+            scaling=self.scaling,
+            is_causal=False,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        output, _ = self.o_proj(attn_output)
+        return output
+
+
+class Qwen3DecoderLayer(nn.Module):
+
+    def __init__(
+        self,
+        config: Qwen3Config,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        self.self_attn = Qwen3Attention(
+            config=config,
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            num_kv_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
+            rope_theta=getattr(config, "rope_theta", 10000),
+            rope_scaling=getattr(config, "rope_scaling", None),
+            max_position_embeddings=getattr(config, "max_position_embeddings", 8192),
+            quant_config=quant_config,
+            bias=getattr(config, "attention_bias", False) or getattr(config, "bias", False),
+            bias_o_proj=getattr(config, "attention_bias", False) or getattr(config, "bias", False),
+            prefix=f"{prefix}.self_attn",
+        )
+        self.mlp = Qwen3MLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            bias=getattr(config, "mlp_bias", False),
+            prefix=f"{prefix}.mlp",
+        )
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Qwen3Model(TextEncoder):
+
+    def __init__(self, config: Qwen3Config) -> None:
+        super().__init__(config)
+        self.config = config
+        self.quant_config = self.config.quant_config
+
+        self.vocab_size = config.vocab_size
+        self.org_vocab_size = config.vocab_size
+
+        self.embed_tokens = VocabParallelEmbedding(
+            self.vocab_size,
+            config.hidden_size,
+            org_num_embeddings=config.vocab_size,
+            quant_config=config.quant_config,
+        )
+
+        self.layers = nn.ModuleList([
+            Qwen3DecoderLayer(
+                config=config,
+                quant_config=config.quant_config,
+                prefix=f"{config.prefix}.layers.{i}",
+            ) for i in range(config.num_hidden_layers)
+        ])
+
+        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Qwen3RotaryEmbedding(config=config)
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        **kwargs,
+    ) -> BaseEncoderOutput:
+        del kwargs
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        hidden_states = inputs_embeds if inputs_embeds is not None else self.get_input_embeddings(input_ids)
+
+        if position_ids is None:
+            position_ids = torch.arange(0, hidden_states.shape[1], device=hidden_states.device).unsqueeze(0)
+
+        causal_attention_mask: torch.Tensor | None = None
+        if attention_mask is not None:
+            cache_position = position_ids[0]
+            causal_attention_mask = sdpa_mask(
+                batch_size=hidden_states.shape[0],
+                cache_position=cache_position,
+                kv_length=attention_mask.shape[-1],
+                kv_offset=0,
+                attention_mask=attention_mask,
+            )
+
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        all_hidden_states: tuple[Any, ...] | None = () if output_hidden_states else None
+        for layer in self.layers:
+            if all_hidden_states is not None:
+                all_hidden_states += (hidden_states,)
+            hidden_states = layer(
+                hidden_states=hidden_states,
+                attention_mask=causal_attention_mask,
+                position_embeddings=position_embeddings,
+            )
+
+        hidden_states = self.norm(hidden_states)
+        if all_hidden_states is not None:
+            all_hidden_states += (hidden_states,)
+
+        return BaseEncoderOutput(
+            last_hidden_state=hidden_states,
+            hidden_states=all_hidden_states,
+            attention_mask=attention_mask,
+        )
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            # Z-Image Qwen3 checkpoints are usually prefixed with `model.`.
+            if name.startswith("model."):
+                name = name[len("model."):]
+
+            if "rotary_emb.inv_freq" in name:
+                continue
+            if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                continue
+
+            if "scale" in name:
+                kv_scale_name: str | None = maybe_remap_kv_scale_name(name, params_dict)
+                if kv_scale_name is None:
+                    continue
+                name = kv_scale_name
+
+            for param_name, weight_name, shard_id in self.config.arch_config.stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                mapped_name = name.replace(weight_name, param_name)
+                if mapped_name.endswith(".bias") and mapped_name not in params_dict:
+                    continue
+                if mapped_name not in params_dict:
+                    continue
+
+                param = params_dict[mapped_name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                loaded_params.add(mapped_name)
+                break
+            else:
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if name not in params_dict:
+                    continue
+
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded_params.add(name)
+
+        return loaded_params
+
+
+EntryClass = Qwen3Model

--- a/fastvideo/models/registry.py
+++ b/fastvideo/models/registry.py
@@ -64,6 +64,8 @@ _TEXT_ENCODER_MODELS = {
     "Reason1TextEncoder": ("encoders", "reason1", "Reason1TextEncoder"),
     "Qwen2_5_VLForConditionalGeneration":
     ("encoders", "reason1", "Reason1TextEncoder"),
+    "Qwen3Model": ("encoders", "qwen3", "Qwen3Model"),
+    "Qwen3ForCausalLM": ("encoders", "qwen3", "Qwen3Model"),
     "LTX2GemmaTextEncoderModel": ("encoders", "gemma", "LTX2GemmaTextEncoderModel"),
 }
 

--- a/fastvideo/models/schedulers/scheduling_flow_match_euler_discrete.py
+++ b/fastvideo/models/schedulers/scheduling_flow_match_euler_discrete.py
@@ -107,6 +107,7 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin,
         num_train_timesteps: int = 1000,
         shift: float = 1.0,
         use_dynamic_shifting: bool = False,
+        use_reference_discrete_timesteps: bool = False,
         base_shift: float | None = 0.5,
         max_shift: float | None = 1.15,
         base_image_seq_len: int | None = 256,
@@ -350,7 +351,22 @@ class FlowMatchEulerDiscreteScheduler(SchedulerMixin, ConfigMixin,
             if timesteps_array is None:
                 t_max = self._sigma_to_t(self.sigma_max)
                 t_min = self._sigma_to_t(self.sigma_min)
-                timesteps_array = np.linspace(t_max, t_min, num_inference_steps)
+                if self.config.use_reference_discrete_timesteps:
+                    # Some reference schedulers (for example Z-Image) build a
+                    # num_steps+1 linspace and drop the terminal point.
+                    timesteps_array = np.linspace(
+                        t_max,
+                        t_min,
+                        num_inference_steps + 1,
+                        dtype=np.float32,
+                    )[:-1]
+                else:
+                    timesteps_array = np.linspace(
+                        t_max,
+                        t_min,
+                        num_inference_steps,
+                        dtype=np.float32,
+                    )
             sigmas_array = timesteps_array / self.config.num_train_timesteps
         else:
             sigmas_array = np.array(sigmas).astype(np.float32)

--- a/tests/local_tests/zimage/test_zimage_encoder_parity.py
+++ b/tests/local_tests/zimage/test_zimage_encoder_parity.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Parity test for Z-Image Qwen3 text encoder support in FastVideo.
+
+This compares:
+1) direct transformers AutoModel output, and
+2) FastVideo Qwen3Model wrapper output,
+
+using identical local checkpoint, tokenization, and inputs.
+
+Usage:
+    pytest tests/local_tests/zimage/test_zimage_qwen3_encoder_parity.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import os
+
+import pytest
+import torch
+from torch.testing import assert_close
+from transformers import AutoModel, AutoTokenizer
+from safetensors.torch import safe_open
+
+from fastvideo.configs.models.encoders.qwen3 import Qwen3Config
+from fastvideo.distributed.parallel_state import cleanup_dist_env_and_memory, maybe_init_distributed_environment_and_model_parallel
+from fastvideo.models.registry import ModelRegistry
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ZIMAGE_TEXT_ENCODER_DIR = REPO_ROOT / "official_weights" / "Z-Image" / "text_encoder"
+ZIMAGE_TOKENIZER_DIR = REPO_ROOT / "official_weights" / "Z-Image" / "tokenizer"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _init_dist_and_tp_groups():
+    os.environ.setdefault("MASTER_ADDR", "localhost")
+    os.environ.setdefault("MASTER_PORT", "29531")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+
+    maybe_init_distributed_environment_and_model_parallel(1, 1)
+    yield
+    cleanup_dist_env_and_memory()
+
+
+def _load_json(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _iter_safetensors(path: Path):
+    with safe_open(str(path), framework="pt", device="cpu") as f:
+        for k in f.keys():
+            yield k, f.get_tensor(k)
+
+
+def _iter_pretrained_safetensors(model_dir: Path):
+    single = model_dir / "model.safetensors"
+    if single.exists():
+        yield from _iter_safetensors(single)
+        return
+
+    index = model_dir / "model.safetensors.index.json"
+    if index.exists():
+        idx = _load_json(index)
+        shard_names = sorted(set(idx["weight_map"].values()))
+        for shard in shard_names:
+            yield from _iter_safetensors(model_dir / shard)
+        return
+
+    raise FileNotFoundError(
+        f"Missing safetensors checkpoint in {model_dir} (expected model.safetensors or model.safetensors.index.json)"
+    )
+
+
+@pytest.mark.skipif(not ZIMAGE_TEXT_ENCODER_DIR.exists(), reason="Z-Image text encoder checkpoint required")
+def test_zimage_qwen3_encoder_parity_forward():
+    if not ZIMAGE_TOKENIZER_DIR.exists():
+        pytest.skip(f"Z-Image tokenizer dir not found: {ZIMAGE_TOKENIZER_DIR}")
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    # NOTE: Test failing with torch.bloat16
+    # dtype = torch.bfloat16 if (device.type == "cuda" and torch.cuda.is_bf16_supported()) else torch.float32
+    dtype = torch.float32
+    torch.manual_seed(11)
+
+    tokenizer = AutoTokenizer.from_pretrained(str(ZIMAGE_TOKENIZER_DIR), local_files_only=True)
+
+    prompts = [
+        "A cinematic shot of a rainy neon street at night.",
+        "A watercolor illustration of a fox in autumn leaves.",
+    ]
+    toks = tokenizer(
+        prompts,
+        padding="max_length",
+        truncation=True,
+        max_length=128,
+        return_tensors="pt",
+    )
+    input_ids = toks["input_ids"].to(device)
+    attention_mask = toks["attention_mask"].to(device)
+
+    ref = AutoModel.from_pretrained(
+        str(ZIMAGE_TEXT_ENCODER_DIR),
+        local_files_only=True,
+        trust_remote_code=True,
+        dtype=dtype,
+        low_cpu_mem_usage=True,
+    ).eval().to(device=device, dtype=dtype)
+
+    with torch.no_grad():
+        ref_out = ref(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+            return_dict=True,
+        )
+        ref_last = ref_out.last_hidden_state.detach().float().cpu()
+        ref_hs_m2 = ref_out.hidden_states[-2].detach().float().cpu()
+
+    fv_cls, _ = ModelRegistry.resolve_model_cls("Qwen3Model")
+    cfg_raw = _load_json(ZIMAGE_TEXT_ENCODER_DIR / "config.json")
+    for k in ("_name_or_path", "transformers_version", "model_type", "torch_dtype"):
+        cfg_raw.pop(k, None)
+
+    cfg = Qwen3Config()
+    cfg.update_model_arch(cfg_raw)
+    fv = fv_cls(cfg).eval()
+    loaded = fv.load_weights(_iter_pretrained_safetensors(ZIMAGE_TEXT_ENCODER_DIR))
+    assert loaded, "No Qwen3 weights were loaded into FastVideo model"
+    fv = fv.to(device=device, dtype=dtype)
+
+    with torch.no_grad():
+        fv_out = fv(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+        )
+        fv_last = fv_out.last_hidden_state.detach().float().cpu()
+        assert fv_out.hidden_states is not None
+        fv_hs_m2 = fv_out.hidden_states[-2].detach().float().cpu()
+
+    # Z-Image uses only valid token embeddings selected by attention mask.
+    # Compare parity on that exact path to avoid padded-token artifacts.
+    mask_cpu = attention_mask.detach().bool().cpu()
+    for i in range(mask_cpu.shape[0]):
+        valid = mask_cpu[i]
+        assert_close(ref_last[i][valid], fv_last[i][valid], atol=1e-4, rtol=1e-4)
+        assert_close(ref_hs_m2[i][valid], fv_hs_m2[i][valid], atol=1e-4, rtol=1e-4)

--- a/tests/local_tests/zimage/test_zimage_scheduler_parity.py
+++ b/tests/local_tests/zimage/test_zimage_scheduler_parity.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Parity tests for Z-Image FlowMatchEulerDiscreteScheduler.
+
+These tests compare FastVideo's scheduler implementation against the
+reference scheduler shipped in the local Z-Image repository.
+
+Usage:
+    pytest tests/local_tests/zimage/test_zimage_scheduler_parity.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from torch.testing import assert_close
+
+from fastvideo.models.schedulers.scheduling_flow_match_euler_discrete import (
+    FlowMatchEulerDiscreteScheduler as FastVideoScheduler,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ZIMAGE_SRC = REPO_ROOT / "Z-Image" / "src"
+ZIMAGE_SCHEDULER_CFG = (
+    REPO_ROOT / "official_weights" / "Z-Image" / "scheduler" / "scheduler_config.json"
+)
+
+
+if str(ZIMAGE_SRC) not in sys.path:
+    sys.path.insert(0, str(ZIMAGE_SRC))
+
+try:
+    from zimage.scheduler import FlowMatchEulerDiscreteScheduler as ReferenceScheduler
+except Exception as exc:  # pragma: no cover - handled by skip in fixture
+    ReferenceScheduler = None
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+
+@pytest.fixture(scope="module")
+def scheduler_config() -> dict:
+    if not ZIMAGE_SCHEDULER_CFG.exists():
+        pytest.skip(f"Z-Image scheduler config not found: {ZIMAGE_SCHEDULER_CFG}")
+    with ZIMAGE_SCHEDULER_CFG.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def scheduler_pair(scheduler_config: dict):
+    if ReferenceScheduler is None:
+        pytest.skip(f"Cannot import Z-Image reference scheduler: {_IMPORT_ERROR}")
+
+    kwargs = {
+        "num_train_timesteps": scheduler_config["num_train_timesteps"],
+        "shift": scheduler_config["shift"],
+        "use_dynamic_shifting": scheduler_config["use_dynamic_shifting"],
+    }
+    ref = ReferenceScheduler(**kwargs)
+    fv = FastVideoScheduler(**kwargs, use_reference_discrete_timesteps=True)
+    return ref, fv
+
+
+def _run_step_loop(ref_scheduler, fv_scheduler, sample_shape=(2, 4, 32, 32)):
+    torch.manual_seed(123)
+
+    ref_sample = torch.randn(sample_shape, dtype=torch.float32)
+    fv_sample = ref_sample.clone()
+
+    for t in ref_scheduler.timesteps:
+        model_output = torch.randn_like(ref_sample)
+
+        ref_next = ref_scheduler.step(
+            model_output,
+            t,
+            ref_sample,
+            return_dict=False,
+        )[0]
+        fv_next = fv_scheduler.step(
+            model_output,
+            t,
+            fv_sample,
+            return_dict=False,
+        )[0]
+
+        assert_close(ref_next, fv_next, atol=1e-6, rtol=1e-6)
+
+        ref_sample = ref_next
+        fv_sample = fv_next
+
+
+def test_zimage_scheduler_parity_default_schedule_and_step(scheduler_pair):
+    ref, fv = scheduler_pair
+
+    num_inference_steps = 8
+    ref.set_timesteps(num_inference_steps=num_inference_steps, device="cpu")
+    fv.set_timesteps(num_inference_steps=num_inference_steps, device="cpu")
+
+    assert_close(ref.timesteps, fv.timesteps, atol=1e-4, rtol=1e-6)
+    assert_close(ref.sigmas, fv.sigmas, atol=1e-7, rtol=1e-6)
+
+    _run_step_loop(ref, fv)
+
+
+def test_zimage_scheduler_parity_dynamic_shifting_with_mu(scheduler_config: dict):
+    if ReferenceScheduler is None:
+        pytest.skip(f"Cannot import Z-Image reference scheduler: {_IMPORT_ERROR}")
+
+    kwargs = {
+        "num_train_timesteps": scheduler_config["num_train_timesteps"],
+        "shift": scheduler_config["shift"],
+        "use_dynamic_shifting": True,
+    }
+    ref = ReferenceScheduler(**kwargs)
+    fv = FastVideoScheduler(**kwargs, use_reference_discrete_timesteps=True)
+
+    mu = 0.75
+    num_inference_steps = 8
+    ref.set_timesteps(num_inference_steps=num_inference_steps, device="cpu", mu=mu)
+    fv.set_timesteps(num_inference_steps=num_inference_steps, device="cpu", mu=mu)
+
+    assert_close(ref.timesteps, fv.timesteps, atol=1e-4, rtol=1e-6)
+    assert_close(ref.sigmas, fv.sigmas, atol=1e-7, rtol=1e-6)
+
+    _run_step_loop(ref, fv)

--- a/tests/local_tests/zimage/test_zimage_tokenizer_parity.py
+++ b/tests/local_tests/zimage/test_zimage_tokenizer_parity.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Parity test for Z-Image tokenizer loading and tokenization behavior.
+
+This compares:
+1) direct transformers AutoTokenizer loading from local tokenizer dir, and
+2) FastVideo TokenizerLoader loading path,
+
+using identical prompts and tokenization settings.
+
+Usage:
+    pytest tests/local_tests/zimage/test_zimage_tokenizer_parity.py -v
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+import torch
+from torch.testing import assert_close
+from transformers import AutoTokenizer
+
+from fastvideo.models.loader.component_loader import TokenizerLoader
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ZIMAGE_TOKENIZER_DIR = REPO_ROOT / "official_weights" / "Z-Image" / "tokenizer"
+
+
+@dataclass
+class _DummyPipelineConfig:
+    text_encoder_configs: tuple = field(default_factory=tuple)
+
+
+@dataclass
+class _DummyFastVideoArgs:
+    pipeline_config: _DummyPipelineConfig = field(default_factory=_DummyPipelineConfig)
+
+
+def _load_reference_tokenizer():
+    if not ZIMAGE_TOKENIZER_DIR.exists():
+        pytest.skip(f"Z-Image tokenizer dir not found: {ZIMAGE_TOKENIZER_DIR}")
+    return AutoTokenizer.from_pretrained(str(ZIMAGE_TOKENIZER_DIR), local_files_only=True)
+
+
+def _load_fastvideo_tokenizer():
+    if not ZIMAGE_TOKENIZER_DIR.exists():
+        pytest.skip(f"Z-Image tokenizer dir not found: {ZIMAGE_TOKENIZER_DIR}")
+    loader = TokenizerLoader()
+    return loader.load(str(ZIMAGE_TOKENIZER_DIR), _DummyFastVideoArgs())
+
+
+def test_zimage_tokenizer_loader_and_tokenization_parity():
+    ref_tok = _load_reference_tokenizer()
+    fv_tok = _load_fastvideo_tokenizer()
+
+    prompts = [
+        "A close-up portrait of a cat in warm studio lighting.",
+        "An oil painting of a lighthouse at sunset.",
+    ]
+
+    tok_kwargs = {
+        "padding": "max_length",
+        "max_length": 96,
+        "truncation": True,
+        "return_tensors": "pt",
+    }
+
+    ref_out = ref_tok(prompts, **tok_kwargs)
+    fv_out = fv_tok(prompts, **tok_kwargs)
+
+    assert_close(ref_out["input_ids"], fv_out["input_ids"], atol=0, rtol=0)
+    assert_close(ref_out["attention_mask"], fv_out["attention_mask"], atol=0, rtol=0)
+
+    # Compare key tokenizer attributes that affect generation-time behavior.
+    assert ref_tok.padding_side == fv_tok.padding_side
+    assert ref_tok.pad_token_id == fv_tok.pad_token_id
+    assert ref_tok.eos_token_id == fv_tok.eos_token_id
+
+
+@pytest.mark.skipif(not ZIMAGE_TOKENIZER_DIR.exists(), reason="Z-Image tokenizer assets are required")
+def test_zimage_tokenizer_chat_template_parity():
+    ref_tok = _load_reference_tokenizer()
+    fv_tok = _load_fastvideo_tokenizer()
+
+    if not hasattr(ref_tok, "apply_chat_template") or not hasattr(fv_tok, "apply_chat_template"):
+        pytest.skip("Tokenizer does not expose apply_chat_template")
+
+    messages = [{"role": "user", "content": "Describe a futuristic city skyline."}]
+
+    # Keep kwargs minimal for broad compatibility across tokenizer versions.
+    ref_text = ref_tok.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    fv_text = fv_tok.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+
+    assert ref_text == fv_text
+
+    ref_tokens = ref_tok(ref_text, padding="max_length", max_length=128, truncation=True, return_tensors="pt")
+    fv_tokens = fv_tok(fv_text, padding="max_length", max_length=128, truncation=True, return_tensors="pt")
+
+    assert_close(ref_tokens["input_ids"], fv_tokens["input_ids"], atol=0, rtol=0)
+    assert_close(ref_tokens["attention_mask"], fv_tokens["attention_mask"], atol=0, rtol=0)

--- a/tests/local_tests/zimage/test_zimage_vae_parity.py
+++ b/tests/local_tests/zimage/test_zimage_vae_parity.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Parity test for Z-Image VAE (AutoencoderKL decode path).
+
+This compares FastVideo's AutoencoderKL wrapper against the Z-Image
+reference AutoencoderKL implementation using the same local weights.
+
+Usage:
+    pytest tests/local_tests/zimage/test_zimage_vae_parity.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import load_file as safetensors_load_file
+from torch.testing import assert_close
+
+from fastvideo.configs.models.vaes.autoencoder_kl import AutoencoderKLVAEConfig
+from fastvideo.models.vaes.autoencoder_kl import AutoencoderKL as FastVideoAutoencoderKL
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ZIMAGE_SRC = REPO_ROOT / "Z-Image" / "src"
+ZIMAGE_VAE_DIR = REPO_ROOT / "official_weights" / "Z-Image" / "vae"
+ZIMAGE_VAE_CFG = ZIMAGE_VAE_DIR / "config.json"
+ZIMAGE_VAE_WEIGHTS = ZIMAGE_VAE_DIR / "diffusion_pytorch_model.safetensors"
+
+if str(ZIMAGE_SRC) not in sys.path:
+    sys.path.insert(0, str(ZIMAGE_SRC))
+
+try:
+    from zimage.autoencoder import AutoencoderKL as ReferenceAutoencoderKL
+except Exception as exc:  # pragma: no cover - handled by skip
+    ReferenceAutoencoderKL = None
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+
+def _load_cfg() -> dict:
+    if not ZIMAGE_VAE_CFG.exists():
+        pytest.skip(f"Z-Image VAE config not found: {ZIMAGE_VAE_CFG}")
+    with ZIMAGE_VAE_CFG.open("r", encoding="utf-8") as f:
+        cfg = json.load(f)
+    cfg.pop("_class_name", None)
+    cfg.pop("_diffusers_version", None)
+    cfg.pop("_name_or_path", None)
+    return cfg
+
+
+def _load_weights() -> dict[str, torch.Tensor]:
+    if not ZIMAGE_VAE_WEIGHTS.exists():
+        pytest.skip(f"Z-Image VAE weights not found: {ZIMAGE_VAE_WEIGHTS}")
+    return safetensors_load_file(str(ZIMAGE_VAE_WEIGHTS), device="cpu")
+
+
+def _build_reference(cfg: dict, weights: dict[str, torch.Tensor]) -> torch.nn.Module:
+    if ReferenceAutoencoderKL is None:
+        pytest.skip(f"Cannot import Z-Image reference autoencoder: {_IMPORT_ERROR}")
+
+    ref = ReferenceAutoencoderKL(
+        in_channels=cfg["in_channels"],
+        out_channels=cfg["out_channels"],
+        down_block_types=tuple(cfg["down_block_types"]),
+        up_block_types=tuple(cfg["up_block_types"]),
+        block_out_channels=tuple(cfg["block_out_channels"]),
+        layers_per_block=cfg["layers_per_block"],
+        latent_channels=cfg["latent_channels"],
+        norm_num_groups=cfg["norm_num_groups"],
+        scaling_factor=cfg["scaling_factor"],
+        shift_factor=cfg["shift_factor"],
+        use_quant_conv=cfg["use_quant_conv"],
+        use_post_quant_conv=cfg["use_post_quant_conv"],
+        mid_block_add_attention=cfg["mid_block_add_attention"],
+    ).eval()
+    ref.load_state_dict(weights, strict=True)
+    return ref
+
+
+def _build_fastvideo(cfg: dict, weights: dict[str, torch.Tensor]) -> torch.nn.Module:
+    fv_cfg = AutoencoderKLVAEConfig()
+    fv_cfg.update_model_arch(cfg)
+    fv = FastVideoAutoencoderKL(fv_cfg).eval()
+    fv.load_state_dict(weights, strict=True)
+    return fv
+
+
+def test_zimage_vae_decode_parity():
+    torch.manual_seed(7)
+
+    cfg = _load_cfg()
+    weights = _load_weights()
+
+    ref = _build_reference(cfg, weights)
+    fv = _build_fastvideo(cfg, weights)
+
+    # Decode-only parity is the critical path for Z-Image pipeline integration.
+    latents = torch.randn(1, cfg["latent_channels"], 8, 8, dtype=torch.float32)
+
+    with torch.no_grad():
+        ref_out = ref.decode(latents, return_dict=False)[0].detach().float()
+        fv_out = fv.decode(latents, return_dict=False)[0].detach().float()
+
+    assert ref_out.shape == fv_out.shape
+    assert_close(ref_out, fv_out, atol=1e-4, rtol=1e-4)


### PR DESCRIPTION
# Summary
This PR introduces the initial Z-Image text-to-image integration work into FastVideo, focused on core component compatibility and parity validation against the local Z-Image reference implementation. It adds native Qwen3 text-encoder support, aligns scheduler timestep behavior with Z-Image reference semantics, and adds local parity tests for scheduler, tokenizer, text encoder, and VAE decode path. This is an in-progress port intended to establish correctness foundations before final end-to-end pipeline parity.

# What changed
## Model (Text Encoder)
- Added native Qwen3 encoder config and model implementation in FastVideo.
- Implemented Qwen3 architecture wiring with RoPE, grouped KV attention handling, SDPA attention path, RMSNorm, and tensor-parallel compatible linear layers.
- Added robust weight loading for Qwen3 checkpoints, including support for `model.`-prefixed keys and stacked parameter remapping (QKV and gate/up projections).
- Exported Qwen3 config in encoder config registry and added model registry mappings for Qwen3Model and Qwen3ForCausalLM.

## Scheduler
- Extended FlowMatchEulerDiscreteScheduler with use_reference_discrete_timesteps.
- Added Z-Image-compatible timestep construction mode (build num_steps + 1 linspace and drop terminal point) to match reference scheduler behavior.
- Preserved existing scheduler behavior as default when the new flag is not enabled.

## Parity tests (local)
- Added scheduler parity test against Z-Image reference scheduler:
  - default timestep schedule + step loop parity
  - dynamic shifting parity with mu
- Added tokenizer parity test:
  - TokenizerLoader vs AutoTokenizer parity on input_ids and attention_mask
  - chat template parity checks where available
- Added VAE decode parity test:
  - FastVideo AutoencoderKL vs Z-Image reference autoencoder using identical local weights/config.
- Added Qwen3 text encoder parity test:
  - FastVideo Qwen3 vs transformers AutoModel on identical local checkpoint/tokenization
  - compares last hidden state and hidden_states[-2] on valid-token positions

# How to test
## Prerequisites
- Local Z-Image reference repo available at Z-Image/src
- Local model assets under official_weights/Z-Image
- PyTorch + transformers + safetensors installed

From repo root, run:
```
pytest tests/local_tests/zimage/
```

# Current status / known gap
- **Scheduler parity**: passing
- **Tokenizer parity**: passing
- **VAE decode parity**: passing
- **Qwen3 encoder parity**: passing in float32 path, not passing in bfloat16
- **ZImageTransformer2DModel**: in-progress