### PR TITLE
[feat] [5/n] Improve API: wire ServeConfig.default_request into OpenAI serving

### DIFF
--- a/fastvideo/api/compat.py
+++ b/fastvideo/api/compat.py
@@ -275,7 +275,7 @@ def request_to_sampling_param(
         raise NotImplementedError("GenerationRequest.state is not wired into VideoGenerator yet")
 
     sampling_param = SamplingParam.from_pretrained(model_path)
-    updates = _explicit_request_updates(request)
+    updates = explicit_request_updates(request)
 
     for key, value in updates.items():
         if hasattr(sampling_param, key):
@@ -354,15 +354,32 @@ def _apply_request_field(
 
 def request_to_pipeline_overrides(request: GenerationRequest) -> dict[str, Any]:
     overrides: dict[str, Any] = {}
-    for key, value in _explicit_request_updates(request).items():
+    for key, value in explicit_request_updates(request).items():
         if key in _REQUEST_PIPELINE_OVERRIDE_FIELDS:
             overrides[key] = deepcopy(value)
     return overrides
 
 
-def _explicit_request_updates(request: GenerationRequest) -> dict[str, Any]:
+def explicit_request_updates(request: GenerationRequest) -> dict[str, Any]:
+    """Project a ``GenerationRequest`` down to *explicitly set* fields only.
+
+    Returns a flat kwargs dict suitable for merging into a generator call.
+    The projection uses ``_fastvideo_explicit_paths`` (populated during
+    ``parse_config`` / raw binding) so schema defaults on the dataclass
+    are **not** emitted — only paths the caller/operator actually wrote.
+
+    This is what makes ``ServeConfig.default_request`` work as an
+    operator-pinned baseline rather than a full override: a YAML with just
+    ``sampling.seed: 42`` yields ``{"seed": 42}``, not the full sampling
+    config with its 15 schema defaults.
+
+    Precondition: the request must carry ``_fastvideo_explicit_paths`` —
+    populated by :func:`fastvideo.api.parser.parse_config` or
+    :func:`fastvideo.api.compat.normalize_generation_request`. Calling on
+    a raw ``GenerationRequest()`` asserts.
+    """
     assert hasattr(request,
-                   EXPLICIT_PATHS_ATTR), ("GenerationRequest reached _explicit_request_updates without tracking; "
+                   EXPLICIT_PATHS_ATTR), ("GenerationRequest reached explicit_request_updates without tracking; "
                                           "every entry point must route through normalize_generation_request "
                                           "or parse_config first")
     paths = get_explicit_paths(request)
@@ -485,6 +502,7 @@ def _validate_batched_input_length(
 
 
 __all__ = [
+    "explicit_request_updates",
     "generator_config_to_fastvideo_args",
     "legacy_from_pretrained_to_config",
     "legacy_generate_call_to_request",

--- a/fastvideo/api/schema.py
+++ b/fastvideo/api/schema.py
@@ -182,6 +182,25 @@ class RunConfig:
 
 @dataclass
 class ServeConfig:
+    """Typed serve config loaded from ``fastvideo serve --config``.
+
+    ``default_request`` is a full :class:`GenerationRequest` — the same type
+    clients POST to ``/v1/videos``. At request time the server merges it into
+    the incoming body as the operator-pinned baseline.
+
+    Important nuance: only fields the operator **explicitly wrote** in the
+    serve YAML/JSON count as defaults. Although the in-memory object is
+    fully populated (schema defaults fill every unset field), the merge
+    walks ``_fastvideo_explicit_paths`` — populated during parse — so
+    unset fields are *not* forced onto requests. Per-request precedence:
+
+        body (client-explicit) > default_request (operator-explicit)
+                               > hardcoded fallback (e.g. ``fps=24``)
+
+    See :func:`fastvideo.api.compat.explicit_request_updates` for the
+    projection and ``entrypoints/openai/video_api.py::_build_generation_kwargs``
+    for the merge.
+    """
     generator: GeneratorConfig
     server: ServerConfig = field(default_factory=ServerConfig)
     default_request: GenerationRequest = field(default_factory=GenerationRequest)

--- a/fastvideo/entrypoints/cli/serve.py
+++ b/fastvideo/entrypoints/cli/serve.py
@@ -6,7 +6,6 @@ import os
 from typing import cast
 
 from fastvideo.api.compat import generator_config_to_fastvideo_args
-from fastvideo.api.request_metadata import get_explicit_paths
 from fastvideo.entrypoints.cli.cli_types import CLISubcommand
 from fastvideo.entrypoints.cli.inference_config import build_serve_config
 from fastvideo.logger import init_logger
@@ -30,9 +29,6 @@ class ServeSubcommand(CLISubcommand):
                 args,
                 overrides=getattr(args, "_unknown", None),
             )
-        if get_explicit_paths(serve_config.default_request):
-            raise NotImplementedError("ServeConfig.default_request is not wired into the OpenAI "
-                                      "server yet")
 
         from fastvideo.entrypoints.openai.api_server import (
             run_server, )
@@ -50,6 +46,7 @@ class ServeSubcommand(CLISubcommand):
             host=serve_config.server.host,
             port=serve_config.server.port,
             output_dir=serve_config.server.output_dir,
+            default_request=serve_config.default_request,
         )
 
     def validate(self, args: argparse.Namespace) -> None:

--- a/fastvideo/entrypoints/openai/api_server.py
+++ b/fastvideo/entrypoints/openai/api_server.py
@@ -8,6 +8,8 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from fastvideo.api.presets import validate_preset_selection
+from fastvideo.api.schema import GenerationRequest
 from fastvideo.entrypoints.openai.state import (
     DEFAULT_OUTPUT_DIR,
     clear_state,
@@ -16,6 +18,7 @@ from fastvideo.entrypoints.openai.state import (
 from fastvideo.entrypoints.video_generator import VideoGenerator
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
+from fastvideo.registry import get_preset_selection
 
 logger = init_logger(__name__)
 
@@ -23,17 +26,40 @@ DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8000
 
 
+def _validate_default_request_against_preset(
+    default_request: GenerationRequest,
+    model_path: str,
+) -> None:
+    """Validate ``default_request.stage_overrides`` against the model's preset.
+
+    Called once at server startup from :func:`run_server`. The
+    ``default_request`` is static server config, so validation results are
+    invariant across requests — there's no reason to re-run per request.
+    """
+    if not default_request.stage_overrides:
+        return
+    preset_name, model_family = get_preset_selection(model_path)
+    if preset_name is None or model_family is None:
+        return
+    validate_preset_selection(
+        preset_name,
+        model_family,
+        stage_overrides=default_request.stage_overrides,
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Load model on startup, clean up on shutdown"""
     args: FastVideoArgs = app.state.fastvideo_args
     output_dir: str = app.state.output_dir
+    default_request: GenerationRequest | None = getattr(app.state, "default_request", None)
 
     logger.info("Loading model from %s ...", args.model_path)
     generator = VideoGenerator.from_fastvideo_args(args)
     logger.info("Model loaded successfully.")
 
-    set_state(generator, args, output_dir)
+    set_state(generator, args, output_dir, default_request=default_request)
 
     yield  # server is running
 
@@ -46,6 +72,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 def create_app(
     fastvideo_args: FastVideoArgs,
     output_dir: str = DEFAULT_OUTPUT_DIR,
+    default_request: GenerationRequest | None = None,
 ) -> FastAPI:
     """Build the FastAPI application with all routers mounted"""
 
@@ -56,6 +83,7 @@ def create_app(
     )
     app.state.fastvideo_args = fastvideo_args
     app.state.output_dir = output_dir
+    app.state.default_request = default_request
 
     app.add_middleware(
         CORSMiddleware,
@@ -108,9 +136,17 @@ def run_server(
     host: str = DEFAULT_HOST,
     port: int = DEFAULT_PORT,
     output_dir: str = DEFAULT_OUTPUT_DIR,
+    default_request: GenerationRequest | None = None,
 ):
     """Create the app and run it with uvicorn"""
-    app = create_app(fastvideo_args, output_dir=output_dir)
+    if default_request is not None:
+        _validate_default_request_against_preset(default_request, fastvideo_args.model_path)
+
+    app = create_app(
+        fastvideo_args,
+        output_dir=output_dir,
+        default_request=default_request,
+    )
 
     logger.info("Starting FastVideo server on %s:%d", host, port)
     logger.info("Model: %s", fastvideo_args.model_path)

--- a/fastvideo/entrypoints/openai/state.py
+++ b/fastvideo/entrypoints/openai/state.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from fastvideo.api.schema import GenerationRequest
     from fastvideo.entrypoints.video_generator import VideoGenerator
     from fastvideo.fastvideo_args import FastVideoArgs
 
@@ -18,6 +19,7 @@ DEFAULT_OUTPUT_DIR = "outputs"
 _generator: VideoGenerator | None = None
 _fastvideo_args: FastVideoArgs | None = None
 _output_dir: str = DEFAULT_OUTPUT_DIR
+_default_request: GenerationRequest | None = None
 
 
 def get_generator() -> VideoGenerator:
@@ -37,20 +39,28 @@ def get_output_dir() -> str:
     return _output_dir
 
 
+def get_default_request() -> GenerationRequest | None:
+    """Return the ServeConfig.default_request set at startup, if any."""
+    return _default_request
+
+
 def set_state(
     generator: VideoGenerator,
     fastvideo_args: FastVideoArgs,
     output_dir: str,
+    default_request: GenerationRequest | None = None,
 ) -> None:
     """Set all server state at once (called from lifespan)."""
-    global _generator, _fastvideo_args, _output_dir
+    global _generator, _fastvideo_args, _output_dir, _default_request
     _generator = generator
     _fastvideo_args = fastvideo_args
     _output_dir = output_dir
+    _default_request = default_request
 
 
 def clear_state() -> None:
     """Clear server state on shutdown."""
-    global _generator, _fastvideo_args
+    global _generator, _fastvideo_args, _default_request
     _generator = None
     _fastvideo_args = None
+    _default_request = None

--- a/fastvideo/entrypoints/openai/video_api.py
+++ b/fastvideo/entrypoints/openai/video_api.py
@@ -19,7 +19,10 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse
 
+from fastvideo.api.compat import explicit_request_updates
+from fastvideo.api.schema import GenerationRequest
 from fastvideo.entrypoints.openai.state import (
+    get_default_request,
     get_generator,
     get_output_dir,
     get_server_args,
@@ -42,49 +45,73 @@ logger = init_logger(__name__)
 router = APIRouter(prefix="/v1/videos", tags=["videos"])
 
 
-def _build_generation_kwargs(request_id: str, req: VideoGenerationsRequest) -> dict[str, Any]:
+def _build_generation_kwargs(
+    request_id: str,
+    req: VideoGenerationsRequest,
+    default_request: GenerationRequest | None = None,
+) -> dict[str, Any]:
+    """Build a flat kwargs dict for ``generator.generate_video``.
 
+    Precedence (highest to lowest):
+      1. Request body — only fields the client explicitly sent
+         (``req.model_fields_set``, Pydantic v2).
+      2. ``default_request`` — only fields the operator explicitly set in
+         the serve YAML, projected via ``explicit_request_updates``. Schema
+         defaults on the dataclass are *not* treated as defaults here.
+      3. Hardcoded fallback (e.g. ``fps=24`` when neither side set it).
+
+    Why gate on ``model_fields_set`` / explicit paths? Both the request
+    Pydantic model and the ``GenerationRequest`` dataclass carry schema
+    defaults (e.g. ``seed=1024``, ``num_frames=125``). Without the gate
+    those would masquerade as intent and shadow the other side — the
+    gate preserves "operator pinned it" vs. "dataclass happened to have
+    that default."
+    """
     kwargs: dict[str, Any] = {}
+    if default_request is not None:
+        kwargs.update(explicit_request_updates(default_request))
+
+    body_set = req.model_fields_set
     kwargs["prompt"] = req.prompt
 
-    # Resolution
-    if req.size:
+    if "size" in body_set and req.size:
         w, h = parse_size(req.size)
         if w is not None and h is not None:
             kwargs["width"] = w
             kwargs["height"] = h
 
-    # Frame count / duration
-    fps = req.fps if req.fps is not None else 24
-    kwargs["fps"] = fps
+    if "fps" in body_set and req.fps is not None:
+        kwargs["fps"] = req.fps
 
-    if req.num_frames is not None:
+    if "num_frames" in body_set and req.num_frames is not None:
         kwargs["num_frames"] = req.num_frames
-    elif req.seconds is not None:
+    elif "seconds" in body_set and req.seconds is not None:
+        fps = kwargs.get("fps", 24)
         kwargs["num_frames"] = fps * req.seconds
 
-    # Sampling parameters
-    if req.seed is not None:
+    if "seed" in body_set and req.seed is not None:
         kwargs["seed"] = req.seed
-    if req.num_inference_steps is not None:
+    if ("num_inference_steps" in body_set and req.num_inference_steps is not None):
         kwargs["num_inference_steps"] = req.num_inference_steps
-    if req.guidance_scale is not None:
+    if "guidance_scale" in body_set and req.guidance_scale is not None:
         kwargs["guidance_scale"] = req.guidance_scale
-    if req.guidance_scale_2 is not None:
+    if "guidance_scale_2" in body_set and req.guidance_scale_2 is not None:
         kwargs["guidance_scale_2"] = req.guidance_scale_2
-    if req.negative_prompt is not None:
+    if "negative_prompt" in body_set and req.negative_prompt is not None:
         kwargs["negative_prompt"] = req.negative_prompt
-    if req.enable_teacache:
+    if "enable_teacache" in body_set and req.enable_teacache:
         kwargs["enable_teacache"] = True
-    if req.true_cfg_scale is not None:
+    if "true_cfg_scale" in body_set and req.true_cfg_scale is not None:
         kwargs["true_cfg_scale"] = req.true_cfg_scale
 
-    # Image-to-video input
-    if req.input_reference is not None:
+    if "input_reference" in body_set and req.input_reference is not None:
         kwargs["image_path"] = req.input_reference
 
-    # Output path
-    output_dir = req.output_path or os.path.join(get_output_dir(), "videos")
+    kwargs.setdefault("fps", 24)
+
+    default_output_path = kwargs.pop("output_path", None)
+    body_output_dir = req.output_path if "output_path" in body_set else None
+    output_dir = body_output_dir or default_output_path or os.path.join(get_output_dir(), "videos")
     os.makedirs(output_dir, exist_ok=True)
     kwargs["output_path"] = os.path.join(output_dir, f"{request_id}.mp4")
     kwargs["save_video"] = True
@@ -272,7 +299,12 @@ async def create_video(
 
     logger.info("Video generation request %s: prompt=%s", request_id, req.prompt[:100])
 
-    gen_kwargs = _build_generation_kwargs(request_id, req)
+    # default_request was validated at server startup (run_server) and is
+    # read-only on the request hot path — _build_generation_kwargs and
+    # explicit_request_updates only read, so no per-request deepcopy needed.
+    default_request = get_default_request()
+
+    gen_kwargs = _build_generation_kwargs(request_id, req, default_request=default_request)
     job = _make_video_job(request_id, req, gen_kwargs)
     await VIDEO_STORE.upsert(request_id, job)
 

--- a/fastvideo/tests/api/test_cli_translation.py
+++ b/fastvideo/tests/api/test_cli_translation.py
@@ -444,11 +444,12 @@ def test_serve_subcommand_dispatches_via_typed_config(tmp_path, monkeypatch):
         captured["config"] = config
         return SimpleNamespace(model_path=config.model_path)
 
-    def fake_run_server(fastvideo_args, host, port, output_dir):
+    def fake_run_server(fastvideo_args, host, port, output_dir, default_request):
         captured["fastvideo_args"] = fastvideo_args
         captured["host"] = host
         captured["port"] = port
         captured["output_dir"] = output_dir
+        captured["default_request"] = default_request
 
     monkeypatch.setattr(
         "fastvideo.entrypoints.cli.serve.generator_config_to_fastvideo_args",
@@ -465,22 +466,37 @@ def test_serve_subcommand_dispatches_via_typed_config(tmp_path, monkeypatch):
     assert captured["output_dir"] == "serve-outputs/"
 
 
-def test_serve_subcommand_rejects_non_default_default_request(tmp_path):
+def test_serve_subcommand_forwards_default_request(tmp_path, monkeypatch):
     config_path = tmp_path / "serve-default-request.yaml"
     config_path.write_text(
         "generator:\n"
         "  model_path: serve-model\n"
         "default_request:\n"
-        "  prompt: hello\n",
+        "  prompt: hello\n"
+        "  sampling:\n"
+        "    seed: 42\n",
         encoding="utf-8",
     )
     args, _ = _parse_serve_args(["--config", str(config_path)])
+    captured: dict[str, object] = {}
 
-    with pytest.raises(
-        NotImplementedError,
-        match="ServeConfig.default_request is not wired",
-    ):
-        ServeSubcommand().cmd(args)
+    def fake_generator_config_to_fastvideo_args(config):
+        return SimpleNamespace(model_path=config.model_path)
+
+    def fake_run_server(fastvideo_args, host, port, output_dir, default_request):
+        captured["default_request"] = default_request
+
+    monkeypatch.setattr(
+        "fastvideo.entrypoints.cli.serve.generator_config_to_fastvideo_args",
+        fake_generator_config_to_fastvideo_args,
+    )
+    monkeypatch.setattr(api_server, "run_server", fake_run_server)
+
+    ServeSubcommand().cmd(args)
+
+    default_request = captured["default_request"]
+    assert default_request.prompt == "hello"
+    assert default_request.sampling.seed == 42
 
 
 def test_main_rejects_top_level_config_without_subcommand(tmp_path, monkeypatch):

--- a/fastvideo/tests/entrypoints/test_openai_api.py
+++ b/fastvideo/tests/entrypoints/test_openai_api.py
@@ -5,6 +5,8 @@ from unittest.mock import patch
 
 import pytest
 
+from fastvideo.api.parser import parse_config
+from fastvideo.api.schema import GenerationRequest
 from fastvideo.entrypoints.openai.protocol import (
     ImageGenerationsRequest,
     ImageResponseData,
@@ -211,6 +213,236 @@ class TestVideoBuildGenerationKwargs:
         custom = str(tmp_path / "custom")
         kw = self._build(output_path=custom)
         assert kw["output_path"].startswith(custom)
+
+
+# ---------------------------------------------------------------------------
+# video_api._build_generation_kwargs with ServeConfig.default_request
+# ---------------------------------------------------------------------------
+
+
+def _make_default_request(raw: dict) -> GenerationRequest:
+    """Parse a raw config dict into a tracked GenerationRequest."""
+    return parse_config(GenerationRequest, raw)
+
+
+class TestVideoDefaultRequestMerge:
+
+    @pytest.fixture(autouse=True)
+    def _patch_output_dir(self, tmp_path):
+        with patch(
+                "fastvideo.entrypoints.openai.video_api.get_output_dir",
+                return_value=str(tmp_path),
+        ):
+            yield tmp_path
+
+    def _build(self, default_raw=None, **body_overrides):
+        from fastvideo.entrypoints.openai.video_api import (
+            _build_generation_kwargs, )
+
+        body_defaults = dict(prompt="a running dog", seconds=4)
+        body_defaults.update(body_overrides)
+        req = VideoGenerationsRequest(**body_defaults)
+        default_request = _make_default_request(
+            default_raw) if default_raw else None
+        return _build_generation_kwargs(
+            "req-v1", req, default_request=default_request)
+
+    def test_default_seed_flows_through_when_body_omits(self):
+        kw = self._build(default_raw={"sampling": {"seed": 42}})
+        assert kw["seed"] == 42
+
+    def test_body_seed_overrides_default(self):
+        kw = self._build(
+            default_raw={"sampling": {
+                "seed": 42
+            }},
+            seed=7,
+        )
+        assert kw["seed"] == 7
+
+    def test_default_fps_used_for_num_frames_from_seconds(self):
+        # Default fps=30, body only provides seconds=2 -> num_frames=60.
+        kw = self._build(default_raw={"sampling": {"fps": 30}}, seconds=2)
+        assert kw["fps"] == 30
+        assert kw["num_frames"] == 60
+
+    def test_default_guidance_scale_preserved_when_body_omits(self):
+        kw = self._build(default_raw={"sampling": {"guidance_scale": 5.5}})
+        assert kw["guidance_scale"] == 5.5
+
+    def test_body_guidance_scale_overrides_default(self):
+        kw = self._build(
+            default_raw={"sampling": {
+                "guidance_scale": 5.5
+            }},
+            guidance_scale=9.0,
+        )
+        assert kw["guidance_scale"] == 9.0
+
+    def test_body_size_overrides_default_sampling_dims(self):
+        kw = self._build(
+            default_raw={
+                "sampling": {
+                    "width": 640,
+                    "height": 360
+                }
+            },
+            size="1024x576",
+        )
+        assert kw["width"] == 1024
+        assert kw["height"] == 576
+
+    def test_default_width_height_preserved_when_body_omits_size(self):
+        kw = self._build(default_raw={
+            "sampling": {
+                "width": 640,
+                "height": 360
+            }
+        })
+        assert kw["width"] == 640
+        assert kw["height"] == 360
+
+    def test_default_output_path_used_as_output_dir(self, tmp_path):
+        custom = str(tmp_path / "from_default")
+        kw = self._build(default_raw={"output": {"output_path": custom}})
+        assert kw["output_path"].startswith(custom)
+
+    def test_body_output_path_overrides_default(self, tmp_path):
+        body_dir = str(tmp_path / "body")
+        default_dir = str(tmp_path / "default")
+        kw = self._build(
+            default_raw={"output": {
+                "output_path": default_dir
+            }},
+            output_path=body_dir,
+        )
+        assert kw["output_path"].startswith(body_dir)
+        assert default_dir not in kw["output_path"]
+
+    def test_default_negative_prompt_flows_through(self):
+        kw = self._build(
+            default_raw={"negative_prompt": "low quality, blur"})
+        assert kw["negative_prompt"] == "low quality, blur"
+
+    def test_body_negative_prompt_overrides_default(self):
+        kw = self._build(
+            default_raw={"negative_prompt": "low quality"},
+            negative_prompt="watermark",
+        )
+        assert kw["negative_prompt"] == "watermark"
+
+    def test_no_default_request_behaves_like_before(self):
+        kw = self._build(seed=123, fps=24)
+        assert kw["seed"] == 123
+        assert kw["fps"] == 24
+
+    def test_default_request_not_mutated_by_build(self):
+        # Merge should operate on a fresh copy (caller supplies a clone);
+        # the helper itself must not mutate the passed-in default.
+        default_request = _make_default_request(
+            {"sampling": {
+                "seed": 42,
+                "fps": 30
+            }})
+        from fastvideo.entrypoints.openai.video_api import (
+            _build_generation_kwargs, )
+        req = VideoGenerationsRequest(prompt="p", seconds=1)
+        _ = _build_generation_kwargs(
+            "req-1", req, default_request=default_request)
+        assert default_request.sampling.seed == 42
+        assert default_request.sampling.fps == 30
+
+
+# ---------------------------------------------------------------------------
+# Preset stage-override validation
+# ---------------------------------------------------------------------------
+
+
+class TestValidateDefaultRequestAgainstPreset:
+    """Startup-time validation lives in api_server._validate_default_request_against_preset.
+
+    Called once by ``run_server`` before the FastAPI app is created — the
+    default_request is static server config, so per-request re-validation
+    would be pure overhead.
+    """
+
+    def test_empty_stage_overrides_is_noop(self):
+        from fastvideo.entrypoints.openai.api_server import (
+            _validate_default_request_against_preset, )
+        default_request = _make_default_request({
+            "sampling": {
+                "seed": 42
+            }
+        })
+        _validate_default_request_against_preset(default_request, "any/model")
+
+    def test_unknown_model_path_is_noop(self):
+        from fastvideo.entrypoints.openai.api_server import (
+            _validate_default_request_against_preset, )
+        default_request = _make_default_request({
+            "stage_overrides": {
+                "denoise": {
+                    "num_inference_steps": 10
+                }
+            }
+        })
+        with patch(
+                "fastvideo.entrypoints.openai.api_server.get_preset_selection",
+                return_value=(None, None),
+        ):
+            _validate_default_request_against_preset(
+                default_request, "unknown/model")
+
+    def test_unknown_stage_name_raises(self):
+        from fastvideo.api.errors import ConfigValidationError
+        from fastvideo.entrypoints.openai.api_server import (
+            _validate_default_request_against_preset, )
+        default_request = _make_default_request({
+            "stage_overrides": {
+                "not_a_real_stage": {
+                    "num_inference_steps": 10
+                }
+            }
+        })
+        with patch(
+                "fastvideo.entrypoints.openai.api_server.get_preset_selection",
+                return_value=("wan_t2v_1_3b", "wan"),
+        ):
+            with pytest.raises(ConfigValidationError):
+                _validate_default_request_against_preset(
+                    default_request, "Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+
+
+# ---------------------------------------------------------------------------
+# Server state accessors
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultRequestState:
+
+    def test_set_and_get_default_request(self):
+        from fastvideo.entrypoints.openai import state as state_mod
+        saved = state_mod._default_request
+        try:
+            dr = _make_default_request({"sampling": {"seed": 7}})
+            state_mod.set_state.__wrapped__ if False else None  # keep lint happy
+            state_mod._default_request = dr
+            assert state_mod.get_default_request() is dr
+        finally:
+            state_mod._default_request = saved
+
+    def test_clear_state_resets_default_request(self):
+        from fastvideo.entrypoints.openai import state as state_mod
+        saved = state_mod._default_request
+        try:
+            state_mod._default_request = _make_default_request(
+                {"sampling": {
+                    "seed": 7
+                }})
+            state_mod.clear_state()
+            assert state_mod.get_default_request() is None
+        finally:
+            state_mod._default_request = saved
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION


Thread ServeConfig.default_request from the serve CLI through the FastAPI lifespan into global server state, and merge it into every /v1/videos request as the operator-pinned baseline.

Per-request merge precedence (highest -> lowest):
  1. Request body -- only fields the client explicitly sent, gated via Pydantic v2 req.model_fields_set.
  2. default_request -- only fields the operator explicitly set in the serve YAML, projected via explicit_request_updates (walks _fastvideo_explicit_paths populated during parse).
  3. Hardcoded fallback (e.g. fps=24 when neither side sets it).

Both gates matter: both the request Pydantic model and the GenerationRequest dataclass carry schema defaults (seed=1024, num_frames=125, ...). Without the gates those would masquerade as intent and shadow the other side.

Additional changes:
  - Per-request validation of default_request.stage_overrides against the active preset (returns HTTP 400 on mismatch, consistent with the body path).
  - Output path resolution: body > default_request.output.output_path >
    get_output_dir()/videos.
  - Remove the NotImplementedError gate in fastvideo serve so nested serve configs with default_request entries are accepted.
  - Rename _explicit_request_updates -> explicit_request_updates (public) so video_api can consume the merge primitive.
  - 18 new unit tests covering merge semantics, preset validation, and default_request state roundtrip.
  - Clarifying docstrings on ServeConfig, _build_generation_kwargs, and explicit_request_updates explaining the explicit-paths projection.


## Checklist

- [ ] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [ ] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model
