### PR TITLE
[feat] Add typed LTX-2 continuation state and streaming session store

### DIFF
--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -354,6 +354,8 @@ surfaces:
       return_frames: request.output.return_frames
       return_trajectory_latents: request.runtime.return_trajectory_latents
       return_trajectory_decoded: request.runtime.return_trajectory_decoded
+      continuation_state: request.state
+      return_continuation_state: request.output.return_state
     preset_owned:
       t_thresh: request.stage_overrides.refine.t_thresh
       spatial_refine_only: request.stage_overrides.refine.spatial_refine_only

--- a/fastvideo/api/compat.py
+++ b/fastvideo/api/compat.py
@@ -577,7 +577,7 @@ def _validate_continuation_state(state: ContinuationState) -> None:
     if not isinstance(state.payload, Mapping):
         raise ValueError(f"GenerationRequest.state.payload must be a mapping; got "
                          f"{type(state.payload).__name__}")
-    if _KNOWN_CONTINUATION_KINDS and state.kind not in _KNOWN_CONTINUATION_KINDS:
+    if state.kind not in _KNOWN_CONTINUATION_KINDS:
         known = sorted(_KNOWN_CONTINUATION_KINDS)
         raise ValueError(f"Unknown ContinuationState kind {state.kind!r}; registered "
                          f"kinds: {known}. Import the model family that owns this kind "

--- a/fastvideo/api/compat.py
+++ b/fastvideo/api/compat.py
@@ -17,6 +17,7 @@ from fastvideo.api.request_metadata import (
 )
 from fastvideo.api.schema import (
     CompileConfig,
+    ContinuationState,
     GenerationRequest,
     GeneratorConfig,
     InputConfig,
@@ -325,10 +326,13 @@ def request_to_sampling_param(
 ) -> SamplingParam:
     if request.plan is not None:
         raise NotImplementedError("GenerationRequest.plan is not wired into VideoGenerator yet")
-    if request.state is not None:
-        raise NotImplementedError("GenerationRequest.state is not wired into VideoGenerator yet")
 
     sampling_param = SamplingParam.from_pretrained(model_path)
+    if request.state is not None:
+        _validate_continuation_state(request.state)
+        sampling_param.continuation_state = request.state
+    if request.output.return_state:
+        sampling_param.return_continuation_state = True
     updates = explicit_request_updates(request)
 
     for key, value in updates.items():
@@ -549,6 +553,37 @@ def _serialize_generation_request(request: GenerationRequest) -> dict[str, Any]:
 
 _SCHEMA_DEFAULT_UPDATES = _extract_request_updates(config_to_dict(GenerationRequest()))
 
+_KNOWN_CONTINUATION_KINDS: set[str] = set()
+
+
+def register_continuation_kind(kind: str) -> None:
+    """Register a :class:`ContinuationState.kind` as recognized.
+
+    PR 7 wires the envelope through; per-kind payload deserializers live
+    with each model family (e.g. ``fastvideo.pipelines.basic.ltx2.
+    continuation.LTX2ContinuationState``). The registry lets the
+    public-API compat layer validate the kind early, before the state
+    reaches the pipeline.
+    """
+    if not isinstance(kind, str) or not kind:
+        raise ValueError("ContinuationState kind must be a non-empty string")
+    _KNOWN_CONTINUATION_KINDS.add(kind)
+
+
+def _validate_continuation_state(state: ContinuationState) -> None:
+    if not isinstance(state.kind, str) or not state.kind:
+        raise ValueError("GenerationRequest.state.kind must be a non-empty string; got "
+                         f"{state.kind!r}")
+    if not isinstance(state.payload, Mapping):
+        raise ValueError(f"GenerationRequest.state.payload must be a mapping; got "
+                         f"{type(state.payload).__name__}")
+    if _KNOWN_CONTINUATION_KINDS and state.kind not in _KNOWN_CONTINUATION_KINDS:
+        known = sorted(_KNOWN_CONTINUATION_KINDS)
+        raise ValueError(f"Unknown ContinuationState kind {state.kind!r}; registered "
+                         f"kinds: {known}. Import the model family that owns this kind "
+                         "(e.g. `import fastvideo.pipelines.basic.ltx2.continuation`) "
+                         "to register it, or drop the state field.")
+
 
 def _fan_out_batched_input_value(
     source_request: GenerationRequest,
@@ -582,6 +617,7 @@ __all__ = [
     "load_generator_config_from_file",
     "normalize_generation_request",
     "normalize_generator_config",
+    "register_continuation_kind",
     "request_to_pipeline_overrides",
     "request_to_sampling_param",
 ]

--- a/fastvideo/api/sampling_param.py
+++ b/fastvideo/api/sampling_param.py
@@ -107,6 +107,14 @@ class SamplingParam:
     ltx2_stg_blocks_video: list[int] = field(default_factory=lambda: [29])
     ltx2_stg_blocks_audio: list[int] = field(default_factory=lambda: [29])
 
+    # Continuation state carried across streaming/multi-segment calls (LTX-2).
+    # Concrete type is fastvideo.api.schema.ContinuationState; kept as Any
+    # to avoid circular imports at dataclass definition time.
+    continuation_state: Any | None = None
+    # When True, the pipeline returns a ContinuationState on the result so
+    # the caller can resume from the generated segment.
+    return_continuation_state: bool = False
+
     # Misc
     save_video: bool = True
     return_frames: bool = True

--- a/fastvideo/api/sampling_param.py
+++ b/fastvideo/api/sampling_param.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
 import copy
 from dataclasses import dataclass, field, fields
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastvideo.logger import init_logger
 from fastvideo.utils import StoreBoolean
+
+if TYPE_CHECKING:
+    from fastvideo.api.schema import ContinuationState
 
 logger = init_logger(__name__)
 
@@ -107,10 +112,8 @@ class SamplingParam:
     ltx2_stg_blocks_video: list[int] = field(default_factory=lambda: [29])
     ltx2_stg_blocks_audio: list[int] = field(default_factory=lambda: [29])
 
-    # Continuation state carried across streaming/multi-segment calls (LTX-2).
-    # Concrete type is fastvideo.api.schema.ContinuationState; kept as Any
-    # to avoid circular imports at dataclass definition time.
-    continuation_state: Any | None = None
+    # Continuation state carried across streaming/multi-segment calls.
+    continuation_state: ContinuationState | None = None
     # When True, the pipeline returns a ContinuationState on the result so
     # the caller can resume from the generated segment.
     return_continuation_state: bool = False
@@ -139,7 +142,7 @@ class SamplingParam:
         self.__post_init__()
 
     @classmethod
-    def from_pretrained(cls, model_path: str) -> "SamplingParam":
+    def from_pretrained(cls, model_path: str) -> SamplingParam:
         sampling_param = cls._from_preset(model_path)
         if sampling_param is not None:
             return sampling_param
@@ -155,7 +158,7 @@ class SamplingParam:
     def _from_preset(
         cls,
         model_path: str,
-    ) -> "SamplingParam | None":
+    ) -> SamplingParam | None:
         """Build a SamplingParam from preset defaults.
 
         Returns ``None`` when no preset is configured for

--- a/fastvideo/entrypoints/streaming/__init__.py
+++ b/fastvideo/entrypoints/streaming/__init__.py
@@ -1,4 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 from fastvideo.entrypoints.streaming.server import run_server
+from fastvideo.entrypoints.streaming.session_store import (
+    BlobStore,
+    InMemoryBlobStore,
+    InMemorySessionStore,
+    SessionStore,
+)
 
-__all__ = ["run_server"]
+__all__ = [
+    "BlobStore",
+    "InMemoryBlobStore",
+    "InMemorySessionStore",
+    "SessionStore",
+    "run_server",
+]

--- a/fastvideo/entrypoints/streaming/session_store.py
+++ b/fastvideo/entrypoints/streaming/session_store.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Session state store for the FastVideo streaming server.
+
+The streaming server keeps continuation state (decoded frames + audio
+latents from the previous segment) server-side so the client doesn't
+re-upload multi-megabyte tensors each WebSocket message. Two operations
+are needed:
+
+* ``snapshot(session_id) -> ContinuationState`` — serialize the current
+  state so it can be exported (e.g. over HTTP) or migrated to a
+  different server.
+* ``hydrate(state) -> session_id`` — load a previously serialized state
+  into a new session (for resume-after-disconnect flows).
+
+The store is an ABC with an :class:`InMemorySessionStore` default; Redis
+or other backends can drop in without touching the pipeline.
+
+Large tensor payloads (video frames, audio latents) are kept out of the
+JSON payload via an accompanying :class:`BlobStore`. Both stores share a
+process today; they are separate types so that a future implementation
+can put blobs on S3 while keeping session metadata in Redis.
+"""
+from __future__ import annotations
+
+import threading
+import uuid
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from fastvideo.api.schema import ContinuationState
+
+
+class BlobStore(ABC):
+    """Opaque byte-blob storage keyed by id.
+
+    A :class:`ContinuationState` payload can reference large tensors
+    stored in a :class:`BlobStore` rather than inlining them, so the
+    JSON payload stays small when the state travels over the wire.
+    """
+
+    @abstractmethod
+    def put(self, data: bytes, *, mime: str = "application/octet-stream") -> str:
+        """Store ``data`` and return a blob id for later retrieval."""
+
+    @abstractmethod
+    def get(self, blob_id: str) -> bytes:
+        """Load a previously stored blob. Raises ``KeyError`` if absent."""
+
+    @abstractmethod
+    def drop(self, blob_id: str) -> None:
+        """Remove a blob. Missing ids are a no-op."""
+
+    @abstractmethod
+    def __contains__(self, blob_id: str) -> bool:
+        ...
+
+
+@dataclass(frozen=True)
+class _BlobRecord:
+    data: bytes
+    mime: str
+
+
+class InMemoryBlobStore(BlobStore):
+    """Thread-safe in-memory :class:`BlobStore` for single-process servers."""
+
+    def __init__(self) -> None:
+        self._blobs: dict[str, _BlobRecord] = {}
+        self._lock = threading.Lock()
+
+    def put(self, data: bytes, *, mime: str = "application/octet-stream") -> str:
+        blob_id = uuid.uuid4().hex
+        with self._lock:
+            self._blobs[blob_id] = _BlobRecord(data=data, mime=mime)
+        return blob_id
+
+    def get(self, blob_id: str) -> bytes:
+        with self._lock:
+            record = self._blobs.get(blob_id)
+        if record is None:
+            raise KeyError(f"Unknown blob id: {blob_id}")
+        return record.data
+
+    def drop(self, blob_id: str) -> None:
+        with self._lock:
+            self._blobs.pop(blob_id, None)
+
+    def __contains__(self, blob_id: str) -> bool:
+        with self._lock:
+            return blob_id in self._blobs
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._blobs)
+
+
+class SessionStore(ABC):
+    """Keyed store for per-session continuation state.
+
+    Implementations own the session-id → state mapping. The streaming
+    server calls :meth:`store` after each segment and :meth:`snapshot`
+    when a client explicitly asks for an exportable state handle.
+    """
+
+    @abstractmethod
+    def store(self, session_id: str, state: ContinuationState) -> None:
+        """Persist ``state`` for ``session_id``, replacing any prior value."""
+
+    @abstractmethod
+    def snapshot(self, session_id: str) -> ContinuationState | None:
+        """Return the current state for ``session_id`` (or ``None``)."""
+
+    @abstractmethod
+    def hydrate(
+        self,
+        state: ContinuationState,
+        *,
+        session_id: str | None = None,
+    ) -> str:
+        """Install ``state`` as the starting point for a session.
+
+        When ``session_id`` is ``None`` the store allocates a fresh id
+        (UUID4); when provided the store uses it verbatim, overwriting
+        any prior state at that id.
+        """
+
+    @abstractmethod
+    def drop(self, session_id: str) -> None:
+        """Forget a session. Missing ids are a no-op."""
+
+    @abstractmethod
+    def __contains__(self, session_id: str) -> bool:
+        ...
+
+    @abstractmethod
+    def __iter__(self) -> Iterator[str]:
+        ...
+
+
+class InMemorySessionStore(SessionStore):
+    """Thread-safe in-memory :class:`SessionStore`.
+
+    Default implementation used by single-process deployments; a future
+    Redis-backed store can be dropped in without changes to the server.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, ContinuationState] = {}
+        self._lock = threading.Lock()
+
+    def store(self, session_id: str, state: ContinuationState) -> None:
+        with self._lock:
+            self._sessions[session_id] = state
+
+    def snapshot(self, session_id: str) -> ContinuationState | None:
+        with self._lock:
+            return self._sessions.get(session_id)
+
+    def hydrate(
+        self,
+        state: ContinuationState,
+        *,
+        session_id: str | None = None,
+    ) -> str:
+        sid = session_id or uuid.uuid4().hex
+        with self._lock:
+            self._sessions[sid] = state
+        return sid
+
+    def drop(self, session_id: str) -> None:
+        with self._lock:
+            self._sessions.pop(session_id, None)
+
+    def __contains__(self, session_id: str) -> bool:
+        with self._lock:
+            return session_id in self._sessions
+
+    def __iter__(self) -> Iterator[str]:
+        with self._lock:
+            return iter(list(self._sessions))
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._sessions)
+
+
+__all__ = [
+    "BlobStore",
+    "InMemoryBlobStore",
+    "InMemorySessionStore",
+    "SessionStore",
+]

--- a/fastvideo/entrypoints/streaming/session_store.py
+++ b/fastvideo/entrypoints/streaming/session_store.py
@@ -63,7 +63,14 @@ class _BlobRecord:
 
 
 class InMemoryBlobStore(BlobStore):
-    """Thread-safe in-memory :class:`BlobStore` for single-process servers."""
+    """Thread-safe in-memory :class:`BlobStore` for single-process servers.
+
+    No eviction policy — callers are responsible for calling
+    :meth:`drop` when a blob's owning state is replaced or a session
+    ends. A redis- or filesystem-backed :class:`BlobStore` should
+    replace this when the streaming server lands as a real service
+    (PR 7.5+).
+    """
 
     def __init__(self) -> None:
         self._blobs: dict[str, _BlobRecord] = {}
@@ -143,6 +150,12 @@ class InMemorySessionStore(SessionStore):
 
     Default implementation used by single-process deployments; a future
     Redis-backed store can be dropped in without changes to the server.
+
+    No eviction / TTL / bounded capacity — sessions only leave via
+    :meth:`drop`. The live streaming server (PR 7.5+) is responsible
+    for bounding growth and for dropping any :class:`BlobStore` blobs
+    referenced by a state when that state is replaced or a session
+    ends; this class does not know about blobs.
     """
 
     def __init__(self) -> None:

--- a/fastvideo/pipelines/basic/ltx2/__init__.py
+++ b/fastvideo/pipelines/basic/ltx2/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Importing continuation registers the "ltx2.v1" continuation kind with
+# the public compat layer so GenerationRequest.state(kind="ltx2.v1") is
+# recognized on the public API boundary.
+from fastvideo.pipelines.basic.ltx2 import continuation  # noqa: F401

--- a/fastvideo/pipelines/basic/ltx2/continuation.py
+++ b/fastvideo/pipelines/basic/ltx2/continuation.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed continuation state for the LTX-2 streaming pipeline.
+
+Segment N+1 conditions on segment N's trailing decoded frames and
+denoised audio latents. Historically (``FastVideo-internal/ui/
+ltx2-streaming/server/gpu_pool.py``) this state lived on the GPU as
+hidden per-worker globals (``ltx2_continuation_images``,
+``ltx2_continuation_audio_latents``); there was no way for a client to
+snapshot it, migrate it, or round-trip it through an HTTP/RPC boundary.
+
+PR 7 lifts the state into a typed, JSON-serializable object. The typed
+class lives here because the payload shape is model-specific; the
+envelope (``ContinuationState(kind, payload)``) is shared public API.
+
+Serialization contract:
+
+* Video frames are encoded as PNG bytes (lossless, indexable) and then
+  base64'd; optionally a :class:`BlobStore` can hold them by id instead.
+* Audio latents are encoded as ``{dtype, shape, bytes}`` (base64'd raw
+  buffer) or referenced via a blob id.
+* Either way the returned payload is a plain JSON-serializable dict so
+  the state survives a Dynamo RPC or an HTTP round-trip.
+"""
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from fastvideo.api.compat import register_continuation_kind
+from fastvideo.api.schema import ContinuationState
+
+if TYPE_CHECKING:
+    import numpy as np
+    import torch
+
+    from fastvideo.entrypoints.streaming.session_store import BlobStore
+
+LTX2_CONTINUATION_KIND = "ltx2.v1"
+"""Public ``ContinuationState.kind`` for LTX-2 payloads."""
+
+LTX2_CONTINUATION_SCHEMA_VERSION = 1
+"""Payload schema version carried inside ``payload.schema_version``."""
+
+DEFAULT_INLINE_THRESHOLD_BYTES = 2 * 1024 * 1024
+"""Tensors larger than this go to the blob store (if available). 2 MiB
+is below typical single-JSON-message limits (Dynamo: 4 MiB, Postgres
+TOAST: 1 GiB) and well above per-frame PNG payloads (~200 KiB at
+512x512)."""
+
+
+@dataclass
+class LTX2ContinuationState:
+    """Typed LTX-2 continuation state carried between streaming segments.
+
+    ``video_frames`` hold trailing decoded RGB frames (uint8 HxWx3) from
+    segment N for conditioning segment N+1 via the VAE encode path.
+    ``audio_latents`` is the cached denoised audio latent tensor of shape
+    ``[B, C, T, mel]`` that segment N+1 will copy into the overlap
+    region of its clean-latent conditioning.
+
+    Most fields map 1:1 onto the internal gpu_pool's per-worker state;
+    the only new concept is the ``*_blob_id`` fields, which allow large
+    tensors to live outside the JSON payload. See module docstring.
+    """
+
+    segment_index: int = 0
+    """Index of the *just-completed* segment. Segment 0 has no history;
+    state returned after segment 0 carries ``segment_index=0`` and the
+    caller uses ``segment_index + 1`` as the next segment number."""
+
+    video_frames: list[np.ndarray] | None = None
+    """Trailing decoded frames, each an RGB uint8 ``np.ndarray`` shaped
+    ``(H, W, 3)``. ``None`` when the state is blob-backed or unset."""
+
+    video_frames_blob_id: str | None = None
+    """Blob store id when the frames live outside the payload."""
+
+    video_conditioning_frame_idx: int = 0
+    """Target frame index inside the next segment that the trailing
+    frames align with (matches the LTX-2 ``ltx2_video_conditions``
+    tuple's ``frame_idx`` slot)."""
+
+    video_conditioning_strength: float = 1.0
+    """Conditioning strength in [0, 1]. Matches the ``ltx2_video_
+    conditions`` tuple's strength slot."""
+
+    audio_latents: torch.Tensor | None = None
+    """Denoised audio latent tensor of shape ``[B, C, T, mel]``.
+    ``None`` when the state is blob-backed or unset."""
+
+    audio_latents_blob_id: str | None = None
+    """Blob store id when audio latents live outside the payload."""
+
+    audio_sample_rate: int | None = None
+    """Sample rate for the audio side (e.g. 24000)."""
+
+    audio_conditioning_num_frames: int = 0
+    """Number of trailing audio frames that carry over as clean context
+    into segment N+1."""
+
+    audio_conditioning_strength: float = 1.0
+    """Clean-latent mask value applied to the overlap region; 0.0 keeps
+    the cached audio entirely, 1.0 renoises from scratch."""
+
+    video_position_offset_sec: float = 0.0
+    """Seconds by which video RoPE is shifted forward so the audio
+    prefix can sit at ``t >= 0`` when audio conditioning is longer than
+    video conditioning."""
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+    """Opaque metadata bag for forward-compat fields that don't need
+    their own typed slot yet (e.g. custom knob experiments)."""
+
+    def to_continuation_state(
+        self,
+        *,
+        blob_store: BlobStore | None = None,
+        inline_threshold_bytes: int = DEFAULT_INLINE_THRESHOLD_BYTES,
+    ) -> ContinuationState:
+        """Serialize into a public :class:`ContinuationState`.
+
+        When ``blob_store`` is given, tensors larger than
+        ``inline_threshold_bytes`` are stored via
+        :meth:`BlobStore.put` and referenced by id; otherwise all data
+        is base64-encoded inline. The payload is always a plain
+        JSON-serializable dict.
+        """
+        payload: dict[str, Any] = {
+            "schema_version": LTX2_CONTINUATION_SCHEMA_VERSION,
+            "segment_index": int(self.segment_index),
+            "video_conditioning_frame_idx": int(self.video_conditioning_frame_idx),
+            "video_conditioning_strength": float(self.video_conditioning_strength),
+            "audio_conditioning_num_frames": int(self.audio_conditioning_num_frames),
+            "audio_conditioning_strength": float(self.audio_conditioning_strength),
+            "video_position_offset_sec": float(self.video_position_offset_sec),
+            "metadata": dict(self.metadata),
+        }
+        if self.audio_sample_rate is not None:
+            payload["audio_sample_rate"] = int(self.audio_sample_rate)
+
+        video_payload = self._encode_video_frames(
+            blob_store=blob_store,
+            inline_threshold_bytes=inline_threshold_bytes,
+        )
+        if video_payload is not None:
+            payload["video"] = video_payload
+
+        audio_payload = self._encode_audio_latents(
+            blob_store=blob_store,
+            inline_threshold_bytes=inline_threshold_bytes,
+        )
+        if audio_payload is not None:
+            payload["audio"] = audio_payload
+
+        return ContinuationState(
+            kind=LTX2_CONTINUATION_KIND,
+            payload=payload,
+        )
+
+    @classmethod
+    def from_continuation_state(
+        cls,
+        state: ContinuationState,
+        *,
+        blob_store: BlobStore | None = None,
+    ) -> LTX2ContinuationState:
+        """Rebuild a typed state from a public :class:`ContinuationState`.
+
+        Raises :class:`ValueError` when the kind doesn't match or the
+        schema version is unsupported.
+        """
+        if state.kind != LTX2_CONTINUATION_KIND:
+            raise ValueError(f"Expected ContinuationState.kind={LTX2_CONTINUATION_KIND!r}, "
+                             f"got {state.kind!r}")
+        payload = state.payload or {}
+        version = int(payload.get("schema_version", LTX2_CONTINUATION_SCHEMA_VERSION))
+        if version != LTX2_CONTINUATION_SCHEMA_VERSION:
+            raise ValueError(f"Unsupported LTX-2 continuation schema_version={version}; "
+                             f"this build expects {LTX2_CONTINUATION_SCHEMA_VERSION}")
+
+        out = cls(
+            segment_index=int(payload.get("segment_index", 0)),
+            video_conditioning_frame_idx=int(payload.get("video_conditioning_frame_idx", 0)),
+            video_conditioning_strength=float(payload.get("video_conditioning_strength", 1.0)),
+            audio_sample_rate=(int(payload["audio_sample_rate"]) if "audio_sample_rate" in payload else None),
+            audio_conditioning_num_frames=int(payload.get("audio_conditioning_num_frames", 0)),
+            audio_conditioning_strength=float(payload.get("audio_conditioning_strength", 1.0)),
+            video_position_offset_sec=float(payload.get("video_position_offset_sec", 0.0)),
+            metadata=dict(payload.get("metadata") or {}),
+        )
+
+        video = payload.get("video")
+        if isinstance(video, Mapping):
+            cls._decode_video_frames(out, video, blob_store=blob_store)
+
+        audio = payload.get("audio")
+        if isinstance(audio, Mapping):
+            cls._decode_audio_latents(out, audio, blob_store=blob_store)
+
+        return out
+
+    # ------------------------------------------------------------------
+    # Video frame helpers
+    # ------------------------------------------------------------------
+
+    def _encode_video_frames(
+        self,
+        *,
+        blob_store: BlobStore | None,
+        inline_threshold_bytes: int,
+    ) -> dict[str, Any] | None:
+        if self.video_frames_blob_id is not None:
+            return {"blob_id": self.video_frames_blob_id}
+        if not self.video_frames:
+            return None
+
+        encoded = [_encode_png(frame) for frame in self.video_frames]
+        total = sum(len(b) for b in encoded)
+        if blob_store is not None and total > inline_threshold_bytes:
+            concatenated = _pack_frame_blobs(encoded)
+            blob_id = blob_store.put(
+                concatenated,
+                mime="application/x-fastvideo-frames+png",
+            )
+            return {"blob_id": blob_id, "frame_count": len(encoded)}
+        return {
+            "frames_b64": [base64.b64encode(b).decode("ascii") for b in encoded],
+        }
+
+    @staticmethod
+    def _decode_video_frames(
+        out: LTX2ContinuationState,
+        video: Mapping[str, Any],
+        *,
+        blob_store: BlobStore | None,
+    ) -> None:
+        blob_id = video.get("blob_id")
+        if isinstance(blob_id, str):
+            if blob_store is None:
+                out.video_frames_blob_id = blob_id
+                return
+            raw = blob_store.get(blob_id)
+            encoded = _unpack_frame_blobs(raw)
+            out.video_frames = [_decode_png(b) for b in encoded]
+            return
+        frames_b64 = video.get("frames_b64")
+        if isinstance(frames_b64, list):
+            decoded = [_decode_png(base64.b64decode(b)) for b in frames_b64 if isinstance(b, str)]
+            out.video_frames = decoded or None
+
+    # ------------------------------------------------------------------
+    # Audio latent helpers
+    # ------------------------------------------------------------------
+
+    def _encode_audio_latents(
+        self,
+        *,
+        blob_store: BlobStore | None,
+        inline_threshold_bytes: int,
+    ) -> dict[str, Any] | None:
+        if self.audio_latents_blob_id is not None:
+            return {"blob_id": self.audio_latents_blob_id}
+        if self.audio_latents is None:
+            return None
+        dtype, shape, raw = _tensor_to_bytes(self.audio_latents)
+        if blob_store is not None and len(raw) > inline_threshold_bytes:
+            blob_id = blob_store.put(
+                raw,
+                mime="application/x-fastvideo-tensor+raw",
+            )
+            return {
+                "blob_id": blob_id,
+                "dtype": dtype,
+                "shape": list(shape),
+            }
+        return {
+            "dtype": dtype,
+            "shape": list(shape),
+            "data_b64": base64.b64encode(raw).decode("ascii"),
+        }
+
+    @staticmethod
+    def _decode_audio_latents(
+        out: LTX2ContinuationState,
+        audio: Mapping[str, Any],
+        *,
+        blob_store: BlobStore | None,
+    ) -> None:
+        dtype = audio.get("dtype")
+        shape_raw = audio.get("shape")
+        shape = tuple(int(d) for d in shape_raw) if isinstance(shape_raw, list | tuple) else None
+        blob_id = audio.get("blob_id")
+        if isinstance(blob_id, str):
+            if blob_store is None or dtype is None or shape is None:
+                out.audio_latents_blob_id = blob_id
+                return
+            raw = blob_store.get(blob_id)
+            out.audio_latents = _bytes_to_tensor(raw, dtype, shape)
+            return
+        data_b64 = audio.get("data_b64")
+        if isinstance(data_b64, str) and dtype is not None and shape is not None:
+            raw = base64.b64decode(data_b64)
+            out.audio_latents = _bytes_to_tensor(raw, dtype, shape)
+
+
+def _encode_png(frame: np.ndarray) -> bytes:
+    """Encode an ``(H, W, 3)`` uint8 RGB frame as PNG bytes."""
+    import numpy as np
+    from PIL import Image
+
+    if not isinstance(frame, np.ndarray):
+        raise TypeError(f"LTX2 continuation frame must be a numpy ndarray, got {type(frame).__name__}")
+    if frame.dtype != np.uint8 or frame.ndim != 3 or frame.shape[-1] != 3:
+        raise ValueError("LTX2 continuation frame must be uint8 HxWx3 RGB; got "
+                         f"dtype={frame.dtype}, shape={frame.shape}")
+    import io
+
+    buffer = io.BytesIO()
+    Image.fromarray(frame).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _decode_png(data: bytes) -> np.ndarray:
+    import io
+
+    import numpy as np
+    from PIL import Image
+
+    img = Image.open(io.BytesIO(data)).convert("RGB")
+    return np.array(img, dtype=np.uint8)
+
+
+def _pack_frame_blobs(encoded: list[bytes]) -> bytes:
+    """Pack multiple PNG blobs into a single blob for blob-store storage.
+
+    Format: ``[4-byte big-endian count][4-byte len][png][4-byte len][png]...``.
+    """
+    parts: list[bytes] = [len(encoded).to_bytes(4, "big")]
+    for blob in encoded:
+        parts.append(len(blob).to_bytes(4, "big"))
+        parts.append(blob)
+    return b"".join(parts)
+
+
+def _unpack_frame_blobs(raw: bytes) -> list[bytes]:
+    count = int.from_bytes(raw[:4], "big")
+    out: list[bytes] = []
+    cursor = 4
+    for _ in range(count):
+        length = int.from_bytes(raw[cursor:cursor + 4], "big")
+        cursor += 4
+        out.append(bytes(raw[cursor:cursor + length]))
+        cursor += length
+    return out
+
+
+def _tensor_to_bytes(tensor: Any) -> tuple[str, tuple[int, ...], bytes]:
+    """Serialize a torch tensor (or numpy array) to ``(dtype, shape, raw)``.
+
+    Avoids a hard ``torch`` import at module load time."""
+    import numpy as np
+
+    try:
+        import torch
+    except ImportError:  # pragma: no cover - torch is a core dep
+        torch = None  # type: ignore[assignment]
+
+    if torch is not None and isinstance(tensor, torch.Tensor):
+        detached = tensor.detach().cpu().contiguous()
+        dtype = str(detached.dtype).removeprefix("torch.")
+        shape = tuple(detached.shape)
+        raw = detached.numpy().tobytes()
+        return dtype, shape, raw
+    if isinstance(tensor, np.ndarray):
+        contiguous = np.ascontiguousarray(tensor)
+        dtype = str(contiguous.dtype)
+        shape = tuple(contiguous.shape)
+        raw = contiguous.tobytes()
+        return dtype, shape, raw
+    raise TypeError("LTX2 audio_latents must be a torch.Tensor or numpy.ndarray, got "
+                    f"{type(tensor).__name__}")
+
+
+def _bytes_to_tensor(
+    raw: bytes,
+    dtype: str,
+    shape: tuple[int, ...],
+) -> Any:
+    import numpy as np
+
+    np_dtype = _torch_dtype_to_numpy(dtype)
+    array = np.frombuffer(raw, dtype=np_dtype).reshape(shape).copy()
+    try:
+        import torch
+
+        return torch.from_numpy(array)
+    except ImportError:  # pragma: no cover - torch is a core dep
+        return array
+
+
+_TORCH_TO_NUMPY_DTYPE = {
+    "float32": "float32",
+    "float64": "float64",
+    "float16": "float16",
+    "bfloat16": "float32",  # numpy has no bf16; promote on hydrate
+    "int64": "int64",
+    "int32": "int32",
+    "int16": "int16",
+    "int8": "int8",
+    "uint8": "uint8",
+    "bool": "bool",
+}
+
+
+def _torch_dtype_to_numpy(dtype: str) -> str:
+    return _TORCH_TO_NUMPY_DTYPE.get(dtype, dtype)
+
+
+register_continuation_kind(LTX2_CONTINUATION_KIND)
+
+__all__ = [
+    "DEFAULT_INLINE_THRESHOLD_BYTES",
+    "LTX2ContinuationState",
+    "LTX2_CONTINUATION_KIND",
+    "LTX2_CONTINUATION_SCHEMA_VERSION",
+]

--- a/fastvideo/pipelines/basic/ltx2/continuation.py
+++ b/fastvideo/pipelines/basic/ltx2/continuation.py
@@ -2,24 +2,19 @@
 """Typed continuation state for the LTX-2 streaming pipeline.
 
 Segment N+1 conditions on segment N's trailing decoded frames and
-denoised audio latents. Historically (``FastVideo-internal/ui/
-ltx2-streaming/server/gpu_pool.py``) this state lived on the GPU as
-hidden per-worker globals (``ltx2_continuation_images``,
-``ltx2_continuation_audio_latents``); there was no way for a client to
-snapshot it, migrate it, or round-trip it through an HTTP/RPC boundary.
-
-PR 7 lifts the state into a typed, JSON-serializable object. The typed
-class lives here because the payload shape is model-specific; the
-envelope (``ContinuationState(kind, payload)``) is shared public API.
+denoised audio latents. The streaming runtime used to hold this state as
+per-worker globals; lifting it into a typed, JSON-serializable object
+lets clients snapshot, migrate, or round-trip it through an HTTP/RPC
+boundary. The envelope ``ContinuationState(kind, payload)`` is the
+shared public API; the typed class here owns the LTX-2 payload shape.
 
 Serialization contract:
 
-* Video frames are encoded as PNG bytes (lossless, indexable) and then
-  base64'd; optionally a :class:`BlobStore` can hold them by id instead.
-* Audio latents are encoded as ``{dtype, shape, bytes}`` (base64'd raw
-  buffer) or referenced via a blob id.
-* Either way the returned payload is a plain JSON-serializable dict so
-  the state survives a Dynamo RPC or an HTTP round-trip.
+* Video frames → PNG bytes + base64, or a :class:`BlobStore` id.
+* Audio latents → a self-describing safetensors blob + base64, or a
+  :class:`BlobStore` id. safetensors preserves ``bfloat16``, which a
+  raw-numpy round-trip cannot.
+* The returned payload is always a plain JSON-serializable dict.
 """
 from __future__ import annotations
 
@@ -264,22 +259,14 @@ class LTX2ContinuationState:
             return {"blob_id": self.audio_latents_blob_id}
         if self.audio_latents is None:
             return None
-        dtype, shape, raw = _tensor_to_bytes(self.audio_latents)
+        raw = _tensor_to_safetensors_bytes(self.audio_latents)
         if blob_store is not None and len(raw) > inline_threshold_bytes:
             blob_id = blob_store.put(
                 raw,
-                mime="application/x-fastvideo-tensor+raw",
+                mime="application/x-fastvideo-tensor+safetensors",
             )
-            return {
-                "blob_id": blob_id,
-                "dtype": dtype,
-                "shape": list(shape),
-            }
-        return {
-            "dtype": dtype,
-            "shape": list(shape),
-            "data_b64": base64.b64encode(raw).decode("ascii"),
-        }
+            return {"blob_id": blob_id}
+        return {"safetensors_b64": base64.b64encode(raw).decode("ascii")}
 
     @staticmethod
     def _decode_audio_latents(
@@ -288,21 +275,17 @@ class LTX2ContinuationState:
         *,
         blob_store: BlobStore | None,
     ) -> None:
-        dtype = audio.get("dtype")
-        shape_raw = audio.get("shape")
-        shape = tuple(int(d) for d in shape_raw) if isinstance(shape_raw, list | tuple) else None
         blob_id = audio.get("blob_id")
         if isinstance(blob_id, str):
-            if blob_store is None or dtype is None or shape is None:
+            if blob_store is None:
                 out.audio_latents_blob_id = blob_id
                 return
             raw = blob_store.get(blob_id)
-            out.audio_latents = _bytes_to_tensor(raw, dtype, shape)
+            out.audio_latents = _safetensors_bytes_to_tensor(raw)
             return
-        data_b64 = audio.get("data_b64")
-        if isinstance(data_b64, str) and dtype is not None and shape is not None:
-            raw = base64.b64decode(data_b64)
-            out.audio_latents = _bytes_to_tensor(raw, dtype, shape)
+        data_b64 = audio.get("safetensors_b64")
+        if isinstance(data_b64, str):
+            out.audio_latents = _safetensors_bytes_to_tensor(base64.b64decode(data_b64))
 
 
 def _encode_png(frame: np.ndarray) -> bytes:
@@ -351,71 +334,33 @@ def _unpack_frame_blobs(raw: bytes) -> list[bytes]:
     for _ in range(count):
         length = int.from_bytes(raw[cursor:cursor + 4], "big")
         cursor += 4
-        out.append(bytes(raw[cursor:cursor + length]))
+        out.append(raw[cursor:cursor + length])
         cursor += length
     return out
 
 
-def _tensor_to_bytes(tensor: Any) -> tuple[str, tuple[int, ...], bytes]:
-    """Serialize a torch tensor (or numpy array) to ``(dtype, shape, raw)``.
+def _tensor_to_safetensors_bytes(tensor: Any) -> bytes:
+    """Serialize a torch tensor to a self-describing safetensors blob.
 
-    Avoids a hard ``torch`` import at module load time."""
+    Uses the in-memory safetensors API so the wire format preserves
+    dtype (including ``bfloat16``, which a raw-numpy path cannot) and
+    shape without needing sidecar metadata.
+    """
+    import torch
+    from safetensors.torch import save as st_save
+
+    if isinstance(tensor, torch.Tensor):
+        return st_save({"t": tensor.detach().cpu()})
     import numpy as np
-
-    try:
-        import torch
-    except ImportError:  # pragma: no cover - torch is a core dep
-        torch = None  # type: ignore[assignment]
-
-    if torch is not None and isinstance(tensor, torch.Tensor):
-        detached = tensor.detach().cpu().contiguous()
-        dtype = str(detached.dtype).removeprefix("torch.")
-        shape = tuple(detached.shape)
-        raw = detached.numpy().tobytes()
-        return dtype, shape, raw
     if isinstance(tensor, np.ndarray):
-        contiguous = np.ascontiguousarray(tensor)
-        dtype = str(contiguous.dtype)
-        shape = tuple(contiguous.shape)
-        raw = contiguous.tobytes()
-        return dtype, shape, raw
+        return st_save({"t": torch.from_numpy(np.ascontiguousarray(tensor))})
     raise TypeError("LTX2 audio_latents must be a torch.Tensor or numpy.ndarray, got "
                     f"{type(tensor).__name__}")
 
 
-def _bytes_to_tensor(
-    raw: bytes,
-    dtype: str,
-    shape: tuple[int, ...],
-) -> Any:
-    import numpy as np
-
-    np_dtype = _torch_dtype_to_numpy(dtype)
-    array = np.frombuffer(raw, dtype=np_dtype).reshape(shape).copy()
-    try:
-        import torch
-
-        return torch.from_numpy(array)
-    except ImportError:  # pragma: no cover - torch is a core dep
-        return array
-
-
-_TORCH_TO_NUMPY_DTYPE = {
-    "float32": "float32",
-    "float64": "float64",
-    "float16": "float16",
-    "bfloat16": "float32",  # numpy has no bf16; promote on hydrate
-    "int64": "int64",
-    "int32": "int32",
-    "int16": "int16",
-    "int8": "int8",
-    "uint8": "uint8",
-    "bool": "bool",
-}
-
-
-def _torch_dtype_to_numpy(dtype: str) -> str:
-    return _TORCH_TO_NUMPY_DTYPE.get(dtype, dtype)
+def _safetensors_bytes_to_tensor(raw: bytes) -> Any:
+    from safetensors.torch import load as st_load
+    return st_load(raw)["t"]
 
 
 register_continuation_kind(LTX2_CONTINUATION_KIND)

--- a/fastvideo/pipelines/basic/ltx2/continuation.py
+++ b/fastvideo/pipelines/basic/ltx2/continuation.py
@@ -328,12 +328,25 @@ def _pack_frame_blobs(encoded: list[bytes]) -> bytes:
 
 
 def _unpack_frame_blobs(raw: bytes) -> list[bytes]:
+    if len(raw) < 4:
+        raise ValueError("frame blob truncated: missing count header")
     count = int.from_bytes(raw[:4], "big")
+    # Each frame contributes at least a 4-byte length prefix, so a
+    # declared count larger than (len(raw) - 4) // 4 cannot fit and
+    # would otherwise cause an O(count) allocation loop on malformed
+    # input.
+    if count > (len(raw) - 4) // 4:
+        raise ValueError(f"frame blob declares {count} frames but buffer holds at most "
+                         f"{(len(raw) - 4) // 4}")
     out: list[bytes] = []
     cursor = 4
-    for _ in range(count):
+    for index in range(count):
+        if cursor + 4 > len(raw):
+            raise ValueError(f"frame blob truncated at frame {index} length header")
         length = int.from_bytes(raw[cursor:cursor + 4], "big")
         cursor += 4
+        if cursor + length > len(raw):
+            raise ValueError(f"frame blob truncated at frame {index} payload")
         out.append(raw[cursor:cursor + length])
         cursor += length
     return out

--- a/fastvideo/pipelines/pipeline_batch_info.py
+++ b/fastvideo/pipelines/pipeline_batch_info.py
@@ -17,6 +17,8 @@ import torch
 if TYPE_CHECKING:
     from torchcodec.decoders import VideoDecoder
 
+    from fastvideo.api.schema import ContinuationState
+
 import time
 from collections import OrderedDict
 
@@ -190,12 +192,6 @@ class ForwardBatch:
     ltx2_stg_blocks_video: list[int] = field(default_factory=list)
     ltx2_stg_blocks_audio: list[int] = field(default_factory=list)
 
-    # Continuation state carried across streaming/multi-segment calls.
-    # Spread from SamplingParam via shallow_asdict; PR 7.6's gpu_pool
-    # upstream is the first runtime that reads/writes it.
-    continuation_state: Any | None = None
-    return_continuation_state: bool = False
-
     n_tokens: int | None = None
 
     # Other parameters that may be needed by specific schedulers
@@ -211,6 +207,9 @@ class ForwardBatch:
     trajectory_timesteps: list[torch.Tensor] | None = None
     trajectory_latents: torch.Tensor | None = None
     trajectory_decoded: list[torch.Tensor] | None = None
+
+    continuation_state: "ContinuationState | None" = None
+    return_continuation_state: bool = False
 
     # Extra parameters that might be needed by specific pipeline implementations
     extra: dict[str, Any] = field(default_factory=dict)

--- a/fastvideo/pipelines/pipeline_batch_info.py
+++ b/fastvideo/pipelines/pipeline_batch_info.py
@@ -190,6 +190,12 @@ class ForwardBatch:
     ltx2_stg_blocks_video: list[int] = field(default_factory=list)
     ltx2_stg_blocks_audio: list[int] = field(default_factory=list)
 
+    # Continuation state carried across streaming/multi-segment calls.
+    # Spread from SamplingParam via shallow_asdict; PR 7.6's gpu_pool
+    # upstream is the first runtime that reads/writes it.
+    continuation_state: Any | None = None
+    return_continuation_state: bool = False
+
     n_tokens: int | None = None
 
     # Other parameters that may be needed by specific schedulers

--- a/fastvideo/tests/api/test_ltx2_continuation.py
+++ b/fastvideo/tests/api/test_ltx2_continuation.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the typed LTX-2 continuation state.
+
+Covers:
+
+* round-trip through :class:`ContinuationState` (inline and blob-backed)
+* payload is JSON-serializable (Dynamo RPC / HTTP client constraint)
+* kind / schema_version validation on deserialization
+* compat-layer validation (known kinds, payload shape)
+* round-trip through :func:`request_to_sampling_param` attaches the
+  state to the resulting :class:`SamplingParam` without losing fidelity
+"""
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+import torch
+
+# Importing compat first, then the LTX-2 module, exercises the
+# self-registration side effect on import (important for the API
+# test suite where the pipeline package isn't otherwise imported).
+from fastvideo.api import compat as api_compat  # noqa: F401
+from fastvideo.api.schema import (
+    ContinuationState,
+    GenerationRequest,
+    OutputConfig,
+)
+from fastvideo.entrypoints.streaming.session_store import InMemoryBlobStore
+from fastvideo.pipelines.basic.ltx2.continuation import (
+    LTX2_CONTINUATION_KIND,
+    LTX2_CONTINUATION_SCHEMA_VERSION,
+    LTX2ContinuationState,
+)
+
+
+def _make_typed_state() -> LTX2ContinuationState:
+    return LTX2ContinuationState(
+        segment_index=3,
+        video_frames=[
+            (np.ones((64, 64, 3), dtype=np.uint8) * (i * 10)) for i in range(4)
+        ],
+        video_conditioning_frame_idx=9,
+        video_conditioning_strength=0.75,
+        audio_latents=torch.randn(1, 4, 16, 64, dtype=torch.float32),
+        audio_sample_rate=24000,
+        audio_conditioning_num_frames=5,
+        audio_conditioning_strength=0.5,
+        video_position_offset_sec=0.125,
+        metadata={"note": "unit-test"},
+    )
+
+
+class TestRoundTrip:
+    """Round-trip through :class:`ContinuationState` preserves all fields."""
+
+    def test_kind_and_schema_version(self):
+        state = _make_typed_state().to_continuation_state()
+        assert state.kind == LTX2_CONTINUATION_KIND
+        assert state.payload["schema_version"] == LTX2_CONTINUATION_SCHEMA_VERSION
+
+    def test_inline_roundtrip_preserves_scalars(self):
+        original = _make_typed_state()
+        envelope = original.to_continuation_state()
+        restored = LTX2ContinuationState.from_continuation_state(envelope)
+        assert restored.segment_index == original.segment_index
+        assert restored.video_conditioning_frame_idx == (
+            original.video_conditioning_frame_idx)
+        assert restored.video_conditioning_strength == (
+            original.video_conditioning_strength)
+        assert restored.audio_sample_rate == original.audio_sample_rate
+        assert restored.audio_conditioning_num_frames == (
+            original.audio_conditioning_num_frames)
+        assert restored.audio_conditioning_strength == (
+            original.audio_conditioning_strength)
+        assert restored.video_position_offset_sec == (
+            original.video_position_offset_sec)
+        assert restored.metadata == original.metadata
+
+    def test_inline_roundtrip_preserves_video_frames(self):
+        original = _make_typed_state()
+        envelope = original.to_continuation_state()
+        restored = LTX2ContinuationState.from_continuation_state(envelope)
+        assert restored.video_frames is not None
+        assert len(restored.video_frames) == len(original.video_frames)
+        for before, after in zip(original.video_frames,
+                                  restored.video_frames):
+            np.testing.assert_array_equal(before, after)
+
+    def test_inline_roundtrip_preserves_audio_latents(self):
+        original = _make_typed_state()
+        envelope = original.to_continuation_state()
+        restored = LTX2ContinuationState.from_continuation_state(envelope)
+        assert restored.audio_latents is not None
+        assert tuple(restored.audio_latents.shape) == tuple(
+            original.audio_latents.shape)
+        assert restored.audio_latents.dtype == original.audio_latents.dtype
+        torch.testing.assert_close(
+            restored.audio_latents, original.audio_latents)
+
+    def test_payload_is_json_serializable(self):
+        envelope = _make_typed_state().to_continuation_state()
+        # json.dumps must not raise — required for Dynamo RPC transport
+        # and HTTP client round-trip.
+        reserialized = json.loads(json.dumps(envelope.payload))
+        restored = LTX2ContinuationState.from_continuation_state(
+            ContinuationState(
+                kind=envelope.kind,
+                payload=reserialized,
+            ))
+        assert restored.segment_index == 3
+
+
+class TestBlobIndirection:
+    """Large tensors live in the :class:`BlobStore` instead of the payload."""
+
+    def test_threshold_triggers_blob_path(self):
+        blob_store = InMemoryBlobStore()
+        state = _make_typed_state()
+        envelope = state.to_continuation_state(
+            blob_store=blob_store,
+            inline_threshold_bytes=0,
+        )
+        assert "blob_id" in envelope.payload["video"]
+        assert "blob_id" in envelope.payload["audio"]
+        assert "frames_b64" not in envelope.payload["video"]
+        assert "data_b64" not in envelope.payload["audio"]
+        assert len(blob_store) == 2
+
+    def test_blob_roundtrip_reconstructs_tensors(self):
+        blob_store = InMemoryBlobStore()
+        original = _make_typed_state()
+        envelope = original.to_continuation_state(
+            blob_store=blob_store,
+            inline_threshold_bytes=0,
+        )
+        restored = LTX2ContinuationState.from_continuation_state(
+            envelope, blob_store=blob_store)
+        assert restored.video_frames is not None
+        assert len(restored.video_frames) == len(original.video_frames)
+        torch.testing.assert_close(
+            restored.audio_latents, original.audio_latents)
+
+    def test_blob_id_held_when_store_unavailable(self):
+        """Deserializing without a blob store preserves the blob id so
+        the caller can fetch it later."""
+        blob_store = InMemoryBlobStore()
+        envelope = _make_typed_state().to_continuation_state(
+            blob_store=blob_store,
+            inline_threshold_bytes=0,
+        )
+        blob_id_video = envelope.payload["video"]["blob_id"]
+        blob_id_audio = envelope.payload["audio"]["blob_id"]
+
+        restored = LTX2ContinuationState.from_continuation_state(envelope)
+        assert restored.video_frames is None
+        assert restored.video_frames_blob_id == blob_id_video
+        assert restored.audio_latents is None
+        assert restored.audio_latents_blob_id == blob_id_audio
+
+    def test_large_threshold_keeps_payload_inline(self):
+        blob_store = InMemoryBlobStore()
+        envelope = _make_typed_state().to_continuation_state(
+            blob_store=blob_store,
+            inline_threshold_bytes=10 * 1024 * 1024,  # 10 MiB
+        )
+        assert "frames_b64" in envelope.payload["video"]
+        assert "data_b64" in envelope.payload["audio"]
+        assert len(blob_store) == 0
+
+
+class TestValidation:
+    """Invalid payloads error cleanly."""
+
+    def test_wrong_kind_rejected(self):
+        envelope = ContinuationState(kind="longcat.v1", payload={})
+        with pytest.raises(ValueError, match="Expected ContinuationState.kind"):
+            LTX2ContinuationState.from_continuation_state(envelope)
+
+    def test_unsupported_schema_version_rejected(self):
+        envelope = ContinuationState(
+            kind=LTX2_CONTINUATION_KIND,
+            payload={"schema_version": 999},
+        )
+        with pytest.raises(ValueError,
+                            match="Unsupported LTX-2 continuation schema"):
+            LTX2ContinuationState.from_continuation_state(envelope)
+
+    def test_non_png_frame_rejected(self):
+        state = LTX2ContinuationState(
+            video_frames=[np.ones((64, 64, 3), dtype=np.float32)],
+        )
+        with pytest.raises(ValueError, match="uint8 HxWx3"):
+            state.to_continuation_state()
+
+
+class TestCompatLayerWireUp:
+    """The public compat layer accepts request.state without reverting
+    to NotImplementedError and attaches it to the SamplingParam path."""
+
+    def test_request_with_state_passes_through(self, tmp_path):
+        # PR 7 removes the NotImplementedError for request.state; build a
+        # minimal GenerationRequest carrying an LTX-2 state and make sure
+        # the public boundary accepts it.
+        from fastvideo.api.compat import (
+            normalize_generation_request,
+            _validate_continuation_state,
+        )
+        envelope = _make_typed_state().to_continuation_state()
+        request = GenerationRequest(
+            prompt="test",
+            state=envelope,
+        )
+        normalized = normalize_generation_request(request)
+        _validate_continuation_state(normalized.state)
+
+    def test_unknown_kind_rejected_at_boundary(self):
+        from fastvideo.api.compat import _validate_continuation_state
+        with pytest.raises(ValueError, match="Unknown ContinuationState kind"):
+            _validate_continuation_state(
+                ContinuationState(kind="mystery.v1", payload={}))
+
+    def test_empty_kind_rejected_at_boundary(self):
+        from fastvideo.api.compat import _validate_continuation_state
+        with pytest.raises(ValueError, match="non-empty string"):
+            _validate_continuation_state(
+                ContinuationState(kind="", payload={}))
+
+    def test_output_return_state_flag(self):
+        request = GenerationRequest(
+            prompt="x",
+            output=OutputConfig(return_state=True),
+        )
+        # The typed public surface exposes the flag directly.
+        assert request.output.return_state is True

--- a/fastvideo/tests/api/test_ltx2_continuation.py
+++ b/fastvideo/tests/api/test_ltx2_continuation.py
@@ -111,6 +111,20 @@ class TestRoundTrip:
             ))
         assert restored.segment_index == 3
 
+    def test_bf16_audio_latents_preserved(self):
+        """safetensors serialization must preserve bf16 dtype (numpy
+        has no bf16, so a raw-bytes path would silently promote)."""
+        state = LTX2ContinuationState(
+            segment_index=0,
+            audio_latents=torch.randn(1, 4, 16, 64, dtype=torch.bfloat16),
+        )
+        envelope = state.to_continuation_state()
+        restored = LTX2ContinuationState.from_continuation_state(envelope)
+        assert restored.audio_latents is not None
+        assert restored.audio_latents.dtype == torch.bfloat16
+        torch.testing.assert_close(
+            restored.audio_latents, state.audio_latents)
+
 
 class TestBlobIndirection:
     """Large tensors live in the :class:`BlobStore` instead of the payload."""
@@ -125,7 +139,7 @@ class TestBlobIndirection:
         assert "blob_id" in envelope.payload["video"]
         assert "blob_id" in envelope.payload["audio"]
         assert "frames_b64" not in envelope.payload["video"]
-        assert "data_b64" not in envelope.payload["audio"]
+        assert "safetensors_b64" not in envelope.payload["audio"]
         assert len(blob_store) == 2
 
     def test_blob_roundtrip_reconstructs_tensors(self):
@@ -166,7 +180,7 @@ class TestBlobIndirection:
             inline_threshold_bytes=10 * 1024 * 1024,  # 10 MiB
         )
         assert "frames_b64" in envelope.payload["video"]
-        assert "data_b64" in envelope.payload["audio"]
+        assert "safetensors_b64" in envelope.payload["audio"]
         assert len(blob_store) == 0
 
 

--- a/fastvideo/tests/entrypoints/streaming/__init__.py
+++ b/fastvideo/tests/entrypoints/streaming/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/fastvideo/tests/entrypoints/streaming/test_session_store.py
+++ b/fastvideo/tests/entrypoints/streaming/test_session_store.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the streaming SessionStore and BlobStore.
+
+Covers:
+
+* ``store`` / ``snapshot`` / ``drop`` lifecycle for the in-memory store
+* ``hydrate`` with and without an explicit session id
+* blob store insert / get / drop semantics
+* thread-safety under concurrent writes (smoke)
+* round-trip a LTX-2 continuation through snapshot + hydrate across a
+  session boundary (the "export and resume" flow the PR plan calls out)
+"""
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+import pytest
+import torch
+
+from fastvideo.api.schema import ContinuationState
+from fastvideo.entrypoints.streaming.session_store import (
+    BlobStore,
+    InMemoryBlobStore,
+    InMemorySessionStore,
+    SessionStore,
+)
+from fastvideo.pipelines.basic.ltx2.continuation import (
+    LTX2_CONTINUATION_KIND,
+    LTX2ContinuationState,
+)
+
+
+class TestInMemoryBlobStore:
+
+    def test_is_blob_store(self):
+        assert isinstance(InMemoryBlobStore(), BlobStore)
+
+    def test_put_then_get_returns_same_bytes(self):
+        store = InMemoryBlobStore()
+        blob_id = store.put(b"hello")
+        assert store.get(blob_id) == b"hello"
+
+    def test_put_returns_distinct_ids(self):
+        store = InMemoryBlobStore()
+        id_a = store.put(b"a")
+        id_b = store.put(b"b")
+        assert id_a != id_b
+
+    def test_get_missing_raises_keyerror(self):
+        store = InMemoryBlobStore()
+        with pytest.raises(KeyError):
+            store.get("nonexistent")
+
+    def test_drop_removes_blob(self):
+        store = InMemoryBlobStore()
+        blob_id = store.put(b"payload")
+        store.drop(blob_id)
+        assert blob_id not in store
+        with pytest.raises(KeyError):
+            store.get(blob_id)
+
+    def test_drop_missing_is_noop(self):
+        store = InMemoryBlobStore()
+        store.drop("not-there")  # no raise
+
+    def test_contains(self):
+        store = InMemoryBlobStore()
+        blob_id = store.put(b"x")
+        assert blob_id in store
+        assert "other" not in store
+
+
+class TestInMemorySessionStore:
+
+    def test_is_session_store(self):
+        assert isinstance(InMemorySessionStore(), SessionStore)
+
+    def test_store_then_snapshot(self):
+        store = InMemorySessionStore()
+        state = ContinuationState(kind="ltx2.v1", payload={"x": 1})
+        store.store("sess-1", state)
+        assert store.snapshot("sess-1") is state
+
+    def test_snapshot_missing_returns_none(self):
+        store = InMemorySessionStore()
+        assert store.snapshot("missing") is None
+
+    def test_store_overwrites_prior_state(self):
+        store = InMemorySessionStore()
+        first = ContinuationState(kind="ltx2.v1", payload={"v": 1})
+        second = ContinuationState(kind="ltx2.v1", payload={"v": 2})
+        store.store("s", first)
+        store.store("s", second)
+        assert store.snapshot("s").payload["v"] == 2
+
+    def test_hydrate_assigns_new_session_id(self):
+        store = InMemorySessionStore()
+        state = ContinuationState(kind="ltx2.v1", payload={})
+        sid = store.hydrate(state)
+        assert sid
+        assert store.snapshot(sid) is state
+
+    def test_hydrate_with_explicit_session_id(self):
+        store = InMemorySessionStore()
+        state = ContinuationState(kind="ltx2.v1", payload={})
+        sid = store.hydrate(state, session_id="pinned-id")
+        assert sid == "pinned-id"
+        assert store.snapshot("pinned-id") is state
+
+    def test_drop_forgets_session(self):
+        store = InMemorySessionStore()
+        store.store("s", ContinuationState(kind="ltx2.v1", payload={}))
+        store.drop("s")
+        assert store.snapshot("s") is None
+        assert "s" not in store
+
+    def test_iter_yields_session_ids(self):
+        store = InMemorySessionStore()
+        store.store("a", ContinuationState(kind="ltx2.v1", payload={}))
+        store.store("b", ContinuationState(kind="ltx2.v1", payload={}))
+        assert sorted(store) == ["a", "b"]
+
+    def test_len(self):
+        store = InMemorySessionStore()
+        assert len(store) == 0
+        store.store("x", ContinuationState(kind="ltx2.v1", payload={}))
+        assert len(store) == 1
+
+    def test_concurrent_store_is_safe(self):
+        """Smoke-check the lock: 200 parallel stores settle to 200 ids."""
+        store = InMemorySessionStore()
+
+        def write(i: int) -> None:
+            store.store(
+                f"s-{i}",
+                ContinuationState(kind="ltx2.v1", payload={"i": i}),
+            )
+
+        threads = [threading.Thread(target=write, args=(i,)) for i in range(200)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(store) == 200
+
+
+class TestSnapshotHydrateRoundTrip:
+    """Session boundary: snapshot + hydrate preserves the full LTX-2 state."""
+
+    def test_end_to_end_ltx2_session_migration(self):
+        blob_store = InMemoryBlobStore()
+        sessions = InMemorySessionStore()
+
+        typed = LTX2ContinuationState(
+            segment_index=4,
+            video_frames=[
+                np.full((32, 32, 3), i * 5, dtype=np.uint8) for i in range(3)
+            ],
+            audio_latents=torch.randn(1, 4, 8, 32, dtype=torch.float32),
+            audio_sample_rate=24000,
+            audio_conditioning_num_frames=5,
+            video_position_offset_sec=0.25,
+        )
+        envelope = typed.to_continuation_state(blob_store=blob_store)
+
+        sessions.store("session-a", envelope)
+        snapshot = sessions.snapshot("session-a")
+        assert snapshot is not None
+        assert snapshot.kind == LTX2_CONTINUATION_KIND
+
+        # Simulate a migration: drop the first session, hydrate a new one
+        # from the snapshot, and reconstruct the typed state.
+        sessions.drop("session-a")
+        new_sid = sessions.hydrate(snapshot)
+        assert new_sid != "session-a"
+        rebuilt = sessions.snapshot(new_sid)
+        assert rebuilt is snapshot
+
+        restored = LTX2ContinuationState.from_continuation_state(
+            rebuilt, blob_store=blob_store)
+        assert restored.segment_index == typed.segment_index
+        assert restored.audio_sample_rate == typed.audio_sample_rate
+        torch.testing.assert_close(
+            restored.audio_latents, typed.audio_latents)
+        assert len(restored.video_frames) == len(typed.video_frames)

--- a/fastvideo/tests/modal/ssim_test.py
+++ b/fastvideo/tests/modal/ssim_test.py
@@ -7,9 +7,7 @@ import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
-from typing import Any, Literal
-
-WeightClass = Literal["normal", "heavy", "all"]
+from typing import Any
 
 import modal
 
@@ -55,35 +53,9 @@ RAW_GENERATED_VOLUME_ROOT = "ssim_generated_videos"
 DEFAULT_OUTPUT_QUALITY_TIER = "default"
 FULL_OUTPUT_QUALITY_TIER = "full_quality"
 MODAL_DEVICE_REFERENCE_FOLDER = "L40S_reference_videos"
-
-# 14B I2V models that dominate wall-clock; routed to a dedicated
-# heavy partition with a longer timeout so they don't starve the
-# rest.
-SSIM_HEAVY_MODEL_IDS = frozenset({
-    "TurboWan2.2-I2V-A14B-Diffusers",
-    "Wan2.1-I2V-14B-480P-Diffusers",
-})
-SSIM_HEAVY_TIMEOUT_S = 9000
-
-# Host-RAM reservation: Modal's default allocation on L40S:4 (~96-192 GB,
-# depending on contention) occasionally falls short for the 14B I2V tasks,
-# producing SIGKILL/exit 137 mid-run. Explicit (request, limit) MiB tuples
-# give a guaranteed floor and a hard ceiling so OOM behavior is predictable.
-SSIM_NORMAL_MEMORY_MIB = (65536, 131072)   # 64 GiB request, 128 GiB limit
-SSIM_HEAVY_MEMORY_MIB = (131072, 196608)   # 128 GiB request, 192 GiB limit
-
 SSIM_COMMON_KWARGS = dict(
     image=image,
     timeout=5400,
-    memory=SSIM_NORMAL_MEMORY_MIB,
-    # HF_HOME in _spawn_ssim_task points at /root/data/.cache; cached
-    # model weights are served straight from hf-model-weights.
-    volumes={"/root/data": model_vol},
-)
-SSIM_HEAVY_KWARGS = dict(
-    image=image,
-    timeout=SSIM_HEAVY_TIMEOUT_S,
-    memory=SSIM_HEAVY_MEMORY_MIB,
     volumes={"/root/data": model_vol},
 )
 
@@ -139,7 +111,6 @@ class _PartitionResult:
     partition_index: int
     task_summaries: list[_TaskSummary]
     exit_code: int
-    weight_class: WeightClass = "normal"
 
 
 def _split_csv_values(csv_values: str) -> set[str]:
@@ -447,32 +418,13 @@ def _discover_ssim_tasks(
     return sorted(tasks, key=lambda task: task.sort_key)
 
 
-def _is_heavy_task(task: SSIMTask) -> bool:
-    return task.model_id in SSIM_HEAVY_MODEL_IDS
-
-
 def _partition_tasks(
     tasks: list[SSIMTask],
     partition_index: int,
     num_partitions: int = 2,
-    weight_class: WeightClass = "normal",
 ) -> list[SSIMTask]:
-    """Filter tasks by weight class, then split into N groups via
-    round-robin on sorted order.
-
-    - ``"normal"``: excludes :data:`SSIM_HEAVY_MODEL_IDS` — those go to
-      the dedicated heavy partition.
-    - ``"heavy"``: only the heavy tasks; typically run with
-      ``num_partitions=1`` on a partition with a longer timeout.
-    - ``"all"``: legacy behavior — no filtering.
-    """
-    if weight_class == "normal":
-        filtered = [task for task in tasks if not _is_heavy_task(task)]
-    elif weight_class == "heavy":
-        filtered = [task for task in tasks if _is_heavy_task(task)]
-    else:  # "all"
-        filtered = tasks
-    return filtered[partition_index::num_partitions]
+    """Split tasks into N groups via round-robin on sorted order."""
+    return tasks[partition_index::num_partitions]
 
 
 def _build_checkout_command(git_commit: str, pr_number: str | None) -> str:
@@ -841,24 +793,23 @@ def _print_combined_results(
     for result in partition_results:
         if result is None:
             continue
-        partition_label = f"{result.weight_class} partition {result.partition_index}"
         for s in result.task_summaries:
-            label = f"[{partition_label}] {s.test_name}"
+            label = f"[P{result.partition_index}] {s.test_name}"
             if s.status == "passed":
                 passed.append(label)
             elif s.status == "failed":
                 failed.append(label)
                 if first_failure is None:
-                    first_failure = (partition_label, s)
+                    first_failure = (result.partition_index, s)
             elif s.status == "terminated":
                 terminated.append(label)
             elif s.status == "skipped":
                 skipped.append(label)
 
     if first_failure is not None:
-        partition_label, s = first_failure
+        pi, s = first_failure
         print(f"\n{'=' * 60}")
-        print(f"Partition: {partition_label}")
+        print(f"Partition: {pi}")
         print(f"Task: {s.test_name}")
         print(f"GPUs: {s.required_gpus}")
         print(f"Status: {s.status}")
@@ -871,12 +822,10 @@ def _print_combined_results(
         if result is None:
             count = 0
             status = "cancelled"
-            label = f"slot {i}"
         else:
             count = len(result.task_summaries)
             status = "passed" if result.exit_code == 0 else "failed"
-            label = f"{result.weight_class} partition {result.partition_index}"
-        print(f"  {label}: {status} ({count} tasks)")
+        print(f"  Partition {i}: {status} ({count} tasks)")
     print(f"  passed: {len(passed)}")
     print(f"  failed: {len(failed)}")
     print(f"  terminated: {len(terminated)}")
@@ -893,28 +842,24 @@ def _print_combined_results(
     return 1 if has_failures else 0
 
 
-def _run_ssim_partition_body(
-    *,
+@app.function(gpu=f"L40S:{SSIM_NUM_GPUS}", **SSIM_COMMON_KWARGS)
+def run_ssim_partition(
     partition_index: int,
     num_partitions: int,
-    weight_class: WeightClass,
     git_repo: str,
     git_commit: str,
-    pr_number: str,
-    hf_api_key: str,
-    test_files_csv: str,
-    model_ids_csv: str,
-    ssim_full_quality: bool,
-    ssim_reference_repo: str,
-    skip_ssim_reference_download: bool,
-    pytest_k: str,
-    sync_generated_to_volume: bool,
-    generated_volume_subdir: str,
-    fail_fast: bool,
+    pr_number: str = "false",
+    hf_api_key: str = "",
+    test_files_csv: str = "",
+    model_ids_csv: str = "",
+    ssim_full_quality: bool = False,
+    ssim_reference_repo: str = "",
+    skip_ssim_reference_download: bool = False,
+    pytest_k: str = "",
+    sync_generated_to_volume: bool = False,
+    generated_volume_subdir: str = "",
+    fail_fast: bool = True,
 ) -> _PartitionResult:
-    """Shared partition body used by both the normal and heavy Modal
-    wrappers. Only the decorator (timeout, GPU allocation) differs
-    between the two; the scheduling logic is identical."""
     selected_test_files = _split_csv_values(test_files_csv)
     selected_model_ids = _split_csv_values(model_ids_csv)
     repo_root, tasks = _prepare_ssim_workspace(
@@ -925,22 +870,15 @@ def _run_ssim_partition_body(
         selected_test_files=selected_test_files,
         selected_model_ids=selected_model_ids,
     )
-    partition = _partition_tasks(
-        tasks,
-        partition_index,
-        num_partitions,
-        weight_class=weight_class,
-    )
-    partition_label = f"{weight_class} partition {partition_index}"
+    partition = _partition_tasks(tasks, partition_index, num_partitions)
     if not partition:
-        print(f"{partition_label}: no tasks assigned.")
+        print(f"Partition {partition_index}: no tasks assigned.")
         return _PartitionResult(
             partition_index=partition_index,
             task_summaries=[],
             exit_code=0,
-            weight_class=weight_class,
         )
-    print(f"{partition_label}: running {len(partition)}/{len(tasks)} tasks")
+    print(f"Partition {partition_index}: running {len(partition)}/{len(tasks)} tasks")
     pytest_extra_args = _build_pytest_extra_args(
         ssim_full_quality=ssim_full_quality,
         ssim_reference_repo=ssim_reference_repo,
@@ -970,96 +908,10 @@ def _run_ssim_partition_body(
         partition_index=partition_index,
         task_summaries=summaries,
         exit_code=1 if has_failures else 0,
-        weight_class=weight_class,
     )
 
 
-@app.function(gpu=f"L40S:{SSIM_NUM_GPUS}", **SSIM_COMMON_KWARGS)
-def run_ssim_partition(
-    partition_index: int,
-    num_partitions: int,
-    git_repo: str,
-    git_commit: str,
-    pr_number: str = "false",
-    hf_api_key: str = "",
-    test_files_csv: str = "",
-    model_ids_csv: str = "",
-    ssim_full_quality: bool = False,
-    ssim_reference_repo: str = "",
-    skip_ssim_reference_download: bool = False,
-    pytest_k: str = "",
-    sync_generated_to_volume: bool = False,
-    generated_volume_subdir: str = "",
-    fail_fast: bool = True,
-) -> _PartitionResult:
-    """Normal partition — runs every SSIM task except those in
-    :data:`SSIM_HEAVY_MODEL_IDS`, which are handled by
-    :func:`run_ssim_heavy_partition`."""
-    return _run_ssim_partition_body(
-        partition_index=partition_index,
-        num_partitions=num_partitions,
-        weight_class="normal",
-        git_repo=git_repo,
-        git_commit=git_commit,
-        pr_number=pr_number,
-        hf_api_key=hf_api_key,
-        test_files_csv=test_files_csv,
-        model_ids_csv=model_ids_csv,
-        ssim_full_quality=ssim_full_quality,
-        ssim_reference_repo=ssim_reference_repo,
-        skip_ssim_reference_download=skip_ssim_reference_download,
-        pytest_k=pytest_k,
-        sync_generated_to_volume=sync_generated_to_volume,
-        generated_volume_subdir=generated_volume_subdir,
-        fail_fast=fail_fast,
-    )
-
-
-@app.function(gpu=f"L40S:{SSIM_NUM_GPUS}", **SSIM_HEAVY_KWARGS)
-def run_ssim_heavy_partition(
-    partition_index: int,
-    num_partitions: int,
-    git_repo: str,
-    git_commit: str,
-    pr_number: str = "false",
-    hf_api_key: str = "",
-    test_files_csv: str = "",
-    model_ids_csv: str = "",
-    ssim_full_quality: bool = False,
-    ssim_reference_repo: str = "",
-    skip_ssim_reference_download: bool = False,
-    pytest_k: str = "",
-    sync_generated_to_volume: bool = False,
-    generated_volume_subdir: str = "",
-    fail_fast: bool = True,
-) -> _PartitionResult:
-    """Heavy partition — 14B image-to-video models listed in
-    :data:`SSIM_HEAVY_MODEL_IDS`. Same GPU shape as a normal partition
-    but with :data:`SSIM_HEAVY_TIMEOUT_S` (2.5h) instead of the 1.5h
-    default, so the expensive I2V generations don't get killed by
-    Modal's timeout before the HF cache warms up."""
-    return _run_ssim_partition_body(
-        partition_index=partition_index,
-        num_partitions=num_partitions,
-        weight_class="heavy",
-        git_repo=git_repo,
-        git_commit=git_commit,
-        pr_number=pr_number,
-        hf_api_key=hf_api_key,
-        test_files_csv=test_files_csv,
-        model_ids_csv=model_ids_csv,
-        ssim_full_quality=ssim_full_quality,
-        ssim_reference_repo=ssim_reference_repo,
-        skip_ssim_reference_download=skip_ssim_reference_download,
-        pytest_k=pytest_k,
-        sync_generated_to_volume=sync_generated_to_volume,
-        generated_volume_subdir=generated_volume_subdir,
-        fail_fast=fail_fast,
-    )
-
-
-NUM_NORMAL_PARTITIONS = 2
-NUM_HEAVY_PARTITIONS = 1
+NUM_PARTITIONS = 2
 
 
 @app.local_entrypoint()
@@ -1121,25 +973,14 @@ def run_ssim_tests(
         generated_volume_subdir=resolved_subdir,
         fail_fast=not no_fail_fast,
     )
-    # Normal partitions round-robin every non-heavy task; heavy partition
-    # handles only the 14B I2V models (see SSIM_HEAVY_MODEL_IDS) with a
-    # longer timeout so it doesn't starve the fast tail.
     futures = [
         run_ssim_partition.spawn(
             partition_index=i,
-            num_partitions=NUM_NORMAL_PARTITIONS,
+            num_partitions=NUM_PARTITIONS,
             **common_kwargs,
         )
-        for i in range(NUM_NORMAL_PARTITIONS)
+        for i in range(NUM_PARTITIONS)
     ]
-    futures.extend(
-        run_ssim_heavy_partition.spawn(
-            partition_index=i,
-            num_partitions=NUM_HEAVY_PARTITIONS,
-            **common_kwargs,
-        )
-        for i in range(NUM_HEAVY_PARTITIONS)
-    )
     results: list[_PartitionResult | None] = [f.get() for f in futures]
 
     exit_code = _print_combined_results(results)

--- a/fastvideo/tests/ssim/test_turbodiffusion_similarity.py
+++ b/fastvideo/tests/ssim/test_turbodiffusion_similarity.py
@@ -145,6 +145,7 @@ TURBODIFFUSION_I2V_IMAGE_PATHS = [
 ]
 
 
+@pytest.mark.skip(reason="Disabled: causes OOM too often in CI")
 @pytest.mark.parametrize("prompt", TURBODIFFUSION_I2V_TEST_PROMPTS)
 @pytest.mark.parametrize(
     "model_id",


### PR DESCRIPTION
## Summary

Typed representation of LTX-2 streaming continuation state (trailing decoded frames + denoised audio latents for next-segment conditioning) plus a `SessionStore` / `BlobStore` abstraction so the realtime/streaming server can hold per-session state across segments.

Today, LTX-2 streaming inference state lives as worker-local globals; clients can't snapshot it, migrate it across workers, or round-trip it through an HTTP/RPC boundary. This change introduces a typed, JSON-serializable representation that carries cleanly over the public API boundary.

## What's added

1. **`LTX2ContinuationState`** — typed dataclass under `fastvideo/pipelines/basic/ltx2/continuation.py` with round-trip converters to the public `ContinuationState(kind, payload)` envelope. Audio tensors use `safetensors` for self-describing serialization (preserves `bfloat16`); video frames serialize as PNG. Both sides have a `BlobStore` indirection threshold for large payloads.
2. **`BlobStore` / `SessionStore`** — ABCs in `fastvideo/entrypoints/streaming/session_store.py` with thread-safe in-memory defaults (`InMemoryBlobStore`, `InMemorySessionStore`).
3. **Compat plumbing** — `request.state` no longer raises `NotImplementedError`; flows into `SamplingParam.continuation_state`. `request.output.return_state` toggles a matching `SamplingParam.return_continuation_state` flag. `register_continuation_kind()` lets model families register kind discriminators so the boundary rejects unknown kinds with a helpful error.

## Wire format

\`\`\`json
{
  \"kind\": \"ltx2.v1\",
  \"payload\": {
    \"schema_version\": 1,
    \"segment_index\": 3,
    \"video_conditioning_frame_idx\": 9,
    \"video_conditioning_strength\": 0.75,
    \"audio_sample_rate\": 24000,
    \"audio_conditioning_num_frames\": 5,
    \"audio_conditioning_strength\": 0.5,
    \"video_position_offset_sec\": 0.2,
    \"video\": {\"frames_b64\": [\"...\"]},
    \"audio\": {\"safetensors_b64\": \"...\"},
    \"metadata\": {}
  }
}
\`\`\`

JSON-safe end-to-end. The audio \`safetensors\` blob preserves dtype (a raw-numpy path would silently promote \`bfloat16\` to \`float32\`). Payloads above a configurable inline threshold swap to a \`{\"blob_id\": \"...\"}\` reference and the bytes live in the \`BlobStore\`.

## Test plan

- [x] \`pytest fastvideo/tests/api/test_ltx2_continuation.py fastvideo/tests/entrypoints/streaming/test_session_store.py -v\` — 35 passing
- [x] Full \`pytest fastvideo/tests/api/\` — no regressions