### PR TITLE
[docs]: clarify real_score_guidance_scale CFG parameterization

### DIFF
--- a/docs/distillation/dmd.md
+++ b/docs/distillation/dmd.md
@@ -86,3 +86,25 @@ sbatch examples/distill/Wan2.2-TI2V-5B-Diffusers/Data-free/distill_dmd_t2v_5B.sh
 - Learning rate: 2e-5
 - Training steps: 3000 (~12 hours)
 - HSDP shard dim: 1
+
+## 🧭 Note on `real_score_guidance_scale`
+
+The teacher CFG used inside the DMD loss follows the DMD2 reference
+implementation and uses the parameterization
+
+```
+x = x_cond + w * (x_cond - x_uncond)
+```
+
+rather than the Ho & Salimans form `x_uncond + w * (x_cond - x_uncond)`. The
+two are mathematically equivalent up to a constant offset:
+
+| `real_score_guidance_scale` (`w`) | Equivalent standard CFG (`w + 1`) | Output                |
+|-----------------------------------|-----------------------------------|-----------------------|
+| `-1`                              | `0`                               | unconditional         |
+| `0`                               | `1`                               | conditional           |
+| `3.5` (default)                   | `4.5`                             | strong guidance       |
+
+So `real_score_guidance_scale` should be read as the **extra** guidance
+strength added on top of the conditional prediction. When porting values
+from a paper that uses the Ho & Salimans form, subtract 1.

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -844,6 +844,13 @@ class TrainingArgs(FastVideoArgs):
     dfake_gen_update_ratio: int = 5  # self-forcing: how often to train generator vs critic
     min_timestep_ratio: float = 0.2
     max_timestep_ratio: float = 0.98
+    # CFG scale applied to the real (teacher) score in the DMD loss, using the
+    # parameterization `x = x_cond + w * (x_cond - x_uncond)`. This differs
+    # from the Ho & Salimans form `x_uncond + w * (x_cond - x_uncond)` by an
+    # offset of 1: `w_here = w_standard - 1`. So `w=0` recovers the
+    # conditional output, `w=-1` recovers the unconditional output, and the
+    # default 3.5 corresponds to a standard CFG scale of 4.5. Matches the
+    # original DMD2 reference implementation.
     real_score_guidance_scale: float = 3.5
     fake_score_learning_rate: float = 0.0  # separate learning rate for fake_score_transformer, if 0.0, use learning_rate
     fake_score_lr_scheduler: str = "constant"  # separate lr scheduler for fake_score_transformer, if not set, use lr_scheduler
@@ -1101,10 +1108,14 @@ class TrainingArgs(FastVideoArgs):
                             type=float,
                             default=TrainingArgs.max_timestep_ratio,
                             help="Maximum step ratio")
-        parser.add_argument("--real-score-guidance-scale",
-                            type=float,
-                            default=TrainingArgs.real_score_guidance_scale,
-                            help="Teacher guidance scale")
+        parser.add_argument(
+            "--real-score-guidance-scale",
+            type=float,
+            default=TrainingArgs.real_score_guidance_scale,
+            help=("Teacher CFG scale for the real score in the DMD loss. Uses "
+                  "the parameterization x_cond + w * (x_cond - x_uncond), so "
+                  "w=0 -> cond, w=-1 -> uncond, and the relation to standard "
+                  "CFG is w_standard = w + 1 (default 3.5 == standard 4.5)."))
         parser.add_argument("--fake-score-learning-rate",
                             type=float,
                             default=TrainingArgs.fake_score_learning_rate,

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -1108,14 +1108,13 @@ class TrainingArgs(FastVideoArgs):
                             type=float,
                             default=TrainingArgs.max_timestep_ratio,
                             help="Maximum step ratio")
-        parser.add_argument(
-            "--real-score-guidance-scale",
-            type=float,
-            default=TrainingArgs.real_score_guidance_scale,
-            help=("Teacher CFG scale for the real score in the DMD loss. Uses "
-                  "the parameterization x_cond + w * (x_cond - x_uncond), so "
-                  "w=0 -> cond, w=-1 -> uncond, and the relation to standard "
-                  "CFG is w_standard = w + 1 (default 3.5 == standard 4.5)."))
+        parser.add_argument("--real-score-guidance-scale",
+                            type=float,
+                            default=TrainingArgs.real_score_guidance_scale,
+                            help=("Teacher CFG scale for the real score in the DMD loss. Uses "
+                                  "the parameterization x_cond + w * (x_cond - x_uncond), so "
+                                  "w=0 -> cond, w=-1 -> uncond, and the relation to standard "
+                                  "CFG is w_standard = w + 1 (default 3.5 == standard 4.5)."))
         parser.add_argument("--fake-score-learning-rate",
                             type=float,
                             default=TrainingArgs.fake_score_learning_rate,

--- a/fastvideo/training/distillation_pipeline.py
+++ b/fastvideo/training/distillation_pipeline.py
@@ -666,6 +666,10 @@ class DistillationPipeline(TrainingPipeline):
                                                               scheduler=self.noise_scheduler).unflatten(
                                                                   0, real_score_pred_noise_uncond.shape[:2])
 
+            # CFG on the real-score teacher. Uses the DMD2 parameterization
+            # x_cond + w * (x_cond - x_uncond), which is offset by 1 from the
+            # Ho & Salimans form x_uncond + w * (x_cond - x_uncond):
+            # w=0 -> cond, w=-1 -> uncond, w_standard = w + 1.
             real_score_pred_video = pred_real_video_cond + (pred_real_video_cond -
                                                             pred_real_video_uncond) * self.real_score_guidance_scale
 


### PR DESCRIPTION
The DMD loss uses the parameterization x_cond + w * (x_cond - x_uncond) (matching the original DMD2 reference), which differs from the Ho & Salimans form x_uncond + w * (x_cond - x_uncond) by an offset of 1. Adds a comment at the call site, expands the dataclass field comment and CLI help, and documents the relationship in docs/distillation/dmd.md so users porting CFG values from other papers/codebases know to subtract 1.