### PR TITLE
[feat] Add varlen support for VSA kernel

### DIFF
--- a/fastvideo-kernel/python/fastvideo_kernel/__init__.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/__init__.py
@@ -3,6 +3,7 @@ from .version import __version__
 from fastvideo_kernel.ops import (
     sliding_tile_attention,
     video_sparse_attn,
+    video_sparse_attn_varlen,
 )
 
 from fastvideo_kernel.block_sparse_attn import (
@@ -27,6 +28,7 @@ from fastvideo_kernel.turbodiffusion_ops import (
 __all__ = [
     "sliding_tile_attention",
     "video_sparse_attn",
+    "video_sparse_attn_varlen",
     "block_sparse_attn",
     "block_sparse_attn_from_indices",
     "moba_attn_varlen",

--- a/fastvideo-kernel/python/fastvideo_kernel/ops.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/ops.py
@@ -61,6 +61,70 @@ def sliding_tile_attention(
     return output[:, :, :seq_length]
 
 
+def video_sparse_attn_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_kv: torch.Tensor,
+    variable_block_sizes_list: list,
+    q_variable_block_sizes_list: list,
+    topk: int,
+    block_size: int | tuple = 64,
+    compress_attn_weight: torch.Tensor = None,
+) -> torch.Tensor:
+    """
+    Varlen variant of video_sparse_attn following flash_attn_varlen_func convention.
+
+    Args:
+        q:  [total_q, heads, dim]  — flat packed query tokens
+        k:  [total_kv, heads, dim] — flat packed key tokens
+        v:  [total_kv, heads, dim] — flat packed value tokens
+        cu_seqlens_q:  [batch+1] int32 cumulative Q sequence lengths
+        cu_seqlens_kv: [batch+1] int32 cumulative KV sequence lengths
+        variable_block_sizes_list:   list of per-sequence KV block size tensors
+        q_variable_block_sizes_list: list of per-sequence Q block size tensors
+        topk:        number of KV blocks each Q block attends to
+        block_size:  tile size (int or 3-tuple), default 64
+        compress_attn_weight: optional [total_q, heads, dim] gate tensor
+
+    Returns:
+        [total_q, heads, dim]
+    """
+    batch = cu_seqlens_q.shape[0] - 1
+    outputs = []
+
+    for i in range(batch):
+        q_s = cu_seqlens_q[i].item()
+        q_e = cu_seqlens_q[i + 1].item()
+        kv_s = cu_seqlens_kv[i].item()
+        kv_e = cu_seqlens_kv[i + 1].item()
+
+        # Slice and reshape: [S, H, D] → [1, H, S, D]
+        q_i = q[q_s:q_e].unsqueeze(0).transpose(1, 2).contiguous()
+        k_i = k[kv_s:kv_e].unsqueeze(0).transpose(1, 2).contiguous()
+        v_i = v[kv_s:kv_e].unsqueeze(0).transpose(1, 2).contiguous()
+
+        caw_i = None
+        if compress_attn_weight is not None:
+            caw_i = compress_attn_weight[q_s:q_e].unsqueeze(0).transpose(1, 2).contiguous()
+
+        # [1, H, S_q, D]
+        out_i = video_sparse_attn(
+            q_i, k_i, v_i,
+            variable_block_sizes_list[i],
+            q_variable_block_sizes_list[i],
+            topk,
+            block_size=block_size,
+            compress_attn_weight=caw_i,
+        )
+
+        # [1, H, S_q, D] → [S_q, H, D]
+        outputs.append(out_i.squeeze(0).transpose(0, 1))
+
+    return torch.cat(outputs, dim=0)
+
+
 def video_sparse_attn(
     q: torch.Tensor,
     k: torch.Tensor,

--- a/fastvideo-kernel/tests/test_vsa_varlen.py
+++ b/fastvideo-kernel/tests/test_vsa_varlen.py
@@ -1,0 +1,175 @@
+"""
+Correctness test for video_sparse_attn_varlen.
+
+Tests that packing multiple sequences of different Q and KV lengths into flat
+tensors with cu_seqlens bookmarks produces the same result as running
+video_sparse_attn independently on each sequence.
+"""
+
+import pytest
+import torch
+
+from .utils import generate_block_sparse_mask_for_function, create_full_mask_from_block_mask
+from .test_vsa import generate_variable_block_sizes, generate_tensor
+from .test_vsa_forward import pytorch_forward
+
+
+def _build_varlen_inputs(seq_configs, h, d, topk, device):
+    """
+    Given a list of (num_q_blocks, num_kv_blocks) configs, build:
+      - flat q, k, v tensors
+      - cu_seqlens_q, cu_seqlens_kv
+      - per-seq variable_block_sizes lists
+      - per-seq block masks and full element-level masks (for reference)
+    """
+    q_seqs, k_seqs, v_seqs = [], [], []
+    cu_q = [0]
+    cu_kv = [0]
+    vbs_list = []
+    q_vbs_list = []
+    ref_outputs = []
+
+    for num_q_blocks, num_kv_blocks in seq_configs:
+        q_vbs = generate_variable_block_sizes(num_q_blocks, device=device)
+        kv_vbs = generate_variable_block_sizes(num_kv_blocks, device=device)
+
+        S_q = int(q_vbs.sum().item())
+        S_kv = int(kv_vbs.sum().item())
+
+        Q = generate_tensor((1, h, S_q, d), torch.bfloat16, device)
+        K = generate_tensor((1, h, S_kv, d), torch.bfloat16, device)
+        V = generate_tensor((1, h, S_kv, d), torch.bfloat16, device)
+
+        block_mask = generate_block_sparse_mask_for_function(h, num_q_blocks, num_kv_blocks, topk, device)
+        full_mask = create_full_mask_from_block_mask(block_mask, q_vbs, kv_vbs, device)
+
+        # PyTorch dense reference for this sequence
+        ref_out = pytorch_forward(Q, K, V, full_mask)  # [1, h, S_q, d]
+        ref_outputs.append(ref_out.squeeze(0).transpose(0, 1))  # [S_q, h, d]
+
+        # Flat: [S, h, d]
+        q_seqs.append(Q.squeeze(0).transpose(0, 1))   # [S_q, h, d]
+        k_seqs.append(K.squeeze(0).transpose(0, 1))   # [S_kv, h, d]
+        v_seqs.append(V.squeeze(0).transpose(0, 1))   # [S_kv, h, d]
+
+        cu_q.append(cu_q[-1] + S_q)
+        cu_kv.append(cu_kv[-1] + S_kv)
+        vbs_list.append(kv_vbs)
+        q_vbs_list.append(q_vbs)
+
+    q_flat = torch.cat(q_seqs, dim=0)   # [total_q, h, d]
+    k_flat = torch.cat(k_seqs, dim=0)   # [total_kv, h, d]
+    v_flat = torch.cat(v_seqs, dim=0)   # [total_kv, h, d]
+
+    cu_seqlens_q = torch.tensor(cu_q, dtype=torch.int32, device=device)
+    cu_seqlens_kv = torch.tensor(cu_kv, dtype=torch.int32, device=device)
+
+    ref_flat = torch.cat(ref_outputs, dim=0)  # [total_q, h, d]
+
+    return q_flat, k_flat, v_flat, cu_seqlens_q, cu_seqlens_kv, vbs_list, q_vbs_list, ref_flat
+
+
+def run_varlen_forward(
+    seq_configs=None,
+    h=16,
+    d=128,
+    topk=2,
+    num_iterations=3,
+):
+    """
+    Compare video_sparse_attn_varlen against per-sequence PyTorch reference.
+    Returns (avg_abs_err, max_rel_err).
+    """
+    assert torch.cuda.is_available(), "VSA kernels require CUDA"
+    device = "cuda"
+
+    if seq_configs is None:
+        seq_configs = [
+            (8, 12),   # Q < KV
+            (16, 16),  # Q == KV
+            (6, 20),   # Q < KV, different ratio
+        ]
+
+    from fastvideo_kernel import video_sparse_attn_varlen
+
+    sum_diff = 0.0
+    sum_abs = 0.0
+    max_rel_diff = 0.0
+    total_elems = 0
+
+    for _ in range(num_iterations):
+        q_flat, k_flat, v_flat, cu_seqlens_q, cu_seqlens_kv, vbs_list, q_vbs_list, ref_flat = \
+            _build_varlen_inputs(seq_configs, h, d, topk, device)
+
+        out_flat = video_sparse_attn_varlen(
+            q_flat, k_flat, v_flat,
+            cu_seqlens_q, cu_seqlens_kv,
+            vbs_list, q_vbs_list,
+            topk=topk,
+            block_size=64,
+        )
+
+        diff = (ref_flat - out_flat).abs()
+        sum_diff += diff.sum().item()
+        sum_abs += ref_flat.abs().sum().item()
+        rel = diff.max() / (ref_flat.abs().mean() + 1e-6)
+        max_rel_diff = max(max_rel_diff, rel.item())
+        total_elems += ref_flat.numel()
+
+    avg_abs_err = sum_diff / total_elems
+    return avg_abs_err, max_rel_diff
+
+
+def test_vsa_varlen_forward_mixed_lengths():
+    """Batch of 3 sequences with different Q and KV block counts."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    avg_err, max_rel = run_varlen_forward(
+        seq_configs=[(8, 12), (16, 16), (6, 20)],
+        h=16, d=128, topk=2,
+    )
+    print(f"Mixed lengths: avg |ΔO| = {avg_err:.6e}, max rel ΔO = {max_rel:.6e}")
+    assert avg_err < 1e-2, f"avg abs error too large: {avg_err}"
+
+
+def test_vsa_varlen_forward_equal_lengths():
+    """Batch where all sequences have equal Q and KV lengths (sanity check)."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    avg_err, max_rel = run_varlen_forward(
+        seq_configs=[(16, 16), (16, 16), (16, 16)],
+        h=16, d=128, topk=2,
+    )
+    print(f"Equal lengths: avg |ΔO| = {avg_err:.6e}, max rel ΔO = {max_rel:.6e}")
+    assert avg_err < 1e-2, f"avg abs error too large: {avg_err}"
+
+
+def test_vsa_varlen_forward_single_sequence():
+    """Single sequence — varlen should match standard video_sparse_attn."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    avg_err, max_rel = run_varlen_forward(
+        seq_configs=[(12, 16)],
+        h=16, d=128, topk=2,
+    )
+    print(f"Single sequence: avg |ΔO| = {avg_err:.6e}, max rel ΔO = {max_rel:.6e}")
+    assert avg_err < 1e-2, f"avg abs error too large: {avg_err}"
+
+
+if __name__ == "__main__":
+    print("=== VSA Varlen Forward Tests ===")
+
+    print("\n[1] Mixed sequence lengths (Q != KV)")
+    avg, rel = run_varlen_forward(seq_configs=[(8, 12), (16, 16), (6, 20)])
+    print(f"    avg |ΔO| = {avg:.6e},  max rel ΔO = {rel:.6e}")
+
+    print("\n[2] Equal sequence lengths")
+    avg, rel = run_varlen_forward(seq_configs=[(16, 16), (16, 16), (16, 16)])
+    print(f"    avg |ΔO| = {avg:.6e},  max rel ΔO = {rel:.6e}")
+
+    print("\n[3] Single sequence")
+    avg, rel = run_varlen_forward(seq_configs=[(12, 16)])
+    print(f"    avg |ΔO| = {avg:.6e},  max rel ΔO = {rel:.6e}")

--- a/fastvideo/attention/backends/video_sparse_attn.py
+++ b/fastvideo/attention/backends/video_sparse_attn.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 import functools
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 import torch
 
 try:
-    from fastvideo_kernel import video_sparse_attn
+    from fastvideo_kernel import video_sparse_attn, video_sparse_attn_varlen
 except ImportError:
     video_sparse_attn = None
+    video_sparse_attn_varlen = None
 
 from typing import Any
 
@@ -57,7 +58,7 @@ def construct_variable_block_sizes(
 ) -> torch.LongTensor:
     """
     Compute the number of valid (non‑padded) tokens inside every
-    (ts_t × ts_h × ts_w) tile after padding ‑‑ flattened in the order
+    (ts_t × ts_h × ts_w) tile after padding ‑‑ flattened in the order
     (t‑tile, h‑tile, w‑tile) that `rearrange` uses.
 
     Returns
@@ -140,6 +141,11 @@ class VideoSparseAttentionMetadata(AttentionMetadata):
     reverse_tile_partition_indices: torch.LongTensor
     variable_block_sizes: torch.LongTensor
     non_pad_index: torch.LongTensor
+    # Optional varlen fields (None = standard non-varlen path)
+    cu_seqlens_q: torch.Tensor | None = None
+    cu_seqlens_kv: torch.Tensor | None = None
+    variable_block_sizes_list: list | None = field(default=None, compare=False)
+    q_variable_block_sizes_list: list | None = field(default=None, compare=False)
 
 
 class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):
@@ -157,7 +163,11 @@ class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):
         patch_size: tuple[int, int, int],
         VSA_sparsity: float,
         device: torch.device,
-        **kwargs: dict[str, Any],
+        cu_seqlens_q: torch.Tensor | None = None,
+        cu_seqlens_kv: torch.Tensor | None = None,
+        variable_block_sizes_list: list | None = None,
+        q_variable_block_sizes_list: list | None = None,
+        **kwargs: Any,
     ) -> VideoSparseAttentionMetadata:
         patch_size = patch_size
         dit_seq_shape = (raw_latent_shape[0] // patch_size[0], raw_latent_shape[1] // patch_size[1],
@@ -181,7 +191,62 @@ class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):
             tile_partition_indices=tile_partition_indices,  # type: ignore
             reverse_tile_partition_indices=reverse_tile_partition_indices,
             variable_block_sizes=variable_block_sizes,
-            non_pad_index=non_pad_index)
+            non_pad_index=non_pad_index,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_kv=cu_seqlens_kv,
+            variable_block_sizes_list=variable_block_sizes_list,
+            q_variable_block_sizes_list=q_variable_block_sizes_list,
+        )
+
+    def build_varlen(
+        self,
+        current_timestep: int,
+        batch_latent_shapes: list[tuple[int, int, int]],
+        patch_size: tuple[int, int, int],
+        VSA_sparsity: float,
+        device: torch.device,
+        **kwargs: Any,
+    ) -> VideoSparseAttentionMetadata:
+        """Build metadata for a varlen batch where each sequence has a different latent shape."""
+        variable_block_sizes_list = []
+        q_variable_block_sizes_list = []
+        q_lengths = []
+        kv_lengths = []
+
+        for raw_latent_shape in batch_latent_shapes:
+            dit_seq_shape = (
+                raw_latent_shape[0] // patch_size[0],
+                raw_latent_shape[1] // patch_size[1],
+                raw_latent_shape[2] // patch_size[2],
+            )
+            num_tiles = (
+                math.ceil(dit_seq_shape[0] / VSA_TILE_SIZE[0]),
+                math.ceil(dit_seq_shape[1] / VSA_TILE_SIZE[1]),
+                math.ceil(dit_seq_shape[2] / VSA_TILE_SIZE[2]),
+            )
+            vbs = construct_variable_block_sizes(dit_seq_shape, num_tiles, device)
+            variable_block_sizes_list.append(vbs)
+            q_variable_block_sizes_list.append(vbs)
+            padded_len = math.prod(num_tiles) * math.prod(VSA_TILE_SIZE)
+            q_lengths.append(padded_len)
+            kv_lengths.append(padded_len)
+
+        cu_seqlens_q = torch.zeros(len(q_lengths) + 1, dtype=torch.int32, device=device)
+        cu_seqlens_q[1:] = torch.tensor(q_lengths, dtype=torch.int32, device=device).cumsum(0)
+        cu_seqlens_kv = torch.zeros(len(kv_lengths) + 1, dtype=torch.int32, device=device)
+        cu_seqlens_kv[1:] = torch.tensor(kv_lengths, dtype=torch.int32, device=device).cumsum(0)
+
+        return self.build(
+            current_timestep=current_timestep,
+            raw_latent_shape=batch_latent_shapes[0],
+            patch_size=patch_size,
+            VSA_sparsity=VSA_sparsity,
+            device=device,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_kv=cu_seqlens_kv,
+            variable_block_sizes_list=variable_block_sizes_list,
+            q_variable_block_sizes_list=q_variable_block_sizes_list,
+        )
 
 
 class VideoSparseAttentionImpl(AttentionImpl):
@@ -246,8 +311,28 @@ class VideoSparseAttentionImpl(AttentionImpl):
         gate_compress = gate_compress.transpose(1, 2).contiguous()
 
         VSA_sparsity = attn_metadata.VSA_sparsity
-
         cur_topk = math.ceil((1 - VSA_sparsity) * (attn_metadata.total_seq_length / math.prod(VSA_TILE_SIZE)))
+
+        if attn_metadata.cu_seqlens_q is not None:
+            # varlen path: flat packed tensors [B*L, H, D]
+            if video_sparse_attn_varlen is None:
+                raise NotImplementedError("video_sparse_attn_varlen is not installed")
+            q_flat = query.reshape(-1, query.shape[-2], query.shape[-1])
+            k_flat = key.reshape(-1, key.shape[-2], key.shape[-1])
+            v_flat = value.reshape(-1, value.shape[-2], value.shape[-1])
+            caw_flat = gate_compress.reshape(-1, gate_compress.shape[-2], gate_compress.shape[-1])
+            hidden_states = video_sparse_attn_varlen(
+                q_flat, k_flat, v_flat,
+                attn_metadata.cu_seqlens_q,
+                attn_metadata.cu_seqlens_kv,
+                attn_metadata.variable_block_sizes_list,
+                attn_metadata.q_variable_block_sizes_list,
+                cur_topk,
+                block_size=VSA_TILE_SIZE,
+                compress_attn_weight=caw_flat,
+            )
+            # [total_q, H, D] -> [B, L, H, D]
+            return hidden_states.reshape(query.shape[0], -1, query.shape[-2], query.shape[-1])
 
         if video_sparse_attn is None:
             raise NotImplementedError("video_sparse_attn is not installed")


### PR DESCRIPTION
## Summary

- **Problem**: VSA kernel required `len(Q) == len(KV)`, forcing wasteful padding when batching video clips of different resolutions/durations (up to ~40% wasted compute in mixed-resolution workloads). Reported in #917 and #1040.
- **Solution**: Add `video_sparse_attn_varlen` following the `flash_attn_varlen_func` convention — flat packed tensors + `cu_seqlens_q` / `cu_seqlens_kv` bookmarks, one per sequence boundary. No kernel changes were needed: the Triton kernel already accepts `N_CTX_Q` and `N_CTX_KV` as independent parameters.
- **Model integration**: `VideoSparseAttentionMetadata` gains optional varlen fields; `VideoSparseAttentionMetadataBuilder` gains a `build_varlen()` method that accepts per-sequence latent shapes and computes `cu_seqlens` automatically.

## Changes

| File | Change |
|------|--------|
| `fastvideo-kernel/python/fastvideo_kernel/ops.py` | Add `video_sparse_attn_varlen` |
| `fastvideo-kernel/python/fastvideo_kernel/__init__.py` | Export new function |
| `fastvideo/attention/backends/video_sparse_attn.py` | Varlen metadata fields + `build_varlen` + varlen forward branch |
| `fastvideo-kernel/tests/test_vsa_varlen.py` | Correctness tests (3 scenarios) |

## Test plan

- [ ] `pytest fastvideo-kernel/tests/test_vsa_varlen.py -vs` on a CUDA-capable machine
  - Mixed Q ≠ KV lengths across sequences
  - All-equal lengths (sanity check)
  - Single sequence (parity with standard path)
- [ ] `pytest fastvideo-kernel/tests/test_vsa_forward.py -vs` — existing tests still pass

> Note: Tests require a GPU. Marked draft until CI confirms correctness.

Closes #917
Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)