### PR TITLE
[ci] add CPU unit tests for train callback system in fastvideo.train

### DIFF
--- a/fastvideo/tests/train/callbacks/__init__.py
+++ b/fastvideo/tests/train/callbacks/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/fastvideo/tests/train/callbacks/test_callback.py
+++ b/fastvideo/tests/train/callbacks/test_callback.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only unit tests for :mod:`fastvideo.train.callbacks.callback`.
+
+Covers the ``Callback`` base class no-op contract and the
+``CallbackDict`` instantiation / dispatch / state-dict logic.
+
+The concrete callback subclasses (``GradNormClipCallback``,
+``EMACallback``, ``ValidationCallback``) have their own test files.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+from fastvideo.train.callbacks.callback import (
+    Callback,
+    CallbackDict,
+    _BUILTIN_CALLBACKS,
+)
+
+
+# ``fastvideo.logger.init_logger`` sets ``propagate=False`` on its
+# loggers, so the standard ``caplog`` fixture cannot observe them.
+# This helper attaches a temporary handler directly to the target
+# logger and yields the captured records.
+@contextmanager
+def _capture_logger(
+    name: str, level: int = logging.WARNING
+) -> Iterator[list[logging.LogRecord]]:
+    logger = logging.getLogger(name)
+    records: list[logging.LogRecord] = []
+
+    class _Handler(logging.Handler):
+
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Handler(level=level)
+    prev_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingCallback(Callback):
+    """Callback that records every hook call into a shared list."""
+
+    def __init__(self, *, tag: str, sink: list[str]) -> None:
+        self._tag = tag
+        self._sink = sink
+
+    def on_train_start(self, method, iteration: int = 0) -> None:
+        self._sink.append(f"{self._tag}:on_train_start:{iteration}")
+
+    def on_training_step_end(
+        self, method, loss_dict, iteration: int = 0
+    ) -> None:
+        self._sink.append(f"{self._tag}:on_training_step_end:{iteration}")
+
+    def on_validation_begin(self, method, iteration: int = 0) -> None:
+        self._sink.append(f"{self._tag}:on_validation_begin:{iteration}")
+
+    def state_dict(self) -> dict[str, Any]:
+        return {"tag": self._tag, "marker": 7}
+
+    def load_state_dict(self, sd: dict[str, Any]) -> None:
+        self._sink.append(f"{self._tag}:load:{sd.get('marker')}")
+
+
+class _NotACallback:
+    """Plain class used to exercise the non-Callback type guard."""
+
+    def __init__(self, **_: Any) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# A. Callback base class
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackBase:
+
+    def test_default_hooks_return_none(self) -> None:
+        cb = Callback()
+        assert cb.on_train_start(method=None) is None
+        assert (
+            cb.on_training_step_end(method=None, loss_dict={}) is None
+        )
+        assert cb.on_before_optimizer_step(method=None) is None
+        assert cb.on_validation_begin(method=None) is None
+        assert cb.on_validation_end(method=None) is None
+        assert cb.on_train_end(method=None) is None
+
+    def test_default_state_dict_round_trip(self) -> None:
+        cb = Callback()
+        assert cb.state_dict() == {}
+        # Default load_state_dict accepts arbitrary state without raising.
+        assert cb.load_state_dict({"unrelated": 1}) is None
+
+
+# ---------------------------------------------------------------------------
+# B. CallbackDict construction
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackDictInit:
+
+    def test_empty_config(self) -> None:
+        cb_dict = CallbackDict({}, training_config=object())
+        assert cb_dict._callbacks == {}
+
+    def test_builtin_name_resolves_without_target(self) -> None:
+        # ``grad_clip`` is a registered builtin.
+        cfg = {"grad_clip": {"max_grad_norm": 0.5}}
+        tc = object()
+        cb_dict = CallbackDict(cfg, training_config=tc)
+
+        assert "grad_clip" in cb_dict._callbacks
+        from fastvideo.train.callbacks.grad_clip import (
+            GradNormClipCallback,
+        )
+        cb = cb_dict._callbacks["grad_clip"]
+        assert isinstance(cb, GradNormClipCallback)
+        # CallbackDict wires up training_config + back-pointer.
+        assert cb.training_config is tc
+        assert cb._callback_dict is cb_dict
+
+    def test_explicit_target_overrides_name_lookup(self) -> None:
+        cfg = {
+            "anything_goes": {
+                "_target_": (
+                    "fastvideo.train.callbacks.grad_clip."
+                    "GradNormClipCallback"
+                ),
+                "max_grad_norm": 1.0,
+            }
+        }
+        cb_dict = CallbackDict(cfg, training_config=object())
+        assert "anything_goes" in cb_dict._callbacks
+
+    def test_unknown_name_without_target_is_skipped(self) -> None:
+        cfg = {"mystery": {"some_arg": 1}}
+        with _capture_logger(
+            "fastvideo.train.callbacks.callback"
+        ) as records:
+            cb_dict = CallbackDict(cfg, training_config=object())
+        assert cb_dict._callbacks == {}
+        assert any(
+            "missing" in r.getMessage() and "mystery" in r.getMessage()
+            for r in records
+        )
+
+    def test_non_callback_target_raises(self) -> None:
+        cfg = {
+            "bad": {
+                "_target_": (
+                    "fastvideo.tests.train.callbacks.test_callback."
+                    "_NotACallback"
+                )
+            }
+        }
+        with pytest.raises(TypeError, match="expected a Callback"):
+            CallbackDict(cfg, training_config=object())
+
+    def test_builtin_registry_has_expected_entries(self) -> None:
+        # Sanity: protect the builtin registry from silent shrinkage.
+        assert set(_BUILTIN_CALLBACKS) >= {
+            "grad_clip",
+            "validation",
+            "ema",
+        }
+
+
+# ---------------------------------------------------------------------------
+# C. Dispatch via __getattr__
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackDictDispatch:
+
+    def _build(
+        self, sink: list[str]
+    ) -> CallbackDict:
+        cb_dict = CallbackDict({}, training_config=object())
+        cb_dict._callbacks["first"] = _RecordingCallback(
+            tag="first", sink=sink
+        )
+        cb_dict._callbacks["second"] = _RecordingCallback(
+            tag="second", sink=sink
+        )
+        return cb_dict
+
+    def test_dispatch_calls_all_in_insertion_order(self) -> None:
+        sink: list[str] = []
+        cb_dict = self._build(sink)
+
+        cb_dict.on_train_start(method=None, iteration=3)
+        assert sink == [
+            "first:on_train_start:3",
+            "second:on_train_start:3",
+        ]
+
+    def test_dispatch_to_hook_some_callbacks_skip(self) -> None:
+        sink: list[str] = []
+        cb_dict = self._build(sink)
+        # The base Callback subclass below only implements one hook;
+        # dispatch should still fan out without raising.
+
+        class _OnlyValidation(Callback):
+
+            def on_validation_end(
+                self, method, iteration: int = 0
+            ) -> None:
+                sink.append(f"vend:{iteration}")
+
+        cb_dict._callbacks["only_v"] = _OnlyValidation()
+        cb_dict.on_validation_end(method=None, iteration=11)
+        assert "vend:11" in sink
+
+    def test_dispatch_unknown_hook_is_noop(self) -> None:
+        # Methods that don't exist on any callback should not raise.
+        cb_dict = self._build([])
+        cb_dict.totally_made_up_hook(method=None, iteration=0)
+
+    def test_underscore_attribute_raises(self) -> None:
+        cb_dict = self._build([])
+        with pytest.raises(AttributeError):
+            getattr(cb_dict, "_does_not_exist")
+
+
+# ---------------------------------------------------------------------------
+# D. state_dict / load_state_dict
+# ---------------------------------------------------------------------------
+
+
+class TestCallbackDictStateDict:
+
+    def _build(self) -> tuple[CallbackDict, list[str]]:
+        sink: list[str] = []
+        cb_dict = CallbackDict({}, training_config=object())
+        cb_dict._callbacks["first"] = _RecordingCallback(
+            tag="first", sink=sink
+        )
+        cb_dict._callbacks["second"] = _RecordingCallback(
+            tag="second", sink=sink
+        )
+        return cb_dict, sink
+
+    def test_state_dict_returns_per_callback_dict(self) -> None:
+        cb_dict, _ = self._build()
+        state = cb_dict.state_dict()
+        assert set(state) == {"first", "second"}
+        assert state["first"] == {"tag": "first", "marker": 7}
+        assert state["second"] == {"tag": "second", "marker": 7}
+
+    def test_load_state_dict_dispatches_to_each(self) -> None:
+        cb_dict, sink = self._build()
+        cb_dict.load_state_dict(
+            {
+                "first": {"marker": 1},
+                "second": {"marker": 2},
+            }
+        )
+        assert sink == ["first:load:1", "second:load:2"]
+
+    def test_load_state_dict_missing_key_warns_no_raise(self) -> None:
+        cb_dict, sink = self._build()
+        with _capture_logger(
+            "fastvideo.train.callbacks.callback"
+        ) as records:
+            cb_dict.load_state_dict({"first": {"marker": 99}})
+        assert sink == ["first:load:99"]
+        assert any(
+            "second" in r.getMessage() and "not found" in r.getMessage()
+            for r in records
+        )

--- a/fastvideo/tests/train/callbacks/test_ema.py
+++ b/fastvideo/tests/train/callbacks/test_ema.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only unit tests for :mod:`fastvideo.train.callbacks.ema`.
+
+Exercises the EMA lifecycle (lazy init, ``start_iter`` gating, decay
+math, ``ema_context`` swap, state-dict round-trip) on a tiny CPU
+``nn.Linear``. ``EMA_FSDP`` works without ``dist.init_process_group``
+because ``dist.is_initialized()`` returns False and ``_to_local_tensor``
+falls through to raw tensors for non-DTensor inputs.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import torch
+
+from fastvideo.train.callbacks.ema import EMACallback
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _Student:
+
+    def __init__(self, transformer: torch.nn.Module | None) -> None:
+        self.transformer = transformer
+
+
+class _RecordingTracker:
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[dict[str, Any], int]] = []
+
+    def log(self, payload: dict[str, Any], step: int) -> None:
+        self.entries.append((payload, step))
+
+
+class _Method:
+
+    def __init__(
+        self,
+        transformer: torch.nn.Module | None,
+        tracker: Any | None = None,
+    ) -> None:
+        self.student = _Student(transformer)
+        self.tracker = tracker
+
+
+def _tiny_transformer(*, fill: float = 0.0) -> torch.nn.Module:
+    m = torch.nn.Linear(4, 2, bias=False)
+    with torch.no_grad():
+        m.weight.fill_(fill)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# A. on_train_start
+# ---------------------------------------------------------------------------
+
+
+class TestOnTrainStart:
+
+    def test_initializes_ema_from_student(self) -> None:
+        transformer = _tiny_transformer(fill=0.5)
+        cb = EMACallback(decay=0.9, start_iter=0)
+        cb.on_train_start(_Method(transformer), iteration=0)
+
+        assert cb.student_ema is not None
+        # Shadow shape matches transformer parameter.
+        shadow = cb.student_ema.shadow["weight"]
+        assert shadow.shape == transformer.weight.shape
+        assert torch.allclose(shadow, transformer.weight.detach().cpu())
+
+    def test_missing_transformer_raises(self) -> None:
+        cb = EMACallback()
+        with pytest.raises(ValueError, match="No student transformer"):
+            cb.on_train_start(_Method(transformer=None), iteration=0)
+
+
+# ---------------------------------------------------------------------------
+# B. on_training_step_end (decay math + start_iter gating)
+# ---------------------------------------------------------------------------
+
+
+class TestOnTrainingStepEnd:
+
+    def test_no_op_before_train_start(self) -> None:
+        cb = EMACallback()
+        # student_ema is None until on_train_start.
+        cb.on_training_step_end(
+            _Method(transformer=None), loss_dict={}, iteration=0
+        )
+        assert not cb._ema_started
+
+    def test_skipped_until_start_iter(self) -> None:
+        transformer = _tiny_transformer(fill=1.0)
+        cb = EMACallback(decay=0.5, start_iter=10)
+        cb.on_train_start(_Method(transformer), iteration=0)
+
+        # Mutate transformer to drift it away from initial shadow.
+        with torch.no_grad():
+            transformer.weight.fill_(7.0)
+
+        cb.on_training_step_end(
+            _Method(transformer), loss_dict={}, iteration=5
+        )
+        # Below start_iter: shadow is untouched, _ema_started False.
+        assert not cb._ema_started
+        assert torch.allclose(
+            cb.student_ema.shadow["weight"],
+            torch.full((2, 4), 1.0),
+        )
+
+    def test_first_active_step_reinits_then_updates(self) -> None:
+        transformer = _tiny_transformer(fill=1.0)
+        cb = EMACallback(decay=0.9, start_iter=10)
+        cb.on_train_start(_Method(transformer), iteration=0)
+
+        # Drift transformer so that re-init has a visible effect.
+        with torch.no_grad():
+            transformer.weight.fill_(5.0)
+
+        cb.on_training_step_end(
+            _Method(transformer), loss_dict={}, iteration=10
+        )
+        # First active step: shadow is re-initialized from the
+        # current transformer (5.0) and *then* update() applies decay
+        # against the same value, so shadow stays at 5.0.
+        assert cb._ema_started
+        assert torch.allclose(
+            cb.student_ema.shadow["weight"],
+            torch.full((2, 4), 5.0),
+        )
+
+    def test_subsequent_step_applies_decay(self) -> None:
+        transformer = _tiny_transformer(fill=2.0)
+        cb = EMACallback(decay=0.9, start_iter=0)
+        cb.on_train_start(_Method(transformer), iteration=0)
+
+        # Step 0: re-init at 2.0, then update against 2.0 → still 2.0.
+        cb.on_training_step_end(
+            _Method(transformer), loss_dict={}, iteration=0
+        )
+        # Step 1: drift transformer to 12.0, expect
+        # shadow = 0.9 * 2.0 + 0.1 * 12.0 = 3.0.
+        with torch.no_grad():
+            transformer.weight.fill_(12.0)
+        cb.on_training_step_end(
+            _Method(transformer), loss_dict={}, iteration=1
+        )
+        assert torch.allclose(
+            cb.student_ema.shadow["weight"],
+            torch.full((2, 4), 3.0),
+            atol=1e-6,
+        )
+
+    def test_tracker_logs_decay(self) -> None:
+        transformer = _tiny_transformer()
+        tracker = _RecordingTracker()
+        cb = EMACallback(decay=0.99, start_iter=0)
+        method = _Method(transformer, tracker=tracker)
+        cb.on_train_start(method, iteration=0)
+        cb.on_training_step_end(method, loss_dict={}, iteration=0)
+
+        assert any(
+            payload.get("ema/decay") == 0.99 and step == 0
+            for payload, step in tracker.entries
+        )
+
+
+# ---------------------------------------------------------------------------
+# C. ema_context
+# ---------------------------------------------------------------------------
+
+
+class TestEmaContext:
+
+    def test_passthrough_when_inactive(self) -> None:
+        transformer = _tiny_transformer(fill=3.0)
+        cb = EMACallback()
+        # No on_train_start → student_ema is None.
+        with cb.ema_context(transformer) as t:
+            assert t is transformer
+            assert torch.allclose(
+                t.weight, torch.full((2, 4), 3.0)
+            )
+
+    def test_swaps_weights_then_restores(self) -> None:
+        transformer = _tiny_transformer(fill=1.0)
+        cb = EMACallback(decay=0.0, start_iter=0)
+        method = _Method(transformer)
+        cb.on_train_start(method, iteration=0)
+
+        # decay=0 → after one step the shadow == current weights == 1.0.
+        cb.on_training_step_end(method, loss_dict={}, iteration=0)
+        # Drift transformer; ema_context should swap shadow (1.0) in
+        # for the duration and restore the post-drift value (9.0).
+        with torch.no_grad():
+            transformer.weight.fill_(9.0)
+
+        with cb.ema_context(transformer) as t:
+            assert torch.allclose(t.weight, torch.full((2, 4), 1.0))
+
+        assert torch.allclose(
+            transformer.weight, torch.full((2, 4), 9.0)
+        )
+
+
+# ---------------------------------------------------------------------------
+# D. State dict round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestStateDict:
+
+    def test_state_dict_empty_before_train_start(self) -> None:
+        cb = EMACallback()
+        assert cb.state_dict() == {}
+
+    def test_round_trip_preserves_shadow_and_started_flag(self) -> None:
+        transformer = _tiny_transformer(fill=4.0)
+        cb = EMACallback(decay=0.5, start_iter=0)
+        method = _Method(transformer)
+        cb.on_train_start(method, iteration=0)
+        cb.on_training_step_end(method, loss_dict={}, iteration=0)
+
+        state = cb.state_dict()
+        assert "student_ema" in state
+        assert state["ema_started"] is True
+
+        # Build a fresh callback and load.
+        fresh = EMACallback(decay=0.5, start_iter=0)
+        fresh.on_train_start(_Method(_tiny_transformer(fill=0.0)),
+                             iteration=0)
+        # Sanity: fresh shadow != saved shadow before load.
+        assert not torch.allclose(
+            fresh.student_ema.shadow["weight"],
+            cb.student_ema.shadow["weight"],
+        )
+        fresh.load_state_dict(state)
+        assert fresh._ema_started is True
+        assert torch.allclose(
+            fresh.student_ema.shadow["weight"],
+            cb.student_ema.shadow["weight"],
+        )
+
+    def test_load_without_student_ema_only_sets_flag(self) -> None:
+        cb = EMACallback()
+        # student_ema is None — load must not attempt to assign shadow.
+        cb.load_state_dict({"ema_started": True})
+        assert cb._ema_started is True
+        assert cb.student_ema is None

--- a/fastvideo/tests/train/callbacks/test_grad_clip.py
+++ b/fastvideo/tests/train/callbacks/test_grad_clip.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only unit tests for :mod:`fastvideo.train.callbacks.grad_clip`.
+
+Exercises ``GradNormClipCallback.on_before_optimizer_step`` against
+synthetic ``nn.Module`` targets with manually populated gradients.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from fastvideo.train.callbacks.grad_clip import GradNormClipCallback
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _RecordingTracker:
+    """Tracker stub that records every ``log`` call."""
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[dict[str, Any], int]] = []
+
+    def log(self, payload: dict[str, Any], step: int) -> None:
+        self.entries.append((payload, step))
+
+
+class _Method:
+    """Minimal stand-in for ``TrainingMethod``."""
+
+    def __init__(
+        self,
+        targets: dict[str, torch.nn.Module],
+        tracker: Any | None = None,
+    ) -> None:
+        self._targets = targets
+        self.tracker = tracker
+        self.iter_seen: int | None = None
+
+    def get_grad_clip_targets(
+        self, iteration: int
+    ) -> dict[str, torch.nn.Module]:
+        self.iter_seen = iteration
+        return self._targets
+
+
+def _make_module(*, grad_value: float, n: int = 4) -> torch.nn.Module:
+    """Return an ``nn.Linear`` whose grads are filled with ``grad_value``."""
+    m = torch.nn.Linear(n, n, bias=False)
+    m.weight.grad = torch.full_like(m.weight, fill_value=grad_value)
+    return m
+
+
+def _grad_norm(module: torch.nn.Module) -> float:
+    flat = torch.cat([p.grad.flatten() for p in module.parameters()])
+    return float(flat.norm(2).item())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestGradNormClipCallback:
+
+    def test_disabled_when_max_norm_non_positive(self) -> None:
+        m = _make_module(grad_value=10.0)
+        before = _grad_norm(m)
+
+        cb = GradNormClipCallback(max_grad_norm=0.0)
+        method = _Method(targets={"m": m})
+        cb.on_before_optimizer_step(method=method, iteration=0)
+
+        # No clipping applied; ``get_grad_clip_targets`` not consulted.
+        assert _grad_norm(m) == before
+        assert method.iter_seen is None
+
+    def test_large_grads_get_clipped(self) -> None:
+        m = _make_module(grad_value=10.0)
+        assert _grad_norm(m) > 1.0
+
+        cb = GradNormClipCallback(max_grad_norm=1.0)
+        cb.on_before_optimizer_step(
+            method=_Method(targets={"m": m}), iteration=0
+        )
+
+        # After clipping the L2 norm should not exceed max_grad_norm
+        # (allow a tiny epsilon for the +1e-6 in the clip helper).
+        assert _grad_norm(m) <= 1.0 + 1e-4
+
+    def test_small_grads_unchanged(self) -> None:
+        m = _make_module(grad_value=0.01)
+        before = _grad_norm(m)
+        assert before < 1.0
+
+        cb = GradNormClipCallback(max_grad_norm=1.0)
+        cb.on_before_optimizer_step(
+            method=_Method(targets={"m": m}), iteration=0
+        )
+
+        # Clip coef >1 is clamped to 1, so values are preserved
+        # (modulo the *1.0 multiply, which is exact for floats).
+        assert abs(_grad_norm(m) - before) < 1e-6
+
+    def test_iteration_forwarded_to_targets(self) -> None:
+        m = _make_module(grad_value=0.5)
+        cb = GradNormClipCallback(max_grad_norm=1.0)
+        method = _Method(targets={"m": m})
+        cb.on_before_optimizer_step(method=method, iteration=42)
+        assert method.iter_seen == 42
+
+    def test_tracker_logged_when_enabled(self) -> None:
+        m = _make_module(grad_value=5.0)
+        tracker = _RecordingTracker()
+        cb = GradNormClipCallback(
+            max_grad_norm=1.0, log_grad_norms=True
+        )
+        cb.on_before_optimizer_step(
+            method=_Method(targets={"layer": m}, tracker=tracker),
+            iteration=7,
+        )
+        assert len(tracker.entries) == 1
+        payload, step = tracker.entries[0]
+        assert step == 7
+        assert "grad_norm/layer" in payload
+        assert payload["grad_norm/layer"] > 0.0
+
+    def test_tracker_not_logged_when_disabled(self) -> None:
+        m = _make_module(grad_value=5.0)
+        tracker = _RecordingTracker()
+        cb = GradNormClipCallback(
+            max_grad_norm=1.0, log_grad_norms=False
+        )
+        cb.on_before_optimizer_step(
+            method=_Method(targets={"m": m}, tracker=tracker),
+            iteration=0,
+        )
+        assert tracker.entries == []
+
+    def test_no_tracker_does_not_raise(self) -> None:
+        m = _make_module(grad_value=5.0)
+        cb = GradNormClipCallback(max_grad_norm=1.0, log_grad_norms=True)
+        # Method without a tracker attribute at all.
+
+        class _BareMethod:
+
+            def get_grad_clip_targets(
+                self, iteration: int
+            ) -> dict[str, torch.nn.Module]:
+                return {"m": m}
+
+        cb.on_before_optimizer_step(method=_BareMethod(), iteration=0)
+        # No assertion — must simply not raise.
+
+    def test_multiple_targets_each_logged(self) -> None:
+        targets = {
+            "head": _make_module(grad_value=4.0),
+            "tail": _make_module(grad_value=8.0),
+        }
+        tracker = _RecordingTracker()
+        cb = GradNormClipCallback(max_grad_norm=1.0)
+        cb.on_before_optimizer_step(
+            method=_Method(targets=targets, tracker=tracker),
+            iteration=1,
+        )
+        keys = {next(iter(p)) for p, _ in tracker.entries}
+        assert keys == {"grad_norm/head", "grad_norm/tail"}

--- a/fastvideo/tests/train/callbacks/test_validation.py
+++ b/fastvideo/tests/train/callbacks/test_validation.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only unit tests for :mod:`fastvideo.train.callbacks.validation`.
+
+Covers the parts of ``ValidationCallback`` that don't need a real
+pipeline or distributed init:
+
+* constructor type coercions and defaults,
+* ``on_validation_begin`` gating logic (every_steps + modulo),
+* ``_find_ema_callback`` lookup via ``_callback_dict``,
+* ``state_dict`` / ``load_state_dict`` rng round-trip.
+
+The heavy ``_run_validation`` path needs a real diffusion pipeline plus
+distributed init and is exercised by Phase 2/3 tests.
+"""
+from __future__ import annotations
+
+import torch
+
+from fastvideo.train.callbacks.callback import CallbackDict
+from fastvideo.train.callbacks.ema import EMACallback
+from fastvideo.train.callbacks.validation import ValidationCallback
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_PIPE_TARGET = "fastvideo.pipelines.basic.wan.wan_pipeline.WanPipeline"
+
+
+def _make_callback(
+    *,
+    every_steps: int = 100,
+    sampling_steps: list[int] | None = None,
+    guidance_scale: float | None = None,
+    num_frames: int | None = None,
+    sampling_timesteps: list[int] | None = None,
+    output_dir: str | None = None,
+) -> ValidationCallback:
+    return ValidationCallback(
+        pipeline_target=_PIPE_TARGET,
+        dataset_file="/tmp/does_not_exist.json",
+        every_steps=every_steps,
+        sampling_steps=sampling_steps,
+        guidance_scale=guidance_scale,
+        num_frames=num_frames,
+        sampling_timesteps=sampling_timesteps,
+        output_dir=output_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# A. Constructor coercions / defaults
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+
+    def test_defaults(self) -> None:
+        cb = _make_callback()
+        assert cb.pipeline_target == _PIPE_TARGET
+        assert cb.dataset_file == "/tmp/does_not_exist.json"
+        assert cb.every_steps == 100
+        assert cb.sampling_steps == [40]
+        assert cb.guidance_scale is None
+        assert cb.num_frames is None
+        assert cb.sampling_timesteps is None
+        assert cb.output_dir is None
+        # Lazy fields not yet populated.
+        assert cb._pipeline is None
+        assert cb._sampling_param is None
+        assert cb.validation_random_generator is None
+
+    def test_string_inputs_are_coerced(self) -> None:
+        # YAML often produces strings for numeric fields; the
+        # constructor must coerce them.
+        cb = ValidationCallback(
+            pipeline_target=_PIPE_TARGET,
+            dataset_file="x.json",
+            every_steps="50",  # type: ignore[arg-type]
+            sampling_steps=["20", "40"],  # type: ignore[arg-type]
+            guidance_scale="4.5",  # type: ignore[arg-type]
+            num_frames="77",  # type: ignore[arg-type]
+            sampling_timesteps=["1000", "500"],
+        )
+        assert cb.every_steps == 50
+        assert cb.sampling_steps == [20, 40]
+        assert cb.guidance_scale == 4.5
+        assert cb.num_frames == 77
+        assert cb.sampling_timesteps == [1000, 500]
+
+    def test_pipeline_kwargs_collected(self) -> None:
+        cb = ValidationCallback(
+            pipeline_target=_PIPE_TARGET,
+            dataset_file="x.json",
+            extra_arg=123,
+            another="value",
+        )
+        # Unknown kwargs are stashed for the pipeline factory.
+        assert cb.pipeline_kwargs == {
+            "extra_arg": 123,
+            "another": "value",
+        }
+
+
+# ---------------------------------------------------------------------------
+# B. on_validation_begin gating
+# ---------------------------------------------------------------------------
+
+
+class _NoRunValidation(ValidationCallback):
+    """Subclass that records ``_run_validation`` calls instead of
+    actually running them — lets us assert the gating logic without a
+    real pipeline."""
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.run_calls: list[int] = []
+
+    def _run_validation(self, method, step: int) -> None:  # type: ignore[override]
+        self.run_calls.append(step)
+
+
+def _make_recording(**kwargs) -> _NoRunValidation:
+    return _NoRunValidation(
+        pipeline_target=_PIPE_TARGET,
+        dataset_file="x.json",
+        **kwargs,
+    )
+
+
+class TestOnValidationBegin:
+
+    def test_skipped_when_every_steps_zero(self) -> None:
+        cb = _make_recording(every_steps=0)
+        cb.on_validation_begin(method=None, iteration=0)
+        cb.on_validation_begin(method=None, iteration=1000)
+        assert cb.run_calls == []
+
+    def test_skipped_on_off_iter(self) -> None:
+        cb = _make_recording(every_steps=50)
+        cb.on_validation_begin(method=None, iteration=49)
+        cb.on_validation_begin(method=None, iteration=51)
+        assert cb.run_calls == []
+
+    def test_runs_on_match(self) -> None:
+        cb = _make_recording(every_steps=50)
+        cb.on_validation_begin(method=None, iteration=50)
+        cb.on_validation_begin(method=None, iteration=100)
+        assert cb.run_calls == [50, 100]
+
+    def test_iter_zero_runs(self) -> None:
+        # 0 % anything == 0 → step 0 fires (matches existing
+        # validation behavior used by ValidationCallback consumers).
+        cb = _make_recording(every_steps=50)
+        cb.on_validation_begin(method=None, iteration=0)
+        assert cb.run_calls == [0]
+
+
+# ---------------------------------------------------------------------------
+# C. _find_ema_callback
+# ---------------------------------------------------------------------------
+
+
+class TestFindEmaCallback:
+
+    def test_returns_none_without_callback_dict(self) -> None:
+        cb = _make_callback()
+        # _callback_dict is not set on bare instances.
+        assert cb._find_ema_callback() is None
+
+    def test_returns_none_when_no_ema_registered(self) -> None:
+        cb = _make_callback()
+        cb_dict = CallbackDict({}, training_config=object())
+        cb._callback_dict = cb_dict
+        assert cb._find_ema_callback() is None
+
+    def test_finds_ema_callback(self) -> None:
+        cb = _make_callback()
+        cb_dict = CallbackDict({}, training_config=object())
+        ema = EMACallback(decay=0.99)
+        cb_dict._callbacks["ema"] = ema
+        cb_dict._callbacks["validation"] = cb
+        cb._callback_dict = cb_dict
+
+        found = cb._find_ema_callback()
+        assert found is ema
+
+
+# ---------------------------------------------------------------------------
+# D. state_dict / load_state_dict (rng round-trip)
+# ---------------------------------------------------------------------------
+
+
+class TestStateDict:
+
+    def test_state_dict_empty_without_generator(self) -> None:
+        cb = _make_callback()
+        # validation_random_generator is None until on_train_start.
+        assert cb.state_dict() == {}
+
+    def test_round_trip_preserves_rng_state(self) -> None:
+        cb = _make_callback()
+        gen = torch.Generator(device="cpu").manual_seed(123)
+        # Advance RNG so a default-init generator on the receiving
+        # side is observably different.
+        for _ in range(5):
+            torch.randn(4, generator=gen)
+        cb.validation_random_generator = gen
+
+        state = cb.state_dict()
+        assert "validation_rng" in state
+
+        # Receiver: fresh generator with a different seed.
+        fresh = _make_callback()
+        fresh.validation_random_generator = (
+            torch.Generator(device="cpu").manual_seed(999)
+        )
+        fresh.load_state_dict(state)
+
+        # After load, both generators draw the same next sample.
+        a = torch.randn(8, generator=cb.validation_random_generator)
+        b = torch.randn(8, generator=fresh.validation_random_generator)
+        assert torch.equal(a, b)
+
+    def test_load_without_generator_is_noop(self) -> None:
+        cb = _make_callback()
+        # Generator is None: load must not raise even when state has
+        # an rng entry.
+        cb.load_state_dict(
+            {"validation_rng": torch.tensor([1, 2, 3], dtype=torch.uint8)}
+        )
+        assert cb.validation_random_generator is None


### PR DESCRIPTION
Adds 48 CPU-only unit tests under fastvideo/tests/train/callbacks/ covering the callback framework introduced for fastvideo/train/:

- Callback / CallbackDict: base no-op contract, builtin-name target resolution, dispatch ordering and unknown-hook tolerance, state_dict / load_state_dict round-trip, missing-key warning.
- GradNormClipCallback: clipping behavior on big vs small grads, short-circuit when max_grad_norm <= 0, tracker logging gated by log_grad_norms / tracker presence, iteration forwarded to get_grad_clip_targets.
- EMACallback: lazy student-EMA init from method.student.transformer, start_iter gating with re-init on first active step, decay math verified by manual hand-calc, ema_context swap+restore, state_dict round-trip preserving shadow + ema_started flag.
- ValidationCallback: constructor type coercions and defaults, on_validation_begin every_steps + modulo gating (including step 0 fires), _find_ema_callback lookup via _callback_dict, rng generator state_dict round-trip.