### PR TITLE
[bugfix]: classify stable_audio fields in schema parity inventory

### DIFF
--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -306,6 +306,30 @@ surfaces:
         sources: [fastvideo.configs.pipelines.wan.MatrixGameI2V480PConfig]
       num_frames_per_block:
         sources: [fastvideo.configs.pipelines.wan.MatrixGameI2V480PConfig]
+      audio_channels:
+        sources:
+          - fastvideo.configs.pipelines.stable_audio.StableAudioT2AConfig
+          - fastvideo.configs.pipelines.stable_audio.StableAudioOpenSmallConfig
+      audio_end_in_s:
+        sources:
+          - fastvideo.configs.pipelines.stable_audio.StableAudioT2AConfig
+          - fastvideo.configs.pipelines.stable_audio.StableAudioOpenSmallConfig
+      audio_start_in_s:
+        sources:
+          - fastvideo.configs.pipelines.stable_audio.StableAudioT2AConfig
+          - fastvideo.configs.pipelines.stable_audio.StableAudioOpenSmallConfig
+      max_audio_duration_s:
+        sources:
+          - fastvideo.configs.pipelines.stable_audio.StableAudioT2AConfig
+          - fastvideo.configs.pipelines.stable_audio.StableAudioOpenSmallConfig
+      sample_size:
+        sources:
+          - fastvideo.configs.pipelines.stable_audio.StableAudioT2AConfig
+          - fastvideo.configs.pipelines.stable_audio.StableAudioOpenSmallConfig
+      sampling_rate:
+        sources:
+          - fastvideo.configs.pipelines.stable_audio.StableAudioT2AConfig
+          - fastvideo.configs.pipelines.stable_audio.StableAudioOpenSmallConfig
     compatibility_only:
       batch_size: "Gen3C inference-only tuning field pending typed batching design."
       gradient_checkpointing: "Gen3C inference-only compatibility field pending typed batching design."
@@ -380,6 +404,13 @@ surfaces:
       ltx2_stg_scale_audio: request.extensions.ltx2.stg_scale_audio
       ltx2_stg_blocks_video: request.extensions.ltx2.stg_blocks_video
       ltx2_stg_blocks_audio: request.extensions.ltx2.stg_blocks_audio
+      audio_start_in_s: request.extensions.stable_audio.audio_start_in_s
+      audio_end_in_s: request.extensions.stable_audio.audio_end_in_s
+      init_audio: request.extensions.stable_audio.init_audio
+      init_audio_strength: request.extensions.stable_audio.init_audio_strength
+      init_noise_level: request.extensions.stable_audio.init_noise_level
+      inpaint_audio: request.extensions.stable_audio.inpaint_audio
+      inpaint_mask: request.extensions.stable_audio.inpaint_mask
     internal_only:
       data_type: "Derived from the request shape and not a public input."
 


### PR DESCRIPTION
## Summary

PR #1260 added new dataclass fields to `SamplingParam` and the `StableAudio*` `PipelineConfig` subclasses but did not update [`docs/design/inference_schema_parity_inventory.yaml`](https://github.com/hao-ai-lab/FastVideo/blob/main/docs/design/inference_schema_parity_inventory.yaml). The schema-parity tests in `fastvideo/tests/api/test_schema_parity_inventory.py` cross-check live dataclass fields against this inventory, so two assertions are currently failing on `main`:

- `test_pipeline_config_extension_fields_are_classified`
- `test_sampling_param_base_fields_are_classified`

This PR adds the missing field classifications under `preset_owned`, following the convention already used for other model-specific extensions (LTX-2, Gen3C, HYWorld, HunyuanGameCraft, etc.).

## Changes

### `pipeline_config_extensions.preset_owned`
Six fields contributed by `StableAudioT2AConfig` and `StableAudioOpenSmallConfig`:

- ``audio_channels``
- ``audio_end_in_s``
- ``audio_start_in_s``
- ``max_audio_duration_s``
- ``sample_size``
- ``sampling_rate``

### `sampling_param_base.preset_owned`
Seven `SamplingParam` fields routed under ``request.extensions.stable_audio.*``:

- ``audio_start_in_s`` / ``audio_end_in_s`` (T2A clip duration)
- ``init_audio`` / ``init_audio_strength`` / ``init_noise_level`` (A2A reference + strength)
- ``inpaint_audio`` / ``inpaint_mask`` (RePaint inpainting)

## Test Evidence

```
$ pytest fastvideo/tests/api/test_schema_parity_inventory.py -q
.............                                                            [100%]
13 passed, 14 warnings in 0.43s
```

Full `fastvideo/tests/api/` and `fastvideo/tests/train/utils/test_config.py` (192 tests) also pass.