### PR TITLE
[ci] pre-commit: drop stale excludes + document agent lint flow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,21 +7,13 @@ exclude: |
     fastvideo-kernel/.*|
     assets/.*|
     tests/.*|
-    demo/.*|
-    predict\.py|
     scripts/.*|
-    assets/prompts/.*|
-    fastvideo/data_preprocess/.*|
     fastvideo/dataset/.*|
     fastvideo/models/.*|
-    fastvideo/sample/.*|
-    fastvideo/train\.py|
-    fastvideo/utils/.*|
     examples/.*|
     \.agents/.*|
     .github/workflows/publish-fastvideo.yml|
-    .github/workflows/_template-build-image.yml|
-    docs/source/inference/support_matrix.md
+    .github/workflows/_template-build-image.yml
   )
 repos:
 - repo: https://github.com/google/yapf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Python 3.10+; 4-space indentation; keep code and imports readable and explicit.
 - Style tools are configured in `pyproject.toml` and `.pre-commit-config.yaml`:
   - `yapf` (format), `ruff` (lint, auto-fix), `mypy` (typing), `codespell`.
+- Lint via `pre-commit run --files <changed paths>` (or `pre-commit run --all-files` for a full sweep) before committing. Do not shell out to `yapf`/`ruff`/`codespell`/`mypy` directly — pre-commit chains them with the project's config and respects the `.pre-commit-config.yaml` excludes (e.g. `fastvideo/tests/` is intentionally skipped). If pre-commit reports `(no files to check)` for your paths, that exclude is deliberate — don't bypass it.
 - Target line length is 80.
 - Naming: `snake_case` for functions/files, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 - Style tools are configured in `pyproject.toml` and `.pre-commit-config.yaml`:
   - `yapf` (format), `ruff` (lint, auto-fix), `mypy` (typing), `codespell`.
 - Lint via `pre-commit run --files <changed paths>` (or `pre-commit run --all-files` for a full sweep) before committing. Do not shell out to `yapf`/`ruff`/`codespell`/`mypy` directly — pre-commit chains them with the project's config and respects the `.pre-commit-config.yaml` excludes (e.g. `fastvideo/tests/` is intentionally skipped). If pre-commit reports `(no files to check)` for your paths, that exclude is deliberate — don't bypass it.
-- Target line length is 80.
+- Target line length is 120 (configured in `pyproject.toml` for ruff, yapf, and isort).
 - Naming: `snake_case` for functions/files, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants.
 
 ## Testing Guidelines


### PR DESCRIPTION
## Purpose

Pure housekeeping for `.pre-commit-config.yaml` plus a small `AGENTS.md` addition documenting how agents (and humans) should drive the lint chain. **No behavior change for any path that exists today** — every removed entry is either a path that no longer exists in the tree or a redundant regex.

## Changes

### `.pre-commit-config.yaml`

Drop 8 dead/redundant entries from the `exclude` regex.

Stale (paths no longer exist):
- `demo/.*`
- `predict\.py`
- `fastvideo/data_preprocess/.*`
- `fastvideo/sample/.*`
- `fastvideo/train\.py`
- `fastvideo/utils/.*` — required trailing slash, so it never actually matched `fastvideo/utils.py`; that file was lintable already
- `docs/source/inference/support_matrix.md`

Redundant:
- `assets/prompts/.*` — already covered by `assets/.*`

All live excludes are preserved as-is, including the intentional ones that protect adapted/vendored code (`fastvideo/third_party/`, `fastvideo-kernel/`, `fastvideo/models/`, `fastvideo/dataset/`, the two `actionlint` workflow carve-outs, etc.). 19 → 11 entries.

### `AGENTS.md`

Add one bullet under **Coding Style & Naming Conventions** capturing the agent lint workflow:

- Run `pre-commit run --files <changed paths>` (or `--all-files`) before committing.
- Don't shell out to `yapf`/`ruff`/`codespell`/`mypy` directly — pre-commit already chains them with the project's config.
- If pre-commit reports `(no files to check)`, that exclude is deliberate; don't bypass it.

This came up while reviewing #1248: touching `fastvideo/tests/performance/*` surfaced that the unanchored `tests/.*` regex matches `fastvideo/tests/...` too, which led to a manual yapf run that dragged in unrelated reformatting. The doc nudge prevents the next agent (or me, in two weeks) from doing the same.

## Test Plan

```bash
# Verify YAML parses and the regex still excludes what it should
python3 -c "import re, yaml; p = re.compile(yaml.safe_load(open('.pre-commit-config.yaml'))['exclude']); \
  [print(f'{s}: excluded={bool(p.search(s))}') for s in [
    'fastvideo/third_party/foo.py', 'fastvideo/models/dits/cosmos.py',
    'examples/inference/basic.py', 'fastvideo/utils.py',
    'demo/foo.py', 'predict.py']]"

# Run the chain on the touched files
pre-commit run --files .pre-commit-config.yaml AGENTS.md
```

## Test Results

```
fastvideo/third_party/foo.py: excluded=True
fastvideo/models/dits/cosmos.py: excluded=True
examples/inference/basic.py: excluded=True
fastvideo/utils.py: excluded=False    # was already lintable; the dead regex never matched it
demo/foo.py: excluded=False           # would lint if it ever came back
predict.py: excluded=False            # same
```

```
codespell................................................................Passed
PyMarkdown...............................................................Passed
Check for spaces in all filenames........................................Passed
```

(yapf / ruff / mypy / actionlint hooks correctly skipped — neither file matches their target type.)

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues
- [x] I added or updated tests for my changes  *(N/A — config-only)*
- [x] I updated documentation if needed  *(`AGENTS.md`)*
- [x] I considered GPU memory impact of my changes  *(N/A)*