### PR TITLE
[docs] add hierarchical AGENTS.md per-directory guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,31 @@ This repository is agent-friendly. Before doing any work, read:
 If you are exploring a new procedure that has no existing SOP, document your
 progress in `.agents/exploration/` and flag it for review at the end of your
 session.
+
+## Per-Directory AGENTS.md
+
+Local guidance lives next to the code. Read the in-scope file before editing:
+
+| Directory | What it covers |
+|-----------|----------------|
+| `fastvideo/AGENTS.md` | Core package map, public API, registry-driven model dispatch |
+| `fastvideo/configs/AGENTS.md` | Arch + pipeline config dataclasses, `param_names_mapping` |
+| `fastvideo/models/AGENTS.md` | DiT / VAE / encoder / scheduler / loader layout (pre-commit excluded) |
+| `fastvideo/layers/AGENTS.md` | Tensor-parallel linear/attention layer rules for ports |
+| `fastvideo/attention/AGENTS.md` | Backend registry + env-var override |
+| `fastvideo/pipelines/AGENTS.md` | Stage ABC, `basic/<model>/`, `preprocess/`, presets |
+| `fastvideo/training/AGENTS.md` | Legacy monolithic pipelines (frozen for existing models) |
+| `fastvideo/train/AGENTS.md` | New modular trainer (methods × models × callbacks, YAML) |
+| `fastvideo/tests/AGENTS.md` | Test taxonomy, conftest, pre-commit-excluded path |
+| `fastvideo/tests/ssim/AGENTS.md` | GPU SSIM regression authoring + reference video sync |
+| `scripts/checkpoint_conversion/AGENTS.md` | Adding a converter for a new HF/official checkpoint |
+
+## Critical: Two Training Stacks Coexist
+
+- `fastvideo/training/` — legacy, monolithic per-model `*_training_pipeline.py` and
+  `*_distillation_pipeline.py`. Still authoritative for shipped models.
+- `fastvideo/train/` — new modular framework (composable methods × models × callbacks
+  driven by YAML). Preferred for new training work.
+
+Pick the matching stack before editing. Do not migrate a pipeline between them
+without an explicit ask — the conventions and config surfaces differ.

--- a/fastvideo/AGENTS.md
+++ b/fastvideo/AGENTS.md
@@ -1,5 +1,7 @@
 # `fastvideo/` — Core Package
 
+**Generated:** 2026-05-02
+
 Inference + training framework for video DiTs. Public API entry: `from fastvideo import VideoGenerator, PipelineConfig, SamplingParam`.
 
 ## Public Surface (`__init__.py`)

--- a/fastvideo/AGENTS.md
+++ b/fastvideo/AGENTS.md
@@ -1,0 +1,65 @@
+# `fastvideo/` — Core Package
+
+Inference + training framework for video DiTs. Public API entry: `from fastvideo import VideoGenerator, PipelineConfig, SamplingParam`.
+
+## Public Surface (`__init__.py`)
+
+```python
+VideoGenerator   # entrypoints/video_generator.py — high-level inference handle
+PipelineConfig   # configs/pipelines/base.py — pipeline wiring dataclass
+SamplingParam    # api/sampling_param.py — runtime sampling knobs
+```
+
+CLI entry: `fastvideo` script → `entrypoints/cli/main.py` (subcommands: `generate`, `serve`, `bench`).
+
+## Layout
+
+```
+fastvideo/
+├── api/             # Schema + presets for the OpenAI-compatible serving layer
+├── attention/       # Backends + selector (FlashAttn / SageAttn / SDPA / VSA / VMoBA / SLA)
+├── configs/         # Per-model arch configs + per-pipeline configs (registry-driven)
+├── dataset/         # Dataloaders (pre-commit excluded — minimal lint surface)
+├── distributed/     # SP/TP groups, device communicators, init helpers
+├── entrypoints/     # cli/, openai/, streaming/, video_generator.py
+├── hooks/           # Runtime hook system for pipelines
+├── layers/          # Tensor-parallel linears + attention wrappers (port targets)
+├── models/          # DiT / VAE / encoder / scheduler / loader (pre-commit excluded)
+├── pipelines/       # basic/<model>/, preprocess/, stages/, training/
+├── platforms/       # CUDA/ROCm capability + AttentionBackendEnum
+├── third_party/     # Vendored externals (lint excluded; do not reformat)
+├── train/           # NEW modular trainer — methods × models × callbacks
+├── training/        # LEGACY monolithic *_training/distillation_pipeline.py
+├── worker/          # Multi-process / Ray executors
+├── workflow/        # Preprocessing workflow base class
+├── registry.py      # Pipeline-config + model-class lookup (canonical)
+├── envs.py          # Env-var declarations
+├── fastvideo_args.py# Runtime arg dataclass passed through pipelines
+└── utils.py         # FlexibleArgumentParser, qualname resolver, etc.
+```
+
+## Where to Look
+
+| Task | Location |
+|------|----------|
+| Add a new pipeline class | `pipelines/basic/<model>/` + `configs/pipelines/<model>.py` + register in `registry.py` |
+| Add a new model component | `models/<role>/<model>.py` + `configs/models/<role>/<model>.py` |
+| Wire an existing model into a new pipeline | `pipelines/basic/<model>/presets.py` + reuse stages from `pipelines/stages/` |
+| Add a converter | `scripts/checkpoint_conversion/<model>_to_*.py` (separate dir, separate AGENTS.md) |
+| Add an attention backend | `attention/backends/<name>.py` + register in selector |
+| Add a runtime CLI flag | `fastvideo_args.py` (avoid `argparse` ad-hoc inside stages) |
+
+## Conventions Specific Here
+
+- `PipelineStage` subclasses (`pipelines/stages/`) own one verb each (encode, schedule, denoise, decode). Compose, don't fork.
+- Every pipeline reads from a `PipelineConfig` subclass and a `SamplingParam`. Never read raw env vars inside a stage — go through `fastvideo.envs`.
+- Logger setup: `from fastvideo.logger import init_logger; logger = init_logger(__name__)`. Do not call `logging.getLogger` directly.
+- Imports between `train/` and `training/` are **forbidden** — they are independent stacks.
+
+## Pre-Commit Exclusions (do not assume linted)
+
+These dirs are listed in `.pre-commit-config.yaml` `exclude`:
+
+- `fastvideo/third_party/`, `fastvideo/dataset/`, `fastvideo/models/`
+
+Editing files there will NOT trigger yapf/ruff/mypy/codespell. Format manually if a sibling file shows clear style; do not introduce new violations.

--- a/fastvideo/attention/AGENTS.md
+++ b/fastvideo/attention/AGENTS.md
@@ -1,0 +1,56 @@
+# `fastvideo/attention/` — Attention Backends
+
+Backend registry + selector wrapping FlashAttn / SageAttn / SageAttn3 / SDPA / VSA / VMoBA / SLA / BSA.
+
+## Layout
+
+```
+attention/
+├── __init__.py            # Exports DistributedAttention, LocalAttention, get_attn_backend
+├── layer.py               # DistributedAttention, DistributedAttention_VSA, LocalAttention
+├── selector.py            # get_attn_backend (cached) + env-var override
+├── backends/
+│   ├── abstract.py        #   AttentionBackend / AttentionMetadata / AttentionMetadataBuilder
+│   ├── flash_attn.py      #   FA2/FA3
+│   ├── sage_attn.py       #   SageAttention v1
+│   ├── sage_attn3.py      #   SageAttention v3
+│   ├── sdpa.py            #   torch SDPA fallback
+│   ├── video_sparse_attn.py  # VSA (paper: Video Sparse Attention)
+│   ├── vmoba.py           #   Video-MoBA
+│   ├── sla.py             #   Sliding-window (STA)
+│   └── bsa_attn.py        #   Block-sparse
+└── utils/
+    ├── flash_attn_cute.py
+    └── flash_attn_no_pad.py
+```
+
+## Selection Order
+
+`get_attn_backend()` resolves via:
+
+1. Env-var override `FASTVIDEO_ATTENTION_BACKEND` (see `STR_BACKEND_ENV_VAR` in `fastvideo/utils.py`).
+2. Per-platform default from `fastvideo/platforms/`.
+3. Heuristic fallback to SDPA.
+
+The result is `@lru_cache`d. Tests that need a specific backend must use the
+`global_force_attn_backend(...)` context manager from `selector.py`, never set
+the env var mid-process.
+
+## Adding a Backend
+
+1. Subclass `AttentionBackend` in `backends/<name>.py`.
+2. Implement `AttentionMetadata` + `AttentionMetadataBuilder` for the new path.
+3. Register the enum value in `fastvideo/platforms/interface.py` (`AttentionBackendEnum`).
+4. Wire string → class resolution in `selector.py`.
+5. Verify the new backend works with `DistributedAttention` (sequence parallel)
+   and `LocalAttention` (single-rank). If it cannot support SP, document the
+   gap in the backend file's module docstring.
+
+## Anti-Patterns
+
+- Calling `torch.nn.functional.scaled_dot_product_attention` directly inside a
+  model's forward — go through `DistributedAttention` / `LocalAttention`.
+- Reading `os.environ[STR_BACKEND_ENV_VAR]` from arbitrary call sites. Use
+  `get_env_variable_attn_backend()`.
+- Caching backend instances per-module. The selector cache is process-wide; do
+  not duplicate it.

--- a/fastvideo/attention/AGENTS.md
+++ b/fastvideo/attention/AGENTS.md
@@ -1,5 +1,7 @@
 # `fastvideo/attention/` — Attention Backends
 
+**Generated:** 2026-05-02
+
 Backend registry + selector wrapping FlashAttn / SageAttn / SageAttn3 / SDPA / VSA / VMoBA / SLA / BSA.
 
 ## Layout

--- a/fastvideo/configs/AGENTS.md
+++ b/fastvideo/configs/AGENTS.md
@@ -1,5 +1,7 @@
 # `fastvideo/configs/` — Config-Driven Model Registry
 
+**Generated:** 2026-05-02
+
 Two layers of dataclass configs feed every pipeline: **arch configs** (what the model is) and **pipeline configs** (how to run it).
 
 ## Layout

--- a/fastvideo/configs/AGENTS.md
+++ b/fastvideo/configs/AGENTS.md
@@ -1,0 +1,51 @@
+# `fastvideo/configs/` — Config-Driven Model Registry
+
+Two layers of dataclass configs feed every pipeline: **arch configs** (what the model is) and **pipeline configs** (how to run it).
+
+## Layout
+
+```
+configs/
+├── configs.py                  # Dataset / loader enums (DatasetType, VideoLoaderType)
+├── utils.py                    # update_config_from_args, shallow_asdict helpers
+├── backend/                    # Attention backend defaults
+├── models/
+│   ├── base.py                 # ModelConfig ABC
+│   ├── dits/                   # DiTConfig per model (wanvideo, ltx2, hunyuan, ...)
+│   ├── vaes/                   # VAEConfig per model
+│   ├── encoders/               # EncoderConfig (t5, clip, llama, qwen2_5, gemma, siglip, ...)
+│   ├── upsamplers/             # UpsamplerConfig (hunyuan15)
+│   └── audio/                  # Audio-model configs (ltx2_audio_vae, ...)
+├── pipelines/
+│   ├── base.py                 # PipelineConfig ABC + (de)serialization
+│   └── <model>.py              # Concrete configs (HunyuanConfig, WanT2V480PConfig, ...)
+└── *.json                      # Frozen reference configs for shipped models
+```
+
+## How Configs Hook Into the Registry
+
+`fastvideo/registry.py` imports every concrete `PipelineConfig` and exposes
+`get_pipeline_config_cls_from_name(...)`. Adding a new pipeline config requires:
+
+1. Subclass `PipelineConfig` in `pipelines/<model>.py`.
+2. Reference its component arch configs (DiT / VAE / encoder / upsampler).
+3. Add the import + name mapping in `fastvideo/registry.py`.
+
+Configs that do not appear in `registry.py` are unreachable from `VideoGenerator`.
+
+## Arch vs Pipeline — Where Does This Field Go?
+
+| Field type | Lives on |
+|-----------|----------|
+| Architecture constants (hidden dim, num heads, layer count) | `configs/models/<role>/<model>.py` |
+| Default sampling params (steps, cfg, shift, fps) | `configs/pipelines/<model>.py` |
+| Runtime overrides (precision, sp_size, tp_size, attention backend) | `configs/pipelines/base.py` defaults + CLI flags via `fastvideo_args.py` |
+| `param_names_mapping` for HF → FastVideo state-dict | Arch config (lives with the model definition) |
+
+If a knob is tunable per inference call → `SamplingParam`, not `PipelineConfig`.
+
+## Anti-Patterns
+
+- Hard-coding architecture constants inside model classes — always read from the arch config.
+- Using `argparse` directly here. Configs deserialize from dicts via `update_config_from_args`.
+- Importing from `fastvideo.pipelines` here. Configs are the lower layer; the dependency is one-way.

--- a/fastvideo/layers/AGENTS.md
+++ b/fastvideo/layers/AGENTS.md
@@ -1,5 +1,7 @@
 # Layer Guidance For Model Ports
 
+**Generated:** 2026-05-02
+
 Use this file when adding FastVideo-native model components. Keep it generic:
 model-specific parameter mappings belong in `scripts/checkpoint_conversion/`, not
 in this directory.

--- a/fastvideo/layers/AGENTS.md
+++ b/fastvideo/layers/AGENTS.md
@@ -1,0 +1,51 @@
+# Layer Guidance For Model Ports
+
+Use this file when adding FastVideo-native model components. Keep it generic:
+model-specific parameter mappings belong in `scripts/checkpoint_conversion/`, not
+in this directory.
+
+## Linear Layers
+
+- Use `ReplicatedLinear` for DiT and VAE hot paths when the layer is not tensor
+  parallel and should expose a normal `weight`/`bias` state-dict surface.
+- Use `QKVParallelLinear` for LLM-style fused query/key/value projections when
+  the existing encoder pattern already expects tensor parallel loading.
+- Use `MergedColumnParallelLinear` for fused MLP gate/up projections that are
+  loaded as packed column shards.
+- Use `ColumnParallelLinear` and `RowParallelLinear` for tensor-parallel encoder
+  blocks that follow existing `t5.py`, `clip.py`, `llama.py`, or `qwen2_5.py`
+  patterns.
+- Do not replace a simple official layer with a fused FastVideo layer unless the
+  conversion script explicitly handles the resulting key and tensor layout.
+
+## Attention Layers
+
+- Use `DistributedAttention` for standard DiT full-sequence attention when the
+  model should participate in sequence parallel execution.
+- Use `LocalAttention` for local/window attention or narrow single-GPU parity
+  paths that match existing component style.
+- Raw `torch.nn.functional.scaled_dot_product_attention` is acceptable for
+  unusual cross-modality flat streams when no FastVideo distributed primitive
+  matches yet. Document the sequence-parallel gap in the owning model file.
+
+## State-Dict Surface
+
+- Prototype the native component before writing conversion mappings. The
+  prototype's `state_dict()` is the source of truth for FastVideo target keys and
+  shapes.
+- Conversion scripts should map official keys into the native state-dict surface;
+  production model code should not be contorted to match checkpoint naming.
+- Fused and packed FastVideo layers may require tensor split/fuse logic in the
+  converter, especially QKV/KV projections and gated MLP projections.
+- Record intentional skipped keys in the conversion script with a reason, such
+  as training-only EMA/logvar/optimizer state or dynamically computed buffers.
+
+## Porting Discipline
+
+- Match the official layer definition and the official instantiation arguments.
+  A reusable class with different constructor args is not reused.
+- Keep architecture constants on the component arch config. Runtime sampling,
+  guidance, precision, and pipeline defaults belong on pipeline config or
+  presets.
+- Prefer small, direct implementations until parity passes. Add helpers only
+  when they serve multiple call sites or make the mapping clearer.

--- a/fastvideo/models/AGENTS.md
+++ b/fastvideo/models/AGENTS.md
@@ -1,5 +1,7 @@
 # `fastvideo/models/` — Model Implementations
 
+**Generated:** 2026-05-02
+
 DiT / VAE / encoder / scheduler / upsampler / audio model classes. **Pre-commit excludes this directory** — yapf/ruff/mypy do not run on commits here. Match neighboring file style manually.
 
 ## Layout

--- a/fastvideo/models/AGENTS.md
+++ b/fastvideo/models/AGENTS.md
@@ -1,0 +1,53 @@
+# `fastvideo/models/` — Model Implementations
+
+DiT / VAE / encoder / scheduler / upsampler / audio model classes. **Pre-commit excludes this directory** — yapf/ruff/mypy do not run on commits here. Match neighboring file style manually.
+
+## Layout
+
+```
+models/
+├── dits/
+│   ├── <model>.py              # Single-file DiT (wanvideo, ltx2, hunyuanvideo, cosmos, ...)
+│   ├── hyworld/                # Multi-file DiT family
+│   ├── lingbotworld/           # ditto
+│   └── matrixgame/             # ditto
+├── vaes/                       # AutoencoderKL variants per model family
+├── encoders/                   # T5, CLIP, Llama, Qwen2.5, Gemma, SigLIP, Reason1, audio conditioner
+├── schedulers/                 # FlowMatch / EulerDiscrete / DPM custom schedulers
+├── upsamplers/                 # Hunyuan15 super-resolution
+├── audio/                      # Audio-VAE/decoder modules (LTX-2 audio, Stable Audio)
+├── camera/                     # Camera-conditioning modules (Gen3C)
+└── loader/                     # component_loader.py, fsdp_load.py, weight_utils.py
+```
+
+`loader/component_loader.py` is the central entry point that the pipeline uses
+to instantiate model components from a HF directory. New components plug in
+through `register_*` calls or by extending the `ComponentLoader` mappings.
+
+## Adding a Model Component (DiT / VAE / Encoder)
+
+1. Read `fastvideo/layers/AGENTS.md` first — it defines which tensor-parallel
+   linear / attention layer to use. Do not freelance.
+2. Define the arch in `models/<role>/<model>.py`. Mirror the official reference's
+   constructor args; do not "improve" the layer choices.
+3. Add the matching arch config in `configs/models/<role>/<model>.py`.
+4. Expose `param_names_mapping` on the config — it is the **source of truth** for
+   the converter under `scripts/checkpoint_conversion/`.
+5. Use `init_logger(__name__)`, not stdlib logging.
+
+## State-Dict Discipline
+
+- The native component's `state_dict()` defines target keys + shapes.
+- Conversion scripts (`scripts/checkpoint_conversion/`) bend to the model, not
+  the other way around.
+- Fused QKV / packed MLP layouts must be documented in the config or the model
+  module — converters need to split/fuse accordingly.
+
+## Anti-Patterns
+
+- Importing `transformers` / `diffusers` model classes at runtime inside the
+  forward path — these belong in the loader, not the architecture file.
+- Adding training-only state (EMA buffers, optimizer state) to the inference
+  state-dict surface.
+- Calling `torch.distributed` directly. Go through `fastvideo.distributed`.
+- Treating this directory as lint-clean. It isn't (see pre-commit excludes).

--- a/fastvideo/pipelines/AGENTS.md
+++ b/fastvideo/pipelines/AGENTS.md
@@ -1,0 +1,69 @@
+# `fastvideo/pipelines/` — Pipeline Composition
+
+Diffusion pipelines are **compositions of `PipelineStage` objects**. Each stage owns one verb (validate / encode / schedule / denoise / decode). Adding a model means assembling stages, not subclassing a megapipeline.
+
+## Layout
+
+```
+pipelines/
+├── pipeline_batch_info.py      # ForwardBatch — the dict passed between stages
+├── lora_pipeline.py            # LoRA-aware base
+├── composed_pipeline_base.py   # Base for stage-composed pipelines
+├── stages/                     # Reusable stage implementations (~30 files)
+│   ├── base.py                 #   PipelineStage ABC + StageVerificationError
+│   ├── input_validation.py     #   Validates ForwardBatch shape/keys
+│   ├── text_encoding.py        #   Generic prompt encoder stage
+│   ├── image_encoding.py       #   Image conditioning
+│   ├── latent_preparation.py   #   Init noise + scheduler
+│   ├── conditioning.py         #   CFG / negative prompt fan-out
+│   ├── denoising.py            #   Standard diffusion loop
+│   ├── sd35_conditioning.py    #   Per-model overrides (named by family)
+│   ├── longcat_*.py            #   LongCat I2V/V2V/refine variants
+│   ├── gen3c_stages.py         #   Gen3C-specific stages
+│   ├── gamecraft_denoising.py  #   GameCraft-specific
+│   └── matrixgame_denoising.py #   MatrixGame-specific
+├── basic/                      # Per-model end-to-end pipelines
+│   ├── hunyuan/, hunyuan15/, hyworld/, gamecraft/, gen3c/, cosmos/
+│   ├── wan/, longcat/, ltx2/, lingbotworld/, magi_human/, matrixgame/
+│   ├── sd35/, stable_audio/, turbodiffusion/
+│   └── <model>/{<model>_pipeline.py, presets.py, __init__.py}
+├── preprocess/                 # Data preprocessing pipelines (ltx2, wan, matrixgame)
+└── training/                   # Training-time pipeline glue
+```
+
+## Stage Authoring Rules
+
+- Subclass `PipelineStage` from `stages/base.py`. Implement `forward(batch, args) -> ForwardBatch`.
+- Implement `verify_input` / `verify_output` — both return `VerificationResult`. Failures raise `StageVerificationError`.
+- Mutate `ForwardBatch` only by reassigning fields you declared in `pipeline_batch_info.py`. New keys → add to the dataclass first.
+- Stages must be **deterministic given the same `ForwardBatch + FastVideoArgs`**. Side effects (logging, profiling) only.
+- Read all knobs from the passed-in `FastVideoArgs` / `PipelineConfig`. Never `os.getenv` directly.
+
+## Per-Model Pipeline Pattern (`basic/<model>/`)
+
+Every model directory has the same skeleton:
+
+```
+basic/<model>/
+├── __init__.py
+├── <model>_pipeline.py      # Composes stages list
+├── presets.py               # Default PipelineConfig + SamplingParam combos
+└── (optional) stage_overrides.py, continuation.py, ...
+```
+
+`presets.py` is the entry point that `registry.py` imports — it must export the named preset constants used elsewhere in the codebase.
+
+## Forking vs Reusing a Stage
+
+Reuse `stages/text_encoding.py` if your model takes text → embeddings via a standard encoder. Fork only when:
+
+- The model needs a **different ForwardBatch shape** (extra inputs, different output keys).
+- The denoising loop has structural differences (causal, refine-then-denoise, multi-stream).
+
+When forking, keep the file name model-prefixed (`longcat_*`, `gamecraft_*`) so the registry stays grep-able.
+
+## Anti-Patterns
+
+- Putting a full pipeline in a single file under `basic/<model>/` instead of composing stages.
+- Reading config from globals or env vars inside a stage.
+- Adding cross-stage state via module-level dicts. Use `ForwardBatch`.

--- a/fastvideo/pipelines/AGENTS.md
+++ b/fastvideo/pipelines/AGENTS.md
@@ -1,5 +1,7 @@
 # `fastvideo/pipelines/` — Pipeline Composition
 
+**Generated:** 2026-05-02
+
 Diffusion pipelines are **compositions of `PipelineStage` objects**. Each stage owns one verb (validate / encode / schedule / denoise / decode). Adding a model means assembling stages, not subclassing a megapipeline.
 
 ## Layout

--- a/fastvideo/tests/AGENTS.md
+++ b/fastvideo/tests/AGENTS.md
@@ -1,5 +1,7 @@
 # `fastvideo/tests/` — Package-Level Test Suite
 
+**Generated:** 2026-05-02
+
 > **Pre-commit excludes `fastvideo/tests/`.** Lint/format hooks do not run on
 > files here. Match style of neighboring tests manually.
 

--- a/fastvideo/tests/AGENTS.md
+++ b/fastvideo/tests/AGENTS.md
@@ -1,0 +1,72 @@
+# `fastvideo/tests/` — Package-Level Test Suite
+
+> **Pre-commit excludes `fastvideo/tests/`.** Lint/format hooks do not run on
+> files here. Match style of neighboring tests manually.
+
+## Layout
+
+```
+tests/
+├── conftest.py            # distributed_setup fixture (1×1 SP/TP init+cleanup)
+├── utils.py               # Shared test helpers
+├── api/                   # api/ schema + presets
+├── attention/             # Backend selector + layer parity
+├── dataset/               # Dataloader smoke tests
+├── distributed/           # SP / TP collectives
+├── encoders/              # Per-encoder parity (t5, clip, llama, qwen, ...)
+├── entrypoints/           # CLI + streaming + OpenAI-compatible server
+│   └── streaming/         #   Streaming-specific tests
+├── hooks/                 # Runtime hook system
+├── inference/             # End-to-end inference smoke
+├── lora_extraction/       # LoRA merge/extract round-trip
+├── modal/                 # Modal CI orchestrators (ssim_test.py, nightly_test.py)
+├── nightly/               # Long-running suites (gated)
+├── ops/                   # Custom kernel / op tests
+├── performance/           # Throughput / memory benchmarks (informational)
+├── ssim/                  # GPU SSIM regressions — see ssim/AGENTS.md
+├── stages/                # Per-stage unit tests
+├── train/                 # New modular trainer tests
+├── training/              # Legacy training pipeline tests
+├── transformers/          # transformers-shim tests
+├── vaes/                  # Per-VAE encode/decode parity
+└── workflow/              # Preprocessing workflow tests
+```
+
+## Run Commands (model-domain order)
+
+```bash
+pytest fastvideo/tests/ -v                        # All package tests
+pytest fastvideo/tests/encoders/ -v               # One domain
+pytest fastvideo/tests/ssim/ -vs                  # SSIM (GPU-heavy; see ssim/AGENTS.md)
+pytest fastvideo/tests/ssim/ -vs --ssim-full-quality   # Full-quality SSIM params
+pytest tests/ -v                                  # Top-level repo tests (different scope)
+modal run fastvideo/tests/modal/ssim_test.py      # Orchestrated CI-style SSIM run
+```
+
+`tests/local_tests/` (top-level) holds component checks that need a local
+working tree but are not part of the package suite.
+
+## Conventions
+
+- Name files `test_<feature>_<expected_behavior>.py`. Place near the domain
+  (`tests/encoders/test_t5_*.py`, not `tests/test_everything.py`).
+- Use the `distributed_setup` fixture for any test that touches
+  `fastvideo.distributed.*`. It seeds torch + numpy and tears down the PG.
+- GPU tests must `pytest.skip(...)` when hardware is missing — never `xfail`.
+  Document `REQUIRED_GPUS` near the top for SSIM tests (see ssim/AGENTS.md).
+- `nightly/` and `performance/` tests should be guarded by an environment marker
+  so the default `pytest fastvideo/tests/` stays fast.
+
+## Modal CI
+
+`tests/modal/ssim_test.py` is the orchestrator that auto-discovers
+`test_*.py` files under `ssim/` and schedules one subprocess per `*_MODEL_TO_PARAMS`
+key. New SSIM tests need no CI wiring — just declare `REQUIRED_GPUS = N`.
+
+## Anti-Patterns
+
+- Adding a hard-coded path to a model checkpoint without a corresponding
+  `pytest.skip` when the path is missing.
+- Forgetting `cleanup_dist_env_and_memory()` in tests that bypass the
+  `distributed_setup` fixture — tears the next test in the worker.
+- Putting Modal-specific code outside `tests/modal/`.

--- a/fastvideo/tests/ssim/AGENTS.md
+++ b/fastvideo/tests/ssim/AGENTS.md
@@ -1,5 +1,7 @@
 # SSIM Directory Guidelines
 
+**Generated:** 2026-05-02
+
 ## Scope
 These instructions apply to everything under `fastvideo/tests/ssim/`.
 

--- a/fastvideo/train/AGENTS.md
+++ b/fastvideo/train/AGENTS.md
@@ -1,5 +1,7 @@
 # `fastvideo/train/` — Modular Training Framework
 
+**Generated:** 2026-05-02
+
 YAML-driven trainer composed from interchangeable **methods × models × callbacks**. Preferred location for new training code. (See sibling `fastvideo/training/AGENTS.md` for the legacy stack.)
 
 ## Layout

--- a/fastvideo/train/AGENTS.md
+++ b/fastvideo/train/AGENTS.md
@@ -1,0 +1,74 @@
+# `fastvideo/train/` — Modular Training Framework
+
+YAML-driven trainer composed from interchangeable **methods × models × callbacks**. Preferred location for new training code. (See sibling `fastvideo/training/AGENTS.md` for the legacy stack.)
+
+## Layout
+
+```
+train/
+├── trainer.py              # Core training loop coordinator
+├── README.md               # User-facing overview (legacy → new diff)
+├── entrypoint/             # train.py + dcp_to_diffusers.py CLI entrypoints
+├── methods/
+│   ├── base.py                  #   TrainingMethod ABC
+│   ├── fine_tuning/             #   FineTuneMethod, DiffusionForcingSFTMethod
+│   ├── distribution_matching/   #   DMD2Method, SelfForcingMethod
+│   ├── knowledge_distillation/  #   KDMethod, KDCausalMethod
+│   └── consistency_model/       #   Consistency-model training methods
+├── models/
+│   ├── base.py             #   ModelBase / CausalModelBase wrappers
+│   ├── wan/, hunyuan/, cosmos/  # Per-family training wrappers
+├── callbacks/              # callback.py base + ema, grad_clip, validation
+└── utils/
+    ├── training_config.py  #   Hierarchical YAML config dataclasses
+    ├── builder.py          #   Build trainer from config
+    ├── checkpoint.py       #   DCP save/load
+    ├── optimizer.py        #   AdamW / fused optimizer factory
+    ├── tracking.py         #   build_tracker (W&B / TensorBoard)
+    └── dataloader.py       #   StatefulDataLoader wiring
+```
+
+## Composition Model
+
+```
+Trainer = Method × Model × [Callback...] × Config
+```
+
+- A **Method** owns the loss + optimizer step (`compute_loss`, `step_post_grad`).
+- A **Model** owns the forward + parameter-grouping (`forward`, `trainable_parameters`).
+- **Callbacks** subscribe to lifecycle hooks (`on_train_start`,
+  `on_training_step_end`, `on_before_optimizer_step`, `on_validation_begin`,
+  `on_validation_end`, `on_train_end`) and compose freely.
+- **Config** is a Pydantic-style hierarchical YAML resolved by
+  `utils/training_config.py`. Dotted-key CLI overrides go through
+  `parse_overrides`.
+
+## Adding a New Model Plugin
+
+1. Subclass `ModelBase` (or `CausalModelBase`) in `models/<family>/`.
+2. Wrap the existing inference DiT from `fastvideo/models/dits/`. Do not
+   reimplement.
+3. Expose `trainable_parameters()` so the optimizer factory can group them.
+4. Register in `utils/builder.py` if the trainer dispatches by name.
+
+## Adding a New Method
+
+1. Subclass `TrainingMethod` in `methods/<family>/`.
+2. Implement `compute_loss(batch, model_outputs) -> dict`.
+3. If the method needs a teacher / second model, expose a `build_extras(cfg)`
+   classmethod — never instantiate inside `__init__`.
+
+## Configs
+
+YAML lives under `examples/train/`. Schemas in `utils/training_config.py`. Add
+new fields with explicit defaults; agents and humans both rely on the dataclass
+to discover knobs.
+
+## Anti-Patterns
+
+- Importing from `fastvideo.training.*` (legacy stack). Forbidden cross-import.
+- Adding a new training method as a fork of an existing pipeline file. Compose
+  via `Method` instead.
+- Logging via stdlib `logging` — use `init_logger(__name__)`.
+- Mutating the global state of a model in a callback. Callbacks operate on the
+  trainer state object passed in.

--- a/fastvideo/training/AGENTS.md
+++ b/fastvideo/training/AGENTS.md
@@ -1,5 +1,7 @@
 # `fastvideo/training/` — Legacy Monolithic Training Pipelines
 
+**Generated:** 2026-05-02
+
 > **Status:** maintenance mode. New training work should go in `fastvideo/train/`.
 > Existing shipped recipes (Wan, LTX-2, MatrixGame distillation) still live here.
 

--- a/fastvideo/training/AGENTS.md
+++ b/fastvideo/training/AGENTS.md
@@ -1,0 +1,56 @@
+# `fastvideo/training/` — Legacy Monolithic Training Pipelines
+
+> **Status:** maintenance mode. New training work should go in `fastvideo/train/`.
+> Existing shipped recipes (Wan, LTX-2, MatrixGame distillation) still live here.
+
+## What's Here
+
+```
+training/
+├── training_pipeline.py                  # Base TrainingPipeline ABC
+├── distillation_pipeline.py              # Base DistillationPipeline (~80 KB)
+├── self_forcing_distillation_pipeline.py # Self-forcing causal distill (~55 KB)
+├── wan_training_pipeline.py              # Wan T2V finetune
+├── wan_i2v_training_pipeline.py          # Wan I2V finetune
+├── wan_distillation_pipeline.py          # Wan T2V distill
+├── wan_i2v_distillation_pipeline.py      # Wan I2V distill
+├── wan_self_forcing_distillation_pipeline.py
+├── ltx2_training_pipeline.py             # LTX-2 training
+├── matrixgame_training_pipeline.py       # MatrixGame training
+├── ode_causal_pipeline.py                # ODE-causal pipeline
+├── checkpointing_utils.py                # save/load helpers
+├── activation_checkpoint.py              # AC wrapping helpers
+├── trackers.py                           # WandbTracker (legacy)
+└── training_utils.py                     # Grad clip, FSDP state-dicts (~75 KB)
+```
+
+## Style of This Stack
+
+- One file per (model × method). Subclass an existing pipeline if your config is
+  a near-clone; otherwise fork and rename.
+- Pipelines are torch-distributed-launched directly (no shared trainer). Each
+  pipeline calls `dist.init_process_group` lifecycle through
+  `fastvideo.distributed`.
+- Configs are flat argparse flags wired in `fastvideo_args.py` and per-pipeline
+  argparse groups. No YAML.
+
+## When to Touch a File Here
+
+- Bugfix or behavior tweak to a shipped recipe (Wan, LTX-2, MatrixGame).
+- Performance / memory regression in `training_utils.py` (used by both stacks).
+- New attention backend that needs distillation-time wiring.
+
+## When to NOT Touch a File Here
+
+- Adding a new model's training. Build it in `fastvideo/train/` instead.
+- Adding a new training method (DMD2 variant, new self-forcing variant) for a
+  model that already has a `train/` plugin. Add a method class in
+  `train/methods/`.
+- Refactoring shared utilities. The new stack owns the modular utilities now.
+
+## Cross-Stack Rule
+
+Imports from `fastvideo.train.*` into `fastvideo.training.*` (or vice versa)
+are **forbidden**. They are independent stacks; mixing them creates cyclic
+dependency hazards. Share via `fastvideo.training.training_utils` or
+`fastvideo.distributed` only when both stacks already use the helper.

--- a/scripts/checkpoint_conversion/AGENTS.md
+++ b/scripts/checkpoint_conversion/AGENTS.md
@@ -1,5 +1,7 @@
 # `scripts/checkpoint_conversion/` — Official → FastVideo Converters
 
+**Generated:** 2026-05-02
+
 > **Pre-commit excludes `scripts/`.** Format / lint by hand against neighboring
 > converters before opening a PR.
 

--- a/scripts/checkpoint_conversion/AGENTS.md
+++ b/scripts/checkpoint_conversion/AGENTS.md
@@ -1,0 +1,67 @@
+# `scripts/checkpoint_conversion/` — Official → FastVideo Converters
+
+> **Pre-commit excludes `scripts/`.** Format / lint by hand against neighboring
+> converters before opening a PR.
+
+## What Lives Here
+
+```
+checkpoint_conversion/
+├── convert_gamecraft_full.py            # Combined DiT + VAE
+├── convert_gamecraft_vae.py             # VAE only
+├── convert_gamecraft_weights.py         # DiT only
+├── convert_gen3c_to_fastvideo.py
+├── convert_ltx2_weights.py
+├── convert_turbodiffusion_to_diffusers.py
+├── convert_turbodiffusion_i2v_to_diffusers.py
+├── extract_llava_text_encoder.py        # Encoder extraction from a multimodal repo
+├── longcat_to_fastvideo.py
+├── stable_audio_to_diffusers.py
+├── wan_to_diffusers.py
+├── validate_longcat_weights.py          # Post-conversion validation
+├── pt_to_safetensors.py                 # Generic format flip
+└── create_hf_repo.py                    # Push to HF after conversion
+```
+
+## Naming Convention
+
+| Pattern | Use |
+|---------|-----|
+| `convert_<model>_*.py` / `<model>_to_<format>.py` | One-shot converter for a model family |
+| `extract_<role>_*.py` | Pull a sub-component out of a multimodal repo |
+| `validate_<model>_*.py` | Post-conversion shape / norm sanity checks |
+| `<format>_to_<format>.py` | Generic format conversion (no model knowledge) |
+
+## Authoring a New Converter
+
+1. **Prototype the FastVideo-native component first** under
+   `fastvideo/models/<role>/<model>.py`. Its `state_dict()` is the target
+   surface — never the other way around.
+2. Mirror the official-checkpoint key pattern → FastVideo-native key pattern in
+   a `param_names_mapping` (declared on the arch config in
+   `fastvideo/configs/models/<role>/<model>.py`).
+3. The converter's only job: load the official checkpoint, apply the mapping
+   (with split/fuse for QKV / packed MLP), and write a safetensors directory
+   that the `ComponentLoader` (`fastvideo/models/loader/`) can read.
+4. Record intentionally skipped keys (training-only EMA, optimizer state,
+   logvar, dynamic buffers) in a constant near the top of the converter — with
+   a one-line reason each.
+5. Add a smoke test under `tests/local_tests/<model>/` or
+   `fastvideo/tests/<role>/` that loads the converted weights and runs a
+   parity assertion against the official reference (1 forward pass).
+
+## Cross-Reference
+
+- `fastvideo/layers/AGENTS.md` — which native layer to target (fused QKV,
+  parallel MLP, etc.). Determines the split/fuse logic in the converter.
+- `fastvideo/models/AGENTS.md` — model-side discipline (lint excluded, native
+  state-dict is the source of truth).
+
+## Anti-Patterns
+
+- Hard-coding tensor renames inside the model class instead of the converter.
+- Converting via a private fork of `transformers` / `diffusers` weight loaders.
+  Read tensors directly with `safetensors` or `torch.load`.
+- Pushing to HF before the validate / smoke test passes locally.
+- Skipping the explicit "skipped keys" list — it documents intent and prevents
+  silent precision loss across re-conversions.


### PR DESCRIPTION
## Summary

Adds 8 new directory-scoped `AGENTS.md` files plus picks up the existing untracked `fastvideo/layers/AGENTS.md`, and extends the root `AGENTS.md` with a per-directory map and a note on the legacy `fastvideo/training/` vs new modular `fastvideo/train/` stacks.

Goal: when an agent (or human) lands in a sub-package, the in-scope `AGENTS.md` answers *what files matter, what conventions apply, what to avoid* without having to re-read the whole codebase. Files are intentionally telegraphic (50–90 lines each) and avoid duplicating `.agents/memory/codebase-map/README.md` or generic Python advice.

## Files

| File | Lines | Purpose |
|------|-------|---------|
| `AGENTS.md` (root) | 85 | + per-directory map, + train/ vs training/ stack distinction |
| `fastvideo/AGENTS.md` | 65 | Package map, public API, pre-commit-excluded subdirs |
| `fastvideo/configs/AGENTS.md` | 51 | Arch vs pipeline config dataclasses; registry hookup |
| `fastvideo/pipelines/AGENTS.md` | 69 | `PipelineStage` ABC, `basic/<model>/` pattern, stage authoring |
| `fastvideo/models/AGENTS.md` | 53 | DiT/VAE/encoder/loader layout; state-dict discipline |
| `fastvideo/attention/AGENTS.md` | 56 | Backend registry, `get_attn_backend` selector, env-var override |
| `fastvideo/training/AGENTS.md` | 56 | Legacy stack scope, when to touch / when not to, cross-import ban |
| `fastvideo/train/AGENTS.md` | 74 | Modular trainer (methods × models × callbacks), YAML configs |
| `fastvideo/tests/AGENTS.md` | 72 | Test taxonomy, conftest, pre-commit-excluded path, Modal CI |
| `scripts/checkpoint_conversion/AGENTS.md` | 67 | Converter authoring rules, naming, validation |
| `fastvideo/layers/AGENTS.md` | 51 | Tensor-parallel layer rules (was untracked locally) |

`fastvideo/tests/ssim/AGENTS.md` was already authoritative and is left untouched.

## Notes

- **Two training stacks coexist** — root `AGENTS.md` now calls this out explicitly so future model adds don't accidentally migrate between `training/` and `train/`.
- **Pre-commit excludes are surfaced** in the per-directory files for `models/`, `dataset/`, `tests/`, `third_party/`, `scripts/` so editors don't assume those paths are linted.
- **Accuracy verified** against source: `AttentionBackendEnum` in `platforms/interface.py`, callback hook names from `train/callbacks/callback.py`, method classes from `train/methods/*/`, `STR_BACKEND_ENV_VAR` value from `utils.py`.
- No source code changed; pre-commit hooks ran clean (`yapf` / `ruff` / `mypy` skipped — no Python files touched; `codespell` and `PyMarkdown` passed).

## Test Evidence

Documentation-only change. `pre-commit` passed on commit. No `pytest` runs needed.