### PR TITLE
[misc]: standardize install instructions on uv pip install

### DIFF
--- a/.agents/memory/codebase-map/README.md
+++ b/.agents/memory/codebase-map/README.md
@@ -119,7 +119,7 @@ FastVideo-WorldModel/
 ## Build & Test Commands
 
 ```bash
-uv pip install -e .[dev]                          # Editable install
+uv pip install -e ".[dev]"                        # Editable install
 pre-commit run --all-files                        # Lint/format/spell
 pytest tests/                                     # Top-level tests
 pytest fastvideo/tests/ -v                        # Package tests

--- a/.agents/skills/launch-experiment/SKILL.md
+++ b/.agents/skills/launch-experiment/SKILL.md
@@ -12,7 +12,7 @@ automates the boilerplate of setting environment variables, picking the right
 entrypoint, and applying defaults from the closest example script.
 
 ## Prerequisites
-- The repo is cloned and `fastvideo` is installed (`uv pip install -e .[dev]`).
+- The repo is cloned and `fastvideo` is installed (`uv pip install -e ".[dev]"`).
 - Dataset is preprocessed (see `docs/training/data_preprocess.md`).
 - `WANDB_API_KEY` is set in the environment (or `WANDB_MODE=offline` for local).
 - GPU resources are available (multi-GPU requires NCCL).

--- a/.buildkite/scripts/pr_test.sh
+++ b/.buildkite/scripts/pr_test.sh
@@ -17,10 +17,18 @@ if ! python3 -m modal --version &> /dev/null; then
     log "Modal not found, installing..."
     if ! command -v uv &> /dev/null; then
         log "uv not found, bootstrapping..."
-        curl -LsSf https://astral.sh/uv/install.sh | sh
+        if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
+            log "Error: Failed to bootstrap uv via astral.sh installer."
+            exit 1
+        fi
         export PATH="$HOME/.local/bin:$PATH"
+        if ! command -v uv &> /dev/null; then
+            log "Error: uv still not on PATH after bootstrap."
+            exit 1
+        fi
     fi
-    uv pip install --system modal
+    # --break-system-packages preserves prior `pip install --user` semantics on PEP 668 agents.
+    uv pip install --system --break-system-packages modal
 
     # Verify installation
     if ! python3 -m modal --version &> /dev/null; then

--- a/.buildkite/scripts/pr_test.sh
+++ b/.buildkite/scripts/pr_test.sh
@@ -15,8 +15,13 @@ log "Project root: $PROJECT_ROOT"
 # Install Modal if not available
 if ! python3 -m modal --version &> /dev/null; then
     log "Modal not found, installing..."
-    python3 -m pip install modal
-    
+    if ! command -v uv &> /dev/null; then
+        log "uv not found, bootstrapping..."
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+    uv pip install --system modal
+
     # Verify installation
     if ! python3 -m modal --version &> /dev/null; then
         log "Error: Failed to install modal. Please install it manually."

--- a/.buildkite/scripts/pre_commit.sh
+++ b/.buildkite/scripts/pre_commit.sh
@@ -13,8 +13,13 @@ log "Project root: $PROJECT_ROOT"
 
 if ! python3 -m pre_commit --version &> /dev/null; then
     log "pre-commit not found, installing..."
-    python3 -m pip install --user pre-commit==4.0.1
-    
+    if ! command -v uv &> /dev/null; then
+        log "uv not found, bootstrapping..."
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+    uv pip install --system pre-commit==4.0.1
+
     if ! python3 -m pre_commit --version &> /dev/null; then
         log "Error: Failed to install pre-commit."
         exit 1

--- a/.buildkite/scripts/pre_commit.sh
+++ b/.buildkite/scripts/pre_commit.sh
@@ -15,10 +15,18 @@ if ! python3 -m pre_commit --version &> /dev/null; then
     log "pre-commit not found, installing..."
     if ! command -v uv &> /dev/null; then
         log "uv not found, bootstrapping..."
-        curl -LsSf https://astral.sh/uv/install.sh | sh
+        if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
+            log "Error: Failed to bootstrap uv via astral.sh installer."
+            exit 1
+        fi
         export PATH="$HOME/.local/bin:$PATH"
+        if ! command -v uv &> /dev/null; then
+            log "Error: uv still not on PATH after bootstrap."
+            exit 1
+        fi
     fi
-    uv pip install --system pre-commit==4.0.1
+    # --break-system-packages preserves prior `pip install --user` semantics on PEP 668 agents.
+    uv pip install --system --break-system-packages pre-commit==4.0.1
 
     if ! python3 -m pre_commit --version &> /dev/null; then
         log "Error: Failed to install pre-commit."

--- a/.github/workflows/infra-docs.yml
+++ b/.github/workflows/infra-docs.yml
@@ -37,10 +37,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-mkdocs.txt
+        run: uv pip install --system -r requirements-mkdocs.txt
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/publish-fastvideo.yml
+++ b/.github/workflows/publish-fastvideo.yml
@@ -56,10 +56,11 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build twine wheel
+        run: uv pip install --system build twine wheel
 
       - name: Build package
         run: |

--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -131,11 +131,13 @@ jobs:
           clang-11 --version
           nvcc --version
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Install PyTorch ${{ matrix.torch-cuda.torch-version }}+cu${{ matrix.torch-cuda.cuda-version }}
         run: |
-          pip install --upgrade pip
-          pip install typing-extensions==4.12.2
-          pip install --no-cache-dir torch==${{ matrix.torch-cuda.torch-version }} --index-url https://download.pytorch.org/whl/${{matrix.torch-cuda.torch-cuda-short}}
+          uv pip install --system typing-extensions==4.12.2
+          uv pip install --system --no-cache-dir torch==${{ matrix.torch-cuda.torch-version }} --index-url https://download.pytorch.org/whl/${{matrix.torch-cuda.torch-cuda-short}}
           nvcc --version
           python --version
           python -c "import torch; print('PyTorch:', torch.__version__)"
@@ -145,20 +147,20 @@ jobs:
       - name: Build wheel
         run: |
           export PYTHONPATH=$GITHUB_WORKSPACE:$PYTHONPATH
-          
-          pip install setuptools ninja packaging wheel triton scikit-build-core cmake build
-          
+
+          uv pip install --system setuptools ninja packaging wheel triton scikit-build-core cmake build
+
           cd fastvideo-kernel
           git submodule update --init --recursive  # Ensure ThunderKittens submodule is initialized
           # Release builds are produced on GPU-less runners, so force-enable TK and target Hopper.
           export TORCH_CUDA_ARCH_LIST="9.0a"
           export CMAKE_ARGS="${CMAKE_ARGS:-} -DFASTVIDEO_KERNEL_BUILD_TK=ON -DCMAKE_CUDA_ARCHITECTURES=90a"
-          
+
           # Build standard wheel (no local version suffix) for PyPI
           python -m build --wheel --outdir dist
-          
+
           # Fix the wheel to be manylinux compliant
-          pip install auditwheel
+          uv pip install --system auditwheel
           # Point auditwheel at torch libs, but do not vendor them into the wheel.
           TORCH_LIB_DIR=$(python - <<'PY'
           import os
@@ -211,10 +213,13 @@ jobs:
           pattern: 'fastvideo_kernel-py*'
           merge-multiple: true
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Build source distribution
         run: |
-          pip install build scikit-build-core cmake ninja
-          
+          uv pip install --system build scikit-build-core cmake ninja
+
           cd fastvideo-kernel
           # We don't need full CUDA/Torch to just package the source (sdist)
           python -m build --sdist --outdir dist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - Static assets: `assets/` (including `assets/images/`, `assets/videos/`, and `assets/prompts/`) and `comfyui/assets/`.
 
 ## Build, Test, and Development Commands
-- `uv pip install -e .[dev]`: editable install with lint/test extras.
+- `uv pip install -e ".[dev]"`: editable install with lint/test extras.
 - `pre-commit install --hook-type pre-commit --hook-type commit-msg`: enable local hooks.
 - `pre-commit run --all-files`: run formatter/lint/type/spelling checks.
 - `pytest tests/`: run top-level test suite.

--- a/benchmarks/fvd/feature_extractors.py
+++ b/benchmarks/fvd/feature_extractors.py
@@ -128,7 +128,7 @@ class CLIPFeatureExtractor(BaseFeatureExtractor):
 
     def __init__(self, device: str = 'cuda', model_name: str = "openai/clip-vit-base-patch32"):
         if not TRANSFORMERS_AVAILABLE:
-            raise ImportError("Please install transformers: pip install transformers")
+            raise ImportError("Please install transformers: uv pip install transformers")
         super().__init__(device)
         self.processor = CLIPProcessor.from_pretrained(model_name)
         self.model = CLIPModel.from_pretrained(model_name).to(self.device)
@@ -171,7 +171,7 @@ class VideoMAEFeatureExtractor(BaseFeatureExtractor):
 
     def __init__(self, device: str = 'cuda', model_name: str = "MCG-NJU/videomae-base"):
         if not TRANSFORMERS_AVAILABLE:
-            raise ImportError("Please install transformers: pip install transformers")
+            raise ImportError("Please install transformers: uv pip install transformers")
         super().__init__(device)
         self.model = VideoMAEModel.from_pretrained(model_name).to(self.device)
         self.model.eval()

--- a/benchmarks/fvd/i3d_model.py
+++ b/benchmarks/fvd/i3d_model.py
@@ -57,7 +57,7 @@ class I3DFeatureExtractor(nn.Module):
         except Exception as e:
             raise RuntimeError(f"Failed to load I3D model from Hugging Face Hub. Error: {e}\n"
                                f"Ensure you have internet connection and huggingface_hub installed:\n"
-                               f"pip install huggingface_hub") from e
+                               f"uv pip install huggingface_hub") from e
 
     def preprocess(self, videos: torch.Tensor) -> torch.Tensor:
         """

--- a/benchmarks/scripts/run.sh
+++ b/benchmarks/scripts/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 1. Install missing dependency
-pip install -q opencv-python-headless transformers huggingface_hub
+uv pip install -q opencv-python-headless transformers huggingface_hub
 
 # 2. Run FVD script
 python benchmarks/fvd/run_fvd.py

--- a/benchmarks/scripts/setup_fvd.sh
+++ b/benchmarks/scripts/setup_fvd.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # 1. Install missing dependency
-pip install -q opencv-python-headless
+uv pip install -q opencv-python-headless

--- a/comfyui/README.md
+++ b/comfyui/README.md
@@ -38,10 +38,10 @@ cp -r /path/to/FastVideo/comfyui /path/to/ComfyUI/custom_nodes/FastVideo
 
 #### Install dependencies:
 
-Currently, the only dependency is `fastvideo`, which can be installed using pip.
+Currently, the only dependency is `fastvideo`, which can be installed with `uv`.
 
 ```bash
-pip install fastvideo
+uv pip install fastvideo
 ```
 
 #### Install missing custom nodes:

--- a/docker/Dockerfile.python3.10
+++ b/docker/Dockerfile.python3.10
@@ -42,7 +42,7 @@ RUN source $HOME/.local/bin/env && \
     uv venv --python 3.10 --seed /opt/venv && \
     source /opt/venv/bin/activate && \
     uv pip install --no-cache-dir --upgrade pip && \
-    uv pip install --no-cache-dir .[dev] && \
+    uv pip install --no-cache-dir ".[dev]" && \
     uv pip install --no-cache-dir https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.4/flash_attn-2.8.3+cu128torch2.11-cp310-cp310-linux_x86_64.whl
 
 COPY . .
@@ -50,7 +50,7 @@ COPY . .
 # Install dependencies using uv and set up shell configuration
 RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
-    uv pip install --no-cache-dir -e .[dev] && \
+    uv pip install --no-cache-dir -e ".[dev]" && \
     git config --unset-all http.https://github.com/.extraheader || true && \
     echo 'source /opt/venv/bin/activate' >> /root/.bashrc && \
     echo 'if [ -n "$ZSH_VERSION" ] && [ -f ~/.zshrc ]; then . ~/.zshrc; elif [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.profile

--- a/docker/Dockerfile.python3.11
+++ b/docker/Dockerfile.python3.11
@@ -42,7 +42,7 @@ RUN source $HOME/.local/bin/env && \
     uv venv --python 3.11 --seed /opt/venv && \
     source /opt/venv/bin/activate && \
     uv pip install --no-cache-dir --upgrade pip && \
-    uv pip install --no-cache-dir .[dev] && \
+    uv pip install --no-cache-dir ".[dev]" && \
     uv pip install --no-cache-dir https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.4/flash_attn-2.8.3+cu128torch2.11-cp311-cp311-linux_x86_64.whl
 
 COPY . .
@@ -50,7 +50,7 @@ COPY . .
 # Install dependencies using uv and set up shell configuration
 RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
-    uv pip install --no-cache-dir -e .[dev] && \
+    uv pip install --no-cache-dir -e ".[dev]" && \
     git config --unset-all http.https://github.com/.extraheader || true && \
     echo 'source /opt/venv/bin/activate' >> /root/.bashrc && \
     echo 'if [ -n "$ZSH_VERSION" ] && [ -f ~/.zshrc ]; then . ~/.zshrc; elif [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.profile

--- a/docker/Dockerfile.python3.12
+++ b/docker/Dockerfile.python3.12
@@ -42,7 +42,7 @@ RUN source $HOME/.local/bin/env && \
     uv venv --python 3.12 --seed /opt/venv && \
     source /opt/venv/bin/activate && \
     uv pip install --no-cache-dir --upgrade pip && \
-    uv pip install --no-cache-dir .[dev] && \
+    uv pip install --no-cache-dir ".[dev]" && \
     uv pip install --no-cache-dir https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.4/flash_attn-2.8.3+cu128torch2.11-cp312-cp312-linux_x86_64.whl
 
 COPY . .
@@ -50,7 +50,7 @@ COPY . .
 # Install dependencies using uv and set up shell configuration
 RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
-    uv pip install --no-cache-dir -e .[dev] && \
+    uv pip install --no-cache-dir -e ".[dev]" && \
     git config --unset-all http.https://github.com/.extraheader || true && \
     echo 'source /opt/venv/bin/activate' >> /root/.bashrc && \
     echo 'if [ -n "$ZSH_VERSION" ] && [ -f ~/.zshrc ]; then . ~/.zshrc; elif [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.profile

--- a/docker/Dockerfile.python3.12.cuda12.9.1
+++ b/docker/Dockerfile.python3.12.cuda12.9.1
@@ -42,7 +42,7 @@ RUN source $HOME/.local/bin/env && \
     uv venv --python 3.12 --seed /opt/venv && \
     source /opt/venv/bin/activate && \
     uv pip install --no-cache-dir --upgrade pip && \
-    uv pip install --no-cache-dir .[dev] && \
+    uv pip install --no-cache-dir ".[dev]" && \
     uv pip install --no-cache-dir flash-attn==2.8.3 --no-build-isolation
 
 COPY . .
@@ -50,7 +50,7 @@ COPY . .
 # Install dependencies using uv and set up shell configuration
 RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
-    uv pip install --no-cache-dir -e .[dev] && \
+    uv pip install --no-cache-dir -e ".[dev]" && \
     git config --unset-all http.https://github.com/.extraheader || true && \
     echo 'source /opt/venv/bin/activate' >> /root/.bashrc && \
     echo 'if [ -n "$ZSH_VERSION" ] && [ -f ~/.zshrc ]; then . ~/.zshrc; elif [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.profile

--- a/docker/rocm7_1.Dockerfile
+++ b/docker/rocm7_1.Dockerfile
@@ -43,7 +43,7 @@ COPY . .
 # Install dependencies using uv and set up shell configuration
 RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
-    uv pip install --no-cache-dir -e .[rocm] && \
+    uv pip install --no-cache-dir -e ".[rocm]" && \
     git config --unset-all http.https://github.com/.extraheader || true && \
     echo 'source /opt/venv/bin/activate' >> /root/.bashrc && \
     echo 'if [ -n "$ZSH_VERSION" ] && [ -f ~/.zshrc ]; then . ~/.zshrc; elif [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.profile

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ This directory contains the FastVideo documentation built with MkDocs.
 
 ```bash
 # Install dependencies
-pip install -r requirements-mkdocs.txt
+uv pip install -r requirements-mkdocs.txt
 
 # Serve docs with live reload (recommended for development)
 mkdocs serve

--- a/docs/contributing/developer_env/runpod.md
+++ b/docs/contributing/developer_env/runpod.md
@@ -99,7 +99,7 @@ cd /FastVideo
 **Install the package**
 
 ```bash
-uv pip install -e .[dev]
+uv pip install -e ".[dev]"
 ```
 
 The Docker image already includes Flash Attention and most heavy dependencies, so this is fast.

--- a/docs/contributing/overview.md
+++ b/docs/contributing/overview.md
@@ -49,7 +49,7 @@ git clone https://github.com/hao-ai-lab/FastVideo.git && cd FastVideo
 Install FastVideo in editable mode and set up hooks:
 
 ```bash
-uv pip install -e .[dev]
+uv pip install -e ".[dev]"
 
 # Optional: FlashAttention (builds native kernels)
 uv pip install flash-attn --no-build-isolation -v

--- a/docs/design/training_architecture.md
+++ b/docs/design/training_architecture.md
@@ -243,7 +243,7 @@ for step in range(start_step, max_steps):
 
 ```bash
 # Install
-uv pip install -e .[dev]
+uv pip install -e ".[dev]"
 
 # Run DMD2 distillation on Wan 2.1
 torchrun --nproc_per_node=8 -m fastvideo.train.entrypoint.train \

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -27,7 +27,7 @@ uv pip install fastvideo
 conda create -n fastvideo python=3.12 -y
 conda activate fastvideo
 
-pip install fastvideo
+uv pip install fastvideo
 ```
 
 ### From source
@@ -41,11 +41,11 @@ uv pip install -e .
 uv pip install flash-attn --no-build-isolation -v
 ```
 
-Alternative with Conda environment:
+Alternative with Conda environment (still drives installs through `uv`):
 
 ```bash
-pip install -e .
-pip install flash-attn --no-build-isolation -v
+uv pip install -e .
+uv pip install flash-attn --no-build-isolation -v
 ```
 
 ## Hardware Requirements

--- a/docs/getting_started/installation/gpu.md
+++ b/docs/getting_started/installation/gpu.md
@@ -58,14 +58,16 @@ uv pip install flash-attn --no-build-isolation -v
 
 #### With Conda environment (alternative)
 
+`uv` works inside an active conda env too, so prefer `uv pip` for the actual install:
+
 ```bash
-pip install fastvideo
+uv pip install fastvideo
 ```
 
 Also optionally install FlashAttention:
 
 ```bash
-pip install flash-attn --no-build-isolation -v
+uv pip install flash-attn --no-build-isolation -v
 ```
 
 ### Installation from Source
@@ -87,7 +89,7 @@ uv pip install -e .
 Alternative with Conda environment:
 
 ```bash
-pip install -e .
+uv pip install -e .
 ```
 
 ### Optional Dependencies
@@ -101,7 +103,7 @@ uv pip install flash-attn --no-build-isolation -v
 Alternative with Conda environment:
 
 ```bash
-pip install flash-attn --no-build-isolation -v
+uv pip install flash-attn --no-build-isolation -v
 ```
 
 ## Set up using Docker

--- a/docs/getting_started/installation/mps.md
+++ b/docs/getting_started/installation/mps.md
@@ -57,8 +57,10 @@ uv pip install fastvideo
 
 #### With Conda environment (alternative)
 
+`uv` works inside an active conda env too, so prefer `uv pip` for the actual install:
+
 ```bash
-pip install fastvideo
+uv pip install fastvideo
 ```
 
 ### Installation from Source
@@ -80,7 +82,7 @@ uv pip install -e .
 Alternative with Conda environment:
 
 ```bash
-pip install -e .
+uv pip install -e .
 ```
 
 ## Development Environment Setup

--- a/docs/inference/gen3c.md
+++ b/docs/inference/gen3c.md
@@ -19,7 +19,7 @@
 - Install MoGe:
 
 ```bash
-pip install git+https://github.com/microsoft/MoGe.git
+uv pip install git+https://github.com/microsoft/MoGe.git
 ```
 
 - If you hit `ImportError: libGL.so.1` (common on Ubuntu/headless nodes), you can try installing OpenCV runtime libs:

--- a/docs/inference/optimizations.md
+++ b/docs/inference/optimizations.md
@@ -54,7 +54,7 @@ FASTVIDEO_ATTENTION_BACKEND=SAGE_ATTN python example.py
 We recommend always installing [Flash Attention 2](https://github.com/Dao-AILab/flash-attention):
 
 ```bash
-pip install flash-attn==2.7.4.post1 --no-build-isolation
+uv pip install flash-attn==2.7.4.post1 --no-build-isolation
 ```
 
 And if using a Hopper+ GPU (ie H100), installing [Flash Attention 3](https://github.com/Dao-AILab/flash-attention?tab=readme-ov-file#flashattention-3-beta-release) by compiling it from source (takes about 10 minutes for me):
@@ -63,7 +63,7 @@ And if using a Hopper+ GPU (ie H100), installing [Flash Attention 3](https://git
 git clone https://github.com/Dao-AILab/flash-attention.git && cd flash-attention
 
 cd hopper
-pip install ninja
+uv pip install ninja
 python setup.py install
 ```
 
@@ -98,7 +98,7 @@ To use [SageAttention](https://github.com/thu-ml/SageAttention) 2.1.1, please co
 ```bash
 git clone https://github.com/thu-ml/SageAttention.git
 cd sageattention
-python setup.py install  # or pip install -e .
+python setup.py install  # or uv pip install -e .
 ```
 
 ### Sage Attention 3

--- a/examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P/README.md
+++ b/examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P/README.md
@@ -4,7 +4,7 @@ These are end-to-end example scripts for distilling Wan2.1 T2V 1.3B model using 
 ### 0. Make sure you have installed VSA
 
 ```bash
-pip install vsa
+uv pip install vsa
 ```
 
 ### 1. Download dataset:

--- a/examples/distill/Wan2.2-TI2V-5B-Diffusers/Data-free/README.md
+++ b/examples/distill/Wan2.2-TI2V-5B-Diffusers/Data-free/README.md
@@ -4,7 +4,7 @@ These are end-to-end example scripts for distilling Wan2.2 TI2V 5B model DMD+VSA
 ### 0. Make sure you have installed VSA
 
 ```bash
-pip install vsa
+uv pip install vsa
 ```
 
 ### Data-free Distillation

--- a/examples/distill/Wan2.2-TI2V-5B-Diffusers/crush_smol/README.md
+++ b/examples/distill/Wan2.2-TI2V-5B-Diffusers/crush_smol/README.md
@@ -4,7 +4,7 @@ These are end-to-end example scripts for distilling Wan2.2 TI2V 5B model DMD+VSA
 ### 0. Make sure you have installed VSA
 
 ```bash
-pip install vsa
+uv pip install vsa
 ```
 
 ### 1. Download dataset:

--- a/examples/inference/basic/basic_gen3c.py
+++ b/examples/inference/basic/basic_gen3c.py
@@ -7,7 +7,7 @@ and the GEN3C diffusion model.
 
 Requirements:
   1. Install MoGe:
-     pip install git+https://github.com/microsoft/MoGe.git
+     uv pip install git+https://github.com/microsoft/MoGe.git
      If you hit `ImportError: libGL.so.1`, install:
      sudo apt-get update && sudo apt-get install -y libgl1 libglib2.0-0 libsm6 libxext6 libxrender1
   2. Download and convert weights:

--- a/examples/inference/basic/basic_stable_audio.py
+++ b/examples/inference/basic/basic_stable_audio.py
@@ -48,7 +48,7 @@ Prerequisites:
      and export your HF token in the shell:
          export HF_TOKEN=hf_...
   2. Install optional inference deps (one-time):
-         pip install k_diffusion einops_exts alias_free_torch torchsde
+         uv pip install k_diffusion einops_exts alias_free_torch torchsde
 """
 from fastvideo import VideoGenerator
 

--- a/fastvideo-kernel/CMakeLists.txt
+++ b/fastvideo-kernel/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.26 FATAL_ERROR)
 project(fastvideo-kernel LANGUAGES CXX)
 
-# Prefer environment variable (used by CI or pip install git+repo_addr) if CMake var is not explicitly set.
+# Prefer environment variable (used by CI or uv pip install git+repo_addr) if CMake var is not explicitly set.
 if(NOT DEFINED GPU_BACKEND AND DEFINED ENV{GPU_BACKEND})
     set(GPU_BACKEND "$ENV{GPU_BACKEND}")
 endif()

--- a/fastvideo-kernel/python/fastvideo_kernel/vmoba.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/vmoba.py
@@ -11,7 +11,7 @@ except ImportError:
 
     def _unsupported(*args, **kwargs):
         raise ImportError(
-            "flash-attn is not installed. Please install it, e.g., `pip install flash-attn`."
+            "flash-attn is not installed. Please install it, e.g., `uv pip install flash-attn`."
         )
 
     _flash_attn_varlen_forward = _unsupported

--- a/fastvideo/attention/backends/sla.py
+++ b/fastvideo/attention/backends/sla.py
@@ -405,7 +405,7 @@ class SageSLAAttentionImpl(AttentionImpl, nn.Module):
 
         if not SAGESLA_ENABLED:
             raise ImportError("SageSLA requires spas_sage_attn. "
-                              "Install with: pip install git+https://github.com/thu-ml/SpargeAttn.git")
+                              "Install with: uv pip install git+https://github.com/thu-ml/SpargeAttn.git")
 
         assert head_size in [64, 128], f"SageSLA requires head_size in [64, 128], got {head_size}"
 

--- a/fastvideo/entrypoints/video_generator.py
+++ b/fastvideo/entrypoints/video_generator.py
@@ -759,7 +759,7 @@ class VideoGenerator:
             import av
         except ImportError:
             logger.warning("PyAV not installed; cannot mux audio. "
-                           "Install with: pip install av")
+                           "Install with: uv pip install av")
             return False
 
         try:

--- a/fastvideo/models/vision_utils.py
+++ b/fastvideo/models/vision_utils.py
@@ -183,7 +183,7 @@ def _load_video_with_ffmpeg(
     except AttributeError as e:
         raise AttributeError(
             "Unable to find an ffmpeg installation on your machine. "
-            "Please install via `pip install imageio-ffmpeg`") from e
+            "Please install via `uv pip install imageio-ffmpeg`") from e
 
     pil_images = []
     original_fps = None

--- a/fastvideo/pipelines/basic/gen3c/depth_estimation.py
+++ b/fastvideo/pipelines/basic/gen3c/depth_estimation.py
@@ -37,7 +37,7 @@ def load_moge_model(
         from moge.model.v1 import MoGeModel
     except ImportError as exc:
         raise ImportError("MoGe is required for GEN3C 3D cache conditioning. "
-                          "Install it with: pip install git+https://github.com/microsoft/MoGe.git. "
+                          "Install it with: uv pip install git+https://github.com/microsoft/MoGe.git. "
                           "If import fails with libGL.so.1, install system deps: "
                           "sudo apt-get install -y libgl1 libglib2.0-0 libsm6 libxext6 libxrender1") from exc
 

--- a/fastvideo/platforms/cuda.py
+++ b/fastvideo/platforms/cuda.py
@@ -195,7 +195,7 @@ class CudaPlatformBase(Platform):
             except ImportError as e:
                 logger.error("Failed to import SageSLA Attention backend: %s", str(e))
                 raise ImportError("SageSLA Attention backend requires spas_sage_attn. "
-                                  "Install with: pip install git+https://github.com/thu-ml/SpargeAttn.git") from e
+                                  "Install with: uv pip install git+https://github.com/thu-ml/SpargeAttn.git") from e
         elif selected_backend == AttentionBackendEnum.TORCH_SDPA:
             logger.info("Using Torch SDPA backend.")
             return "fastvideo.attention.backends.sdpa.SDPABackend"

--- a/fastvideo/tests/modal/pr_test.py
+++ b/fastvideo/tests/modal/pr_test.py
@@ -68,7 +68,7 @@ def run_test(pytest_command: str):
     cd fastvideo-kernel &&
     ./build.sh &&
     cd .. &&
-    uv pip install -e .[test] &&
+    uv pip install -e ".[test]" &&
     {pytest_command}
     """
 

--- a/fastvideo/tests/modal/ssim_test.py
+++ b/fastvideo/tests/modal/ssim_test.py
@@ -480,7 +480,7 @@ def _prepare_ssim_workspace(
     {checkout_command}
     rm -rf fastvideo/tests/ssim/reference_videos
     git_retry git submodule update --init --recursive
-    uv pip install -e .[test]
+    uv pip install -e ".[test]"
     cd fastvideo-kernel
     ./build.sh
     cd ..

--- a/fastvideo/tests/ssim/reference_videos_cli.py
+++ b/fastvideo/tests/ssim/reference_videos_cli.py
@@ -158,7 +158,7 @@ def _load_hf_sdk():
         from huggingface_hub import HfApi, snapshot_download
     except ImportError as exc:
         raise RuntimeError(
-            "huggingface_hub is required for download/upload.\nInstall with: pip install huggingface_hub"
+            "huggingface_hub is required for download/upload.\nInstall with: uv pip install huggingface_hub"
         ) from exc
     return HfApi, snapshot_download
 

--- a/fastvideo/training/training_pipeline.py
+++ b/fastvideo/training/training_pipeline.py
@@ -854,7 +854,7 @@ class TrainingPipeline(LoRAPipeline, ABC):
             import av
         except ImportError:
             logger.warning("PyAV not installed; cannot mux audio. "
-                           "Install with: pip install av")
+                           "Install with: uv pip install av")
             return False
 
         if torch.is_tensor(audio):

--- a/fastvideo/worker/ray_utils.py
+++ b/fastvideo/worker/ray_utils.py
@@ -57,7 +57,7 @@ def assert_ray_available() -> None:
     """Raise an exception if Ray is not available."""
     if ray is None:
         raise ValueError(f"Failed to import Ray: {ray_import_err}."
-                         "Please install Ray with `pip install ray`.")
+                         "Please install Ray with `uv pip install ray`.")
 
 
 def _verify_bundles(placement_group: "PlacementGroup", fastvideo_args: FastVideoArgs, device_str: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ explicit = true
 
 [project.optional-dependencies]
 
-# flash-attn: pip install flash-attn==2.8.1 --no-cache-dir --no-build-isolation
+# flash-attn: uv pip install flash-attn==2.8.1 --no-cache-dir --no-build-isolation
 
 
 lint = [

--- a/pyproject_other.toml
+++ b/pyproject_other.toml
@@ -84,7 +84,7 @@ prerelease = "allow"
 
 [project.optional-dependencies]
 
-# flash-attn: pip install flash-attn==2.8.1 --no-cache-dir --no-build-isolation
+# flash-attn: uv pip install flash-attn==2.8.1 --no-cache-dir --no-build-isolation
 
 
 lint = [

--- a/scripts/checkpoint_conversion/convert_gen3c_to_fastvideo.py
+++ b/scripts/checkpoint_conversion/convert_gen3c_to_fastvideo.py
@@ -378,7 +378,7 @@ def download_checkpoint(
 ) -> Path:
     """Download checkpoint from HuggingFace Hub."""
     if hf_hub_download is None:
-        raise RuntimeError("huggingface_hub is required for --download. Install with: pip install huggingface_hub")
+        raise RuntimeError("huggingface_hub is required for --download. Install with: uv pip install huggingface_hub")
     
     print(f"Downloading {filename} from {repo_id}...")
     path = hf_hub_download(
@@ -403,7 +403,7 @@ def resolve_model_dir(
     if snapshot_download is None:
         raise RuntimeError(
             "huggingface_hub is required to download component source. "
-            "Install with: pip install huggingface_hub")
+            "Install with: uv pip install huggingface_hub")
 
     print(f"Downloading component source repo: {model_name_or_path}")
     downloaded = snapshot_download(

--- a/tests/local_tests/stable_audio/README.md
+++ b/tests/local_tests/stable_audio/README.md
@@ -26,7 +26,7 @@ The tests skip cleanly with a helpful message if no token is set.
 One-shot:
 
 ```bash
-pip install k_diffusion einops_exts alias_free_torch torchsde
+uv pip install k_diffusion einops_exts alias_free_torch torchsde
 ```
 
 ### 3. Clone the upstream reference repo
@@ -35,12 +35,12 @@ The pipeline-level parity tests (`test_stable_audio_pipeline_parity.py`,
 `test_stable_audio_a2a_parity.py`) and the VAE-component parity tests
 (`test_oobleck_vae_parity.py`, `test_oobleck_vae_official_parity.py`)
 import directly from `stable_audio_tools`. Clone it under the repo
-root and `pip install` editable, then add it to `.gitignore`:
+root and `uv pip install` editable, then add it to `.gitignore`:
 
 ```bash
 cd <FastVideo repo root>
 git clone --depth 1 https://github.com/Stability-AI/stable-audio-tools.git
-pip install --no-deps -e ./stable-audio-tools
+uv pip install --no-deps -e ./stable-audio-tools
 echo "/stable-audio-tools/" >> .git/info/exclude   # personal ignore
 ```
 

--- a/tests/local_tests/stable_audio/test_oobleck_vae_official_parity.py
+++ b/tests/local_tests/stable_audio/test_oobleck_vae_official_parity.py
@@ -26,8 +26,8 @@ Skips when:
   * `stable-audio-tools` isn't importable (clone missing or its
     `alias_free_torch` dep isn't installed). Install via:
         git clone --depth 1 https://github.com/Stability-AI/stable-audio-tools.git
-        pip install --no-deps -e ./stable-audio-tools
-        pip install alias_free_torch
+        uv pip install --no-deps -e ./stable-audio-tools
+        uv pip install alias_free_torch
 """
 from __future__ import annotations
 
@@ -55,8 +55,8 @@ def _stable_audio_tools_available() -> bool:
     reason=(
         "Official `stable-audio-tools` not importable. Install with:\n"
         "  git clone --depth 1 https://github.com/Stability-AI/stable-audio-tools.git\n"
-        "  pip install --no-deps -e ./stable-audio-tools\n"
-        "  pip install alias_free_torch"
+        "  uv pip install --no-deps -e ./stable-audio-tools\n"
+        "  uv pip install alias_free_torch"
     ),
 )
 def test_oobleck_official_parity():

--- a/tests/local_tests/stable_audio/test_oobleck_vae_parity.py
+++ b/tests/local_tests/stable_audio/test_oobleck_vae_parity.py
@@ -19,8 +19,8 @@ Skips when:
 
 Install official deps once via:
     git clone --depth 1 https://github.com/Stability-AI/stable-audio-tools.git
-    pip install --no-deps -e ./stable-audio-tools
-    pip install k_diffusion einops_exts alias_free_torch
+    uv pip install --no-deps -e ./stable-audio-tools
+    uv pip install k_diffusion einops_exts alias_free_torch
 """
 from __future__ import annotations
 
@@ -90,7 +90,7 @@ _skip_no_access = pytest.mark.skipif(
 _skip_no_official = pytest.mark.skipif(
     not _stable_audio_tools_available(),
     reason=("`stable_audio_tools` not importable. Clone "
-            "https://github.com/Stability-AI/stable-audio-tools and `pip install` "
+            "https://github.com/Stability-AI/stable-audio-tools and `uv pip install` "
             "its deps (k_diffusion, einops_exts, alias_free_torch)."),
 )
 

--- a/tests/local_tests/stable_audio/test_stable_audio_pipeline_parity.py
+++ b/tests/local_tests/stable_audio/test_stable_audio_pipeline_parity.py
@@ -102,7 +102,7 @@ def _load_official_diffusion_cond(device: torch.device):
     not _stable_audio_tools_inference_available(),
     reason=("`stable_audio_tools.inference.generation` not importable. "
             "Clone https://github.com/Stability-AI/stable-audio-tools and "
-            "`pip install` its deps (k_diffusion, einops_exts, alias_free_torch)."),
+            "`uv pip install` its deps (k_diffusion, einops_exts, alias_free_torch)."),
 )
 def test_stable_audio_pipeline_official_parity():
     setup_hf_env()


### PR DESCRIPTION
## Summary

Convert every `pip install ...` install-from-source instruction in the tracked codebase to `uv pip install ...` per `AGENTS.md`. Editable installs with extras now use the quoted form (`-e ".[dev]"`, `".[rocm]"`, `".[test]"`) so they work cleanly under zsh as well as bash/sh.

50 files, mechanical. No dependency or version changes.

## Scope

| Area | Notes |
|---|---|
| Docs | `installation*.md`, `optimizations.md`, `gen3c.md`, contributing pages, comfyui README, top-level docs README |
| READMEs | `comfyui/`, `examples/distill/*/`, `tests/local_tests/stable_audio/` |
| Scripts/examples | `benchmarks/scripts/*.sh`, `examples/inference/basic/basic_*.py` install-hint comments, `scripts/checkpoint_conversion/convert_gen3c_to_fastvideo.py` |
| Source exception strings | `Install with: pip install av/ray/MoGe/...` → `uv pip install ...` across `fastvideo/`, `benchmarks/fvd/`, `fastvideo-kernel/` |
| Test files | `tests/local_tests/stable_audio/test_oobleck_*` and `test_stable_audio_pipeline_*` setup blurbs and skip messages |
| Dockerfiles | All 5 (`docker/Dockerfile.python3.{10,11,12}`, `Dockerfile.python3.12.cuda12.9.1`, `rocm7_1.Dockerfile`) — extras now quoted |
| Modal runners | `fastvideo/tests/modal/{ssim_test,pr_test}.py` quoted `-e ".[test]"` |
| CI shell | `.buildkite/scripts/{pre_commit,pr_test}.sh` bootstrap `uv` via the official installer if missing on the runner before installing pre-commit / modal |
| CI workflows | `.github/workflows/{infra-docs,publish-fastvideo,publish-kernel}.yml` use `astral-sh/setup-uv@v3` + `uv pip install --system` |
| Editable-install consistency | `AGENTS.md` + 3 contributor docs convert unquoted `.[dev]` → `".[dev]"` |
| Skill metadata | `.agents/memory/codebase-map/README.md`, `.agents/skills/launch-experiment/SKILL.md` |
| pyproject hints | `pyproject.toml`, `pyproject_other.toml` flash-attn install-hint comments |

## Out of scope (intentionally untouched)

- Untracked third-party clones (`stable-audio-tools/`, `daVinci-MagiHuman/`).
- Generated artifacts (`fastvideo.egg-info/PKG-INFO`).
- Dependency versions or extras lists in `pyproject.toml` — only the install-hint comment is rewritten.

## Test evidence

- Pre-commit hooks pass on the full diff (`yapf`, `ruff`, `codespell`, `PyMarkdown`, `actionlint`, `mypy`, filename checks, suggestion).
- `grep -rn "pip install"` on tracked source returns zero matches that aren't `uv pip install` (apart from the literal `pip install` argument inside `python3 -m pip install --user pre-commit==4.0.1` style comments in commit messages, which aren't source).

## Why a separate PR (not piggybacked on `upgrade_torch`)

Per request from the maintainer: this is a non-functional install-instructions sweep that should land independently of the torch version bump. Conflicts with `upgrade_torch` are limited to the docker flash-attn URL line and the pyproject `torch` pin — both on different lines from the install-instruction edits, so the rebase will be mechanical.