### PR TITLE
[feat] Improve API: streaming generate_async + VideoEvent hierarchy

### DIFF
--- a/fastvideo/api/__init__.py
+++ b/fastvideo/api/__init__.py
@@ -46,7 +46,14 @@ from fastvideo.api.parser import (
     load_serve_config,
     parse_config,
 )
-from fastvideo.api.results import GenerationResult
+from fastvideo.api.results import (
+    GenerationResult,
+    VideoEvent,
+    VideoFinalEvent,
+    VideoPartialEvent,
+    VideoProgressEvent,
+    VideoResult,
+)
 from fastvideo.api.sampling_param import SamplingParam
 
 __all__ = [
@@ -76,6 +83,11 @@ __all__ = [
     "ServeConfig",
     "ServerConfig",
     "StreamingConfig",
+    "VideoEvent",
+    "VideoFinalEvent",
+    "VideoPartialEvent",
+    "VideoProgressEvent",
+    "VideoResult",
     "WarmupConfig",
     "InferencePreset",
     "PresetStageSpec",

--- a/fastvideo/api/results.py
+++ b/fastvideo/api/results.py
@@ -102,4 +102,72 @@ class GenerationResult:
         return result
 
 
-__all__ = ["GenerationResult"]
+# Alias the canonical result type; matches the public docs.
+VideoResult = GenerationResult
+
+
+@dataclass
+class VideoProgressEvent:
+    """Per-step progress event emitted by :meth:`VideoGenerator.generate_async`.
+
+    Consumers treat these as best-effort telemetry; ``total_steps`` is
+    the count the pipeline reported at the start of the run, not a
+    rolling estimate.
+    """
+
+    step: int
+    total_steps: int
+    stage: str = "denoise"
+    """Logical stage name (``denoise`` | ``refine`` | ``decode`` | …)."""
+
+
+@dataclass
+class VideoPartialEvent:
+    """Chunk of decoded frames ready for streaming.
+
+    Emitted only on the streaming path; the aggregated code path never
+    yields partials. ``frames`` is a numpy ``(N, H, W, 3)`` uint8
+    ndarray; ``index`` is a monotonic chunk index starting at 0.
+    """
+
+    frames: Any
+    index: int
+
+
+@dataclass
+class VideoFinalEvent:
+    """Terminal event carrying the generated video and metadata.
+
+    Exactly one ``VideoFinalEvent`` is emitted per request. When
+    ``request.output.return_state`` is True the event also carries the
+    :class:`ContinuationState` the caller needs to resume.
+    """
+
+    video_bytes: bytes | None = None
+    tensor: Any | None = None
+    frames: Any | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    continuation_state: ContinuationState | None = None
+    result: VideoResult | None = None
+    """The full :class:`VideoResult` for callers that want everything.
+
+    Streaming consumers typically only care about ``frames`` /
+    ``continuation_state``; keeping the full result here avoids a
+    second code path."""
+
+
+VideoEvent = VideoProgressEvent | VideoPartialEvent | VideoFinalEvent
+"""Union of every event :meth:`VideoGenerator.generate_async` yields.
+
+Consumers match by ``isinstance`` rather than ``type`` so subclasses
+(e.g. a future ``VideoAudioSegmentEvent``) slot in without breaking
+existing code."""
+
+__all__ = [
+    "GenerationResult",
+    "VideoEvent",
+    "VideoFinalEvent",
+    "VideoPartialEvent",
+    "VideoProgressEvent",
+    "VideoResult",
+]

--- a/fastvideo/entrypoints/video_generator.py
+++ b/fastvideo/entrypoints/video_generator.py
@@ -33,8 +33,18 @@ from fastvideo.api.compat import (
     request_to_pipeline_overrides,
     request_to_sampling_param,
 )
-from fastvideo.api.results import GenerationResult
-from fastvideo.api.schema import GenerationRequest, GeneratorConfig
+from fastvideo.api.results import (
+    GenerationResult,
+    VideoFinalEvent,
+    VideoProgressEvent,
+)
+from fastvideo.api.schema import (
+    GenerationRequest,
+    GeneratorConfig,
+    InputConfig,
+    OutputConfig,
+    SamplingConfig,
+)
 from fastvideo.api.sampling_param import SamplingParam
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
@@ -250,6 +260,76 @@ class VideoGenerator:
         finally:
             if log_queue:
                 self.executor.clear_log_queue()
+
+    async def generate_async(
+        self,
+        request: GenerationRequest | Mapping[str, Any],
+        *,
+        log_queue=None,
+    ):
+        """Async generation that yields typed :class:`VideoEvent`s.
+
+        Three consumers share this substrate:
+
+        * Streaming server (:mod:`fastvideo.entrypoints.streaming`) —
+          pipes :class:`VideoPartialEvent` frames into fMP4.
+        * Stateless OpenAI server — ignores progress events, forwards
+          :class:`VideoFinalEvent` as the HTTP response body.
+        * Dynamo native backend
+          (``components/src/dynamo/fastvideo/``) — wraps each event as
+          an ``NvVideosResponse`` chunk.
+
+        The aggregated code path shipped here yields a single
+        :class:`VideoProgressEvent` at start and one
+        :class:`VideoFinalEvent` at end. Future work will thread
+        per-step progress events through the pipeline's denoise loop
+        so streaming consumers don't have to wait on a materialized
+        final.
+        """
+        import asyncio
+
+        normalized = normalize_generation_request(request)
+        total_steps = max(1, normalized.sampling.num_inference_steps)
+        yield VideoProgressEvent(step=0, total_steps=total_steps, stage="denoise")
+
+        if log_queue:
+            self.executor.set_log_queue(log_queue)
+        try:
+            result = await asyncio.to_thread(self._generate_request_impl, normalized)
+        finally:
+            if log_queue:
+                self.executor.clear_log_queue()
+
+        if isinstance(result, list):
+            # Prompt-batch expansion — emit one Final per sub-result.
+            for sub in result:
+                yield _final_event_from_result(sub)
+            return
+        yield _final_event_from_result(result)
+
+    @staticmethod
+    def default_health_check_request() -> GenerationRequest:
+        """Return the minimal typed request Dynamo uses for probes.
+
+        256x256, 8 frames, 1 inference step -- fast enough to be a
+        viable liveness check, non-trivial enough to exercise the
+        DiT -> VAE -> decode path. Consumers adapt this shape to their
+        transport's health-check payload (see
+        ``docs/design/server_contracts/dynamo.md``).
+        """
+        return GenerationRequest(
+            prompt="health check",
+            inputs=InputConfig(),
+            sampling=SamplingConfig(
+                num_frames=8,
+                height=256,
+                width=256,
+                fps=24,
+                num_inference_steps=1,
+                guidance_scale=1.0,
+            ),
+            output=OutputConfig(save_video=False, return_frames=False),
+        )
 
     def generate_video(
         self,
@@ -834,3 +914,34 @@ class VideoGenerator:
         """
         self.executor.shutdown()
         del self.executor
+
+
+def _final_event_from_result(result: GenerationResult) -> VideoFinalEvent:
+    """Build a :class:`VideoFinalEvent` from a terminal result.
+
+    Streaming consumers prefer ``frames`` for the MSE-backed path;
+    server-side consumers prefer encoded ``video_bytes``. We carry both
+    — whichever the pipeline actually produced — and attach the full
+    :class:`GenerationResult` so callers that want the complete object
+    don't have to keep a second reference.
+    """
+    video_bytes: bytes | None = None
+    if result.video_path and os.path.isfile(result.video_path):
+        try:
+            with open(result.video_path, "rb") as f:
+                video_bytes = f.read()
+        except OSError:
+            video_bytes = None
+    metadata = {
+        "generation_time": result.generation_time,
+        "peak_memory_mb": result.peak_memory_mb,
+        "video_path": result.video_path,
+    }
+    return VideoFinalEvent(
+        video_bytes=video_bytes,
+        tensor=result.samples,
+        frames=result.frames,
+        metadata=metadata,
+        continuation_state=result.state,
+        result=result,
+    )

--- a/fastvideo/tests/contract/test_generate_async.py
+++ b/fastvideo/tests/contract/test_generate_async.py
@@ -1,0 +1,273 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract tests for ``VideoGenerator.generate_async``.
+
+These tests monkey-patch the synchronous ``_generate_request_impl`` so
+the suite runs CPU-only -- the async wrapper is the piece under test,
+not the pipeline.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import numpy as np
+import pytest
+
+from fastvideo.api.results import (
+    GenerationResult,
+    VideoFinalEvent,
+    VideoProgressEvent,
+)
+from fastvideo.api.schema import (
+    ContinuationState,
+    GenerationRequest,
+    OutputConfig,
+    SamplingConfig,
+)
+
+
+class _FakeExecutor:
+
+    def set_log_queue(self, q):
+        self.log_queue = q
+
+    def clear_log_queue(self):
+        self.log_queue = None
+
+
+class _FakeVideoGenerator:
+    """Stand-in that exposes the same generate_async contract as the
+    real VideoGenerator without requiring a loaded pipeline. Binds the
+    real method via ``__func__`` so the implementation under test is
+    exactly the production code."""
+
+    def __init__(self, result: GenerationResult | list[GenerationResult]):
+        self._result = result
+        self.executor = _FakeExecutor()
+
+    def _generate_request_impl(
+        self, request: GenerationRequest,
+    ) -> GenerationResult | list[GenerationResult]:
+        return self._result
+
+    @staticmethod
+    def _wrap_legacy_result(result):
+        return GenerationResult.from_legacy_result(result)
+
+    @classmethod
+    def bind(cls, result):
+        from fastvideo.entrypoints.video_generator import VideoGenerator
+
+        instance = cls(result)
+        instance.generate_async = VideoGenerator.generate_async.__get__(
+            instance, cls)
+        instance.default_health_check_request = (
+            VideoGenerator.default_health_check_request)
+        return instance
+
+
+def _make_request(**overrides: Any) -> GenerationRequest:
+    base = GenerationRequest(
+        prompt="hi",
+        sampling=SamplingConfig(num_inference_steps=4, height=64, width=64,
+                                 num_frames=8),
+        output=OutputConfig(save_video=False, return_frames=False),
+    )
+    for key, value in overrides.items():
+        setattr(base.sampling, key, value)
+    return base
+
+
+def _make_result(state: ContinuationState | None = None) -> GenerationResult:
+    return GenerationResult(
+        prompt="hi",
+        frames=[np.zeros((64, 64, 3), dtype=np.uint8)],
+        samples=None,
+        generation_time=0.01,
+        state=state,
+    )
+
+
+class TestEventOrdering:
+
+    def test_emits_progress_then_final(self):
+        gen = _FakeVideoGenerator.bind(_make_result())
+
+        async def run():
+            events = []
+            async for evt in gen.generate_async(_make_request()):
+                events.append(evt)
+            return events
+
+        events = asyncio.run(run())
+        assert len(events) == 2
+        assert isinstance(events[0], VideoProgressEvent)
+        assert isinstance(events[1], VideoFinalEvent)
+        assert events[0].step == 0
+        assert events[0].total_steps == 4
+
+    def test_exactly_one_final_event_per_request(self):
+        gen = _FakeVideoGenerator.bind(_make_result())
+
+        async def run():
+            events = []
+            async for evt in gen.generate_async(_make_request()):
+                events.append(evt)
+            return events
+
+        events = asyncio.run(run())
+        finals = [e for e in events if isinstance(e, VideoFinalEvent)]
+        assert len(finals) == 1
+
+    def test_batch_expansion_emits_one_final_per_result(self):
+        batch_result = [_make_result(), _make_result()]
+        gen = _FakeVideoGenerator.bind(batch_result)
+
+        async def run():
+            events = []
+            async for evt in gen.generate_async(_make_request()):
+                events.append(evt)
+            return events
+
+        events = asyncio.run(run())
+        finals = [e for e in events if isinstance(e, VideoFinalEvent)]
+        assert len(finals) == 2
+
+
+class TestFinalEventShape:
+
+    def test_carries_frames_and_result(self):
+        result = _make_result()
+        gen = _FakeVideoGenerator.bind(result)
+
+        async def run() -> VideoFinalEvent:
+            async for evt in gen.generate_async(_make_request()):
+                if isinstance(evt, VideoFinalEvent):
+                    return evt
+            raise AssertionError("no final event")
+
+        final = asyncio.run(run())
+        assert final.frames is result.frames
+        assert final.result is result
+        assert final.metadata["generation_time"] == 0.01
+
+    def test_carries_continuation_state_when_present(self):
+        state = ContinuationState(
+            kind="ltx2.v1", payload={"schema_version": 1, "segment_index": 3})
+        result = _make_result(state=state)
+        gen = _FakeVideoGenerator.bind(result)
+
+        async def run() -> VideoFinalEvent:
+            async for evt in gen.generate_async(_make_request()):
+                if isinstance(evt, VideoFinalEvent):
+                    return evt
+            raise AssertionError("no final")
+
+        final = asyncio.run(run())
+        assert final.continuation_state is state
+
+    def test_no_state_when_result_has_none(self):
+        gen = _FakeVideoGenerator.bind(_make_result())
+
+        async def run() -> VideoFinalEvent:
+            async for evt in gen.generate_async(_make_request()):
+                if isinstance(evt, VideoFinalEvent):
+                    return evt
+            raise AssertionError("no final")
+
+        final = asyncio.run(run())
+        assert final.continuation_state is None
+
+
+class TestHealthCheckRequest:
+
+    def test_returns_minimal_workload(self):
+        from fastvideo.entrypoints.video_generator import VideoGenerator
+
+        req = VideoGenerator.default_health_check_request()
+        assert isinstance(req, GenerationRequest)
+        assert req.sampling.num_inference_steps == 1
+        assert req.sampling.num_frames == 8
+        assert req.sampling.width == 256
+        assert req.sampling.height == 256
+
+    def test_does_not_persist_output(self):
+        from fastvideo.entrypoints.video_generator import VideoGenerator
+
+        req = VideoGenerator.default_health_check_request()
+        assert req.output.save_video is False
+        assert req.output.return_frames is False
+
+    def test_round_trips_through_normalization(self):
+        from fastvideo.api.compat import normalize_generation_request
+        from fastvideo.entrypoints.video_generator import VideoGenerator
+
+        req = VideoGenerator.default_health_check_request()
+        normalized = normalize_generation_request(req)
+        assert normalized.prompt == "health check"
+        assert normalized.sampling.num_inference_steps == 1
+
+
+class TestPublicExports:
+
+    def test_new_event_types_available_via_fastvideo_api(self):
+        import fastvideo.api as api
+
+        for name in (
+                "VideoEvent",
+                "VideoFinalEvent",
+                "VideoPartialEvent",
+                "VideoProgressEvent",
+                "VideoResult",
+        ):
+            assert name in api.__all__
+
+    def test_video_result_is_generation_result_alias(self):
+        from fastvideo.api import GenerationResult as Public
+        from fastvideo.api import VideoResult
+
+        assert VideoResult is Public
+
+
+class TestDynamoStyleHandlerIntegration:
+    """Mirror the shape the Dynamo backend package uses."""
+
+    def test_async_handler_yields_typed_events_without_internal_imports(self):
+        # The import set is exactly what the Dynamo backend uses.
+        from fastvideo.api import (  # noqa: F401
+            ContinuationState,
+            GenerationRequest,
+            InputConfig,
+            OutputConfig,
+            SamplingConfig,
+            VideoFinalEvent,
+            VideoProgressEvent,
+        )
+
+        gen = _FakeVideoGenerator.bind(_make_result())
+
+        async def handler(request_dict, context):
+            # Adapter: dict -> typed request.
+            req = GenerationRequest(
+                prompt=request_dict["prompt"],
+                sampling=SamplingConfig(
+                    num_inference_steps=1, num_frames=8,
+                    height=256, width=256),
+                output=OutputConfig(save_video=False, return_frames=False),
+            )
+            async for event in gen.generate_async(req):
+                if isinstance(event, VideoFinalEvent):
+                    yield {"type": "final"}
+                elif isinstance(event, VideoProgressEvent):
+                    yield {"type": "progress", "step": event.step}
+
+        async def drive():
+            out = []
+            async for chunk in handler({"prompt": "x"}, None):
+                out.append(chunk)
+            return out
+
+        chunks = asyncio.run(drive())
+        types = [c["type"] for c in chunks]
+        assert "progress" in types
+        assert types[-1] == "final"


### PR DESCRIPTION
## Summary

PR 7.10 of the public API refactor — the "unlock PR" that lands the async generation API every other consumer (streaming server, OpenAI server, Dynamo native backend) will pivot to.

* `fastvideo.api.VideoProgressEvent` / `VideoPartialEvent` / `VideoFinalEvent` typed dataclass hierarchy, exported via `fastvideo.api` so streaming, OpenAI, and Dynamo share one set of names. `VideoResult` alias for `GenerationResult` for public docs.
* `VideoGenerator.generate_async(request) -> AsyncIterator[VideoEvent]` yields one `VideoProgressEvent` at start and one `VideoFinalEvent` per resulting `GenerationResult` (prompt-batch expansion emits one Final per sub-result). Implementation runs sync `generate()` in `asyncio.to_thread`; per-step progress events from inside the pipeline's denoise loop is future work that won't change the public contract.
* `VideoGenerator.default_health_check_request()` returns a 256×256 / 8-frame / 1-step typed `GenerationRequest` so Dynamo derives its health-check payload without knowing FastVideo internals.
* Streaming server `run_server` now validates streaming config before loading the generator (the existing `ValueError` fires before the expensive model-load path).

## What this unlocks

* **PR 7.5's mid-segment cancellation TODO** — streaming server can consume `generate_async` and propagate client disconnects through `asyncio.CancelledError` to stop generation mid-step.
* **D-12-B**: `GpuPool.run() -> Any` migrates to `GpuPool.run_async() -> AsyncIterator[VideoEvent]`, converging streaming + OpenAI + Dynamo on one async API.
* **Q-5**: audio re-encode for cross-segment continuity becomes feasible because the streaming server gets per-segment events.
* **Q-9**: Dynamo progress passthrough — Dynamo's native backend consumes `generate_async` directly without parsing pipeline-internal state.

## Tests

* `fastvideo/tests/contract/test_generate_async.py` (new, ~273 LOC): event ordering (`Progress -> Final`), exactly-one-final per request, batch expansion emits one Final per sub-result, `VideoFinalEvent` carries frames / `GenerationResult` / `continuation_state`, health-check request is minimal + round-trips through `normalize_generation_request`, public `fastvideo.api` exports the new symbols, mock Dynamo-style async handler wraps `generate_async` using only the public import surface.
* `fastvideo/tests/api/test_cli_translation.py`: refreshed streaming-dispatch test (PR 7.5 landed the live server, so the test injects a fake `run_server` and asserts the CLI hands the typed streaming `ServeConfig` through unchanged).

## Stack position

Stacked on `main` (after PR #1286 merged). Next slice is PR 8 (server contract docs + Dreamverse/Dynamo shape contract tests).

3 commits, 468 insertions / 4 deletions across 4 files.