### PR TITLE
[feat]: T5-Gemma encoder for MagiHuman pipeline (2/8)

### DIFF
--- a/fastvideo/configs/models/encoders/__init__.py
+++ b/fastvideo/configs/models/encoders/__init__.py
@@ -9,10 +9,11 @@ from fastvideo.configs.models.encoders.reason1 import Reason1ArchConfig, Reason1
 from fastvideo.configs.models.encoders.gemma import LTX2GemmaConfig
 from fastvideo.configs.models.encoders.stable_audio_conditioner import (StableAudioConditionerArchConfig,
                                                                         StableAudioConditionerConfig)
+from fastvideo.configs.models.encoders.t5gemma import T5GemmaEncoderConfig
 
 __all__ = [
     "EncoderConfig", "TextEncoderConfig", "ImageEncoderConfig", "BaseEncoderOutput", "CLIPTextConfig",
     "CLIPVisionConfig", "WAN2_1ControlCLIPVisionConfig", "LlamaConfig", "T5Config", "T5LargeConfig", "Qwen2_5_VLConfig",
     "Reason1ArchConfig", "Reason1Config", "LTX2GemmaConfig", "SiglipVisionConfig", "StableAudioConditionerArchConfig",
-    "StableAudioConditionerConfig"
+    "StableAudioConditionerConfig", "T5GemmaEncoderConfig"
 ]

--- a/fastvideo/configs/models/encoders/t5gemma.py
+++ b/fastvideo/configs/models/encoders/t5gemma.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Config for the T5-Gemma encoder used by daVinci-MagiHuman.
+
+The reference pipeline uses `transformers.models.t5gemma.T5GemmaEncoderModel`
+on `google/t5gemma-9b-9b-ul2`. That is a gated Google repository, so the
+encoder weights are not bundled inside GAIR/daVinci-MagiHuman; they are
+loaded from the T5-Gemma HF repo directly.
+
+Encoder shape (verified from google/t5gemma-9b-9b-ul2/config.json):
+    layers=42, hidden=3584, heads=16, kv_heads=8, head_dim=256,
+    intermediate=14336, rope_theta=10000.0, max_pos=8192,
+    layer_types alternate sliding_attention / full_attention.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from fastvideo.configs.models.encoders.base import (
+    TextEncoderArchConfig,
+    TextEncoderConfig,
+)
+
+
+def _is_t5gemma_model(n: str, m) -> bool:
+    return n.endswith("t5gemma_model") or n.endswith("_t5gemma_model")
+
+
+@dataclass
+class T5GemmaEncoderArchConfig(TextEncoderArchConfig):
+    architectures: list[str] = field(default_factory=lambda: ["T5GemmaEncoderModel"])
+
+    hidden_size: int = 3584
+    num_hidden_layers: int = 42
+    num_attention_heads: int = 16
+    num_key_value_heads: int = 8
+    head_dim: int = 256
+    intermediate_size: int = 14336
+    max_position_embeddings: int = 8192
+    rope_theta: float = 10000.0
+    vocab_size: int = 256000
+
+    # MagiHuman fixes prompt embed length at 640 via pad_or_trim.
+    text_len: int = 640
+
+    pad_token_id: int = 0
+    eos_token_id: int = 1
+
+    # Path to the upstream gated repo. When set, the FastVideo loader will
+    # pull the encoder directly via `T5GemmaEncoderModel.from_pretrained`.
+    t5gemma_model_path: str = "google/t5gemma-9b-9b-ul2"
+    t5gemma_dtype: str = "bfloat16"
+
+    _fsdp_shard_conditions: list = field(default_factory=lambda: [_is_t5gemma_model])
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # WHY: upstream `t5_gemma_model.py:25` tokenizes without
+        # padding/max_length, then `prompt_process.py` pad_or_trim-s the
+        # encoded states. Keep only tensor return here so
+        # MagiHumanLatentPreparationStage can pad/trim post-encode while
+        # preserving the real original prompt length.
+        self.tokenizer_kwargs.pop("truncation", None)
+        self.tokenizer_kwargs.pop("max_length", None)
+        self.tokenizer_kwargs.pop("padding", None)
+
+
+@dataclass
+class T5GemmaEncoderConfig(TextEncoderConfig):
+    arch_config: TextEncoderArchConfig = field(default_factory=T5GemmaEncoderArchConfig)
+
+    prefix: str = "t5gemma"

--- a/fastvideo/configs/models/encoders/t5gemma.py
+++ b/fastvideo/configs/models/encoders/t5gemma.py
@@ -21,10 +21,6 @@ from fastvideo.configs.models.encoders.base import (
 )
 
 
-def _is_t5gemma_model(n: str, m) -> bool:
-    return n.endswith("t5gemma_model") or n.endswith("_t5gemma_model")
-
-
 @dataclass
 class T5GemmaEncoderArchConfig(TextEncoderArchConfig):
     architectures: list[str] = field(default_factory=lambda: ["T5GemmaEncoderModel"])
@@ -50,7 +46,13 @@ class T5GemmaEncoderArchConfig(TextEncoderArchConfig):
     t5gemma_model_path: str = "google/t5gemma-9b-9b-ul2"
     t5gemma_dtype: str = "bfloat16"
 
-    _fsdp_shard_conditions: list = field(default_factory=lambda: [_is_t5gemma_model])
+    # The HF T5-Gemma encoder is lazy-loaded on first forward (see
+    # `fastvideo/models/encoders/t5gemma.py`), so no FastVideo-owned
+    # submodules exist at FSDP-apply time. An empty list makes
+    # `shard_model()` log a warning and return cleanly instead of raising
+    # "No layer modules were sharded" — sharding of the lazy HF model is
+    # the activation pipeline's responsibility.
+    _fsdp_shard_conditions: list = field(default_factory=list)
 
     def __post_init__(self) -> None:
         super().__post_init__()

--- a/fastvideo/models/encoders/t5gemma.py
+++ b/fastvideo/models/encoders/t5gemma.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+"""T5-Gemma encoder wrapper for daVinci-MagiHuman.
+
+MagiHuman uses `transformers.models.t5gemma.T5GemmaEncoderModel` on
+`google/t5gemma-9b-9b-ul2` (a gated Google repo). This wrapper follows the
+same lazy-loading pattern as `fastvideo/models/encoders/gemma.py`: we keep
+the HF module under `self._t5gemma_model` and exclude it from
+`named_parameters` so FastVideo's weight loader does not try to load
+encoder shards from the converted repo directory.
+
+For the base MagiHuman T2V port there are no additional connector layers
+on top — the pipeline prompt-preprocessing stage handles pad-or-trim to
+`text_len` and exposes both the padded embedding and the original length.
+"""
+from __future__ import annotations
+
+import os
+
+import torch
+from torch import nn
+
+from fastvideo.configs.models.encoders import BaseEncoderOutput, TextEncoderConfig
+from fastvideo.models.encoders.base import TextEncoder
+from fastvideo.platforms import AttentionBackendEnum
+
+
+class T5GemmaEncoderModel(TextEncoder):
+    """Thin wrapper over HuggingFace's `T5GemmaEncoderModel`.
+
+    On first `forward`, the wrapper lazily instantiates the upstream encoder
+    from `t5gemma_model_path` (defaulting to `google/t5gemma-9b-9b-ul2`).
+    Afterwards, forward returns a `BaseEncoderOutput` with
+    `last_hidden_state = [B, L, 3584]` matching MagiHuman's
+    `context.half()` output.
+    """
+
+    _supported_attention_backends = (
+        AttentionBackendEnum.FLASH_ATTN,
+        AttentionBackendEnum.TORCH_SDPA,
+    )
+
+    def __init__(self, config: TextEncoderConfig) -> None:
+        super().__init__(config)
+        arch = config.arch_config
+        self.t5gemma_model_path: str = arch.t5gemma_model_path
+        self.t5gemma_dtype: str = arch.t5gemma_dtype
+        self._t5gemma_model = None
+
+    def named_parameters(self, prefix: str = "", recurse: bool = True):
+        # The upstream encoder is loaded lazily and its parameters are
+        # managed by HF, not FastVideo's loader. Hide them from the parent
+        # module-tree traversal so Diffusers-repo weight loading does not
+        # try to match them.
+        for name, param in super().named_parameters(prefix=prefix, recurse=recurse):
+            if name.startswith("_t5gemma_model.") or name == "_t5gemma_model":
+                continue
+            yield name, param
+
+    def _build_t5gemma_model(self, device: torch.device | None = None):
+        from transformers.models.t5gemma import T5GemmaEncoderModel as HFEncoder
+
+        path = self.t5gemma_model_path
+        if not path:
+            raise ValueError(
+                "t5gemma_model_path must be set. Expected "
+                "`google/t5gemma-9b-9b-ul2` or a local path to an "
+                "equivalent T5-Gemma encoder."
+            )
+        dtype = getattr(torch, self.t5gemma_dtype, torch.bfloat16)
+        model = HFEncoder.from_pretrained(
+            path,
+            is_encoder_decoder=False,
+            dtype=dtype,
+        )
+        if os.getenv("FASTVIDEO_ATTENTION_BACKEND") == "TORCH_SDPA":
+            if hasattr(model.config, "attn_implementation"):
+                model.config.attn_implementation = "sdpa"
+            if hasattr(model.config, "_attn_implementation"):
+                model.config._attn_implementation = "sdpa"
+        if device is not None:
+            model = model.to(device=device)
+        model.eval()
+        return model
+
+    @property
+    def t5gemma_model(self):
+        if self._t5gemma_model is None:
+            # Lazy-load on CPU if no device is known yet; `forward` will
+            # move the model to the input's device on first call.
+            self._t5gemma_model = self._build_t5gemma_model()
+        return self._t5gemma_model
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        output_hidden_states: bool | None = None,
+        **kwargs,
+    ) -> BaseEncoderOutput:
+        # Ensure the lazy-loaded encoder lives on the same device as the
+        # input; lazy-loading leaves it on CPU until the first forward.
+        ref = input_ids if input_ids is not None else inputs_embeds
+        target_device = ref.device if ref is not None else None
+        model = self.t5gemma_model
+        if target_device is not None:
+            first_param = next(model.parameters(), None)
+            if first_param is not None and first_param.device != target_device:
+                model = model.to(device=target_device)
+                self._t5gemma_model = model
+        outputs = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            output_hidden_states=bool(output_hidden_states),
+        )
+        # MagiHuman casts to fp16 at this point; keep the raw dtype here and
+        # leave precision management to the pipeline's postprocess stage.
+        return BaseEncoderOutput(
+            last_hidden_state=outputs["last_hidden_state"],
+            hidden_states=getattr(outputs, "hidden_states", None),
+            attention_mask=attention_mask,
+        )
+
+
+EntryClass = T5GemmaEncoderModel

--- a/fastvideo/models/encoders/t5gemma.py
+++ b/fastvideo/models/encoders/t5gemma.py
@@ -110,9 +110,10 @@ class T5GemmaEncoderModel(TextEncoder):
                 self._t5gemma_model = model
         outputs = model(
             input_ids=input_ids,
+            position_ids=position_ids,
             attention_mask=attention_mask,
             inputs_embeds=inputs_embeds,
-            output_hidden_states=bool(output_hidden_states),
+            output_hidden_states=output_hidden_states,
         )
         # MagiHuman casts to fp16 at this point; keep the raw dtype here and
         # leave precision management to the pipeline's postprocess stage.

--- a/fastvideo/models/encoders/t5gemma.py
+++ b/fastvideo/models/encoders/t5gemma.py
@@ -15,6 +15,7 @@ on top — the pipeline prompt-preprocessing stage handles pad-or-trim to
 from __future__ import annotations
 
 import os
+from typing import Iterable
 
 import torch
 
@@ -122,6 +123,21 @@ class T5GemmaEncoderModel(TextEncoder):
             hidden_states=getattr(outputs, "hidden_states", None),
             attention_mask=attention_mask,
         )
+
+    def load_weights(
+        self, weights: Iterable[tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        # The HF T5-Gemma encoder is lazy-loaded from `t5gemma_model_path`
+        # (see `_build_t5gemma_model`), so this wrapper owns zero
+        # FastVideo-native parameters and `named_parameters()` is filtered
+        # to hide the HF submodule. `TextEncoderLoader.load_model()` calls
+        # `model.load_weights(...)` unconditionally, so we must define it
+        # here. Returning an empty set matches the empty `weights_to_load`
+        # set the loader computes from `named_parameters()`, satisfying
+        # its strict-load check.
+        for _ in weights:
+            pass
+        return set()
 
 
 EntryClass = T5GemmaEncoderModel

--- a/fastvideo/models/encoders/t5gemma.py
+++ b/fastvideo/models/encoders/t5gemma.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import os
 
 import torch
-from torch import nn
 
 from fastvideo.configs.models.encoders import BaseEncoderOutput, TextEncoderConfig
 from fastvideo.models.encoders.base import TextEncoder

--- a/tests/local_tests/magi_human/test_magi_human_t5gemma_parity.py
+++ b/tests/local_tests/magi_human/test_magi_human_t5gemma_parity.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity test: FastVideo T5GemmaEncoderModel vs direct HF
+`T5GemmaEncoderModel.from_pretrained(...)`.
+
+FastVideo's wrapper is intentionally thin — it lazy-loads the same HF
+class on the same gated repo (`google/t5gemma-9b-9b-ul2`) that the
+upstream MagiHuman pipeline uses (see
+daVinci-MagiHuman/inference/model/t5_gemma/t5_gemma_model.py). This
+test guards against future regressions in the wrapper (e.g. accidental
+mutation of `last_hidden_state`, wrong dtype cast, forgetting to pass
+attention_mask) by comparing wrapper forward output against a direct HF
+forward on the same model.
+
+Skips when the T5-Gemma repo isn't accessible (gated — requires user's
+HF token with accepted terms of use).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+from torch.testing import assert_close
+
+
+_T5GEMMA_ID = "google/t5gemma-9b-9b-ul2"
+
+
+def _hf_token():
+    for k in ("HF_TOKEN", "HUGGINGFACE_HUB_TOKEN", "HF_API_KEY"):
+        v = os.environ.get(k)
+        if v:
+            return v
+    return None
+
+
+def _can_access_t5gemma() -> bool:
+    token = _hf_token()
+    if token is None:
+        return False
+    try:
+        from huggingface_hub import hf_hub_download
+        hf_hub_download(
+            repo_id=_T5GEMMA_ID, filename="config.json", token=token,
+        )
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="MagiHuman T5-Gemma parity requires CUDA (encoder is 9B params).",
+)
+@pytest.mark.skipif(
+    not _can_access_t5gemma(),
+    reason=(f"{_T5GEMMA_ID} not accessible — gated Google repo; set "
+            f"HF_TOKEN / HF_API_KEY and accept the terms of use."),
+)
+def test_magi_human_t5gemma_wrapper_parity():
+    # Alias any of the three token env vars to HF_TOKEN (what transformers
+    # reads) before constructing models.
+    for src in ("HF_TOKEN", "HUGGINGFACE_HUB_TOKEN", "HF_API_KEY"):
+        v = os.environ.get(src)
+        if v:
+            os.environ.setdefault("HF_TOKEN", v)
+            os.environ.setdefault("HUGGINGFACE_HUB_TOKEN", v)
+            break
+
+    device = torch.device("cuda:0")
+
+    # --- Upstream / direct HF path (matches the reference pipeline's
+    #     `T5GemmaEncoder` wrapper exactly: see
+    #     daVinci-MagiHuman/inference/model/t5_gemma/t5_gemma_model.py) ---
+    from transformers import AutoTokenizer
+    from transformers.models.t5gemma import T5GemmaEncoderModel as HFEncoder
+
+    tokenizer = AutoTokenizer.from_pretrained(_T5GEMMA_ID)
+    ref_model = HFEncoder.from_pretrained(
+        _T5GEMMA_ID, is_encoder_decoder=False, dtype=torch.bfloat16,
+    ).to(device).eval()
+
+    # --- FastVideo wrapper path ---
+    from fastvideo.configs.models.encoders.t5gemma import T5GemmaEncoderConfig
+    from fastvideo.models.encoders.t5gemma import T5GemmaEncoderModel as FVEncoder
+
+    fv_config = T5GemmaEncoderConfig()
+    fv_config.arch_config.t5gemma_model_path = _T5GEMMA_ID
+    fv_model = FVEncoder(fv_config)
+
+    # --- Identical input ---
+    prompt = (
+        "A warm afternoon scene: a person sits on a park bench reading "
+        "a book, surrounded by softly swaying trees."
+    )
+    inputs = tokenizer(
+        [prompt], return_tensors="pt", padding=True, truncation=False,
+    ).to(device)
+
+    with torch.inference_mode():
+        ref_out = ref_model(**inputs)
+        ref_hidden = ref_out["last_hidden_state"].detach().float().cpu()
+
+        # FastVideo wrapper: forward through the adapter; it lazy-loads the
+        # encoder on first call and moves it to the input's device.
+        fv_out = fv_model(
+            input_ids=inputs["input_ids"],
+            attention_mask=inputs.get("attention_mask"),
+        )
+        fv_hidden = fv_out.last_hidden_state.detach().float().cpu()
+
+    print(
+        f"ref_hidden shape={tuple(ref_hidden.shape)} "
+        f"abs_mean={ref_hidden.abs().mean().item():.6f}"
+    )
+    print(
+        f"fv_hidden  shape={tuple(fv_hidden.shape)} "
+        f"abs_mean={fv_hidden.abs().mean().item():.6f}"
+    )
+    diff = (ref_hidden - fv_hidden).abs()
+    print(
+        f"diff max={diff.max().item():.6e} "
+        f"mean={diff.mean().item():.6e}"
+    )
+
+    assert ref_hidden.shape == fv_hidden.shape
+    # Both sides run the exact same HF model on the exact same inputs;
+    # drift is bounded by nondeterminism in SDPA + bf16 matmul. This
+    # should be <= 1e-3 end-to-end.
+    assert_close(fv_hidden, ref_hidden, atol=1e-3, rtol=1e-3)

--- a/tests/local_tests/magi_human/test_magi_human_t5gemma_parity.py
+++ b/tests/local_tests/magi_human/test_magi_human_t5gemma_parity.py
@@ -88,26 +88,47 @@ def test_magi_human_t5gemma_wrapper_parity():
     fv_config.arch_config.t5gemma_model_path = _T5GEMMA_ID
     fv_model = FVEncoder(fv_config)
 
-    # --- Identical input ---
-    prompt = (
+    # Two different-length prompts so the batched `attention_mask` carries
+    # zeros (padding tokens). A single prompt would leave all-ones in the
+    # mask and silently miss any "forgot to pass attention_mask" regression.
+    prompts = [
         "A warm afternoon scene: a person sits on a park bench reading "
-        "a book, surrounded by softly swaying trees."
-    )
+        "a book, surrounded by softly swaying trees.",
+        "Sunrise over a quiet harbor.",
+    ]
     inputs = tokenizer(
-        [prompt], return_tensors="pt", padding=True, truncation=False,
+        prompts, return_tensors="pt", padding=True, truncation=False,
     ).to(device)
+    assert (inputs["attention_mask"] == 0).any(), (
+        "Expected at least one padding token across the batch."
+    )
+
+    # Build explicit position_ids (shifted, non-default) to assert that the
+    # wrapper actually forwards position_ids — silently dropping them would
+    # match the bf16 tolerance on the default 0..L-1 path.
+    seq_len = inputs["input_ids"].shape[1]
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0).expand(
+        inputs["input_ids"].shape[0], -1
+    )
 
     with torch.inference_mode():
-        ref_out = ref_model(**inputs)
+        ref_out = ref_model(
+            input_ids=inputs["input_ids"],
+            attention_mask=inputs["attention_mask"],
+            position_ids=position_ids,
+            output_hidden_states=True,
+        )
         ref_hidden = ref_out["last_hidden_state"].detach().float().cpu()
+        ref_all_hiddens = ref_out["hidden_states"]
 
-        # FastVideo wrapper: forward through the adapter; it lazy-loads the
-        # encoder on first call and moves it to the input's device.
         fv_out = fv_model(
             input_ids=inputs["input_ids"],
-            attention_mask=inputs.get("attention_mask"),
+            attention_mask=inputs["attention_mask"],
+            position_ids=position_ids,
+            output_hidden_states=True,
         )
         fv_hidden = fv_out.last_hidden_state.detach().float().cpu()
+        fv_all_hiddens = fv_out.hidden_states
 
     print(
         f"ref_hidden shape={tuple(ref_hidden.shape)} "
@@ -128,3 +149,24 @@ def test_magi_human_t5gemma_wrapper_parity():
     # drift is bounded by nondeterminism in SDPA + bf16 matmul. This
     # should be <= 1e-3 end-to-end.
     assert_close(fv_hidden, ref_hidden, atol=1e-3, rtol=1e-3)
+
+    # The wrapper must preserve the encoder's native dtype (bf16) on
+    # `last_hidden_state`; MagiHuman's downstream `.half()` cast is the
+    # pipeline's job, not the wrapper's.
+    assert fv_out.last_hidden_state.dtype == torch.bfloat16, (
+        f"Expected bf16 last_hidden_state, got {fv_out.last_hidden_state.dtype}"
+    )
+
+    # `output_hidden_states=True` must produce a tuple matching the
+    # reference's hidden-state tuple length (42 layers + 1 embedding).
+    assert fv_all_hiddens is not None, "output_hidden_states=True produced None"
+    assert len(fv_all_hiddens) == len(ref_all_hiddens), (
+        f"hidden_states tuple length mismatch: "
+        f"fv={len(fv_all_hiddens)} ref={len(ref_all_hiddens)}"
+    )
+
+    # The wrapper must propagate the input attention_mask back out on
+    # BaseEncoderOutput — downstream stages key off it for pad_or_trim.
+    assert fv_out.attention_mask is inputs["attention_mask"], (
+        "Wrapper must echo the input attention_mask unchanged."
+    )


### PR DESCRIPTION
## Summary

Adds the T5-Gemma 9b-9b-ul2 text encoder used by daVinci-MagiHuman as its text-conditioning path.

**Pure addition.** No existing pipeline imports this yet - the encoder is dead code on the stack tip until the activation switch in 8/8 (`magi-activate`).

## Changes

| File | LOC | Purpose |
|---|---:|---|
| `fastvideo/models/encoders/t5gemma.py` | 127 | T5-Gemma encoder forward |
| `fastvideo/configs/models/encoders/t5gemma.py` | 70 | `T5GemmaEncoderConfig` arch dataclass |
| `fastvideo/configs/models/encoders/__init__.py` | +1 export | `T5GemmaEncoderConfig` |
| `tests/local_tests/magi_human/__init__.py` | new | Init the magi_human family test dir |
| `tests/local_tests/magi_human/test_magi_human_t5gemma_parity.py` | 130 | Bit-exact vs `google/t5gemma-9b-9b-ul2` |

## Verification

- `pre-commit run --files <changed paths>` ✓ (yapf, ruff, codespell, mypy green)
- Parity test gating: skips without GPU; skips without `HF_TOKEN` for the gated `google/t5gemma-9b-9b-ul2` repo.
- Self-testing: this PR ships both the encoder and its bit-exact parity test.

## Stack context

Step **2 of 8** in the PR #1280 decomposition. Stacked on #1295.

```
main → #1293 → #1294 → #1295 → #THIS (2/8) → ...
                                  └── will/magi-02-t5gemma
```

## Provenance

Source PR: #1280 (`will/magi` @ `4e160363`)