### PR TITLE
[feat]: MagiHuman pipeline stages (4/8)

### DIFF
--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -78,6 +78,7 @@ class ComponentLoader(ABC):
         module_loaders = {
             "scheduler": (SchedulerLoader, "diffusers"),
             "transformer": (TransformerLoader, "diffusers"),
+            "sr_transformer": (TransformerLoader, "diffusers"),
             "transformer_2": (TransformerLoader, "diffusers"),
             "transformer_3": (TransformerLoader, "diffusers"),
             "vae": (VAELoader, "diffusers"),

--- a/fastvideo/pipelines/basic/magi_human/__init__.py
+++ b/fastvideo/pipelines/basic/magi_human/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/fastvideo/pipelines/basic/magi_human/stages/__init__.py
+++ b/fastvideo/pipelines/basic/magi_human/stages/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+from fastvideo.pipelines.basic.magi_human.stages.audio_decoding import MagiHumanAudioDecodingStage
+from fastvideo.pipelines.basic.magi_human.stages.denoising import MagiHumanDenoisingStage
+from fastvideo.pipelines.basic.magi_human.stages.latent_preparation import MagiHumanLatentPreparationStage
+from fastvideo.pipelines.basic.magi_human.stages.reference_image import MagiHumanReferenceImageStage
+from fastvideo.pipelines.basic.magi_human.stages.sr_denoising import MagiHumanSRDenoisingStage
+from fastvideo.pipelines.basic.magi_human.stages.sr_latent_preparation import MagiHumanSRLatentPreparationStage
+
+__all__ = [
+    "MagiHumanAudioDecodingStage",
+    "MagiHumanDenoisingStage",
+    "MagiHumanLatentPreparationStage",
+    "MagiHumanReferenceImageStage",
+    "MagiHumanSRDenoisingStage",
+    "MagiHumanSRLatentPreparationStage",
+]

--- a/fastvideo/pipelines/basic/magi_human/stages/audio_decoding.py
+++ b/fastvideo/pipelines/basic/magi_human/stages/audio_decoding.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Audio decoding stage for daVinci-MagiHuman.
+
+Takes the denoised audio latent that `MagiHumanDenoisingStage` leaves
+on `batch.audio_latents` and decodes it to a waveform using the
+Stable Audio Open 1.0 VAE. Mirrors the upstream post-process path
+(see `MagiEvaluator.post_process` in
+daVinci-MagiHuman/inference/pipeline/video_generate.py:503):
+
+    latent_audio.squeeze(0)                 # (L, C_latent)
+    audio = self.audio_vae.decode(latent_audio.T)   # (1, audio_ch, samples)
+    audio = audio.squeeze(0).T.cpu().numpy()        # (samples, audio_ch)
+    audio = resample_audio_sinc(audio, _UPSTREAM_AUDIO_TIME_STRETCH)
+
+The stage stores the resampled waveform on `batch.extra["audio"]`
+(shape `[samples, audio_channels]`) and the sample rate on
+`batch.extra["audio_sample_rate"]`. FastVideo's `VideoGenerator._mux_audio`
+then reads those, writes a temp wav, and muxes it into the output mp4
+via PyAV — same plumbing LTX-2 and Stable Audio use.
+"""
+from __future__ import annotations
+
+import numpy as np
+import torch
+from scipy.signal import resample as _scipy_resample
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.stages.validators import VerificationResult
+
+# 441/512 is daVinci-MagiHuman's audio time-stretch ratio that aligns
+# the 44.1 kHz Stable-Audio output with the 25-fps video frame rate.
+# See daVinci-MagiHuman/inference/pipeline/video_generate.py:516.
+_UPSTREAM_AUDIO_TIME_STRETCH = 441.0 / 512.0
+
+# Stable Audio Open 1.0 native sample rate (per stabilityai/stable-audio-open-1.0
+# model card and fastvideo/configs/models/vaes/oobleck.py::OobleckVAEArchConfig.sampling_rate).
+_SA_AUDIO_OPEN_SAMPLE_RATE = 44100
+
+
+def _resample_sinc(audio: np.ndarray, time_stretching: float) -> np.ndarray:
+    """Resample the audio to ``new_length = int(L * time_stretching)`` samples.
+
+    Mirrors upstream ``video_process.resample_audio_sinc`` which calls
+    ``scipy.signal.resample`` (FFT-based polyphase resampling that
+    approximates ideal sinc interpolation). This avoids the
+    high-frequency aliasing and roll-off that ``F.interpolate(mode='linear')``
+    would introduce on a 25 fps × ~5 s wav (`scipy` is already a direct
+    fastvideo dep, so this is dependency-free relative to the previous
+    implementation).
+    """
+    if time_stretching == 1.0:
+        return audio
+    new_length = int(audio.shape[0] * time_stretching)
+    resampled = _scipy_resample(audio.astype(np.float32), new_length, axis=0)
+    return np.asarray(resampled, dtype=np.float32)
+
+
+class MagiHumanAudioDecodingStage(PipelineStage):
+    """Decode `batch.audio_latents` to a waveform using Stable Audio's VAE.
+
+    The VAE is loaded lazily by `SAAudioVAEModel.sa_audio_vae_model` — the
+    first call triggers a snapshot_download (requires HF token + accepted
+    terms on stabilityai/stable-audio-open-1.0).
+    """
+
+    def __init__(
+        self,
+        audio_vae,
+        time_stretching: float = _UPSTREAM_AUDIO_TIME_STRETCH,
+    ) -> None:
+        super().__init__()
+        self.audio_vae = audio_vae
+        self.time_stretching = time_stretching
+
+    def verify_input(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    def verify_output(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    @torch.inference_mode()
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        latent_audio = getattr(batch, "audio_latents", None)
+        if latent_audio is None:
+            # Joint AV: missing audio latents means the denoising stage broke.
+            raise ValueError("MagiHumanAudioDecodingStage requires batch.audio_latents to be set. "
+                             "Did the denoising stage produce them? Joint AV pipeline expects "
+                             "both video and audio latents from MagiHumanDenoisingStage.")
+
+        # Upstream shape: `[B, L, C_latent]` from the DiT; AutoencoderOobleck
+        # expects `[B, C_latent, L]`. MagiEvaluator.post_process does
+        # `latent_audio.squeeze(0); audio_vae.decode(latent_audio.T)`
+        # (which yields `[C_latent, L]`, implicit batch=1). We keep the
+        # batch dim and transpose L<->C.
+        latent_bcl = latent_audio.permute(0, 2, 1).contiguous()
+
+        # Decode: [B, C_latent, L] -> [B, audio_channels, samples]
+        audio_out = self.audio_vae.decode(latent_bcl)
+
+        audio_np = audio_out.squeeze(0).T.float().cpu().numpy()
+        audio_np = _resample_sinc(audio_np, self.time_stretching)
+
+        # Conform to FastVideo convention: VideoGenerator._mux_audio
+        # reads these two keys and muxes via PyAV.
+        if batch.extra is None:
+            batch.extra = {}
+        batch.extra["audio"] = audio_np
+        batch.extra["audio_sample_rate"] = int(getattr(self.audio_vae, "sampling_rate", _SA_AUDIO_OPEN_SAMPLE_RATE))
+        return batch

--- a/fastvideo/pipelines/basic/magi_human/stages/denoising.py
+++ b/fastvideo/pipelines/basic/magi_human/stages/denoising.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Joint-modality denoising stage for daVinci-MagiHuman base text-to-AV.
+
+Runs the FlowUniPC denoise loop with CFG=2 over video + audio latents
+jointly. Text embeddings are already pad-or-trimmed to `t5_gemma_target_length`
+by `MagiHumanLatentPreparationStage`; the original context lengths are
+stashed on the batch as `magi_original_text_lens` / `magi_original_neg_text_lens`.
+"""
+from __future__ import annotations
+
+import copy
+
+import torch
+from tqdm import tqdm
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.forward_context import set_forward_context
+from fastvideo.hooks.activation_trace import trace_step
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.stages.validators import VerificationResult
+from fastvideo.pipelines.basic.magi_human.stages.latent_preparation import (
+    StaticPackedInputs,
+    assemble_packed_inputs,
+    build_static_packed_inputs,
+    unpack_tokens,
+)
+
+
+def _dit_forward(
+    dit,
+    video_latent: torch.Tensor,
+    audio_feat_len: int,
+    txt_feat: torch.Tensor,
+    txt_feat_len: int,
+    static_packed: StaticPackedInputs,
+    coords_style: str,
+    video_in_channels: int,
+    audio_in_channels: int,
+    patch_size: tuple[int, int, int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    x, coords, mm = assemble_packed_inputs(
+        static=static_packed,
+        txt_feat=txt_feat,
+        txt_feat_len=txt_feat_len,
+        coords_style=coords_style,
+    )
+    video_token_num = static_packed.video_token_num
+    out = dit(x, coords, mm)
+    return unpack_tokens(
+        out,
+        video_token_num=video_token_num,
+        audio_feat_len=audio_feat_len,
+        video_in_channels=video_in_channels,
+        audio_in_channels=audio_in_channels,
+        latent_shape=tuple(video_latent.shape),
+        patch_size=patch_size,
+    )
+
+
+def _overwrite_first_frame(
+    video_latent: torch.Tensor,
+    image_latent: torch.Tensor | None,
+) -> torch.Tensor:
+    if image_latent is not None:
+        video_latent[:, :, :1] = image_latent.to(
+            device=video_latent.device,
+            dtype=video_latent.dtype,
+        )[:, :, :1]
+    return video_latent
+
+
+class MagiHumanDenoisingStage(PipelineStage):
+    """UniPC-flow joint denoising with CFG=2 over (video, audio) latents."""
+
+    def __init__(
+        self,
+        transformer,
+        scheduler,
+        patch_size: tuple[int, int, int] = (1, 2, 2),
+        video_in_channels: int = 192,
+        audio_in_channels: int = 64,
+        video_txt_guidance_scale: float = 5.0,
+        audio_txt_guidance_scale: float = 5.0,
+        cfg_number: int = 2,
+        coords_style: str = "v2",
+        video_guidance_high_t_threshold: int = 500,
+        video_guidance_low_t_value: float = 2.0,
+    ) -> None:
+        super().__init__()
+        self.transformer = transformer
+        self.scheduler = scheduler
+        self.patch_size = patch_size
+        self.video_in_channels = video_in_channels
+        self.audio_in_channels = audio_in_channels
+        self.video_txt_guidance_scale = video_txt_guidance_scale
+        self.audio_txt_guidance_scale = audio_txt_guidance_scale
+        self.cfg_number = cfg_number
+        self.coords_style = coords_style
+        self.video_guidance_high_t_threshold = video_guidance_high_t_threshold
+        self.video_guidance_low_t_value = video_guidance_low_t_value
+
+    def verify_input(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    def verify_output(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    @torch.inference_mode()
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        device = batch.latents.device
+        shift = fastvideo_args.pipeline_config.flow_shift
+        # Video and audio use independent FlowUniPC state (upstream
+        # inference/pipeline/video_generate.py:404-407 instantiates two
+        # separate schedulers). Sharing one scheduler causes the
+        # `model_outputs` buffer for the video step to pollute the audio
+        # step's diff calculation (different shapes -> broadcast error).
+        video_scheduler = copy.deepcopy(self.scheduler)
+        audio_scheduler = copy.deepcopy(self.scheduler)
+        video_scheduler.set_timesteps(
+            batch.num_inference_steps,
+            device=device,
+            shift=shift,
+        )
+        audio_scheduler.set_timesteps(
+            batch.num_inference_steps,
+            device=device,
+            shift=shift,
+        )
+        timesteps = video_scheduler.timesteps
+
+        video_latent = batch.latents
+        audio_latent = batch.audio_latents
+        image_latent = getattr(batch, "image_latent", None)
+
+        # Expect [1, L, 3584] text embeds plus a list of original lengths.
+        txt_feat = batch.prompt_embeds[0]
+        txt_feat_len = int(batch.magi_original_text_lens[0])
+
+        neg_txt_feat: torch.Tensor | None = None
+        neg_txt_feat_len: int = 0
+        if self.cfg_number == 2:
+            neg_list = batch.negative_prompt_embeds or []
+            if not neg_list:
+                raise ValueError("CFG=2 requires negative prompt embeddings; got None. "
+                                 "Did the prompt encoding stage run?")
+            else:
+                neg_txt_feat = neg_list[0]
+                neg_txt_feat_len = int(batch.magi_original_neg_text_lens[0])
+
+        audio_feat_len = int(audio_latent.shape[1])
+
+        disable_tqdm = not getattr(fastvideo_args, "log_level_progress", True)
+        for idx, t in enumerate(tqdm(timesteps, disable=disable_tqdm)):
+            video_latent = _overwrite_first_frame(video_latent, image_latent)
+            # Precompute packed video+audio tokens after any TI2V first-frame
+            # overwrite. Text varies per cond/uncond call and is attached in
+            # _dit_forward via assemble_packed_inputs.
+            static_packed = build_static_packed_inputs(
+                video_latent=video_latent,
+                audio_latent=audio_latent,
+                audio_feat_len=audio_feat_len,
+                patch_size=self.patch_size,
+                coords_style=self.coords_style,
+                layout=getattr(batch, "magi_static_packed_layout", None),
+            )
+            with trace_step(idx), set_forward_context(
+                    current_timestep=int(t.item()) if torch.is_tensor(t) else int(t),
+                    attn_metadata=None,
+            ):
+                v_cond_video, v_cond_audio = _dit_forward(
+                    self.transformer,
+                    video_latent=video_latent,
+                    audio_feat_len=audio_feat_len,
+                    txt_feat=txt_feat,
+                    txt_feat_len=txt_feat_len,
+                    static_packed=static_packed,
+                    coords_style=self.coords_style,
+                    video_in_channels=self.video_in_channels,
+                    audio_in_channels=self.audio_in_channels,
+                    patch_size=self.patch_size,
+                )
+
+                if self.cfg_number == 2:
+                    v_uncond_video, v_uncond_audio = _dit_forward(
+                        self.transformer,
+                        video_latent=video_latent,
+                        audio_feat_len=audio_feat_len,
+                        txt_feat=neg_txt_feat,
+                        txt_feat_len=neg_txt_feat_len,
+                        static_packed=static_packed,
+                        coords_style=self.coords_style,
+                        video_in_channels=self.video_in_channels,
+                        audio_in_channels=self.audio_in_channels,
+                        patch_size=self.patch_size,
+                    )
+                else:
+                    v_uncond_video = None
+                    v_uncond_audio = None
+
+            if self.cfg_number == 2:
+                video_guidance = (self.video_txt_guidance_scale
+                                  if t > self.video_guidance_high_t_threshold else self.video_guidance_low_t_value)
+                assert v_uncond_video is not None and v_uncond_audio is not None
+                v_video = v_uncond_video + video_guidance * (v_cond_video - v_uncond_video)
+                v_audio = v_uncond_audio + self.audio_txt_guidance_scale * (v_cond_audio - v_uncond_audio)
+            else:
+                v_video = v_cond_video
+                v_audio = v_cond_audio
+
+            # Independent scheduler state per modality (see comment above).
+            video_latent = video_scheduler.step(
+                v_video,
+                t,
+                video_latent,
+                return_dict=False,
+            )[0]
+            audio_latent = audio_scheduler.step(
+                v_audio,
+                t,
+                audio_latent,
+                return_dict=False,
+            )[0]
+
+        video_latent = _overwrite_first_frame(video_latent, image_latent)
+        batch.latents = video_latent
+        batch.audio_latents = audio_latent
+        return batch

--- a/fastvideo/pipelines/basic/magi_human/stages/latent_preparation.py
+++ b/fastvideo/pipelines/basic/magi_human/stages/latent_preparation.py
@@ -1,0 +1,590 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Latent preparation stage for daVinci-MagiHuman base text-to-AV.
+
+Produces:
+  - random video latent of shape `[1, z_dim, latent_T, latent_H, latent_W]`,
+  - random audio latent of shape `[1, num_frames, 64]` (the DiT jointly
+    denoises both modalities),
+  - padded T5-Gemma text embedding (target length 640) plus the original
+    (pre-pad) context length, which the UniPC + CFG loop needs so the
+    unconditional path sees the same padded length.
+
+Also stakes out the per-token coords / modality map that the DiT consumes
+(replicates the reference `MagiDataProxy.process_input`).
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+from einops import rearrange
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.stages.validators import VerificationResult
+
+# Matches inference/common/sequence_schema.py in the reference.
+MODALITY_VIDEO = 0
+MODALITY_AUDIO = 1
+MODALITY_TEXT = 2
+
+# Audio temporal compression ratio: 1 audio frame → 1/4 latent frame.
+# Mirrors data_proxy.py:206 `(audio_feat_len - 1) // 4 + 1` where 4 is
+# the audio VAE's temporal stride (same as vae_stride[0] for video).
+_AUDIO_TEMPORAL_COMPRESSION = 4
+
+# v1 text-coord reference shape: (T=2, H=1, W=1).
+# Mirrors data_proxy.py:202 `ref_feat_shape=(2, 1, 1)` for coords_style=="v1".
+_V1_TEXT_REF_SHAPE: tuple[int, int, int] = (2, 1, 1)
+
+
+def _build_coords(
+    shape: tuple[int, int, int],
+    ref_feat_shape: tuple[int, int, int],
+    offset_thw: tuple[int, int, int] = (0, 0, 0),
+    device: torch.device | None = None,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    if device is None:
+        device = torch.device("cpu")
+    ori_t, ori_h, ori_w = shape
+    ref_t, ref_h, ref_w = ref_feat_shape
+    offset_t, offset_h, offset_w = offset_thw
+    time_rng = torch.arange(ori_t, device=device, dtype=dtype) + offset_t
+    h_rng = torch.arange(ori_h, device=device, dtype=dtype) + offset_h
+    w_rng = torch.arange(ori_w, device=device, dtype=dtype) + offset_w
+    tg, hg, wg = torch.meshgrid(time_rng, h_rng, w_rng, indexing="ij")
+    coords = torch.stack([tg, hg, wg], dim=-1).reshape(-1, 3)
+    meta = torch.tensor(
+        [ori_t, ori_h, ori_w, ref_t, ref_h, ref_w],
+        device=device,
+        dtype=dtype,
+    ).expand(coords.size(0), -1)
+    return torch.cat([coords, meta], dim=-1)
+
+
+def _pad_or_trim_dim1(t: torch.Tensor, target: int) -> tuple[torch.Tensor, int]:
+    """Pad-or-trim along dim 1. Returns (new_tensor, original_length)."""
+    current = t.size(1)
+    if current < target:
+        pad = [0, 0, 0, target - current]
+        return F.pad(t, pad, "constant", 0.0), current
+    return t[:, :target], target
+
+
+def _img2tokens(x_t: torch.Tensor, t_patch: int, patch: int) -> torch.Tensor:
+    """Pack a video latent [B, C, T, H, W] -> [B, L, C * t_patch * patch^2].
+
+    Per-token feature ordering is channel-major ``(C pT pH pW)``: the DiT's
+    ``video_embedder`` weight was trained on the layout produced by
+    upstream's grouped-conv ``UnfoldNd`` packer (channel slowest, patch
+    elements fastest). Spatial-major ``(pT pH pW C)`` silently permutes the
+    in-features and produces noise output. Asymmetric with
+    ``unpack_tokens`` which uses ``(pT pH pW C)`` to match
+    ``final_linear_video``'s trained output layout.
+    """
+    B, C, T, H, W = x_t.shape
+    assert T % t_patch == 0 and H % patch == 0 and W % patch == 0, (
+        f"Latent dims {T,H,W} must divide ({t_patch}, {patch}, {patch})")
+    return rearrange(
+        x_t,
+        "B C (T pT) (H pH) (W pW) -> B (T H W) (C pT pH pW)",
+        pT=t_patch,
+        pH=patch,
+        pW=patch,
+    ).contiguous()
+
+
+class MagiHumanLatentPreparationStage(PipelineStage):
+    """Prepare latents, coords, modality maps, and padded text embed."""
+
+    def __init__(
+        self,
+        vae_stride: tuple[int, int, int] = (4, 16, 16),
+        z_dim: int = 48,
+        patch_size: tuple[int, int, int] = (1, 2, 2),
+        fps: int = 25,
+        t5_gemma_target_length: int = 640,
+        coords_style: Literal["v1", "v2"] = "v2",
+        text_offset: int = 0,
+        audio_in_channels: int = 64,
+    ) -> None:
+        super().__init__()
+        self.vae_stride = vae_stride
+        self.z_dim = z_dim
+        self.patch_size = patch_size
+        self.fps = fps
+        self.t5_gemma_target_length = t5_gemma_target_length
+        self.coords_style = coords_style
+        self.text_offset = text_offset
+        self.audio_in_channels = audio_in_channels
+
+    def verify_input(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    def verify_output(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        fps = self.fps
+        # Prefer the caller-provided `batch.num_frames` (the standard
+        # SamplingParam knob — production preset and SSIM tests both set
+        # it). Fall back to `batch.num_seconds * fps + 1` when num_frames
+        # is unset or the image-default sentinel (1). This matches
+        # upstream MagiDataProxy.process_input which derives `num_frames
+        # = seconds * fps + 1` and rejects values that don't satisfy
+        # `(num_frames - 1) % vae_temporal_stride == 0`.
+        requested_num_frames = int(getattr(batch, "num_frames", None) or 0)
+        if requested_num_frames > 1:
+            num_frames = requested_num_frames
+        else:
+            seconds = int(getattr(batch, "num_seconds", None) or 4)
+            num_frames = seconds * fps + 1
+        latent_T = (num_frames - 1) // 4 + 1
+
+        # Match upstream pipeline.py:61-64 + video_generate.py:254-261:
+        # the requested 272p height snaps to 256, while width stays 480.
+        br_h = int(batch.height) if batch.height else 256
+        br_w = int(batch.width) if batch.width else 480
+        pT, pH, pW = self.patch_size
+        vt, vh, vw = self.vae_stride
+        # Snap to patch granularity (matches reference).
+        latent_H = (br_h // vh // pH) * pH
+        latent_W = (br_w // vw // pW) * pW
+        actual_H = latent_H * vh
+        actual_W = latent_W * vw
+        batch.height = actual_H
+        batch.width = actual_W
+
+        generator = torch.Generator(device=device)
+        if batch.seed is not None:
+            generator.manual_seed(int(batch.seed))
+
+        # Video latent: [1, z_dim, latent_T, latent_H, latent_W]
+        video_latent = torch.randn(
+            (1, self.z_dim, latent_T, latent_H, latent_W),
+            generator=generator,
+            device=device,
+            dtype=torch.float32,
+        )
+        image_latent = getattr(batch, "image_latent", None)
+        if image_latent is not None:
+            video_latent[:, :, :1] = image_latent.to(
+                device=video_latent.device,
+                dtype=video_latent.dtype,
+            )[:, :, :1]
+        # Audio latent: [1, num_frames, audio_in_channels]
+        audio_latent = torch.randn(
+            (1, num_frames, self.audio_in_channels),
+            generator=generator,
+            device=device,
+            dtype=torch.float32,
+        )
+
+        # Prompt embeds: the upstream TextEncodingStage already ran. It
+        # produced a list of [1, L, D] tensors per prompt. Pad/trim each
+        # to the target length and store the original length so the DiT
+        # stage can build the correct modality-map slices.
+        padded_prompt_embeds: list[torch.Tensor] = []
+        padded_prompt_lens: list[int] = []
+        for embed in batch.prompt_embeds:
+            # embed: [1, L, 3584]
+            padded, original = _pad_or_trim_dim1(
+                embed.to(torch.float32),
+                target=self.t5_gemma_target_length,
+            )
+            padded_prompt_embeds.append(padded)
+            padded_prompt_lens.append(original)
+        batch.prompt_embeds = padded_prompt_embeds
+        # Stash the original text length list on the batch for the denoise
+        # stage — FastVideo's ForwardBatch doesn't have a first-class field
+        # for this so we attach it.
+        batch.magi_original_text_lens = padded_prompt_lens
+
+        # Matching negative prompts.
+        if batch.negative_prompt_embeds is not None and batch.negative_prompt_embeds:
+            padded_neg: list[torch.Tensor] = []
+            padded_neg_lens: list[int] = []
+            for embed in batch.negative_prompt_embeds:
+                padded, original = _pad_or_trim_dim1(
+                    embed.to(torch.float32),
+                    target=self.t5_gemma_target_length,
+                )
+                padded_neg.append(padded)
+                padded_neg_lens.append(original)
+            batch.negative_prompt_embeds = padded_neg
+            batch.magi_original_neg_text_lens = padded_neg_lens
+
+        batch.latents = video_latent
+        batch.audio_latents = audio_latent
+        batch.num_frames = num_frames
+        batch.magi_latent_T = latent_T
+        batch.magi_latent_H = latent_H
+        batch.magi_latent_W = latent_W
+        # Precompute the step-invariant packed layout (coords / modality
+        # maps / channel-padding width) once; the denoise loop reuses it
+        # every step instead of rebuilding meshgrids on each call.
+        batch.magi_static_packed_layout = precompute_static_packed_layout(
+            latent_shape=tuple(video_latent.shape),  # type: ignore[arg-type]
+            audio_feat_len=int(audio_latent.shape[1]),
+            z_dim=self.z_dim,
+            audio_in_channels=self.audio_in_channels,
+            patch_size=self.patch_size,
+            coords_style=self.coords_style,
+            device=video_latent.device,
+        )
+        return batch
+
+
+class StaticPackedInputs:
+    """Step-invariant packed inputs: video+audio tokens, coords, modality map.
+
+    Computed once before the denoise loop; reused for every cond/uncond call.
+    Text tokens are NOT included here because cond/uncond have different lengths.
+    """
+
+    __slots__ = (
+        "video_tokens",
+        "audio_tokens",
+        "video_coords",
+        "audio_coords",
+        "video_mm",
+        "audio_mm",
+        "video_token_num",
+        "audio_feat_len",
+        "max_ch",
+    )
+
+    def __init__(
+        self,
+        video_tokens: torch.Tensor,
+        audio_tokens: torch.Tensor,
+        video_coords: torch.Tensor,
+        audio_coords: torch.Tensor,
+        video_mm: torch.Tensor,
+        audio_mm: torch.Tensor,
+        max_ch: int,
+    ) -> None:
+        self.video_tokens = video_tokens
+        self.audio_tokens = audio_tokens
+        self.video_coords = video_coords
+        self.audio_coords = audio_coords
+        self.video_mm = video_mm
+        self.audio_mm = audio_mm
+        self.video_token_num = video_tokens.size(0)
+        self.audio_feat_len = audio_tokens.size(0)
+        self.max_ch = max_ch
+
+
+class StaticPackedLayout:
+    """Step- and value-invariant portion of the static packed inputs.
+
+    Coords, modality maps, and the channel-padding width depend only on the
+    latent shape, audio length, channel widths, and patch sizes — all fixed
+    for a single generation. Precompute once before the denoise loop and
+    reuse on every step. Only the per-step token tensors must be rebuilt.
+    """
+
+    __slots__ = (
+        "video_coords",
+        "audio_coords",
+        "video_mm",
+        "audio_mm",
+        "max_ch",
+        "video_token_num",
+        "audio_feat_len",
+    )
+
+    def __init__(
+        self,
+        video_coords: torch.Tensor,
+        audio_coords: torch.Tensor,
+        video_mm: torch.Tensor,
+        audio_mm: torch.Tensor,
+        max_ch: int,
+        video_token_num: int,
+        audio_feat_len: int,
+    ) -> None:
+        self.video_coords = video_coords
+        self.audio_coords = audio_coords
+        self.video_mm = video_mm
+        self.audio_mm = audio_mm
+        self.max_ch = max_ch
+        self.video_token_num = video_token_num
+        self.audio_feat_len = audio_feat_len
+
+
+def precompute_static_packed_layout(
+    latent_shape: tuple[int, int, int, int, int],
+    audio_feat_len: int,
+    z_dim: int,
+    audio_in_channels: int,
+    patch_size: tuple[int, int, int],
+    coords_style: Literal["v1", "v2"] = "v2",
+    device: torch.device | None = None,
+    dtype: torch.dtype = torch.float32,
+) -> StaticPackedLayout:
+    """Precompute the invariant fields used by ``build_static_packed_inputs``.
+
+    Arguments are derived from configs and latent shape — none depend on
+    the current denoising-step values. Call this once in the latent
+    preparation stage (or any pre-loop site) and pass the result via the
+    ``layout=`` arg of ``build_static_packed_inputs`` to skip the
+    meshgrid/full() work on every step.
+    """
+    pT, pH, pW = patch_size
+    _, _, T, H, W = latent_shape
+    if device is None:
+        device = torch.device("cpu")
+
+    video_token_num = (T // pT) * (H // pH) * (W // pW)
+    # `_img2tokens` packs to channel `z_dim * pT * pH * pW`; audio tokens
+    # are `audio_in_channels` wide — both are config constants.
+    max_ch = max(z_dim * pT * pH * pW, audio_in_channels)
+
+    video_ref_shape = (T // pT, H // pH, W // pW)
+    video_coords = _build_coords(
+        shape=video_ref_shape,
+        ref_feat_shape=video_ref_shape,
+        device=device,
+        dtype=dtype,
+    )
+
+    if coords_style == "v2":
+        audio_ref_t = (audio_feat_len - 1) // _AUDIO_TEMPORAL_COMPRESSION + 1
+        audio_coords = _build_coords(
+            shape=(audio_feat_len, 1, 1),
+            ref_feat_shape=(audio_ref_t // pT, 1, 1),
+            device=device,
+            dtype=dtype,
+        )
+    else:
+        audio_coords = _build_coords(
+            shape=(audio_feat_len, 1, 1),
+            ref_feat_shape=(T // pT, 1, 1),
+            device=device,
+            dtype=dtype,
+        )
+
+    video_mm = torch.full((video_token_num, ), MODALITY_VIDEO, dtype=torch.int64, device=device)
+    audio_mm = torch.full((audio_feat_len, ), MODALITY_AUDIO, dtype=torch.int64, device=device)
+
+    return StaticPackedLayout(
+        video_coords=video_coords,
+        audio_coords=audio_coords,
+        video_mm=video_mm,
+        audio_mm=audio_mm,
+        max_ch=max_ch,
+        video_token_num=video_token_num,
+        audio_feat_len=audio_feat_len,
+    )
+
+
+def build_static_packed_inputs(
+    video_latent: torch.Tensor,
+    audio_latent: torch.Tensor,
+    audio_feat_len: int,
+    patch_size: tuple[int, int, int],
+    coords_style: Literal["v1", "v2"] = "v2",
+    layout: StaticPackedLayout | None = None,
+) -> StaticPackedInputs:
+    """Build the step-invariant portion of the packed token stream.
+
+    Returns video+audio tokens (padded to a common channel width), their
+    coords, and their modality slices. Text is excluded because cond/uncond
+    differ in length; call assemble_packed_inputs to attach text per call.
+
+    Mirrors SingleData.token_sequence / coords_mapping / modality_mapping in
+    inference/pipeline/data_proxy.py, minus the text portion.
+
+    When ``layout`` is provided, coords / modality maps / max_ch are taken
+    from the precomputed values and only the per-step token tensors are
+    rebuilt; this is the hot-path call from the denoising loop. When
+    ``layout`` is None the function recomputes everything from scratch
+    (e.g. for one-shot tests via ``build_packed_inputs``).
+    """
+    pT, pH, pW = patch_size
+    assert video_latent.size(0) == 1, "batch size 1 required for MagiHuman base"
+
+    video_tokens = _img2tokens(video_latent, t_patch=pT, patch=pH)[0]
+    audio_tokens = audio_latent[0, :audio_feat_len].contiguous()
+
+    if layout is not None:
+        max_ch = layout.max_ch
+        video_tokens = F.pad(video_tokens, (0, max_ch - video_tokens.size(-1)))
+        audio_tokens = F.pad(audio_tokens, (0, max_ch - audio_tokens.size(-1)))
+        return StaticPackedInputs(
+            video_tokens=video_tokens,
+            audio_tokens=audio_tokens,
+            video_coords=layout.video_coords,
+            audio_coords=layout.audio_coords,
+            video_mm=layout.video_mm,
+            audio_mm=layout.audio_mm,
+            max_ch=max_ch,
+        )
+
+    # Slow path: rebuild every invariant from scratch. Kept for the
+    # ``build_packed_inputs`` one-shot wrapper used by tests/parity helpers.
+    _, z_dim, T, H, W = video_latent.shape
+
+    max_ch = max(video_tokens.size(-1), audio_tokens.size(-1))
+    video_tokens = F.pad(video_tokens, (0, max_ch - video_tokens.size(-1)))
+    audio_tokens = F.pad(audio_tokens, (0, max_ch - audio_tokens.size(-1)))
+
+    device = video_tokens.device
+    dtype = video_tokens.dtype
+    video_token_num = video_tokens.size(0)
+
+    video_mm = torch.full((video_token_num, ), MODALITY_VIDEO, dtype=torch.int64, device=device)
+    audio_mm = torch.full((audio_feat_len, ), MODALITY_AUDIO, dtype=torch.int64, device=device)
+
+    video_ref_shape = (T // pT, H // pH, W // pW)
+    video_coords = _build_coords(
+        shape=video_ref_shape,
+        ref_feat_shape=video_ref_shape,
+        device=device,
+        dtype=dtype,
+    )
+
+    if coords_style == "v2":
+        audio_ref_t = (audio_feat_len - 1) // _AUDIO_TEMPORAL_COMPRESSION + 1
+        audio_coords = _build_coords(
+            shape=(audio_feat_len, 1, 1),
+            ref_feat_shape=(audio_ref_t // pT, 1, 1),
+            device=device,
+            dtype=dtype,
+        )
+    else:
+        audio_coords = _build_coords(
+            shape=(audio_feat_len, 1, 1),
+            ref_feat_shape=(T // pT, 1, 1),
+            device=device,
+            dtype=dtype,
+        )
+
+    return StaticPackedInputs(
+        video_tokens=video_tokens,
+        audio_tokens=audio_tokens,
+        video_coords=video_coords,
+        audio_coords=audio_coords,
+        video_mm=video_mm,
+        audio_mm=audio_mm,
+        max_ch=max_ch,
+    )
+
+
+def assemble_packed_inputs(
+    static: StaticPackedInputs,
+    txt_feat: torch.Tensor,
+    txt_feat_len: int,
+    coords_style: Literal["v1", "v2"] = "v2",
+    text_offset: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Attach per-call text tokens to the precomputed static packed inputs.
+
+    Returns (token_seq, coords, modality_map) ready for the DiT.
+    """
+    text_tokens = txt_feat[0, :txt_feat_len].contiguous()
+    max_ch = max(static.max_ch, text_tokens.size(-1))
+
+    video_tokens = F.pad(static.video_tokens, (0, max_ch - static.video_tokens.size(-1)))
+    audio_tokens = F.pad(static.audio_tokens, (0, max_ch - static.audio_tokens.size(-1)))
+    text_tokens = F.pad(text_tokens, (0, max_ch - text_tokens.size(-1)))
+    token_seq = torch.cat([video_tokens, audio_tokens, text_tokens], dim=0)
+
+    device = token_seq.device
+    dtype = token_seq.dtype
+    text_mm = torch.full((txt_feat_len, ), MODALITY_TEXT, dtype=torch.int64, device=device)
+    mm = torch.cat([static.video_mm, static.audio_mm, text_mm], dim=0)
+
+    if coords_style == "v2":
+        text_coords = _build_coords(
+            shape=(txt_feat_len, 1, 1),
+            ref_feat_shape=(1, 1, 1),
+            offset_thw=(-txt_feat_len, 0, 0),
+            device=device,
+            dtype=dtype,
+        )
+    else:
+        text_coords = _build_coords(
+            shape=(txt_feat_len, 1, 1),
+            ref_feat_shape=_V1_TEXT_REF_SHAPE,
+            offset_thw=(text_offset, 0, 0),
+            device=device,
+            dtype=dtype,
+        )
+
+    coords = torch.cat([static.video_coords, static.audio_coords, text_coords], dim=0)
+    return token_seq, coords, mm
+
+
+def build_packed_inputs(
+    video_latent: torch.Tensor,
+    audio_latent: torch.Tensor,
+    audio_feat_len: int,
+    txt_feat: torch.Tensor,
+    txt_feat_len: int,
+    patch_size: tuple[int, int, int],
+    coords_style: Literal["v1", "v2"] = "v2",
+    text_offset: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build the full packed token stream in one call (backwards-compat wrapper).
+
+    Equivalent to assemble_packed_inputs(build_static_packed_inputs(...), ...).
+    Prefer calling the two helpers separately when the static portion can be
+    reused across multiple calls (e.g. cond/uncond in the denoise loop).
+    """
+    static = build_static_packed_inputs(
+        video_latent=video_latent,
+        audio_latent=audio_latent,
+        audio_feat_len=audio_feat_len,
+        patch_size=patch_size,
+        coords_style=coords_style,
+    )
+    return assemble_packed_inputs(
+        static=static,
+        txt_feat=txt_feat,
+        txt_feat_len=txt_feat_len,
+        coords_style=coords_style,
+        text_offset=text_offset,
+    )
+
+
+def unpack_tokens(
+    output: torch.Tensor,  # [L, max(V_ch, A_ch)]
+    video_token_num: int,
+    audio_feat_len: int,
+    video_in_channels: int,
+    audio_in_channels: int,
+    latent_shape: tuple[int, int, int, int, int],  # [1, z_dim, T, H, W]
+    patch_size: tuple[int, int, int],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Inverse of `build_packed_inputs` for the DiT output.
+
+    Splits the flat output back into a video latent (un-patched into
+    B C T H W) and an audio latent (B, L, 64).
+    """
+    pT, pH, pW = patch_size
+    _, z_dim, T, H, W = latent_shape
+    tH, tW = H // pH, W // pW
+
+    video_flat = output[:video_token_num, :video_in_channels]
+    video_latent = rearrange(
+        video_flat,
+        "(T H W) (pT pH pW C) -> C (T pT) (H pH) (W pW)",
+        H=tH,
+        W=tW,
+        pT=pT,
+        pH=pH,
+        pW=pW,
+    ).contiguous().unsqueeze(0)
+
+    audio_latent = output[
+        video_token_num:video_token_num + audio_feat_len,
+        :audio_in_channels,
+    ].unsqueeze(0)
+
+    return video_latent, audio_latent

--- a/fastvideo/pipelines/basic/magi_human/stages/reference_image.py
+++ b/fastvideo/pipelines/basic/magi_human/stages/reference_image.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reference-image encoding for MagiHuman TI2V.
+
+The upstream daVinci-MagiHuman TI2V path encodes the user image through the
+Wan VAE and overwrites the first denoising latent frame with that clean latent
+at every step. This stage mirrors `MagiEvaluator.encode_image` and stashes the
+normalized latent on `batch.image_latent` for the latent-prep and denoise stages.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from diffusers.utils import load_image
+from diffusers.video_processor import VideoProcessor
+from PIL import Image
+
+from fastvideo.distributed import get_local_torch_device
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.stages.validators import VerificationResult
+
+
+def _resizecrop(image: Image.Image, height: int, width: int) -> Image.Image:
+    """Mirror upstream `resizecrop`: center-crop to target aspect ratio."""
+    current_width, current_height = image.size
+    if current_width == width and current_height == height:
+        return image
+    if current_height / current_width > height / width:
+        new_width = int(current_width)
+        new_height = int(new_width * height / width)
+    else:
+        new_height = int(current_height)
+        new_width = int(new_height * width / height)
+    left = (current_width - new_width) / 2
+    top = (current_height - new_height) / 2
+    right = (current_width + new_width) / 2
+    bottom = (current_height + new_height) / 2
+    return image.crop((left, top, right, bottom))
+
+
+class MagiHumanReferenceImageStage(PipelineStage):
+    """Encode a TI2V reference image into the first-frame video latent."""
+
+    def __init__(self, vae: Any, vae_scale_factor: int = 16) -> None:
+        super().__init__()
+        self.vae = vae
+        self.video_processor = VideoProcessor(vae_scale_factor=vae_scale_factor)
+
+    def verify_input(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    def verify_output(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    @torch.inference_mode()
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        image = getattr(batch, "image", None) or batch.pil_image
+        if image is None and batch.image_path is not None:
+            image = load_image(batch.image_path)
+        if image is None:
+            raise ValueError("MagiHuman TI2V requires `image_path` or `pil_image`.")
+        if not isinstance(image, Image.Image):
+            raise TypeError(f"MagiHuman TI2V expects a PIL image or image path, got {type(image)}")
+        if batch.height is None or batch.width is None:
+            raise ValueError("MagiHuman TI2V requires concrete height and width before image encoding.")
+
+        height = int(batch.height)
+        width = int(batch.width)
+        device = get_local_torch_device()
+
+        image = _resizecrop(image.convert("RGB"), height, width)
+        image_tensor = self.video_processor.preprocess(
+            image,
+            height=height,
+            width=width,
+        ).to(device=device, dtype=torch.float32)
+        image_tensor = image_tensor.unsqueeze(2)
+
+        self.vae = self.vae.to(device)
+        encoded = self.vae.encode(image_tensor)
+        image_latent = encoded.mean if hasattr(encoded, "mean") else encoded
+
+        # FastVideo's Wan VAE returns unnormalized posterior means; upstream
+        # `WanVAE.encode` applies `(mu - mean) / std` before returning.
+        shift_factor = getattr(self.vae, "shift_factor", None)
+        if shift_factor is not None:
+            if isinstance(shift_factor, torch.Tensor):
+                image_latent = image_latent - shift_factor.to(image_latent.device, image_latent.dtype)
+            else:
+                image_latent = image_latent - shift_factor
+        scaling_factor = getattr(self.vae, "scaling_factor", None)
+        if scaling_factor is not None:
+            if isinstance(scaling_factor, torch.Tensor):
+                image_latent = image_latent * scaling_factor.to(image_latent.device, image_latent.dtype)
+            else:
+                image_latent = image_latent * scaling_factor
+
+        batch.image_latent = image_latent.to(torch.float32)
+        return batch

--- a/fastvideo/pipelines/basic/magi_human/stages/sr_denoising.py
+++ b/fastvideo/pipelines/basic/magi_human/stages/sr_denoising.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SR video-only denoising stage for daVinci-MagiHuman SR-540p."""
+from __future__ import annotations
+
+import copy
+
+import torch
+from tqdm import tqdm
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.forward_context import set_forward_context
+from fastvideo.hooks.activation_trace import trace_step
+from fastvideo.pipelines.basic.magi_human.stages.denoising import (
+    _dit_forward,
+    _overwrite_first_frame,
+)
+from fastvideo.pipelines.basic.magi_human.stages.latent_preparation import (
+    build_static_packed_inputs, )
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.stages.validators import VerificationResult
+
+
+class MagiHumanSRDenoisingStage(PipelineStage):
+    """Denoise only the SR video latent; audio passes through unchanged."""
+
+    def __init__(
+        self,
+        transformer,
+        scheduler,
+        patch_size: tuple[int, int, int] = (1, 2, 2),
+        video_in_channels: int = 192,
+        audio_in_channels: int = 64,
+        sr_num_inference_steps: int = 5,
+        sr_video_txt_guidance_scale: float = 3.5,
+        use_cfg_trick: bool = True,
+        cfg_trick_start_frame: int = 13,
+        cfg_trick_value: float = 2.0,
+        cfg_number: int = 2,
+        coords_style: str = "v1",
+    ) -> None:
+        super().__init__()
+        self.transformer = transformer
+        self.scheduler = scheduler
+        self.patch_size = patch_size
+        self.video_in_channels = video_in_channels
+        self.audio_in_channels = audio_in_channels
+        self.sr_num_inference_steps = sr_num_inference_steps
+        self.sr_video_txt_guidance_scale = sr_video_txt_guidance_scale
+        self.use_cfg_trick = use_cfg_trick
+        self.cfg_trick_start_frame = cfg_trick_start_frame
+        self.cfg_trick_value = cfg_trick_value
+        self.cfg_number = cfg_number
+        self.coords_style = coords_style
+
+    def verify_input(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    def verify_output(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    @torch.inference_mode()
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        device = batch.latents.device
+        shift = fastvideo_args.pipeline_config.flow_shift
+        video_scheduler = copy.deepcopy(self.scheduler)
+        video_scheduler.set_timesteps(
+            self.sr_num_inference_steps,
+            device=device,
+            shift=shift,
+        )
+
+        video_latent = batch.latents
+        audio_latent = batch.audio_latents
+        audio_feat_len = int(audio_latent.shape[1])
+        image_latent = getattr(batch, "image_latent", None)
+
+        txt_feat = batch.prompt_embeds[0]
+        txt_feat_len = int(batch.magi_original_text_lens[0])
+
+        neg_txt_feat: torch.Tensor | None = None
+        neg_txt_feat_len = 0
+        if self.cfg_number == 2:
+            neg_list = batch.negative_prompt_embeds or []
+            if not neg_list:
+                raise ValueError("SR CFG=2 requires negative prompt embeddings.")
+            neg_txt_feat = neg_list[0]
+            neg_txt_feat_len = int(batch.magi_original_neg_text_lens[0])
+
+        latent_length = video_latent.shape[2]
+        guidance = torch.tensor(
+            self.sr_video_txt_guidance_scale,
+            device=device,
+            dtype=video_latent.dtype,
+        ).expand(1, 1, latent_length, 1, 1).clone()
+        if self.use_cfg_trick:
+            guidance[:, :, :self.cfg_trick_start_frame] = min(
+                self.cfg_trick_value,
+                self.sr_video_txt_guidance_scale,
+            )
+
+        disable_tqdm = not getattr(fastvideo_args, "log_level_progress", True)
+        for idx, t in enumerate(tqdm(video_scheduler.timesteps, disable=disable_tqdm)):
+            video_latent = _overwrite_first_frame(video_latent, image_latent)
+            static_packed = build_static_packed_inputs(
+                video_latent=video_latent,
+                audio_latent=audio_latent,
+                audio_feat_len=audio_feat_len,
+                patch_size=self.patch_size,
+                coords_style=self.coords_style,
+                layout=getattr(batch, "magi_static_packed_layout", None),
+            )
+            with trace_step(idx), set_forward_context(
+                    current_timestep=int(t.item()) if torch.is_tensor(t) else int(t),
+                    attn_metadata=None,
+            ):
+                v_cond_video, _ = _dit_forward(
+                    self.transformer,
+                    video_latent=video_latent,
+                    audio_feat_len=audio_feat_len,
+                    txt_feat=txt_feat,
+                    txt_feat_len=txt_feat_len,
+                    static_packed=static_packed,
+                    coords_style=self.coords_style,
+                    video_in_channels=self.video_in_channels,
+                    audio_in_channels=self.audio_in_channels,
+                    patch_size=self.patch_size,
+                )
+                if self.cfg_number == 2:
+                    assert neg_txt_feat is not None
+                    v_uncond_video, _ = _dit_forward(
+                        self.transformer,
+                        video_latent=video_latent,
+                        audio_feat_len=audio_feat_len,
+                        txt_feat=neg_txt_feat,
+                        txt_feat_len=neg_txt_feat_len,
+                        static_packed=static_packed,
+                        coords_style=self.coords_style,
+                        video_in_channels=self.video_in_channels,
+                        audio_in_channels=self.audio_in_channels,
+                        patch_size=self.patch_size,
+                    )
+                    v_video = v_uncond_video + guidance * (v_cond_video - v_uncond_video)
+                else:
+                    v_video = v_cond_video
+
+            video_latent = video_scheduler.step(
+                v_video,
+                t,
+                video_latent,
+                return_dict=False,
+            )[0]
+
+        batch.latents = _overwrite_first_frame(video_latent, image_latent)
+        batch.audio_latents = audio_latent
+        return batch

--- a/fastvideo/pipelines/basic/magi_human/stages/sr_latent_preparation.py
+++ b/fastvideo/pipelines/basic/magi_human/stages/sr_latent_preparation.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Super-resolution latent preparation for daVinci-MagiHuman SR-540p."""
+from __future__ import annotations
+
+from functools import partial
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from diffusers.utils import load_image
+from diffusers.video_processor import VideoProcessor
+from PIL import Image
+
+from fastvideo.distributed import get_local_torch_device
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.pipelines.basic.magi_human.stages.reference_image import (
+    _resizecrop, )
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.stages.validators import VerificationResult
+
+
+class ZeroSNRDDPMDiscretization:
+    """Upstream ZeroSNR schedule used to corrupt interpolated SR latents."""
+
+    def __init__(
+        self,
+        linear_start: float = 0.00085,
+        linear_end: float = 0.0120,
+        num_timesteps: int = 1000,
+        shift_scale: float = 1.0,
+        keep_start: bool = False,
+        post_shift: bool = False,
+    ) -> None:
+        if keep_start and not post_shift:
+            linear_start = linear_start / (shift_scale + (1 - shift_scale) * linear_start)
+        self.num_timesteps = num_timesteps
+        betas = torch.linspace(
+            linear_start**0.5,
+            linear_end**0.5,
+            num_timesteps,
+            dtype=torch.float64,
+        )**2
+        alphas = 1.0 - betas.numpy()
+        self.alphas_cumprod = np.cumprod(alphas, axis=0)
+        self.post_shift = post_shift
+        self.shift_scale = shift_scale
+
+        if not post_shift:
+            self.alphas_cumprod = self.alphas_cumprod / (shift_scale + (1 - shift_scale) * self.alphas_cumprod)
+
+    def __call__(
+        self,
+        n: int,
+        do_append_zero: bool = True,
+        device: str | torch.device = "cpu",
+        flip: bool = False,
+    ) -> torch.Tensor:
+        sigmas = self.get_sigmas(n, device=device)
+        if do_append_zero:
+            sigmas = torch.cat([sigmas, sigmas.new_zeros([1])])
+        return torch.flip(sigmas, (0, )) if flip else sigmas
+
+    def get_sigmas(
+        self,
+        n: int,
+        device: str | torch.device = "cpu",
+    ) -> torch.Tensor:
+        if n < self.num_timesteps:
+            timesteps = np.linspace(
+                self.num_timesteps - 1,
+                0,
+                n,
+                endpoint=False,
+            ).astype(int)[::-1]
+            alphas_cumprod = self.alphas_cumprod[timesteps]
+        elif n == self.num_timesteps:
+            alphas_cumprod = self.alphas_cumprod
+        else:
+            raise ValueError(f"n must be <= {self.num_timesteps}, got {n}")
+
+        to_torch = partial(torch.tensor, dtype=torch.float32, device=device)
+        alphas_cumprod_sqrt = to_torch(alphas_cumprod).sqrt()
+        alphas_cumprod_sqrt_0 = alphas_cumprod_sqrt[0].clone()
+        alphas_cumprod_sqrt_T = alphas_cumprod_sqrt[-1].clone()
+
+        alphas_cumprod_sqrt -= alphas_cumprod_sqrt_T
+        alphas_cumprod_sqrt *= alphas_cumprod_sqrt_0 / (alphas_cumprod_sqrt_0 - alphas_cumprod_sqrt_T)
+
+        if self.post_shift:
+            alphas_cumprod_sqrt = (alphas_cumprod_sqrt**2 / (self.shift_scale +
+                                                             (1 - self.shift_scale) * alphas_cumprod_sqrt**2))**0.5
+        return torch.flip(alphas_cumprod_sqrt, (0, ))
+
+
+class MagiHumanSRLatentPreparationStage(PipelineStage):
+    """Upsample base latents, add SR noise, and refresh SR conditioning."""
+
+    def __init__(
+        self,
+        vae: Any,
+        vae_stride: tuple[int, int, int] = (4, 16, 16),
+        patch_size: tuple[int, int, int] = (1, 2, 2),
+        noise_value: int = 220,
+        sr_audio_noise_scale: float = 0.7,
+        sr_height: int = 512,
+        sr_width: int = 896,
+        vae_scale_factor: int = 16,
+    ) -> None:
+        super().__init__()
+        self.vae = vae
+        self.vae_stride = vae_stride
+        self.patch_size = patch_size
+        self.noise_value = noise_value
+        self.sr_audio_noise_scale = sr_audio_noise_scale
+        self.sr_height = sr_height
+        self.sr_width = sr_width
+        self.sigmas = ZeroSNRDDPMDiscretization()(1000, do_append_zero=False, flip=True)
+        self.video_processor = VideoProcessor(vae_scale_factor=vae_scale_factor)
+
+    def verify_input(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    def verify_output(self, batch, fastvideo_args):
+        return VerificationResult()
+
+    @torch.inference_mode()
+    def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        device = batch.latents.device
+        _, _, latent_t, _, _ = batch.latents.shape
+        _, vh, vw = self.vae_stride
+        _, pH, pW = self.patch_size
+        latent_h = (self.sr_height // vh // pH) * pH
+        latent_w = (self.sr_width // vw // pW) * pW
+        actual_h = latent_h * vh
+        actual_w = latent_w * vw
+
+        latent_video = F.interpolate(
+            batch.latents,
+            size=(latent_t, latent_h, latent_w),
+            mode="trilinear",
+            align_corners=True,
+        )
+        if self.noise_value != 0:
+            noise = torch.randn_like(latent_video, device=device)
+            sigma = self.sigmas.to(device)[self.noise_value]
+            latent_video = latent_video * sigma + noise * (1 - sigma**2)**0.5
+
+        batch.latents = latent_video
+        batch.audio_latents = (
+            torch.randn_like(batch.audio_latents, device=batch.audio_latents.device) * self.sr_audio_noise_scale +
+            batch.audio_latents * (1 - self.sr_audio_noise_scale))
+        batch.height = actual_h
+        batch.width = actual_w
+        batch.magi_latent_T = latent_t
+        batch.magi_latent_H = latent_h
+        batch.magi_latent_W = latent_w
+        # Invalidate the static packed layout precomputed by the base
+        # latent prep stage: SR upsamples `batch.latents` to a larger
+        # spatial grid, which changes video_token_num / video_coords /
+        # video_mm. The SR denoising loop's
+        # `getattr(batch, "magi_static_packed_layout", None)` will then
+        # fall back to the slow path of `build_static_packed_inputs`,
+        # which rebuilds those fields from the new latent shape. SR
+        # only does ~5 denoising steps so the meshgrid recompute cost
+        # is negligible relative to SR-DiT forward.
+        batch.magi_static_packed_layout = None
+
+        if getattr(batch, "image_latent", None) is not None:
+            batch.image_latent = self._encode_image(batch, actual_h, actual_w)
+        return batch
+
+    def _encode_image(
+        self,
+        batch: ForwardBatch,
+        height: int,
+        width: int,
+    ) -> torch.Tensor:
+        image = getattr(batch, "image", None) or batch.pil_image
+        if image is None and batch.image_path is not None:
+            image = load_image(batch.image_path)
+        if image is None:
+            raise ValueError("MagiHuman SR TI2V requires an image for SR re-encoding.")
+        if not isinstance(image, Image.Image):
+            raise TypeError(f"Expected PIL image or image path, got {type(image)}")
+
+        device = get_local_torch_device()
+        image = _resizecrop(image.convert("RGB"), height, width)
+        image_tensor = self.video_processor.preprocess(
+            image,
+            height=height,
+            width=width,
+        ).to(device=device, dtype=torch.float32)
+        image_tensor = image_tensor.unsqueeze(2)
+
+        self.vae = self.vae.to(device)
+        encoded = self.vae.encode(image_tensor)
+        image_latent = encoded.mean if hasattr(encoded, "mean") else encoded
+
+        shift_factor = getattr(self.vae, "shift_factor", None)
+        if shift_factor is not None:
+            if isinstance(shift_factor, torch.Tensor):
+                image_latent = image_latent - shift_factor.to(
+                    image_latent.device,
+                    image_latent.dtype,
+                )
+            else:
+                image_latent = image_latent - shift_factor
+        scaling_factor = getattr(self.vae, "scaling_factor", None)
+        if scaling_factor is not None:
+            if isinstance(scaling_factor, torch.Tensor):
+                image_latent = image_latent * scaling_factor.to(
+                    image_latent.device,
+                    image_latent.dtype,
+                )
+            else:
+                image_latent = image_latent * scaling_factor
+        return image_latent.to(torch.float32)

--- a/fastvideo/tests/stages/test_magi_human_sr_latent_preparation.py
+++ b/fastvideo/tests/stages/test_magi_human_sr_latent_preparation.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test: SR latent prep must invalidate the static-packed layout.
+
+The base latent prep stage (`MagiHumanLatentPreparationStage`) precomputes
+``batch.magi_static_packed_layout`` for the BASE-resolution latent and stashes
+it on the batch so the base denoising loop can reuse it across all denoising
+steps (C4 perf optimization, commit 4190c720).
+
+The SR latent prep stage (`MagiHumanSRLatentPreparationStage`) upsamples
+``batch.latents`` to a much larger spatial grid (e.g. 256x480 -> 512x896 for
+SR-540p), which changes the layout's video_token_num / video_coords / video_mm.
+Without invalidating the layout, the SR denoising loop reuses the stale
+base-sized layout and crashes inside ``MagiHumanDiT.adapter`` with::
+
+    IndexError: The shape of the mask [3243] at index 0 does not match
+    the shape of the indexed tensor [11771, 3584] at index 0
+
+See git f1eeb630 for the fix and a commit-message-level explanation.
+
+This is a pure logic test — no GPU, no model load, no upstream daVinci-MagiHuman
+clone needed. It runs in the default CI suite.
+"""
+from __future__ import annotations
+
+import torch
+
+from fastvideo.pipelines.basic.magi_human.stages.sr_latent_preparation import (
+    MagiHumanSRLatentPreparationStage,
+    ZeroSNRDDPMDiscretization,
+)
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+
+
+def _make_stage() -> MagiHumanSRLatentPreparationStage:
+    """Bypass __init__: only set the fields the T2V forward() path reads."""
+    stage = MagiHumanSRLatentPreparationStage.__new__(
+        MagiHumanSRLatentPreparationStage)
+    # vae + video_processor are only used by `_encode_image` (TI2V path);
+    # T2V skips that branch when `batch.image_latent is None`.
+    stage.vae = None
+    stage.video_processor = None
+    stage.vae_stride = (4, 16, 16)
+    stage.patch_size = (1, 2, 2)
+    # `noise_value=0` skips the sigma noise-injection branch — keeps the
+    # test deterministic and avoids depending on torch.randn.
+    stage.noise_value = 0
+    stage.sr_audio_noise_scale = 0.7
+    stage.sr_height = 512
+    stage.sr_width = 896
+    stage.sigmas = ZeroSNRDDPMDiscretization()(
+        1000, do_append_zero=False, flip=True)
+    return stage
+
+
+def test_sr_latent_prep_invalidates_static_packed_layout():
+    stage = _make_stage()
+
+    base_latent = torch.randn(1, 48, 7, 16, 30, dtype=torch.float32)
+    audio = torch.randn(1, 26, 64, dtype=torch.float32)
+
+    batch = ForwardBatch(data_type="video")
+    batch.latents = base_latent
+    batch.audio_latents = audio
+
+    sentinel = object()
+    batch.magi_static_packed_layout = sentinel  # type: ignore[attr-defined]
+
+    out = stage.forward(batch, fastvideo_args=None)  # type: ignore[arg-type]
+
+    assert out is batch
+    # Sanity: SR actually upsampled to a different spatial grid.
+    assert out.latents.shape[-1] != base_latent.shape[-1]
+    assert out.latents.shape[-2] != base_latent.shape[-2]
+    # The bug-fix invariant: the stale base-sized layout is gone, so the
+    # SR denoising loop's `getattr(batch, "magi_static_packed_layout", None)`
+    # falls back to None and `build_static_packed_inputs` rebuilds the
+    # layout from the new SR-sized latent.
+    assert getattr(out, "magi_static_packed_layout", "<missing>") is None


### PR DESCRIPTION
## Summary

Six new `PipelineStage` subclasses for daVinci-MagiHuman, the package init for the new pipeline directory, and an `sr_transformer` alias in the component loader.

**Dead code** on the stack tip - no `MagiHumanPipeline` orchestrator yet (lands in 5/8), no registry entry (lands in 8/8).

## Changes

| File | LOC | Purpose |
|---|---:|---|
| `fastvideo/pipelines/basic/magi_human/stages/latent_preparation.py` | 590 | Channel-major video token packing, audio-token interleave |
| `fastvideo/pipelines/basic/magi_human/stages/denoising.py` | 228 | Joint AV denoising loop |
| `fastvideo/pipelines/basic/magi_human/stages/sr_latent_preparation.py` | 219 | Trilinear-up + ZeroSNR noise + audio mix for SR pass |
| `fastvideo/pipelines/basic/magi_human/stages/sr_denoising.py` | 156 | SR DiT denoising loop with cfg-trick |
| `fastvideo/pipelines/basic/magi_human/stages/audio_decoding.py` | 111 | Lazy-load Oobleck VAE wrapper, decode audio from latent |
| `fastvideo/pipelines/basic/magi_human/stages/reference_image.py` | 101 | TI2V reference image conditioning |
| `fastvideo/pipelines/basic/magi_human/{__init__.py, stages/__init__.py}` | 17 | Package init + stage exports |
| `fastvideo/models/loader/component_loader.py` | +1 | Register `sr_transformer` module type |
| `fastvideo/tests/stages/test_magi_human_sr_latent_preparation.py` | 78 | Unit-level stage test |

## Verification

- `pre-commit run --files <changed paths>` ✓ (yapf, ruff, codespell, mypy green)
- All stage modules are self-contained: imports only cross-reference sibling stages within this PR; **nothing references the orchestrator** (which lands in 5/8).
- Stage unit test runs in CI without GPU (`pytest fastvideo/tests/stages/test_magi_human_sr_latent_preparation.py -v`).

## Stack context

Step **4 of 8** in the PR #1280 decomposition. This is the first of three sub-PRs from the original PR 6 (which was 4500 LOC, split into stages / orchestrator / provenance for reviewability).

```
... → #1297 (DiT) → #THIS (4/8 stages) → (5/8 orchestrator) → (6/8 provenance) → ...
```

## Provenance

Source PR: #1280 (`will/magi` @ `4e160363`)