### PR TITLE
[feat]: add LongCat causal self-forcing scaffold

### DIFF
--- a/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
+++ b/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
@@ -85,4 +85,6 @@ callbacks:
     max_grad_norm: 1.0
 
 pipeline:
-  flow_shift: 0
+  # Match the released LongCat scheduler config. flow_shift=0.0 collapses
+  # FlowMatch training timesteps to zero in FastVideo's scheduler.
+  flow_shift: 12.0

--- a/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
+++ b/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
@@ -78,6 +78,7 @@ training:
     run_name: longcat_self_forcing
 
   model:
+    # LongCat student rollout uses checkpoint-safe KV cache snapshots.
     enable_gradient_checkpointing_type: full
 
 callbacks:

--- a/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
+++ b/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
@@ -1,0 +1,88 @@
+# Self-Forcing distillation: LongCat-Video T2V 13.6B
+#
+# Experimental scaffold for chunk-wise LongCat self-forcing training in the
+# modular framework. The student uses KV-cache accumulation between chunks.
+
+models:
+  student:
+    _target_: fastvideo.train.models.longcat.LongCatCausalModel
+    init_from: FastVideo/LongCat-Video-T2V-Diffusers
+    trainable: true
+  teacher:
+    _target_: fastvideo.train.models.longcat.LongCatModel
+    init_from: FastVideo/LongCat-Video-T2V-Diffusers
+    trainable: false
+    disable_custom_init_weights: true
+  critic:
+    _target_: fastvideo.train.models.longcat.LongCatModel
+    init_from: FastVideo/LongCat-Video-T2V-Diffusers
+    trainable: true
+    disable_custom_init_weights: true
+
+method:
+  _target_: fastvideo.train.methods.distribution_matching.self_forcing.SelfForcingMethod
+  rollout_mode: simulate
+  generator_update_interval: 5
+  real_score_guidance_scale: 1.0
+  dmd_denoising_steps: [1000, 750, 500, 250]
+
+  chunk_size: 3
+  student_sample_type: sde
+  context_noise: 0.0
+  enable_gradient_in_rollout: true
+  start_gradient_frame: 0
+
+  fake_score_learning_rate: 1.0e-5
+  fake_score_betas: [0.0, 0.999]
+  fake_score_lr_scheduler: constant
+
+training:
+  model_path: FastVideo/LongCat-Video-T2V-Diffusers
+
+  distributed:
+    num_gpus: 8
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 8
+
+  data:
+    data_path: data/LongCat-Syn
+    dataloader_num_workers: 4
+    train_batch_size: 1
+    training_cfg_rate: 0.0
+    seed: 1000
+    num_latent_t: 20
+    num_height: 480
+    num_width: 848
+    num_frames: 77
+
+  optimizer:
+    learning_rate: 1.0e-5
+    betas: [0.0, 0.999]
+    weight_decay: 0.01
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    max_train_steps: 4000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/longcat_self_forcing
+    training_state_checkpointing_steps: 1000
+    checkpoints_total_limit: 3
+
+  tracker:
+    project_name: self-forcing-longcat
+    run_name: longcat_self_forcing
+
+  model:
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  grad_clip:
+    max_grad_norm: 1.0
+
+pipeline:
+  flow_shift: 0

--- a/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
+++ b/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
@@ -8,6 +8,7 @@ models:
     _target_: fastvideo.train.models.longcat.LongCatCausalModel
     init_from: FastVideo/LongCat-Video-T2V-Diffusers
     trainable: true
+    causal_block_size: 3
   teacher:
     _target_: fastvideo.train.models.longcat.LongCatModel
     init_from: FastVideo/LongCat-Video-T2V-Diffusers

--- a/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
+++ b/examples/train/configs/distribution_matching/longcat/self_forcing_t2v.yaml
@@ -2,6 +2,8 @@
 #
 # Experimental scaffold for chunk-wise LongCat self-forcing training in the
 # modular framework. The student uses KV-cache accumulation between chunks.
+# Causal LongCat attention uses plain SDPA instead of LongCat BSA because BSA
+# does not accept the block-causal per-row mask yet.
 
 models:
   student:

--- a/fastvideo/layers/rotary_embedding_3d.py
+++ b/fastvideo/layers/rotary_embedding_3d.py
@@ -68,10 +68,17 @@ class RotaryPositionalEmbedding3D(nn.Module):
         assert self.head_dim % 8 == 0, "head_dim must be a multiple of 8 for 3D RoPE"
         self.base = base
 
-        # Cache for precomputed frequencies
-        self.freqs_dict: dict[tuple, torch.Tensor] = {}
+        # Cache one precomputed table per grid size. Temporal offsets are
+        # applied on demand so long rollouts do not accumulate a new table for
+        # every window start.
+        self.freqs_dict: dict[tuple[int, int, int], torch.Tensor] = {}
 
-    def register_grid_size(self, grid_size: tuple[int, int, int]) -> None:
+    def register_grid_size(
+        self,
+        grid_size: tuple[int, int, int],
+        *,
+        temporal_offset: int = 0,
+    ) -> None:
         """
         Precompute and register frequencies for a given grid size.
         
@@ -81,7 +88,12 @@ class RotaryPositionalEmbedding3D(nn.Module):
         if grid_size not in self.freqs_dict:
             self.freqs_dict[grid_size] = self.precompute_freqs_3d(grid_size)
 
-    def precompute_freqs_3d(self, grid_size: tuple[int, int, int]) -> torch.Tensor:
+    def precompute_freqs_3d(
+        self,
+        grid_size: tuple[int, int, int],
+        *,
+        temporal_offset: int = 0,
+    ) -> torch.Tensor:
         """
         Precompute 3D rotary frequencies.
         
@@ -105,7 +117,11 @@ class RotaryPositionalEmbedding3D(nn.Module):
         freqs_w = 1.0 / (self.base**(torch.arange(0, dim_w, 2)[:(dim_w // 2)].float() / dim_w))
 
         # Create position grids
-        grid_t = torch.arange(num_frames, dtype=torch.float32)
+        grid_t = torch.arange(
+            int(temporal_offset),
+            int(temporal_offset) + num_frames,
+            dtype=torch.float32,
+        )
         grid_h = torch.arange(height, dtype=torch.float32)
         grid_w = torch.arange(width, dtype=torch.float32)
 
@@ -139,6 +155,7 @@ class RotaryPositionalEmbedding3D(nn.Module):
         q: torch.Tensor,
         k: torch.Tensor,
         grid_size: tuple[int, int, int],
+        temporal_offset: int = 0,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         Apply 3D rotary positional embedding to queries and keys.
@@ -152,11 +169,15 @@ class RotaryPositionalEmbedding3D(nn.Module):
             (q_rotated, k_rotated): Rotated query and key tensors
         """
         # Register grid size if not cached
-        if grid_size not in self.freqs_dict:
-            self.register_grid_size(grid_size)
-
-        # Get cached frequencies
-        freqs_cis = self.freqs_dict[grid_size].to(q.device)
+        if temporal_offset == 0:
+            if grid_size not in self.freqs_dict:
+                self.register_grid_size(grid_size)
+            freqs_cis = self.freqs_dict[grid_size].to(q.device)
+        else:
+            freqs_cis = self.precompute_freqs_3d(
+                grid_size,
+                temporal_offset=int(temporal_offset),
+            ).to(q.device)
 
         # Cast to float32 for precision
         q_, k_ = q.float(), k.float()

--- a/fastvideo/layers/rotary_embedding_3d.py
+++ b/fastvideo/layers/rotary_embedding_3d.py
@@ -11,6 +11,8 @@ import torch
 import torch.nn as nn
 from einops import rearrange, repeat
 
+MAX_CACHED_3D_ROPE_FREQS = 16
+
 
 def broadcast(tensors: list[torch.Tensor], dim: int = -1) -> torch.Tensor:
     """
@@ -18,7 +20,8 @@ def broadcast(tensors: list[torch.Tensor], dim: int = -1) -> torch.Tensor:
     """
     num_tensors = len(tensors)
     shape_lens = set(len(t.shape) for t in tensors)
-    assert len(shape_lens) == 1, "tensors must all have the same number of dimensions"
+    if len(shape_lens) != 1:
+        raise ValueError("tensors must all have the same number of dimensions")
 
     shape_len = list(shape_lens)[0]
     dim = (dim + shape_len) if dim < 0 else dim
@@ -26,7 +29,8 @@ def broadcast(tensors: list[torch.Tensor], dim: int = -1) -> torch.Tensor:
     dims = list(zip(*[list(t.shape) for t in tensors], strict=False))
     expandable_dims = [(i, val) for i, val in enumerate(dims) if i != dim]
 
-    assert all(len(set(t[1])) <= 2 for t in expandable_dims), "invalid dimensions for broadcastable concatenation"
+    if not all(len(set(t[1])) <= 2 for t in expandable_dims):
+        raise ValueError("invalid dimensions for broadcastable concatenation")
 
     max_dims = [(t[0], max(t[1])) for t in expandable_dims]
     expanded_dims = [(t[0], (t[1], ) * num_tensors) for t in max_dims]
@@ -67,14 +71,15 @@ class RotaryPositionalEmbedding3D(nn.Module):
         """
         super().__init__()
         self.head_dim = head_dim
-        assert self.head_dim % 8 == 0, "head_dim must be a multiple of 8 for 3D RoPE"
+        if self.head_dim % 8 != 0:
+            raise ValueError("head_dim must be a multiple of 8 for 3D RoPE")
         self.base = base
 
         # Cache one precomputed table per grid size. Temporal offsets are
         # included in the key. The cache is bounded because causal rollouts
         # may visit many offset/window combinations.
         self.freqs_dict: OrderedDict[tuple, torch.Tensor] = OrderedDict()
-        self.max_cached_freqs = 16
+        self.max_cached_freqs = MAX_CACHED_3D_ROPE_FREQS
 
     def register_grid_size(
         self,
@@ -88,11 +93,17 @@ class RotaryPositionalEmbedding3D(nn.Module):
         
         Args:
             grid_size: (T, H, W) tuple of grid dimensions
+            temporal_offset: Absolute frame offset for causal chunked RoPE.
+            device: Device on which to build the frequency table. If omitted,
+                a CPU table is cached and promoted to the runtime device on
+                first use.
         """
+        cache_device = torch.device(device) if device is not None else torch.device(
+            "cpu")
         key = self._cache_key(
             grid_size,
             temporal_offset=temporal_offset,
-            device=torch.device(device or "cpu"),
+            device=cache_device,
         )
         if key not in self.freqs_dict:
             self._cache_freqs(
@@ -215,14 +226,23 @@ class RotaryPositionalEmbedding3D(nn.Module):
             device=q.device,
         )
         if cache_key not in self.freqs_dict:
-            self._cache_freqs(
-                cache_key,
-                self.precompute_freqs_3d(
-                    grid_size,
-                    temporal_offset=int(temporal_offset),
-                    device=q.device,
-                ),
+            cpu_key = self._cache_key(
+                grid_size,
+                temporal_offset=int(temporal_offset),
+                device=torch.device("cpu"),
             )
+            if cpu_key in self.freqs_dict:
+                self._cache_freqs(cache_key,
+                                  self.freqs_dict[cpu_key].to(q.device))
+            else:
+                self._cache_freqs(
+                    cache_key,
+                    self.precompute_freqs_3d(
+                        grid_size,
+                        temporal_offset=int(temporal_offset),
+                        device=q.device,
+                    ),
+                )
         freqs_cis = self.freqs_dict[cache_key]
         self.freqs_dict.move_to_end(cache_key)
 

--- a/fastvideo/layers/rotary_embedding_3d.py
+++ b/fastvideo/layers/rotary_embedding_3d.py
@@ -5,6 +5,8 @@
 Reference: https://arxiv.org/pdf/2104.09864.pdf
 """
 
+from collections import OrderedDict
+
 import torch
 import torch.nn as nn
 from einops import rearrange, repeat
@@ -69,15 +71,17 @@ class RotaryPositionalEmbedding3D(nn.Module):
         self.base = base
 
         # Cache one precomputed table per grid size. Temporal offsets are
-        # applied on demand so long rollouts do not accumulate a new table for
-        # every window start.
-        self.freqs_dict: dict[tuple[int, int, int], torch.Tensor] = {}
+        # included in the key. The cache is bounded because causal rollouts
+        # may visit many offset/window combinations.
+        self.freqs_dict: OrderedDict[tuple, torch.Tensor] = OrderedDict()
+        self.max_cached_freqs = 16
 
     def register_grid_size(
         self,
         grid_size: tuple[int, int, int],
         *,
         temporal_offset: int = 0,
+        device: torch.device | str | None = None,
     ) -> None:
         """
         Precompute and register frequencies for a given grid size.
@@ -85,14 +89,27 @@ class RotaryPositionalEmbedding3D(nn.Module):
         Args:
             grid_size: (T, H, W) tuple of grid dimensions
         """
-        if grid_size not in self.freqs_dict:
-            self.freqs_dict[grid_size] = self.precompute_freqs_3d(grid_size)
+        key = self._cache_key(
+            grid_size,
+            temporal_offset=temporal_offset,
+            device=torch.device(device or "cpu"),
+        )
+        if key not in self.freqs_dict:
+            self._cache_freqs(
+                key,
+                self.precompute_freqs_3d(
+                    grid_size,
+                    temporal_offset=temporal_offset,
+                    device=device,
+                ),
+            )
 
     def precompute_freqs_3d(
         self,
         grid_size: tuple[int, int, int],
         *,
         temporal_offset: int = 0,
+        device: torch.device | str | None = None,
     ) -> torch.Tensor:
         """
         Precompute 3D rotary frequencies.
@@ -112,18 +129,25 @@ class RotaryPositionalEmbedding3D(nn.Module):
         dim_w = 2 * (self.head_dim // 6)
 
         # Compute frequency bands for each dimension
-        freqs_t = 1.0 / (self.base**(torch.arange(0, dim_t, 2)[:(dim_t // 2)].float() / dim_t))
-        freqs_h = 1.0 / (self.base**(torch.arange(0, dim_h, 2)[:(dim_h // 2)].float() / dim_h))
-        freqs_w = 1.0 / (self.base**(torch.arange(0, dim_w, 2)[:(dim_w // 2)].float() / dim_w))
+        freqs_t = 1.0 / (
+            self.base**(torch.arange(0, dim_t, 2, device=device)
+                        [:(dim_t // 2)].float() / dim_t))
+        freqs_h = 1.0 / (
+            self.base**(torch.arange(0, dim_h, 2, device=device)
+                        [:(dim_h // 2)].float() / dim_h))
+        freqs_w = 1.0 / (
+            self.base**(torch.arange(0, dim_w, 2, device=device)
+                        [:(dim_w // 2)].float() / dim_w))
 
         # Create position grids
         grid_t = torch.arange(
             int(temporal_offset),
             int(temporal_offset) + num_frames,
             dtype=torch.float32,
+            device=device,
         )
-        grid_h = torch.arange(height, dtype=torch.float32)
-        grid_w = torch.arange(width, dtype=torch.float32)
+        grid_h = torch.arange(height, dtype=torch.float32, device=device)
+        grid_w = torch.arange(width, dtype=torch.float32, device=device)
 
         # Compute frequencies for each position
         freqs_t = torch.einsum("..., f -> ... f", grid_t, freqs_t)
@@ -150,6 +174,23 @@ class RotaryPositionalEmbedding3D(nn.Module):
 
         return freqs
 
+    def _cache_key(
+        self,
+        grid_size: tuple[int, int, int],
+        *,
+        temporal_offset: int,
+        device: torch.device,
+    ) -> tuple:
+        device_index = -1 if device.index is None else int(device.index)
+        return (tuple(grid_size), int(temporal_offset), device.type,
+                device_index)
+
+    def _cache_freqs(self, key: tuple, freqs: torch.Tensor) -> None:
+        self.freqs_dict[key] = freqs
+        self.freqs_dict.move_to_end(key)
+        while len(self.freqs_dict) > self.max_cached_freqs:
+            self.freqs_dict.popitem(last=False)
+
     def forward(
         self,
         q: torch.Tensor,
@@ -168,16 +209,22 @@ class RotaryPositionalEmbedding3D(nn.Module):
         Returns:
             (q_rotated, k_rotated): Rotated query and key tensors
         """
-        # Register grid size if not cached
-        if temporal_offset == 0:
-            if grid_size not in self.freqs_dict:
-                self.register_grid_size(grid_size)
-            freqs_cis = self.freqs_dict[grid_size].to(q.device)
-        else:
-            freqs_cis = self.precompute_freqs_3d(
-                grid_size,
-                temporal_offset=int(temporal_offset),
-            ).to(q.device)
+        cache_key = self._cache_key(
+            grid_size,
+            temporal_offset=int(temporal_offset),
+            device=q.device,
+        )
+        if cache_key not in self.freqs_dict:
+            self._cache_freqs(
+                cache_key,
+                self.precompute_freqs_3d(
+                    grid_size,
+                    temporal_offset=int(temporal_offset),
+                    device=q.device,
+                ),
+            )
+        freqs_cis = self.freqs_dict[cache_key]
+        self.freqs_dict.move_to_end(cache_key)
 
         # Cast to float32 for precision
         q_, k_ = q.float(), k.float()

--- a/fastvideo/models/dits/longcat.py
+++ b/fastvideo/models/dits/longcat.py
@@ -505,12 +505,15 @@ class LongCatSelfAttention(nn.Module):
         kv_cache: tuple,              # (k_cond, v_cond) - [B, heads, N_cond, head_dim]
         kv_cache_start_frame: int = 0,
         causal_block_size: int | None = None,
-    ) -> torch.Tensor:
+        return_kv: bool = False,
+    ) -> torch.Tensor | tuple:
         """
         Forward using cached K/V from conditioning frames.
         
         x contains only NOISE tokens.
         kv_cache contains pre-computed K/V for CONDITIONING tokens.
+        When return_kv=True, returns the current chunk's pre-RoPE K/V so
+        callers can append it to the streaming cache.
         
         CRITICAL: RoPE positions for noise tokens must start AFTER conditioning.
         We achieve this by padding Q with dummy tokens for conditioning positions,
@@ -548,6 +551,10 @@ class LongCatSelfAttention(nn.Module):
         # Per-head RMS normalization
         q = self.q_norm(q)
         k = self.k_norm(k)
+
+        if return_kv:
+            k_cache_new = k.transpose(1, 2).clone()
+            v_cache_new = v.transpose(1, 2).clone()
 
         # Transpose for RoPE: [B, heads, N, head_dim]
         q_rope = q.transpose(1, 2)
@@ -607,6 +614,8 @@ class LongCatSelfAttention(nn.Module):
         out = out.reshape(B, N, C)
         out, _ = self.to_out(out)
 
+        if return_kv:
+            return out, (k_cache_new, v_cache_new)
         return out
 
 
@@ -918,15 +927,20 @@ class LongCatTransformerBlock(nn.Module):
         if kv_cache is not None:
             # Move cache to device if offloaded
             kv_cache = (kv_cache[0].to(x.device), kv_cache[1].to(x.device))
-            attn_out = self.self_attn.forward_with_kv_cache(
+            attn_result = self.self_attn.forward_with_kv_cache(
                 x_norm,
                 latent_shape=latent_shape,
                 num_cond_latents=num_cond_latents,
                 kv_cache=kv_cache,
                 kv_cache_start_frame=kv_cache_start_frame,
                 causal_block_size=causal_block_size,
+                return_kv=return_kv,
             )
-            kv_cache_new = None  # Don't return cache when using cache
+            if return_kv:
+                attn_out, kv_cache_new = attn_result
+            else:
+                attn_out = attn_result
+                kv_cache_new = None
         else:
             attn_result = self.self_attn(
                 x_norm, 

--- a/fastvideo/models/dits/longcat.py
+++ b/fastvideo/models/dits/longcat.py
@@ -66,6 +66,35 @@ def longcat_to_training_velocity(pred: torch.Tensor) -> torch.Tensor:
     return -pred
 
 
+def build_longcat_causal_block_ranges(
+    *,
+    num_frames: int,
+    chunk_size: int,
+) -> list[tuple[int, int]]:
+    """Match self-forcing rollout: the first block absorbs any remainder."""
+    if num_frames <= 0:
+        raise ValueError("num_frames must be > 0")
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be > 0")
+
+    remaining = num_frames % chunk_size
+    num_blocks = num_frames // chunk_size
+    if num_blocks == 0:
+        num_blocks = 1
+        remaining = num_frames
+
+    ranges = []
+    for block_idx in range(num_blocks):
+        if block_idx == 0:
+            start = 0
+            end = remaining + chunk_size if remaining else chunk_size
+        else:
+            start = remaining + block_idx * chunk_size
+            end = remaining + (block_idx + 1) * chunk_size
+        ranges.append((int(start), int(min(end, num_frames))))
+    return [(start, end) for start, end in ranges if start < end]
+
+
 # ============================================================================
 # Embeddings
 # ============================================================================

--- a/fastvideo/models/dits/longcat.py
+++ b/fastvideo/models/dits/longcat.py
@@ -426,6 +426,7 @@ class LongCatSelfAttention(nn.Module):
         latent_shape: tuple,          # (T_noise, H, W) - shape for noise only
         num_cond_latents: int,        # Number of conditioning latent frames
         kv_cache: tuple,              # (k_cond, v_cond) - [B, heads, N_cond, head_dim]
+        kv_cache_start_frame: int = 0,
     ) -> torch.Tensor:
         """
         Forward using cached K/V from conditioning frames.
@@ -488,7 +489,12 @@ class LongCatSelfAttention(nn.Module):
         # Apply RoPE to full sequence (includes both cond and noise positions)
         # Grid size: (T_cond + T_noise, H, W)
         full_T = num_cond_latents + T
-        q_padding, k_full = self.rope_3d(q_padding, k_full, grid_size=(full_T, H, W))
+        q_padding, k_full = self.rope_3d(
+            q_padding,
+            k_full,
+            grid_size=(full_T, H, W),
+            temporal_offset=int(kv_cache_start_frame),
+        )
         
         # Extract only the noise portion of Q (last N tokens)
         q_rope = q_padding[:, :, -N:].contiguous()
@@ -779,6 +785,7 @@ class LongCatTransformerBlock(nn.Module):
         num_cond_latents: int = 0,    # Number of conditioning latent frames (for I2V)
         return_kv: bool = False,      # Return K/V for caching
         kv_cache: tuple | None = None,  # Pre-computed K/V cache
+        kv_cache_start_frame: int = 0,  # Absolute start frame of retained KV cache
         skip_crs_attn: bool = False,  # Skip cross-attention (for cache init)
         **kwargs
     ) -> torch.Tensor | tuple:
@@ -820,6 +827,7 @@ class LongCatTransformerBlock(nn.Module):
                 latent_shape=latent_shape,
                 num_cond_latents=num_cond_latents,
                 kv_cache=kv_cache,
+                kv_cache_start_frame=kv_cache_start_frame,
             )
             kv_cache_new = None  # Don't return cache when using cache
         else:
@@ -1038,6 +1046,7 @@ class LongCatTransformer3DModel(BaseDiT):
         # === KV Cache Parameters ===
         return_kv: bool = False,               # If True, return (output, kv_cache_dict)
         kv_cache_dict: dict | None = None,     # Pre-computed {block_idx: (k, v)}
+        kv_cache_start_frame: int = 0,         # Absolute start frame of retained KV cache
         skip_crs_attn: bool = False,           # Skip cross-attention (for cache init)
         offload_kv_cache: bool = False,        # Move cache to CPU after compute
         **kwargs
@@ -1098,6 +1107,7 @@ class LongCatTransformer3DModel(BaseDiT):
                 num_cond_latents=num_cond_latents,
                 return_kv=return_kv,
                 kv_cache=block_kv_cache,
+                kv_cache_start_frame=kv_cache_start_frame,
                 skip_crs_attn=skip_crs_attn,
             )
             

--- a/fastvideo/models/dits/longcat.py
+++ b/fastvideo/models/dits/longcat.py
@@ -455,8 +455,11 @@ class LongCatSelfAttention(nn.Module):
                 
                 # Split H and W dimensions by their respective factors
                 T_bsa, H_bsa, W_bsa = latent_shape
-                assert H_bsa % cp_split_hw[0] == 0 and W_bsa % cp_split_hw[1] == 0, \
-                    f"H {H_bsa} must be divisible by {cp_split_hw[0]}, W {W_bsa} must be divisible by {cp_split_hw[1]}"
+                if (H_bsa % cp_split_hw[0] != 0
+                        or W_bsa % cp_split_hw[1] != 0):
+                    raise ValueError(
+                        f"H {H_bsa} must be divisible by {cp_split_hw[0]}, "
+                        f"W {W_bsa} must be divisible by {cp_split_hw[1]}")
                 H_bsa = H_bsa // cp_split_hw[0]
                 W_bsa = W_bsa // cp_split_hw[1]
                 latent_shape_bsa = (T_bsa, H_bsa, W_bsa)
@@ -506,6 +509,11 @@ class LongCatSelfAttention(nn.Module):
         """
         B, N, C = x.shape
         T, H, W = latent_shape
+        if causal_block_size is not None and int(kv_cache_start_frame) != 0:
+            raise ValueError(
+                "LongCat block-causal mask currently assumes cached K/V "
+                "starts at frame 0; got kv_cache_start_frame="
+                f"{kv_cache_start_frame}")
 
         k_cache, v_cache = kv_cache
 

--- a/fastvideo/models/dits/longcat.py
+++ b/fastvideo/models/dits/longcat.py
@@ -61,6 +61,11 @@ def build_longcat_block_causal_mask(
     return mask.unsqueeze(0).unsqueeze(0)
 
 
+def longcat_to_training_velocity(pred: torch.Tensor) -> torch.Tensor:
+    """Convert native LongCat output to FastVideo velocity target sign."""
+    return -pred
+
+
 # ============================================================================
 # Embeddings
 # ============================================================================
@@ -367,6 +372,10 @@ class LongCatSelfAttention(nn.Module):
 
         # === Block-Causal Attention ===
         if causal_block_size is not None:
+            # LongCat's native BSA path cannot consume a per-row causal mask.
+            # Causal/self-forcing therefore uses plain SDPA here; chunked
+            # rollout supplies only prior/current-frame K/V, while this mask
+            # protects any future multi-block forward mode from future leaks.
             attn_mask = build_longcat_block_causal_mask(
                 query_frames=T,
                 key_frames=T,
@@ -575,6 +584,8 @@ class LongCatSelfAttention(nn.Module):
 
         attn_mask = None
         if causal_block_size is not None:
+            # Same as the non-cache causal path: BSA is intentionally bypassed
+            # because the backend does not support this block-causal mask.
             attn_mask = build_longcat_block_causal_mask(
                 query_frames=T,
                 key_frames=full_T,

--- a/fastvideo/models/dits/longcat.py
+++ b/fastvideo/models/dits/longcat.py
@@ -22,6 +22,45 @@ from fastvideo.platforms import AttentionBackendEnum
 from fastvideo.third_party.longcat_video.block_sparse_attention.bsa_interface import flash_attn_bsa_3d
 
 
+def build_longcat_block_causal_mask(
+    *,
+    query_frames: int,
+    key_frames: int,
+    tokens_per_frame: int,
+    causal_block_size: int,
+    device: torch.device | str,
+) -> torch.Tensor:
+    """Build a block-causal mask for LongCat video-token attention.
+
+    Mask entries are True for visible K/V tokens. Frames in the same
+    causal block can attend bidirectionally within that block, but not
+    to later blocks.
+    """
+    if query_frames <= 0:
+        raise ValueError("query_frames must be > 0")
+    if key_frames <= 0:
+        raise ValueError("key_frames must be > 0")
+    if tokens_per_frame <= 0:
+        raise ValueError("tokens_per_frame must be > 0")
+    if causal_block_size <= 0:
+        raise ValueError("causal_block_size must be > 0")
+    if query_frames > key_frames:
+        raise ValueError("query_frames must be <= key_frames")
+
+    cached_frames = key_frames - query_frames
+    q_tokens = query_frames * tokens_per_frame
+    k_tokens = key_frames * tokens_per_frame
+    q_token_idx = torch.arange(q_tokens, device=device)
+    k_token_idx = torch.arange(k_tokens, device=device)
+    q_frame_idx = cached_frames + q_token_idx // tokens_per_frame
+    k_frame_idx = k_token_idx // tokens_per_frame
+    q_block_end = (
+        (q_frame_idx // causal_block_size + 1) * causal_block_size
+    ).clamp(max=key_frames)
+    mask = k_frame_idx.unsqueeze(0) < q_block_end.unsqueeze(1)
+    return mask.unsqueeze(0).unsqueeze(0)
+
+
 # ============================================================================
 # Embeddings
 # ============================================================================
@@ -279,6 +318,7 @@ class LongCatSelfAttention(nn.Module):
         latent_shape: tuple,          # (T, H, W)
         num_cond_latents: int = 0,    # Number of conditioning latent frames (for I2V)
         return_kv: bool = False,      # Return K/V for caching
+        causal_block_size: int | None = None,
         **kwargs
     ) -> torch.Tensor | tuple:
         """
@@ -324,6 +364,31 @@ class LongCatSelfAttention(nn.Module):
         # Transpose back: [B, N, num_heads, head_dim] or [B, H, N, D] for BSA
         q = q_rope.transpose(1, 2)
         k = k_rope.transpose(1, 2)
+
+        # === Block-Causal Attention ===
+        if causal_block_size is not None:
+            attn_mask = build_longcat_block_causal_mask(
+                query_frames=T,
+                key_frames=T,
+                tokens_per_frame=H * W,
+                causal_block_size=int(causal_block_size),
+                device=x.device,
+            )
+            out = torch.nn.functional.scaled_dot_product_attention(
+                q.transpose(1, 2),
+                k.transpose(1, 2),
+                v.transpose(1, 2),
+                attn_mask=attn_mask,
+                dropout_p=0.0,
+                is_causal=False,
+            )
+            out = out.transpose(1, 2)
+            out = out.reshape(B, N, C)
+            out, _ = self.to_out(out)
+
+            if return_kv:
+                return out, (k_cache, v_cache)
+            return out
 
         # === I2V Split Attention ===
         # For I2V, conditioned tokens and noise tokens are processed separately
@@ -427,6 +492,7 @@ class LongCatSelfAttention(nn.Module):
         num_cond_latents: int,        # Number of conditioning latent frames
         kv_cache: tuple,              # (k_cond, v_cond) - [B, heads, N_cond, head_dim]
         kv_cache_start_frame: int = 0,
+        causal_block_size: int | None = None,
     ) -> torch.Tensor:
         """
         Forward using cached K/V from conditioning frames.
@@ -499,10 +565,20 @@ class LongCatSelfAttention(nn.Module):
         # Extract only the noise portion of Q (last N tokens)
         q_rope = q_padding[:, :, -N:].contiguous()
 
-        # Run attention: Q_noise attends to full K/V (cond + noise)
+        attn_mask = None
+        if causal_block_size is not None:
+            attn_mask = build_longcat_block_causal_mask(
+                query_frames=T,
+                key_frames=full_T,
+                tokens_per_frame=H * W,
+                causal_block_size=int(causal_block_size),
+                device=x.device,
+            )
+
+        # Run attention: Q_noise attends to visible cached/current K/V.
         out = torch.nn.functional.scaled_dot_product_attention(
             q_rope, k_full, v_full,
-            attn_mask=None,
+            attn_mask=attn_mask,
             dropout_p=0.0,
             is_causal=False
         )  # [B, heads, N_noise, head_dim]
@@ -786,6 +862,7 @@ class LongCatTransformerBlock(nn.Module):
         return_kv: bool = False,      # Return K/V for caching
         kv_cache: tuple | None = None,  # Pre-computed K/V cache
         kv_cache_start_frame: int = 0,  # Absolute start frame of retained KV cache
+        causal_block_size: int | None = None,
         skip_crs_attn: bool = False,  # Skip cross-attention (for cache init)
         **kwargs
     ) -> torch.Tensor | tuple:
@@ -828,6 +905,7 @@ class LongCatTransformerBlock(nn.Module):
                 num_cond_latents=num_cond_latents,
                 kv_cache=kv_cache,
                 kv_cache_start_frame=kv_cache_start_frame,
+                causal_block_size=causal_block_size,
             )
             kv_cache_new = None  # Don't return cache when using cache
         else:
@@ -836,6 +914,7 @@ class LongCatTransformerBlock(nn.Module):
                 latent_shape=latent_shape,
                 num_cond_latents=num_cond_latents,
                 return_kv=return_kv,
+                causal_block_size=causal_block_size,
             )
             if return_kv:
                 attn_out, kv_cache_new = attn_result
@@ -1047,6 +1126,7 @@ class LongCatTransformer3DModel(BaseDiT):
         return_kv: bool = False,               # If True, return (output, kv_cache_dict)
         kv_cache_dict: dict | None = None,     # Pre-computed {block_idx: (k, v)}
         kv_cache_start_frame: int = 0,         # Absolute start frame of retained KV cache
+        causal_block_size: int | None = None,  # Block size for causal self-attention
         skip_crs_attn: bool = False,           # Skip cross-attention (for cache init)
         offload_kv_cache: bool = False,        # Move cache to CPU after compute
         **kwargs
@@ -1108,6 +1188,7 @@ class LongCatTransformer3DModel(BaseDiT):
                 return_kv=return_kv,
                 kv_cache=block_kv_cache,
                 kv_cache_start_frame=kv_cache_start_frame,
+                causal_block_size=causal_block_size,
                 skip_crs_attn=skip_crs_attn,
             )
             

--- a/fastvideo/pipelines/basic/longcat/longcat_causal_dmd_pipeline.py
+++ b/fastvideo/pipelines/basic/longcat/longcat_causal_dmd_pipeline.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LongCat causal DMD pipeline.
+
+Wires :class:`LongCatCausalDMDDenoisingStage` into the modular pipeline
+so that self-forcing-trained LongCat student weights can be evaluated
+in the same chunked, KV-cached rollout pattern they were trained with.
+Mirrors :class:`WanCausalDMDPipeline` (the Wan counterpart used by
+``self_forcing_causal_t2v.yaml``).
+"""
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.logger import init_logger
+from fastvideo.pipelines import ComposedPipelineBase, LoRAPipeline
+from fastvideo.pipelines.stages import (
+    ConditioningStage,
+    DecodingStage,
+    InputValidationStage,
+    LatentPreparationStage,
+    TextEncodingStage,
+)
+from fastvideo.pipelines.stages.longcat_causal_dmd_denoising import (
+    LongCatCausalDMDDenoisingStage, )
+
+logger = init_logger(__name__)
+
+
+class LongCatCausalDMDPipeline(LoRAPipeline, ComposedPipelineBase):
+
+    _required_config_modules = [
+        "text_encoder",
+        "tokenizer",
+        "vae",
+        "transformer",
+        "scheduler",
+    ]
+
+    def create_pipeline_stages(self, fastvideo_args: FastVideoArgs) -> None:
+        self.add_stage(
+            stage_name="input_validation_stage",
+            stage=InputValidationStage(),
+        )
+
+        self.add_stage(
+            stage_name="prompt_encoding_stage",
+            stage=TextEncodingStage(
+                text_encoders=[self.get_module("text_encoder")],
+                tokenizers=[self.get_module("tokenizer")],
+            ),
+        )
+
+        self.add_stage(
+            stage_name="conditioning_stage",
+            stage=ConditioningStage(),
+        )
+
+        self.add_stage(
+            stage_name="latent_preparation_stage",
+            stage=LatentPreparationStage(
+                scheduler=self.get_module("scheduler"),
+                transformer=self.get_module("transformer", None),
+            ),
+        )
+
+        self.add_stage(
+            stage_name="denoising_stage",
+            stage=LongCatCausalDMDDenoisingStage(
+                transformer=self.get_module("transformer"),
+                scheduler=self.get_module("scheduler"),
+                vae=self.get_module("vae"),
+            ),
+        )
+
+        self.add_stage(
+            stage_name="decoding_stage",
+            stage=DecodingStage(vae=self.get_module("vae")),
+        )
+
+
+EntryClass = LongCatCausalDMDPipeline

--- a/fastvideo/pipelines/basic/longcat/longcat_causal_pipeline.py
+++ b/fastvideo/pipelines/basic/longcat/longcat_causal_pipeline.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LongCat causal multi-step pipeline.
+
+Wires :class:`LongCatCausalDenoisingStage` (multi-step scheduler.step
+per block, KV-cached between blocks) into the modular pipeline. The
+right inference pipeline for DFSFT-trained LongCat models — counterpart
+to :class:`WanCausalPipeline`.
+"""
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.logger import init_logger
+from fastvideo.pipelines import ComposedPipelineBase, LoRAPipeline
+from fastvideo.pipelines.stages import (
+    ConditioningStage,
+    DecodingStage,
+    InputValidationStage,
+    LatentPreparationStage,
+    TextEncodingStage,
+    TimestepPreparationStage,
+)
+from fastvideo.pipelines.stages.longcat_causal_denoising import (
+    LongCatCausalDenoisingStage, )
+
+logger = init_logger(__name__)
+
+
+class LongCatCausalPipeline(LoRAPipeline, ComposedPipelineBase):
+    """LongCat causal pipeline with standard multi-step denoising."""
+
+    _required_config_modules = [
+        "text_encoder",
+        "tokenizer",
+        "vae",
+        "transformer",
+        "scheduler",
+    ]
+
+    def create_pipeline_stages(self, fastvideo_args: FastVideoArgs) -> None:
+        self.add_stage(
+            stage_name="input_validation_stage",
+            stage=InputValidationStage(),
+        )
+
+        self.add_stage(
+            stage_name="prompt_encoding_stage",
+            stage=TextEncodingStage(
+                text_encoders=[self.get_module("text_encoder")],
+                tokenizers=[self.get_module("tokenizer")],
+            ),
+        )
+
+        self.add_stage(
+            stage_name="conditioning_stage",
+            stage=ConditioningStage(),
+        )
+
+        self.add_stage(
+            stage_name="timestep_preparation_stage",
+            stage=TimestepPreparationStage(
+                scheduler=self.get_module("scheduler"), ),
+        )
+
+        self.add_stage(
+            stage_name="latent_preparation_stage",
+            stage=LatentPreparationStage(
+                scheduler=self.get_module("scheduler"),
+                transformer=self.get_module("transformer", None),
+            ),
+        )
+
+        self.add_stage(
+            stage_name="denoising_stage",
+            stage=LongCatCausalDenoisingStage(
+                transformer=self.get_module("transformer"),
+                scheduler=self.get_module("scheduler"),
+                vae=self.get_module("vae"),
+            ),
+        )
+
+        self.add_stage(
+            stage_name="decoding_stage",
+            stage=DecodingStage(vae=self.get_module("vae")),
+        )
+
+
+EntryClass = LongCatCausalPipeline

--- a/fastvideo/pipelines/stages/__init__.py
+++ b/fastvideo/pipelines/stages/__init__.py
@@ -43,6 +43,7 @@ from fastvideo.pipelines.stages.timestep_preparation import (Cosmos25TimestepPre
 from fastvideo.pipelines.stages.longcat_video_vae_encoding import LongCatVideoVAEEncodingStage
 from fastvideo.pipelines.stages.longcat_kv_cache_init import LongCatKVCacheInitStage
 from fastvideo.pipelines.stages.longcat_vc_denoising import LongCatVCDenoisingStage
+from fastvideo.pipelines.stages.longcat_causal_dmd_denoising import LongCatCausalDMDDenoisingStage
 
 __all__ = [
     "PipelineStage",
@@ -93,4 +94,5 @@ __all__ = [
     "LongCatVideoVAEEncodingStage",
     "LongCatKVCacheInitStage",
     "LongCatVCDenoisingStage",
+    "LongCatCausalDMDDenoisingStage",
 ]

--- a/fastvideo/pipelines/stages/__init__.py
+++ b/fastvideo/pipelines/stages/__init__.py
@@ -44,6 +44,7 @@ from fastvideo.pipelines.stages.longcat_video_vae_encoding import LongCatVideoVA
 from fastvideo.pipelines.stages.longcat_kv_cache_init import LongCatKVCacheInitStage
 from fastvideo.pipelines.stages.longcat_vc_denoising import LongCatVCDenoisingStage
 from fastvideo.pipelines.stages.longcat_causal_dmd_denoising import LongCatCausalDMDDenoisingStage
+from fastvideo.pipelines.stages.longcat_causal_denoising import LongCatCausalDenoisingStage
 
 __all__ = [
     "PipelineStage",
@@ -95,4 +96,5 @@ __all__ = [
     "LongCatKVCacheInitStage",
     "LongCatVCDenoisingStage",
     "LongCatCausalDMDDenoisingStage",
+    "LongCatCausalDenoisingStage",
 ]

--- a/fastvideo/pipelines/stages/__init__.py
+++ b/fastvideo/pipelines/stages/__init__.py
@@ -43,8 +43,8 @@ from fastvideo.pipelines.stages.timestep_preparation import (Cosmos25TimestepPre
 from fastvideo.pipelines.stages.longcat_video_vae_encoding import LongCatVideoVAEEncodingStage
 from fastvideo.pipelines.stages.longcat_kv_cache_init import LongCatKVCacheInitStage
 from fastvideo.pipelines.stages.longcat_vc_denoising import LongCatVCDenoisingStage
-from fastvideo.pipelines.stages.longcat_causal_dmd_denoising import LongCatCausalDMDDenoisingStage
 from fastvideo.pipelines.stages.longcat_causal_denoising import LongCatCausalDenoisingStage
+from fastvideo.pipelines.stages.longcat_causal_dmd_denoising import LongCatCausalDMDDenoisingStage
 
 __all__ = [
     "PipelineStage",
@@ -95,6 +95,6 @@ __all__ = [
     "LongCatVideoVAEEncodingStage",
     "LongCatKVCacheInitStage",
     "LongCatVCDenoisingStage",
-    "LongCatCausalDMDDenoisingStage",
     "LongCatCausalDenoisingStage",
+    "LongCatCausalDMDDenoisingStage",
 ]

--- a/fastvideo/pipelines/stages/longcat_causal_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_denoising.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LongCat causal multi-step denoising stage.
+
+Block-by-block causal inference with KV caching, using the full
+scheduler timestep schedule (40-50 steps) rather than DMD few-step.
+This is the right inference pipeline for DFSFT-trained LongCat models.
+
+Mirrors :class:`CausalDenoisingStage` (Wan) but adapted to LongCat's
+``kv_cache_dict`` interface — same buffer-based KV cache as
+:class:`LongCatCausalDMDDenoisingStage` (which we subclass for the
+``_cache_view`` / ``_write_chunk_to_buffer`` helpers and constructor).
+The inner loop swaps DMD's ``pred_noise_to_pred_video`` for the
+standard ``scheduler.step``, with the LongCat-convention noise
+negation (matches :class:`LongCatDenoisingStage`).
+"""
+from __future__ import annotations
+
+import torch
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.forward_context import set_forward_context
+from fastvideo.logger import init_logger
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.longcat_causal_dmd_denoising import (
+    LongCatCausalDMDDenoisingStage, )
+
+logger = init_logger(__name__)
+
+
+class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
+    """Multi-step block-by-block denoising for LongCat with KV cache.
+
+    Each block is fully denoised through ``num_inference_steps``
+    scheduler steps before moving to the next block. After each block
+    is denoised, one extra forward with ``return_kv=True`` is run on
+    the clean denoised context to refresh the KV cache (same pattern
+    as DMD).
+    """
+
+    def forward(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> ForwardBatch:
+        target_dtype = torch.bfloat16
+        autocast_enabled = ((target_dtype != torch.float32)
+                            and not fastvideo_args.disable_autocast)
+
+        latents = batch.latents
+        assert latents is not None
+        b, c, t, h, w = latents.shape
+        device = latents.device
+
+        if t % self.chunk_size != 0:
+            raise ValueError(
+                f"num_latent_frames ({t}) must be divisible by chunk_size "
+                f"({self.chunk_size}) for LongCat causal denoising")
+        num_blocks = t // self.chunk_size
+
+        prompt_embeds = batch.prompt_embeds[0]
+        prompt_attention_mask = (batch.prompt_attention_mask[0]
+                                 if batch.prompt_attention_mask else None)
+        assert torch.isnan(prompt_embeds).sum() == 0
+
+        num_inference_steps = batch.num_inference_steps
+        if num_inference_steps is None or num_inference_steps <= 0:
+            raise ValueError(
+                "num_inference_steps must be a positive int for LongCat "
+                f"causal multi-step denoising; got {num_inference_steps}")
+
+        context_noise = int(
+            getattr(fastvideo_args.pipeline_config, "context_noise", 0))
+
+        cache_state: dict | None = None
+        start_index = 0
+
+        with self.progress_bar(total=num_blocks *
+                               num_inference_steps) as progress_bar:
+            for _ in range(num_blocks):
+                current_latents = latents[:, :,
+                                          start_index:start_index +
+                                          self.chunk_size, :, :].clone()
+
+                # Reset scheduler per block so its multi-step history
+                # starts fresh for the new chunk.
+                self.scheduler.set_timesteps(num_inference_steps,
+                                             device=device)
+                timesteps = self.scheduler.timesteps
+
+                for i, t_cur in enumerate(timesteps):
+                    t_expand = t_cur.expand(b)
+
+                    kv_view, cached_frames = self._cache_view(cache_state)
+
+                    # Transformer expects BCTHW input.
+                    latent_input_bcthw = current_latents.to(target_dtype)
+
+                    with torch.autocast(
+                            device_type="cuda",
+                            dtype=target_dtype,
+                            enabled=autocast_enabled,
+                    ), set_forward_context(
+                            current_timestep=i,
+                            attn_metadata=None,
+                            forward_batch=batch,
+                    ):
+                        pred_noise_bcthw = self.transformer(
+                            hidden_states=latent_input_bcthw,
+                            encoder_hidden_states=prompt_embeds,
+                            encoder_attention_mask=prompt_attention_mask,
+                            timestep=t_expand,
+                            num_cond_latents=cached_frames,
+                            kv_cache_dict=kv_view,
+                            kv_cache_start_frame=0,
+                        )
+                    if isinstance(pred_noise_bcthw, tuple):
+                        raise RuntimeError(
+                            "LongCat transformer returned a tuple when "
+                            "return_kv=False")
+
+                    # LongCat scheduler convention: negate noise pred
+                    # before scheduler.step (matches LongCatDenoisingStage,
+                    # the regular bidirectional pipeline).
+                    pred_noise_bcthw = -pred_noise_bcthw
+
+                    # scheduler.step works on flat [B*T, C, H, W] tensors
+                    # with BTCHW ordering, so permute first.
+                    pred_noise_btchw = pred_noise_bcthw.permute(
+                        0, 2, 1, 3, 4)
+                    latents_btchw = current_latents.permute(0, 2, 1, 3, 4)
+                    nf = self.chunk_size
+                    pred_noise_flat = pred_noise_btchw.flatten(0, 1)
+                    latents_flat = latents_btchw.flatten(0, 1)
+                    updated_flat = self.scheduler.step(
+                        pred_noise_flat,
+                        t_cur,
+                        latents_flat,
+                        return_dict=False,
+                    )[0]
+                    current_latents = updated_flat.unflatten(
+                        0, (b, nf)).permute(0, 2, 1, 3, 4).contiguous()
+
+                    if progress_bar is not None:
+                        progress_bar.update()
+
+                # Write the denoised block back.
+                latents[:, :, start_index:start_index +
+                        self.chunk_size, :, :] = current_latents
+
+                # Refresh KV cache with clean denoised context.
+                t_context = torch.full(
+                    (b, ),
+                    context_noise,
+                    device=device,
+                    dtype=torch.long,
+                )
+                context_bcthw = current_latents.to(target_dtype)
+                _, cached_frames_for_write = self._cache_view(cache_state)
+
+                with torch.autocast(
+                        device_type="cuda",
+                        dtype=target_dtype,
+                        enabled=autocast_enabled,
+                ), set_forward_context(
+                        current_timestep=0,
+                        attn_metadata=None,
+                        forward_batch=batch,
+                ):
+                    out = self.transformer(
+                        hidden_states=context_bcthw,
+                        encoder_hidden_states=prompt_embeds,
+                        timestep=t_context,
+                        num_cond_latents=cached_frames_for_write,
+                        return_kv=True,
+                        skip_crs_attn=True,
+                    )
+                if not isinstance(out, tuple) or len(out) != 2:
+                    raise RuntimeError(
+                        "LongCat transformer did not return (output, kv) "
+                        "with return_kv=True")
+                _, new_chunk = out
+                if not new_chunk:
+                    raise RuntimeError(
+                        "LongCat transformer returned no KV cache when "
+                        "return_kv=True")
+
+                cache_state = self._write_chunk_to_buffer(
+                    cache_state=cache_state,
+                    new_chunk=new_chunk,
+                    new_frames=self.chunk_size,
+                    num_frames_total=t,
+                    device=device,
+                )
+
+                start_index += self.chunk_size
+
+        batch.latents = latents
+        return batch

--- a/fastvideo/pipelines/stages/longcat_causal_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_denoising.py
@@ -15,6 +15,8 @@ negation (matches :class:`LongCatDenoisingStage`).
 """
 from __future__ import annotations
 
+from dataclasses import replace
+
 import torch
 
 from fastvideo.fastvideo_args import FastVideoArgs
@@ -47,8 +49,9 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                             and not fastvideo_args.disable_autocast)
 
         latents = batch.latents
-        assert latents is not None
-        b, c, t, h, w = latents.shape
+        if latents is None:
+            raise ValueError("LongCat causal denoising requires latents")
+        b, _, t, _, _ = latents.shape
         device = latents.device
 
         if t % self.chunk_size != 0:
@@ -60,7 +63,8 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
         prompt_embeds = batch.prompt_embeds[0]
         prompt_attention_mask = (batch.prompt_attention_mask[0]
                                  if batch.prompt_attention_mask else None)
-        assert torch.isnan(prompt_embeds).sum() == 0
+        if torch.isnan(prompt_embeds).any():
+            raise ValueError("prompt_embeds contains NaNs")
 
         num_inference_steps = batch.num_inference_steps
         if num_inference_steps is None or num_inference_steps <= 0:
@@ -68,8 +72,8 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                 "num_inference_steps must be a positive int for LongCat "
                 f"causal multi-step denoising; got {num_inference_steps}")
 
-        context_noise = int(
-            getattr(fastvideo_args.pipeline_config, "context_noise", 0))
+        context_noise = float(
+            getattr(fastvideo_args.pipeline_config, "context_noise", 0.0))
 
         cache_state: dict | None = None
         start_index = 0
@@ -129,7 +133,6 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                     pred_noise_btchw = pred_noise_bcthw.permute(
                         0, 2, 1, 3, 4)
                     latents_btchw = current_latents.permute(0, 2, 1, 3, 4)
-                    nf = self.chunk_size
                     pred_noise_flat = pred_noise_btchw.flatten(0, 1)
                     latents_flat = latents_btchw.flatten(0, 1)
                     updated_flat = self.scheduler.step(
@@ -139,7 +142,8 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                         return_dict=False,
                     )[0]
                     current_latents = updated_flat.unflatten(
-                        0, (b, nf)).permute(0, 2, 1, 3, 4).contiguous()
+                        0, (b, self.chunk_size)).permute(
+                            0, 2, 1, 3, 4).contiguous()
 
                     if progress_bar is not None:
                         progress_bar.update()
@@ -153,7 +157,7 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                     (b, ),
                     context_noise,
                     device=device,
-                    dtype=torch.long,
+                    dtype=torch.float32,
                 )
                 context_bcthw = current_latents.to(target_dtype)
                 _, cached_frames_for_write = self._cache_view(cache_state)
@@ -170,6 +174,7 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                     out = self.transformer(
                         hidden_states=context_bcthw,
                         encoder_hidden_states=prompt_embeds,
+                        encoder_attention_mask=prompt_attention_mask,
                         timestep=t_context,
                         num_cond_latents=cached_frames_for_write,
                         return_kv=True,
@@ -196,5 +201,4 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
 
                 start_index += self.chunk_size
 
-        batch.latents = latents
-        return batch
+        return replace(batch, latents=latents)

--- a/fastvideo/pipelines/stages/longcat_causal_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_denoising.py
@@ -22,6 +22,7 @@ import torch
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.forward_context import set_forward_context
 from fastvideo.logger import init_logger
+from fastvideo.models.dits.longcat import longcat_to_training_velocity
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages.longcat_causal_dmd_denoising import (
     LongCatCausalDMDDenoisingStage, )
@@ -126,7 +127,8 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                     # LongCat scheduler convention: negate noise pred
                     # before scheduler.step (matches LongCatDenoisingStage,
                     # the regular bidirectional pipeline).
-                    pred_noise_bcthw = -pred_noise_bcthw
+                    pred_noise_bcthw = longcat_to_training_velocity(
+                        pred_noise_bcthw)
 
                     # scheduler.step works on flat [B*T, C, H, W] tensors
                     # with BTCHW ordering, so permute first.

--- a/fastvideo/pipelines/stages/longcat_causal_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_denoising.py
@@ -22,7 +22,10 @@ import torch
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.forward_context import set_forward_context
 from fastvideo.logger import init_logger
-from fastvideo.models.dits.longcat import longcat_to_training_velocity
+from fastvideo.models.dits.longcat import (
+    build_longcat_causal_block_ranges,
+    longcat_to_training_velocity,
+)
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages.longcat_causal_dmd_denoising import (
     LongCatCausalDMDDenoisingStage, )
@@ -55,11 +58,11 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
         b, _, t, _, _ = latents.shape
         device = latents.device
 
-        if t % self.chunk_size != 0:
-            raise ValueError(
-                f"num_latent_frames ({t}) must be divisible by chunk_size "
-                f"({self.chunk_size}) for LongCat causal denoising")
-        num_blocks = t // self.chunk_size
+        block_ranges = build_longcat_causal_block_ranges(
+            num_frames=t,
+            chunk_size=self.chunk_size,
+        )
+        num_blocks = len(block_ranges)
 
         prompt_embeds = batch.prompt_embeds[0]
         prompt_attention_mask = (batch.prompt_attention_mask[0]
@@ -77,14 +80,13 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
             getattr(fastvideo_args.pipeline_config, "context_noise", 0.0))
 
         cache_state: dict | None = None
-        start_index = 0
 
         with self.progress_bar(total=num_blocks *
                                num_inference_steps) as progress_bar:
-            for _ in range(num_blocks):
-                current_latents = latents[:, :,
-                                          start_index:start_index +
-                                          self.chunk_size, :, :].clone()
+            for start_index, end_index in block_ranges:
+                block_frames = end_index - start_index
+                current_latents = latents[:, :, start_index:end_index, :, :]
+                current_latents = current_latents.clone()
 
                 # Reset scheduler per block so its multi-step history
                 # starts fresh for the new chunk.
@@ -144,15 +146,14 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                         return_dict=False,
                     )[0]
                     current_latents = updated_flat.unflatten(
-                        0, (b, self.chunk_size)).permute(
+                        0, (b, block_frames)).permute(
                             0, 2, 1, 3, 4).contiguous()
 
                     if progress_bar is not None:
                         progress_bar.update()
 
                 # Write the denoised block back.
-                latents[:, :, start_index:start_index +
-                        self.chunk_size, :, :] = current_latents
+                latents[:, :, start_index:end_index, :, :] = current_latents
 
                 # Refresh KV cache with clean denoised context.
                 t_context = torch.full(
@@ -199,11 +200,9 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                 cache_state = self._write_chunk_to_buffer(
                     cache_state=cache_state,
                     new_chunk=new_chunk,
-                    new_frames=self.chunk_size,
+                    new_frames=block_frames,
                     num_frames_total=t,
                     device=device,
                 )
-
-                start_index += self.chunk_size
 
         return replace(batch, latents=latents)

--- a/fastvideo/pipelines/stages/longcat_causal_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_denoising.py
@@ -162,7 +162,8 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                     dtype=torch.float32,
                 )
                 context_bcthw = current_latents.to(target_dtype)
-                _, cached_frames_for_write = self._cache_view(cache_state)
+                kv_view_for_write, cached_frames_for_write = (
+                    self._cache_view(cache_state))
 
                 with torch.autocast(
                         device_type="cuda",
@@ -179,6 +180,8 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                         encoder_attention_mask=prompt_attention_mask,
                         timestep=t_context,
                         num_cond_latents=cached_frames_for_write,
+                        kv_cache_dict=kv_view_for_write,
+                        kv_cache_start_frame=0,
                         return_kv=True,
                         causal_block_size=self.chunk_size,
                         skip_crs_attn=True,

--- a/fastvideo/pipelines/stages/longcat_causal_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_denoising.py
@@ -112,6 +112,7 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                             num_cond_latents=cached_frames,
                             kv_cache_dict=kv_view,
                             kv_cache_start_frame=0,
+                            causal_block_size=self.chunk_size,
                         )
                     if isinstance(pred_noise_bcthw, tuple):
                         raise RuntimeError(
@@ -172,6 +173,7 @@ class LongCatCausalDenoisingStage(LongCatCausalDMDDenoisingStage):
                         timestep=t_context,
                         num_cond_latents=cached_frames_for_write,
                         return_kv=True,
+                        causal_block_size=self.chunk_size,
                         skip_crs_attn=True,
                     )
                 if not isinstance(out, tuple) or len(out) != 2:

--- a/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LongCat causal DMD denoising stage.
+
+Mirrors :class:`CausalDMDDenosingStage` (Wan) but adapted to LongCat's
+transformer interface, which exposes the streaming KV cache as a
+``{block_idx: (k, v)}`` dict instead of Wan's pre-allocated ``kv_cache``
+list with index tensors.
+
+For each causal block (``chunk_size`` latent frames):
+
+1. Run ``len(dmd_denoising_steps)`` few-step DMD denoising passes,
+   reading from the cached K/V of all previously denoised blocks.
+2. After the block is fully denoised, run one more forward with
+   ``return_kv=True`` and a clean ``context_noise`` timestep to
+   produce K/V for the cache, and write them into a pre-allocated
+   buffer (Wan-style).
+
+Buffer management mirrors the training-side
+:class:`LongCatCausalModel` (fixed-size buffer per layer +
+``write_idx`` pointer) but is inlined here to keep the inference and
+training paths independent.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.forward_context import set_forward_context
+from fastvideo.logger import init_logger
+from fastvideo.models.utils import pred_noise_to_pred_video
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.denoising import DenoisingStage
+from fastvideo.pipelines.stages.validators import StageValidators as V
+from fastvideo.pipelines.stages.validators import VerificationResult
+
+logger = init_logger(__name__)
+
+
+class LongCatCausalDMDDenoisingStage(DenoisingStage):
+    """Block-by-block DMD few-step denoising with LongCat KV cache."""
+
+    def __init__(
+        self,
+        transformer,
+        scheduler,
+        vae=None,
+        chunk_size: int = 3,
+    ) -> None:
+        super().__init__(transformer, scheduler)
+        self.vae = vae
+        # Latent frames per causal block. Defaults to the value used by
+        # the training-side `SelfForcingMethod` config; can be overridden
+        # by the caller if a different rollout shape is needed.
+        self.chunk_size = int(chunk_size)
+        if self.chunk_size <= 0:
+            raise ValueError("chunk_size must be > 0")
+
+    def forward(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> ForwardBatch:
+        target_dtype = torch.bfloat16
+        autocast_enabled = ((target_dtype != torch.float32)
+                            and not fastvideo_args.disable_autocast)
+
+        latents = batch.latents
+        assert latents is not None
+        b, c, t, h, w = latents.shape
+        device = latents.device
+
+        if t % self.chunk_size != 0:
+            raise ValueError(
+                f"num_latent_frames ({t}) must be divisible by chunk_size "
+                f"({self.chunk_size}) for LongCat causal DMD denoising")
+        num_blocks = t // self.chunk_size
+
+        # LongCat uses a single text encoder; prompt_embeds is a list.
+        prompt_embeds = batch.prompt_embeds[0]
+        prompt_attention_mask = (batch.prompt_attention_mask[0]
+                                 if batch.prompt_attention_mask else None)
+        assert torch.isnan(prompt_embeds).sum() == 0
+
+        # DMD few-step timesteps. Optionally remap through the scheduler
+        # if warp_denoising_step is on (mirrors Wan's CausalDMDDenosingStage).
+        dmd_timesteps = torch.tensor(
+            fastvideo_args.pipeline_config.dmd_denoising_steps,
+            dtype=torch.long,
+        ).cpu()
+        if getattr(fastvideo_args.pipeline_config, "warp_denoising_step",
+                   False):
+            scheduler_timesteps = torch.cat(
+                (self.scheduler.timesteps.cpu(),
+                 torch.tensor([0], dtype=torch.float32)))
+            dmd_timesteps = scheduler_timesteps[1000 - dmd_timesteps]
+        dmd_timesteps = dmd_timesteps.to(device)
+
+        context_noise = int(
+            getattr(fastvideo_args.pipeline_config, "context_noise", 0))
+
+        # Lazy-allocated KV buffer state.
+        cache_state: dict[str, Any] | None = None
+        start_index = 0
+
+        with self.progress_bar(total=num_blocks *
+                               len(dmd_timesteps)) as progress_bar:
+            for _ in range(num_blocks):
+                current_latents = latents[:, :,
+                                          start_index:start_index +
+                                          self.chunk_size, :, :].clone()
+                # Track the original noisy latents (BTCHW) for DMD
+                # noise->video conversion across inner steps.
+                noise_latents_btchw = current_latents.permute(
+                    0, 2, 1, 3, 4).contiguous()
+                video_raw_latent_shape = noise_latents_btchw.shape
+
+                for i, t_cur in enumerate(dmd_timesteps):
+                    t_expand = t_cur.repeat(b)
+
+                    kv_view, cached_frames = self._cache_view(cache_state)
+
+                    # Transformer expects BCTHW (Conv3d patch_embed); leave
+                    # input as-is. Output is BCTHW too — permute to BTCHW
+                    # afterwards for the DMD scheduler routines.
+                    latent_input_bcthw = current_latents.to(target_dtype)
+
+                    with torch.autocast(
+                            device_type="cuda",
+                            dtype=target_dtype,
+                            enabled=autocast_enabled,
+                    ), set_forward_context(
+                            current_timestep=i,
+                            attn_metadata=None,
+                            forward_batch=batch,
+                    ):
+                        pred_noise_bcthw = self.transformer(
+                            hidden_states=latent_input_bcthw,
+                            encoder_hidden_states=prompt_embeds,
+                            encoder_attention_mask=prompt_attention_mask,
+                            timestep=t_expand,
+                            num_cond_latents=cached_frames,
+                            kv_cache_dict=kv_view,
+                            kv_cache_start_frame=0,
+                        )
+                    if isinstance(pred_noise_bcthw, tuple):
+                        raise RuntimeError(
+                            "LongCat transformer returned a tuple when "
+                            "return_kv=False")
+                    pred_noise_btchw = pred_noise_bcthw.permute(0, 2, 1, 3,
+                                                                 4)
+
+                    # DMD few-step: convert pred_noise to pred_video
+                    # using the FlowMatch scheduler.
+                    pred_video_btchw = pred_noise_to_pred_video(
+                        pred_noise=pred_noise_btchw.flatten(0, 1),
+                        noise_input_latent=noise_latents_btchw.flatten(0, 1),
+                        timestep=t_expand,
+                        scheduler=self.scheduler,
+                    ).unflatten(0, pred_noise_btchw.shape[:2])
+
+                    if i < len(dmd_timesteps) - 1:
+                        next_t = dmd_timesteps[i + 1] * torch.ones(
+                            [1], dtype=torch.long, device=device)
+                        gen = (batch.generator[0] if isinstance(
+                            batch.generator, list) else batch.generator)
+                        noise = torch.randn(
+                            video_raw_latent_shape,
+                            dtype=pred_video_btchw.dtype,
+                            generator=gen,
+                        ).to(device)
+                        noise_latents_btchw = self.scheduler.add_noise(
+                            pred_video_btchw.flatten(0, 1),
+                            noise.flatten(0, 1),
+                            next_t,
+                        ).unflatten(0, pred_video_btchw.shape[:2])
+                        current_latents = noise_latents_btchw.permute(
+                            0, 2, 1, 3, 4).contiguous()
+                    else:
+                        current_latents = pred_video_btchw.permute(
+                            0, 2, 1, 3, 4).contiguous()
+
+                    if progress_bar is not None:
+                        progress_bar.update()
+
+                # Write the denoised block back to the full latent tensor.
+                latents[:, :, start_index:start_index +
+                        self.chunk_size, :, :] = current_latents
+
+                # Refresh KV cache with the clean denoised context so the
+                # next block can attend to it. Mirrors the training-side
+                # `LongCatCausalModel.predict_noise_streaming` store_kv
+                # path (return_kv=True + skip_crs_attn).
+                t_context = torch.full(
+                    (b, ),
+                    context_noise,
+                    device=device,
+                    dtype=torch.long,
+                )
+                # Transformer wants BCTHW; current_latents already is.
+                context_bcthw = current_latents.to(target_dtype)
+                _, cached_frames_for_write = self._cache_view(cache_state)
+
+                with torch.autocast(
+                        device_type="cuda",
+                        dtype=target_dtype,
+                        enabled=autocast_enabled,
+                ), set_forward_context(
+                        current_timestep=0,
+                        attn_metadata=None,
+                        forward_batch=batch,
+                ):
+                    out = self.transformer(
+                        hidden_states=context_bcthw,
+                        encoder_hidden_states=prompt_embeds,
+                        timestep=t_context,
+                        num_cond_latents=cached_frames_for_write,
+                        return_kv=True,
+                        skip_crs_attn=True,
+                    )
+                if not isinstance(out, tuple) or len(out) != 2:
+                    raise RuntimeError(
+                        "LongCat transformer did not return (output, kv) "
+                        "with return_kv=True")
+                _, new_chunk = out
+                if not new_chunk:
+                    raise RuntimeError(
+                        "LongCat transformer returned no KV cache when "
+                        "return_kv=True")
+
+                cache_state = self._write_chunk_to_buffer(
+                    cache_state=cache_state,
+                    new_chunk=new_chunk,
+                    new_frames=self.chunk_size,
+                    num_frames_total=t,
+                    device=device,
+                )
+
+                start_index += self.chunk_size
+
+        batch.latents = latents
+        return batch
+
+    # ------------------------------------------------------------------
+    # KV cache buffer (inlined from LongCatCausalModel — same pattern,
+    # but no grad-checkpoint / autograd considerations needed here)
+    # ------------------------------------------------------------------
+
+    def _cache_view(
+        self,
+        cache_state: dict[str, Any] | None,
+    ) -> tuple[dict[int, tuple[torch.Tensor, torch.Tensor]] | None, int]:
+        if cache_state is None:
+            return None, 0
+        widx = int(cache_state["write_idx"].item())
+        if widx == 0:
+            return None, 0
+        view = {
+            idx: (buf["k"][:, :, :widx, :], buf["v"][:, :, :widx, :])
+            for idx, buf in cache_state["buffers"].items()
+        }
+        cached_frames = widx // cache_state["tokens_per_frame"]
+        return view, cached_frames
+
+    def _write_chunk_to_buffer(
+        self,
+        *,
+        cache_state: dict[str, Any] | None,
+        new_chunk: dict[int, tuple[torch.Tensor, torch.Tensor]],
+        new_frames: int,
+        num_frames_total: int,
+        device: torch.device,
+    ) -> dict[str, Any]:
+        sample_k, _ = next(iter(new_chunk.values()))
+        if sample_k.ndim != 4:
+            raise ValueError(
+                "Unexpected LongCat KV cache shape; expected [B, H, N, D], "
+                f"got ndim={sample_k.ndim}")
+        new_tokens = int(sample_k.shape[2])
+        if new_tokens % new_frames != 0:
+            raise ValueError(
+                "LongCat KV cache token count is not divisible by the number "
+                f"of frames in the cached chunk: {new_tokens} vs {new_frames}")
+        tokens_per_frame = new_tokens // new_frames
+
+        if cache_state is None:
+            max_tokens = tokens_per_frame * int(num_frames_total)
+            B = int(sample_k.shape[0])
+            H = int(sample_k.shape[1])
+            D = int(sample_k.shape[3])
+            buffers: dict[int, dict[str, torch.Tensor]] = {}
+            for idx, (k, v) in new_chunk.items():
+                buffers[idx] = {
+                    "k":
+                    torch.zeros(
+                        (B, H, max_tokens, D),
+                        dtype=k.dtype,
+                        device=k.device,
+                    ),
+                    "v":
+                    torch.zeros(
+                        (B, H, max_tokens, D),
+                        dtype=v.dtype,
+                        device=v.device,
+                    ),
+                }
+            cache_state = {
+                "buffers": buffers,
+                "write_idx": torch.zeros((),
+                                         dtype=torch.long,
+                                         device=device),
+                "tokens_per_frame": tokens_per_frame,
+                "max_tokens": max_tokens,
+            }
+        else:
+            if cache_state["tokens_per_frame"] != tokens_per_frame:
+                raise ValueError(
+                    "LongCat KV cache token density changed between blocks: "
+                    f"{cache_state['tokens_per_frame']} vs {tokens_per_frame}"
+                )
+
+        widx = int(cache_state["write_idx"].item())
+        new_widx = widx + new_tokens
+        if new_widx > cache_state["max_tokens"]:
+            raise ValueError(
+                "LongCat KV cache buffer overflow: tried to write up to "
+                f"{new_widx} tokens, capacity is {cache_state['max_tokens']}")
+
+        for idx, (k, v) in new_chunk.items():
+            buf = cache_state["buffers"].get(idx)
+            if buf is None:
+                raise ValueError(
+                    f"LongCat returned new K/V for layer {idx} not present "
+                    "in the pre-allocated buffer; the layer set must be "
+                    "consistent across chunks")
+            buf["k"][:, :, widx:new_widx, :].copy_(k.detach())
+            buf["v"][:, :, widx:new_widx, :].copy_(v.detach())
+
+        cache_state["write_idx"].fill_(new_widx)
+        return cache_state
+
+    def verify_input(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> VerificationResult:
+        result = VerificationResult()
+        result.add_check("latents", batch.latents,
+                         [V.is_tensor, V.with_dims(5)])
+        result.add_check("prompt_embeds", batch.prompt_embeds,
+                         V.list_not_empty)
+        result.add_check("generator", batch.generator,
+                         V.generator_or_list_generators)
+        return result

--- a/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
@@ -208,7 +208,8 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                 )
                 # Transformer wants BCTHW; current_latents already is.
                 context_bcthw = current_latents.to(target_dtype)
-                _, cached_frames_for_write = self._cache_view(cache_state)
+                kv_view_for_write, cached_frames_for_write = (
+                    self._cache_view(cache_state))
 
                 with torch.autocast(
                         device_type="cuda",
@@ -225,6 +226,8 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                         encoder_attention_mask=prompt_attention_mask,
                         timestep=t_context,
                         num_cond_latents=cached_frames_for_write,
+                        kv_cache_dict=kv_view_for_write,
+                        kv_cache_start_frame=0,
                         return_kv=True,
                         causal_block_size=self.chunk_size,
                         skip_crs_attn=True,

--- a/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
@@ -22,6 +22,7 @@ training paths independent.
 """
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 import torch
@@ -43,9 +44,9 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
 
     def __init__(
         self,
-        transformer,
-        scheduler,
-        vae=None,
+        transformer: torch.nn.Module,
+        scheduler: Any,
+        vae: Any | None = None,
         chunk_size: int = 3,
     ) -> None:
         super().__init__(transformer, scheduler)
@@ -67,8 +68,9 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                             and not fastvideo_args.disable_autocast)
 
         latents = batch.latents
-        assert latents is not None
-        b, c, t, h, w = latents.shape
+        if latents is None:
+            raise ValueError("LongCat causal DMD denoising requires latents")
+        b, _, t, _, _ = latents.shape
         device = latents.device
 
         if t % self.chunk_size != 0:
@@ -81,7 +83,8 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
         prompt_embeds = batch.prompt_embeds[0]
         prompt_attention_mask = (batch.prompt_attention_mask[0]
                                  if batch.prompt_attention_mask else None)
-        assert torch.isnan(prompt_embeds).sum() == 0
+        if torch.isnan(prompt_embeds).any():
+            raise ValueError("prompt_embeds contains NaNs")
 
         # DMD few-step timesteps. Optionally remap through the scheduler
         # if warp_denoising_step is on (mirrors Wan's CausalDMDDenosingStage).
@@ -97,8 +100,8 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
             dmd_timesteps = scheduler_timesteps[1000 - dmd_timesteps]
         dmd_timesteps = dmd_timesteps.to(device)
 
-        context_noise = int(
-            getattr(fastvideo_args.pipeline_config, "context_noise", 0))
+        context_noise = float(
+            getattr(fastvideo_args.pipeline_config, "context_noise", 0.0))
 
         # Lazy-allocated KV buffer state.
         cache_state: dict[str, Any] | None = None
@@ -199,7 +202,7 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                     (b, ),
                     context_noise,
                     device=device,
-                    dtype=torch.long,
+                    dtype=torch.float32,
                 )
                 # Transformer wants BCTHW; current_latents already is.
                 context_bcthw = current_latents.to(target_dtype)
@@ -217,6 +220,7 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                     out = self.transformer(
                         hidden_states=context_bcthw,
                         encoder_hidden_states=prompt_embeds,
+                        encoder_attention_mask=prompt_attention_mask,
                         timestep=t_context,
                         num_cond_latents=cached_frames_for_write,
                         return_kv=True,
@@ -243,8 +247,7 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
 
                 start_index += self.chunk_size
 
-        batch.latents = latents
-        return batch
+        return replace(batch, latents=latents)
 
     # ------------------------------------------------------------------
     # KV cache buffer (inlined from LongCatCausalModel — same pattern,
@@ -338,8 +341,8 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                     f"LongCat returned new K/V for layer {idx} not present "
                     "in the pre-allocated buffer; the layer set must be "
                     "consistent across chunks")
-            buf["k"][:, :, widx:new_widx, :].copy_(k.detach())
-            buf["v"][:, :, widx:new_widx, :].copy_(v.detach())
+            buf["k"][:, :, widx:new_widx, :].copy_(k)
+            buf["v"][:, :, widx:new_widx, :].copy_(v)
 
         cache_state["write_idx"].fill_(new_widx)
         return cache_state

--- a/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
@@ -26,6 +26,7 @@ from dataclasses import replace
 from typing import Any
 
 import torch
+from diffusers.utils.torch_utils import randn_tensor
 
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.forward_context import set_forward_context
@@ -172,7 +173,7 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                             [1], dtype=torch.long, device=device)
                         gen = (batch.generator[0] if isinstance(
                             batch.generator, list) else batch.generator)
-                        noise = torch.randn(
+                        noise = randn_tensor(
                             video_raw_latent_shape,
                             dtype=pred_video_btchw.dtype,
                             device=device,

--- a/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
@@ -31,7 +31,10 @@ from diffusers.utils.torch_utils import randn_tensor
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.forward_context import set_forward_context
 from fastvideo.logger import init_logger
-from fastvideo.models.dits.longcat import longcat_to_training_velocity
+from fastvideo.models.dits.longcat import (
+    build_longcat_causal_block_ranges,
+    longcat_to_training_velocity,
+)
 from fastvideo.models.utils import pred_noise_to_pred_video
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages.denoising import DenoisingStage
@@ -75,11 +78,11 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
         b, _, t, _, _ = latents.shape
         device = latents.device
 
-        if t % self.chunk_size != 0:
-            raise ValueError(
-                f"num_latent_frames ({t}) must be divisible by chunk_size "
-                f"({self.chunk_size}) for LongCat causal DMD denoising")
-        num_blocks = t // self.chunk_size
+        block_ranges = build_longcat_causal_block_ranges(
+            num_frames=t,
+            chunk_size=self.chunk_size,
+        )
+        num_blocks = len(block_ranges)
 
         # LongCat uses a single text encoder; prompt_embeds is a list.
         prompt_embeds = batch.prompt_embeds[0]
@@ -107,14 +110,13 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
 
         # Lazy-allocated KV buffer state.
         cache_state: dict[str, Any] | None = None
-        start_index = 0
 
         with self.progress_bar(total=num_blocks *
                                len(dmd_timesteps)) as progress_bar:
-            for _ in range(num_blocks):
-                current_latents = latents[:, :,
-                                          start_index:start_index +
-                                          self.chunk_size, :, :].clone()
+            for start_index, end_index in block_ranges:
+                block_frames = end_index - start_index
+                current_latents = latents[:, :, start_index:end_index, :, :]
+                current_latents = current_latents.clone()
                 # Track the original noisy latents (BTCHW) for DMD
                 # noise->video conversion across inner steps.
                 noise_latents_btchw = current_latents.permute(
@@ -194,8 +196,7 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                         progress_bar.update()
 
                 # Write the denoised block back to the full latent tensor.
-                latents[:, :, start_index:start_index +
-                        self.chunk_size, :, :] = current_latents
+                latents[:, :, start_index:end_index, :, :] = current_latents
 
                 # Refresh KV cache with the clean denoised context so the
                 # next block can attend to it. Mirrors the training-side
@@ -246,12 +247,10 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                 cache_state = self._write_chunk_to_buffer(
                     cache_state=cache_state,
                     new_chunk=new_chunk,
-                    new_frames=self.chunk_size,
+                    new_frames=block_frames,
                     num_frames_total=t,
                     device=device,
                 )
-
-                start_index += self.chunk_size
 
         return replace(batch, latents=latents)
 

--- a/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
@@ -143,11 +143,13 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                             num_cond_latents=cached_frames,
                             kv_cache_dict=kv_view,
                             kv_cache_start_frame=0,
+                            causal_block_size=self.chunk_size,
                         )
                     if isinstance(pred_noise_bcthw, tuple):
                         raise RuntimeError(
                             "LongCat transformer returned a tuple when "
                             "return_kv=False")
+                    pred_noise_bcthw = -pred_noise_bcthw
                     pred_noise_btchw = pred_noise_bcthw.permute(0, 2, 1, 3,
                                                                  4)
 
@@ -168,8 +170,9 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                         noise = torch.randn(
                             video_raw_latent_shape,
                             dtype=pred_video_btchw.dtype,
+                            device=device,
                             generator=gen,
-                        ).to(device)
+                        )
                         noise_latents_btchw = self.scheduler.add_noise(
                             pred_video_btchw.flatten(0, 1),
                             noise.flatten(0, 1),
@@ -217,6 +220,7 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                         timestep=t_context,
                         num_cond_latents=cached_frames_for_write,
                         return_kv=True,
+                        causal_block_size=self.chunk_size,
                         skip_crs_attn=True,
                     )
                 if not isinstance(out, tuple) or len(out) != 2:

--- a/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
+++ b/fastvideo/pipelines/stages/longcat_causal_dmd_denoising.py
@@ -30,6 +30,7 @@ import torch
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.forward_context import set_forward_context
 from fastvideo.logger import init_logger
+from fastvideo.models.dits.longcat import longcat_to_training_velocity
 from fastvideo.models.utils import pred_noise_to_pred_video
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages.denoising import DenoisingStage
@@ -152,7 +153,8 @@ class LongCatCausalDMDDenoisingStage(DenoisingStage):
                         raise RuntimeError(
                             "LongCat transformer returned a tuple when "
                             "return_kv=False")
-                    pred_noise_bcthw = -pred_noise_bcthw
+                    pred_noise_bcthw = longcat_to_training_velocity(
+                        pred_noise_bcthw)
                     pred_noise_btchw = pred_noise_bcthw.permute(0, 2, 1, 3,
                                                                  4)
 

--- a/fastvideo/tests/transformers/test_longcat_causal_mask.py
+++ b/fastvideo/tests/transformers/test_longcat_causal_mask.py
@@ -32,6 +32,7 @@ def test_longcat_block_causal_mask_blocks_future_chunks():
         [True, True, True, True],
         [True, True, True, True],
     ]
+    assert mask[0, 0, 1].tolist() == mask[0, 0, 0].tolist()
 
 
 def test_longcat_block_causal_mask_handles_cached_prefix():
@@ -47,6 +48,21 @@ def test_longcat_block_causal_mask_handles_cached_prefix():
         [True, True, True, True, False],
         [True, True, True, True, True],
     ]
+
+
+def test_longcat_block_causal_mask_allows_first_single_block_only():
+    mask = build_longcat_block_causal_mask(
+        query_frames=1,
+        key_frames=1,
+        tokens_per_frame=2,
+        causal_block_size=2,
+        device="cpu",
+    )
+
+    assert _frame_visibility(mask, tokens_per_frame=2) == [
+        [True],
+    ]
+    assert mask[0, 0, 1].tolist() == mask[0, 0, 0].tolist()
 
 
 def test_longcat_block_causal_mask_rejects_invalid_shape():

--- a/fastvideo/tests/transformers/test_longcat_causal_mask.py
+++ b/fastvideo/tests/transformers/test_longcat_causal_mask.py
@@ -3,6 +3,9 @@ import pytest
 import torch
 
 from fastvideo.models.dits.longcat import build_longcat_block_causal_mask
+from fastvideo.train.methods.distribution_matching.self_forcing import (
+    SelfForcingMethod, )
+from fastvideo.train.models.base import ModelBase
 
 
 def _frame_visibility(mask: torch.Tensor, tokens_per_frame: int) -> list[list[bool]]:
@@ -73,4 +76,15 @@ def test_longcat_block_causal_mask_rejects_invalid_shape():
             tokens_per_frame=1,
             causal_block_size=1,
             device="cpu",
+        )
+
+
+def test_longcat_self_forcing_rejects_chunk_block_mismatch():
+    class Student(ModelBase):
+        _causal_block_size = 4
+
+    with pytest.raises(ValueError, match="causal_block_size.*chunk_size"):
+        SelfForcingMethod._validate_causal_block_size(
+            student=Student.__new__(Student),
+            chunk_size=3,
         )

--- a/fastvideo/tests/transformers/test_longcat_causal_mask.py
+++ b/fastvideo/tests/transformers/test_longcat_causal_mask.py
@@ -13,7 +13,6 @@ from fastvideo.models.dits.longcat import (
 )
 from fastvideo.train.methods.distribution_matching.self_forcing import (
     SelfForcingMethod, )
-from fastvideo.train.models.base import ModelBase
 
 
 def _frame_visibility(
@@ -91,12 +90,12 @@ def test_longcat_block_causal_mask_rejects_invalid_shape():
 
 
 def test_longcat_self_forcing_rejects_chunk_block_mismatch():
-    class Student(ModelBase):
+    class Student:
         _causal_block_size = 4
 
     with pytest.raises(ValueError, match="causal_block_size.*chunk_size"):
         SelfForcingMethod._validate_causal_block_size(
-            student=Student.__new__(Student),
+            student=Student(),  # type: ignore[arg-type]
             chunk_size=3,
         )
 

--- a/fastvideo/tests/transformers/test_longcat_causal_mask.py
+++ b/fastvideo/tests/transformers/test_longcat_causal_mask.py
@@ -2,13 +2,24 @@
 import pytest
 import torch
 
-from fastvideo.models.dits.longcat import build_longcat_block_causal_mask
+from fastvideo.configs.models.dits.longcat import (
+    LongCatVideoArchConfig,
+    LongCatVideoConfig,
+)
+from fastvideo.models.dits import longcat as longcat_module
+from fastvideo.models.dits.longcat import (
+    LongCatTransformer3DModel,
+    build_longcat_block_causal_mask,
+)
 from fastvideo.train.methods.distribution_matching.self_forcing import (
     SelfForcingMethod, )
 from fastvideo.train.models.base import ModelBase
 
 
-def _frame_visibility(mask: torch.Tensor, tokens_per_frame: int) -> list[list[bool]]:
+def _frame_visibility(
+    mask: torch.Tensor,
+    tokens_per_frame: int,
+) -> list[list[bool]]:
     token_mask = mask[0, 0]
     frames = []
     for row in token_mask[::tokens_per_frame]:
@@ -88,3 +99,187 @@ def test_longcat_self_forcing_rejects_chunk_block_mismatch():
             student=Student.__new__(Student),
             chunk_size=3,
         )
+
+
+class _UnexpectedAttention(torch.nn.Module):
+    """Constructor-only stand-in for backend-selected attention layers."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def forward(self, *args, **kwargs):
+        raise AssertionError("causal LongCat test should use direct SDPA")
+
+
+def _merge_kv_cache(
+    cache: dict[int, tuple[torch.Tensor, torch.Tensor]] | None,
+    new_chunk: dict[int, tuple[torch.Tensor, torch.Tensor]],
+) -> dict[int, tuple[torch.Tensor, torch.Tensor]]:
+    if cache is None:
+        return new_chunk
+    return {
+        idx: (
+            torch.cat((cache[idx][0], k), dim=2),
+            torch.cat((cache[idx][1], v), dim=2),
+        )
+        for idx, (k, v) in new_chunk.items()
+    }
+
+
+def _tiny_longcat_transformer(monkeypatch) -> LongCatTransformer3DModel:
+    monkeypatch.setattr(
+        longcat_module,
+        "DistributedAttention",
+        _UnexpectedAttention,
+    )
+    monkeypatch.setattr(
+        longcat_module,
+        "LocalAttention",
+        _UnexpectedAttention,
+    )
+
+    arch_config = LongCatVideoArchConfig(
+        hidden_size=16,
+        depth=2,
+        num_attention_heads=2,
+        in_channels=4,
+        out_channels=4,
+        num_channels_latents=4,
+        patch_size=(1, 1, 1),
+        caption_channels=8,
+        adaln_tembed_dim=16,
+        frequency_embedding_size=8,
+        mlp_ratio=1,
+        enable_bsa=False,
+    )
+    model = LongCatTransformer3DModel(
+        config=LongCatVideoConfig(arch_config=arch_config),
+        hf_config={},
+    )
+    for param in model.parameters():
+        if param.ndim > 1:
+            torch.nn.init.normal_(param, mean=0.0, std=0.02)
+        else:
+            torch.nn.init.uniform_(param, a=-0.02, b=0.02)
+    return model.eval()
+
+
+def test_longcat_chunked_causal_rollout_matches_full_prefix(monkeypatch):
+    torch.manual_seed(0)
+    model = _tiny_longcat_transformer(monkeypatch)
+
+    batch_size = 1
+    channels = 4
+    num_frames = 6
+    height = 2
+    width = 2
+    chunk_size = 2
+    text_len = 3
+
+    hidden_states = torch.randn(batch_size, channels, num_frames, height,
+                                width)
+    encoder_hidden_states = torch.randn(batch_size, text_len, 8)
+    encoder_attention_mask = torch.ones(batch_size, text_len)
+    timesteps = torch.full((batch_size, num_frames), 123.0)
+
+    chunked_outputs = []
+    kv_cache = None
+    with torch.no_grad():
+        for start in range(0, num_frames, chunk_size):
+            end = start + chunk_size
+            chunk = hidden_states[:, :, start:end]
+            timestep_chunk = timesteps[:, start:end]
+            cached_frames = start
+
+            chunked = model(
+                hidden_states=chunk,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                timestep=timestep_chunk,
+                num_cond_latents=cached_frames,
+                kv_cache_dict=kv_cache,
+                kv_cache_start_frame=0,
+                causal_block_size=chunk_size,
+                skip_crs_attn=True,
+            )
+
+            prefix = model(
+                hidden_states=hidden_states[:, :, :end],
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                timestep=timesteps[:, :end],
+                causal_block_size=chunk_size,
+                skip_crs_attn=True,
+            )[:, :, start:end]
+            torch.testing.assert_close(chunked, prefix, atol=1e-5, rtol=1e-5)
+            chunked_outputs.append(chunked)
+
+            _, new_cache = model(
+                hidden_states=chunk,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                timestep=timestep_chunk,
+                num_cond_latents=cached_frames,
+                kv_cache_dict=kv_cache,
+                kv_cache_start_frame=0,
+                return_kv=True,
+                causal_block_size=chunk_size,
+                skip_crs_attn=True,
+            )
+            kv_cache = _merge_kv_cache(kv_cache, new_cache)
+
+        full_reference = model(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=encoder_attention_mask,
+            timestep=timesteps,
+            causal_block_size=chunk_size,
+            skip_crs_attn=True,
+        )
+
+    torch.testing.assert_close(
+        torch.cat(chunked_outputs, dim=2),
+        full_reference,
+        atol=1e-5,
+        rtol=1e-5,
+    )
+
+
+def test_longcat_forward_with_kv_cache_matches_rope_offset(monkeypatch):
+    torch.manual_seed(1)
+    model = _tiny_longcat_transformer(monkeypatch)
+    attn = model.blocks[0].self_attn
+
+    batch_size = 1
+    num_frames = 4
+    height = 2
+    width = 2
+    hidden_size = 16
+    chunk_size = 2
+    tokens_per_frame = height * width
+    split = chunk_size * tokens_per_frame
+
+    x = torch.randn(batch_size, num_frames * tokens_per_frame, hidden_size)
+
+    with torch.no_grad():
+        full = attn(
+            x,
+            latent_shape=(num_frames, height, width),
+            causal_block_size=chunk_size,
+        )
+        _, kv_cache = attn(
+            x[:, :split],
+            latent_shape=(chunk_size, height, width),
+            return_kv=True,
+            causal_block_size=chunk_size,
+        )
+        cached = attn.forward_with_kv_cache(
+            x[:, split:],
+            latent_shape=(chunk_size, height, width),
+            num_cond_latents=chunk_size,
+            kv_cache=kv_cache,
+            kv_cache_start_frame=0,
+            causal_block_size=chunk_size,
+        )
+
+    torch.testing.assert_close(cached, full[:, split:], atol=1e-5, rtol=1e-5)

--- a/fastvideo/tests/transformers/test_longcat_causal_mask.py
+++ b/fastvideo/tests/transformers/test_longcat_causal_mask.py
@@ -9,6 +9,7 @@ from fastvideo.configs.models.dits.longcat import (
 from fastvideo.models.dits import longcat as longcat_module
 from fastvideo.models.dits.longcat import (
     LongCatTransformer3DModel,
+    build_longcat_causal_block_ranges,
     build_longcat_block_causal_mask,
 )
 from fastvideo.train.methods.distribution_matching.self_forcing import (
@@ -98,6 +99,25 @@ def test_longcat_self_forcing_rejects_chunk_block_mismatch():
             student=Student(),  # type: ignore[arg-type]
             chunk_size=3,
         )
+
+
+def test_longcat_causal_stage_remainder_goes_in_first_block():
+    assert build_longcat_causal_block_ranges(
+        num_frames=20,
+        chunk_size=3,
+    ) == [(0, 5), (5, 8), (8, 11), (11, 14), (14, 17), (17, 20)]
+    assert build_longcat_causal_block_ranges(
+        num_frames=21,
+        chunk_size=3,
+    ) == [
+        (0, 3),
+        (3, 6),
+        (6, 9),
+        (9, 12),
+        (12, 15),
+        (15, 18),
+        (18, 21),
+    ]
 
 
 class _UnexpectedAttention(torch.nn.Module):

--- a/fastvideo/tests/transformers/test_longcat_causal_mask.py
+++ b/fastvideo/tests/transformers/test_longcat_causal_mask.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from fastvideo.models.dits.longcat import build_longcat_block_causal_mask
+
+
+def _frame_visibility(mask: torch.Tensor, tokens_per_frame: int) -> list[list[bool]]:
+    token_mask = mask[0, 0]
+    frames = []
+    for row in token_mask[::tokens_per_frame]:
+        frames.append([
+            bool(row[frame * tokens_per_frame])
+            for frame in range(token_mask.shape[1] // tokens_per_frame)
+        ])
+    return frames
+
+
+def test_longcat_block_causal_mask_blocks_future_chunks():
+    mask = build_longcat_block_causal_mask(
+        query_frames=4,
+        key_frames=4,
+        tokens_per_frame=2,
+        causal_block_size=2,
+        device="cpu",
+    )
+
+    assert mask.shape == (1, 1, 8, 8)
+    assert _frame_visibility(mask, tokens_per_frame=2) == [
+        [True, True, False, False],
+        [True, True, False, False],
+        [True, True, True, True],
+        [True, True, True, True],
+    ]
+
+
+def test_longcat_block_causal_mask_handles_cached_prefix():
+    mask = build_longcat_block_causal_mask(
+        query_frames=2,
+        key_frames=5,
+        tokens_per_frame=1,
+        causal_block_size=2,
+        device="cpu",
+    )
+
+    assert _frame_visibility(mask, tokens_per_frame=1) == [
+        [True, True, True, True, False],
+        [True, True, True, True, True],
+    ]
+
+
+def test_longcat_block_causal_mask_rejects_invalid_shape():
+    with pytest.raises(ValueError, match="query_frames must be <= key_frames"):
+        build_longcat_block_causal_mask(
+            query_frames=3,
+            key_frames=2,
+            tokens_per_frame=1,
+            causal_block_size=1,
+            device="cpu",
+        )

--- a/fastvideo/train/methods/distribution_matching/self_forcing.py
+++ b/fastvideo/train/methods/distribution_matching/self_forcing.py
@@ -286,7 +286,9 @@ class SelfForcingMethod(DMD2Method):
         return self._student_rollout_streaming(batch, with_grad=with_grad)
 
     def _student_rollout_streaming(self, batch: Any, *, with_grad: bool) -> torch.Tensor:
-        assert isinstance(self.student, CausalModelBase)
+        if not isinstance(self.student, CausalModelBase):
+            raise ValueError("SelfForcingMethod requires a causal student "
+                             "implementing CausalModelBase.")
         latents = batch.latents
         if latents is None:
             raise RuntimeError("TrainingBatch.latents is required for "
@@ -326,35 +328,95 @@ class SelfForcingMethod(DMD2Method):
         cache_tag = "pos"
         self.student.clear_caches(cache_tag=cache_tag)
 
-        for block_idx in range(num_blocks):
-            if block_idx == 0:
-                start = 0
-                end = remaining + chunk if remaining else chunk
-            else:
-                start = remaining + block_idx * chunk
-                end = remaining + (block_idx + 1) * chunk
-            start = int(start)
-            end = int(min(end, num_frames))
-            if start >= end:
-                break
+        try:
+            for block_idx in range(num_blocks):
+                if block_idx == 0:
+                    start = 0
+                    end = remaining + chunk if remaining else chunk
+                else:
+                    start = remaining + block_idx * chunk
+                    end = remaining + (block_idx + 1) * chunk
+                start = int(start)
+                end = int(min(end, num_frames))
+                if start >= end:
+                    break
 
-            noisy_block = noise_full[:, start:end]
-            exit_idx = int(exit_indices[block_idx])
+                noisy_block = noise_full[:, start:end]
+                exit_idx = int(exit_indices[block_idx])
 
-            for step_idx, current_timestep in enumerate(denoising_steps):
-                exit_flag = step_idx == exit_idx
+                for step_idx, current_timestep in enumerate(denoising_steps):
+                    exit_flag = step_idx == exit_idx
 
-                timestep_block = (current_timestep * torch.ones(
-                    (batch_size, end - start),
-                    device=device,
-                    dtype=torch.float32,
-                ))
+                    timestep_block = (current_timestep * torch.ones(
+                        (batch_size, end - start),
+                        device=device,
+                        dtype=torch.float32,
+                    ))
 
-                enable_grad = (bool(with_grad) and bool(self._enable_gradient_in_rollout) and torch.is_grad_enabled()
-                               and start >= int(self._start_gradient_frame))
+                    enable_grad = (
+                        bool(with_grad)
+                        and bool(self._enable_gradient_in_rollout)
+                        and torch.is_grad_enabled()
+                        and start >= int(self._start_gradient_frame))
 
-                if not exit_flag:
-                    with torch.no_grad():
+                    if not exit_flag:
+                        with torch.no_grad():
+                            pred_noise = (self.student.predict_noise_streaming(
+                                noisy_block,
+                                timestep_block,
+                                batch,
+                                conditional=True,
+                                cache_tag=cache_tag,
+                                store_kv=False,
+                                cur_start_frame=start,
+                                cfg_uncond=self._cfg_uncond,
+                                attn_kind="vsa",
+                            ))
+                            if pred_noise is None:
+                                raise RuntimeError("predict_noise_streaming "
+                                                   "returned None "
+                                                   "(store_kv=False)")
+                            pred_x0_chunk = pred_noise_to_pred_video(
+                                pred_noise=pred_noise.flatten(0, 1),
+                                noise_input_latent=(
+                                    noisy_block.flatten(0, 1)),
+                                timestep=timestep_block,
+                                scheduler=self._sf_scheduler,
+                            ).unflatten(0, pred_noise.shape[:2])
+
+                        if step_idx + 1 >= num_steps:
+                            break
+                        next_timestep = denoising_steps[step_idx + 1]
+                        if self._student_sample_type == "sde":
+                            noisy_block = self._sf_add_noise(
+                                pred_x0_chunk,
+                                torch.randn_like(pred_x0_chunk),
+                                next_timestep * torch.ones(
+                                    (batch_size, end - start),
+                                    device=device,
+                                    dtype=torch.float32,
+                                ),
+                            )
+                        else:
+                            sigma_cur = self._timestep_to_sigma(
+                                timestep_block).view(batch_size, end - start,
+                                                     1, 1, 1)
+                            sigma_next = self._timestep_to_sigma(
+                                next_timestep * torch.ones(
+                                    (batch_size, end - start),
+                                    device=device,
+                                    dtype=torch.float32,
+                                )).view(batch_size, end - start, 1, 1, 1)
+                            eps = (
+                                noisy_block -
+                                (1 - sigma_cur) * pred_x0_chunk
+                            ) / sigma_cur.clamp_min(1e-8)
+                            noisy_block = (
+                                (1 - sigma_next) * pred_x0_chunk +
+                                sigma_next * eps)
+                        continue
+
+                    with torch.set_grad_enabled(enable_grad):
                         pred_noise = (self.student.predict_noise_streaming(
                             noisy_block,
                             timestep_block,
@@ -367,102 +429,57 @@ class SelfForcingMethod(DMD2Method):
                             attn_kind="vsa",
                         ))
                         if pred_noise is None:
-                            raise RuntimeError("predict_noise_streaming "
-                                               "returned None "
-                                               "(store_kv=False)")
+                            raise RuntimeError(
+                                "predict_noise_streaming returned "
+                                "None (store_kv=False)")
                         pred_x0_chunk = pred_noise_to_pred_video(
                             pred_noise=pred_noise.flatten(0, 1),
                             noise_input_latent=(noisy_block.flatten(0, 1)),
                             timestep=timestep_block,
                             scheduler=self._sf_scheduler,
                         ).unflatten(0, pred_noise.shape[:2])
+                    break
 
-                    if step_idx + 1 >= num_steps:
-                        break
-                    next_timestep = denoising_steps[step_idx + 1]
-                    if self._student_sample_type == "sde":
-                        noisy_block = self._sf_add_noise(
-                            pred_x0_chunk,
-                            torch.randn_like(pred_x0_chunk),
-                            next_timestep * torch.ones(
-                                (batch_size, end - start),
-                                device=device,
-                                dtype=torch.float32,
-                            ),
-                        )
-                    else:
-                        sigma_cur = self._timestep_to_sigma(timestep_block).view(batch_size, end - start, 1, 1, 1)
-                        sigma_next = self._timestep_to_sigma(next_timestep * torch.ones(
+                denoised_blocks.append(pred_x0_chunk)
+
+                with torch.no_grad():
+                    if self._context_noise > 0.0:
+                        context_timestep = torch.ones(
                             (batch_size, end - start),
                             device=device,
                             dtype=torch.float32,
-                        )).view(batch_size, end - start, 1, 1, 1)
-                        eps = (noisy_block - (1 - sigma_cur) * pred_x0_chunk) / sigma_cur.clamp_min(1e-8)
-                        noisy_block = ((1 - sigma_next) * pred_x0_chunk + sigma_next * eps)
-                    continue
+                        ) * float(self._context_noise)
+                        context_latents = self._sf_add_noise(
+                            pred_x0_chunk.detach(),
+                            torch.randn_like(pred_x0_chunk),
+                            context_timestep,
+                        )
+                    else:
+                        context_timestep = torch.zeros(
+                            (batch_size, end - start),
+                            device=device,
+                            dtype=torch.float32,
+                        )
+                        context_latents = pred_x0_chunk.detach()
 
-                with torch.set_grad_enabled(enable_grad):
-                    pred_noise = (self.student.predict_noise_streaming(
-                        noisy_block,
-                        timestep_block,
+                    _ = self.student.predict_noise_streaming(
+                        context_latents,
+                        context_timestep,
                         batch,
                         conditional=True,
                         cache_tag=cache_tag,
-                        store_kv=False,
+                        store_kv=True,
                         cur_start_frame=start,
                         cfg_uncond=self._cfg_uncond,
                         attn_kind="vsa",
-                    ))
-                    if pred_noise is None:
-                        raise RuntimeError("predict_noise_streaming returned "
-                                           "None (store_kv=False)")
-                    pred_x0_chunk = pred_noise_to_pred_video(
-                        pred_noise=pred_noise.flatten(0, 1),
-                        noise_input_latent=(noisy_block.flatten(0, 1)),
-                        timestep=timestep_block,
-                        scheduler=self._sf_scheduler,
-                    ).unflatten(0, pred_noise.shape[:2])
-                break
-
-            denoised_blocks.append(pred_x0_chunk)
-
-            with torch.no_grad():
-                if self._context_noise > 0.0:
-                    context_timestep = torch.ones(
-                        (batch_size, end - start),
-                        device=device,
-                        dtype=torch.float32,
-                    ) * float(self._context_noise)
-                    context_latents = self._sf_add_noise(
-                        pred_x0_chunk.detach(),
-                        torch.randn_like(pred_x0_chunk),
-                        context_timestep,
                     )
-                else:
-                    context_timestep = torch.zeros(
-                        (batch_size, end - start),
-                        device=device,
-                        dtype=torch.float32,
-                    )
-                    context_latents = pred_x0_chunk.detach()
 
-                _ = self.student.predict_noise_streaming(
-                    context_latents,
-                    context_timestep,
-                    batch,
-                    conditional=True,
-                    cache_tag=cache_tag,
-                    store_kv=True,
-                    cur_start_frame=start,
-                    cfg_uncond=self._cfg_uncond,
-                    attn_kind="vsa",
-                )
+            if not denoised_blocks:
+                raise RuntimeError("Self-forcing rollout produced no blocks")
 
-        if not denoised_blocks:
-            raise RuntimeError("Self-forcing rollout produced no blocks")
-
-        self.student.clear_caches(cache_tag=cache_tag)
-        return torch.cat(denoised_blocks, dim=1)
+            return torch.cat(denoised_blocks, dim=1)
+        finally:
+            self.student.clear_caches(cache_tag=cache_tag)
 
     def _critic_flow_matching_loss(self, batch: Any) -> tuple[torch.Tensor, Any, dict[str, Any]]:
         with torch.no_grad():

--- a/fastvideo/train/methods/distribution_matching/self_forcing.py
+++ b/fastvideo/train/methods/distribution_matching/self_forcing.py
@@ -77,6 +77,10 @@ class SelfForcingMethod(DMD2Method):
             raise ValueError("method_config.chunk_size must be a positive "
                              f"integer, got {chunk_size}")
         self._chunk_size = int(chunk_size)
+        self._validate_causal_block_size(
+            student=self.student,
+            chunk_size=self._chunk_size,
+        )
 
         sample_type_raw = mcfg.get("student_sample_type", "sde")
         sample_type = _require_str(
@@ -154,6 +158,23 @@ class SelfForcingMethod(DMD2Method):
         )
 
         self._sf_denoising_step_list: torch.Tensor | None = None
+
+    @staticmethod
+    def _validate_causal_block_size(
+        *,
+        student: ModelBase,
+        chunk_size: int,
+    ) -> None:
+        causal_block_size = getattr(student, "_causal_block_size", None)
+        if causal_block_size is None:
+            return
+        if int(causal_block_size) != int(chunk_size):
+            raise ValueError(
+                "LongCat causal self-forcing requires "
+                "models.student.causal_block_size to match "
+                "method.chunk_size so training and rollout block "
+                "boundaries stay aligned: "
+                f"{causal_block_size} vs {chunk_size}")
 
     def _get_denoising_step_list(self, device: torch.device) -> torch.Tensor:
         if (self._sf_denoising_step_list is not None and self._sf_denoising_step_list.device == device):

--- a/fastvideo/train/models/longcat/__init__.py
+++ b/fastvideo/train/models/longcat/__init__.py
@@ -3,3 +3,5 @@
 
 from fastvideo.train.models.longcat.longcat import (
     LongCatModel as LongCatModel, )
+from fastvideo.train.models.longcat.longcat_causal import (
+    LongCatCausalModel as LongCatCausalModel, )

--- a/fastvideo/train/models/longcat/longcat.py
+++ b/fastvideo/train/models/longcat/longcat.py
@@ -3,13 +3,10 @@
 
 from __future__ import annotations
 
-from typing import Any, ClassVar, Literal, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING
 
 import torch
 
-from fastvideo.pipelines.basic.longcat.longcat_pipeline import (
-    LongCatPipeline,
-)
 from fastvideo.pipelines import TrainingBatch
 from fastvideo.train.models.wan.wan import WanModel
 
@@ -21,7 +18,6 @@ class LongCatModel(WanModel):
     """LongCat per-role model for training and distillation."""
 
     _transformer_cls_name: str = "LongCatTransformer3DModel"
-    _prompt_pipeline_cls: ClassVar[type[LongCatPipeline]] = LongCatPipeline
 
     @staticmethod
     def _validate_flow_shift(flow_shift: float | None) -> float:

--- a/fastvideo/train/models/longcat/longcat.py
+++ b/fastvideo/train/models/longcat/longcat.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, TYPE_CHECKING
 
 import torch
 
+from fastvideo.models.dits.longcat import longcat_to_training_velocity
 from fastvideo.pipelines import TrainingBatch
 from fastvideo.train.models.wan.wan import WanModel
 
@@ -26,10 +27,16 @@ class LongCatModel(WanModel):
 
         validated = float(flow_shift)
         if validated == 0.0:
-            raise ValueError("LongCat training does not support flow_shift=0.0 because "
-                             "it collapses FlowMatch training timesteps. Use 12.0 to "
-                             "match the released LongCat scheduler config.")
+            raise ValueError(
+                "LongCat training does not support flow_shift=0.0 because "
+                "it collapses FlowMatch training timesteps. Use 12.0 to "
+                "match the released LongCat scheduler config.")
         return validated
+
+    @staticmethod
+    def _to_training_velocity(pred: torch.Tensor) -> torch.Tensor:
+        """Adapt native LongCat output to FastVideo's training target sign."""
+        return longcat_to_training_velocity(pred)
 
     def __init__(
         self,
@@ -129,4 +136,4 @@ class LongCatModel(WanModel):
             cfg_uncond=cfg_uncond,
             attn_kind=attn_kind,
         )
-        return -pred
+        return self._to_training_velocity(pred)

--- a/fastvideo/train/models/longcat/longcat.py
+++ b/fastvideo/train/models/longcat/longcat.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, ClassVar, Literal, TYPE_CHECKING
 
 import torch
 
+from fastvideo.pipelines.basic.longcat.longcat_pipeline import (
+    LongCatPipeline,
+)
 from fastvideo.pipelines import TrainingBatch
 from fastvideo.train.models.wan.wan import WanModel
 
@@ -18,6 +21,7 @@ class LongCatModel(WanModel):
     """LongCat per-role model for training and distillation."""
 
     _transformer_cls_name: str = "LongCatTransformer3DModel"
+    _prompt_pipeline_cls: ClassVar[type[LongCatPipeline]] = LongCatPipeline
 
     @staticmethod
     def _validate_flow_shift(flow_shift: float | None) -> float:

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LongCat streaming model plugin for self-forcing rollouts."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TYPE_CHECKING
+
+import torch
+
+from fastvideo.forward_context import set_forward_context
+from fastvideo.train.models.base import CausalModelBase
+from fastvideo.train.models.longcat.longcat import LongCatModel
+
+if TYPE_CHECKING:
+    from fastvideo.pipelines import TrainingBatch
+    from fastvideo.train.utils.training_config import TrainingConfig
+
+
+class LongCatCausalModel(LongCatModel, CausalModelBase):
+    """LongCat model with chunk-wise KV cache accumulation."""
+
+    def __init__(
+        self,
+        *,
+        init_from: str,
+        training_config: TrainingConfig,
+        trainable: bool = True,
+        disable_custom_init_weights: bool = False,
+        flow_shift: float = 0.0,
+        enable_gradient_checkpointing_type: str | None = None,
+        transformer_override_safetensor: str | None = None,
+    ) -> None:
+        super().__init__(
+            init_from=init_from,
+            training_config=training_config,
+            trainable=trainable,
+            disable_custom_init_weights=disable_custom_init_weights,
+            flow_shift=flow_shift,
+            enable_gradient_checkpointing_type=enable_gradient_checkpointing_type,
+            transformer_override_safetensor=transformer_override_safetensor,
+        )
+        self._streaming_caches: dict[str, dict[int, tuple[torch.Tensor, torch.Tensor]]] = {}
+
+    def clear_caches(self, *, cache_tag: str = "pos") -> None:
+        self._streaming_caches.pop(str(cache_tag), None)
+
+    def predict_noise_streaming(
+        self,
+        noisy_latents: torch.Tensor,
+        timestep: torch.Tensor,
+        batch: TrainingBatch,
+        *,
+        conditional: bool,
+        cache_tag: str = "pos",
+        store_kv: bool = False,
+        cur_start_frame: int = 0,
+        cfg_uncond: dict[str, Any] | None = None,
+        attn_kind: Literal["dense", "vsa"] = "dense",
+    ) -> torch.Tensor | None:
+        if attn_kind not in {"dense", "vsa"}:
+            raise ValueError(f"Unknown attn_kind: {attn_kind!r}")
+        # SelfForcingMethod passes "vsa" for student rollout, but LongCat
+        # selects sparse behavior through its native BSA config, not VSA metadata.
+        cache_tag = str(cache_tag)
+        cur_start_frame = int(cur_start_frame)
+        if cur_start_frame < 0:
+            raise ValueError("cur_start_frame must be >= 0")
+
+        if conditional:
+            text_dict = batch.conditional_dict
+            if text_dict is None:
+                raise RuntimeError("Missing conditional_dict in TrainingBatch")
+        else:
+            text_dict = self._get_uncond_text_dict(batch, cfg_uncond=cfg_uncond)
+
+        transformer = self.transformer
+        dtype = noisy_latents.dtype
+        kv_cache_dict = self._streaming_caches.get(cache_tag)
+
+        with torch.autocast(self.device.type, dtype=dtype), set_forward_context(
+            current_timestep=batch.timesteps,
+            attn_metadata=None,
+        ):
+            if store_kv:
+                empty_embeds = self._empty_kv_cache_inputs(
+                    transformer=transformer,
+                    batch_size=int(noisy_latents.shape[0]),
+                    device=noisy_latents.device,
+                    dtype=dtype,
+                )
+                _, new_cache = transformer(
+                    hidden_states=noisy_latents.permute(0, 2, 1, 3, 4),
+                    encoder_hidden_states=empty_embeds,
+                    timestep=timestep,
+                    num_cond_latents=cur_start_frame,
+                    return_kv=True,
+                    skip_crs_attn=True,
+                )
+                if new_cache is None:
+                    raise RuntimeError("LongCat transformer returned no KV cache")
+                self._streaming_caches[cache_tag] = self._merge_kv_cache_dicts(
+                    kv_cache_dict,
+                    new_cache,
+                )
+                return None
+
+            pred_noise = transformer(
+                hidden_states=noisy_latents.permute(0, 2, 1, 3, 4),
+                encoder_hidden_states=text_dict["encoder_hidden_states"],
+                encoder_attention_mask=text_dict["encoder_attention_mask"],
+                timestep=timestep,
+                num_cond_latents=cur_start_frame,
+                kv_cache_dict=kv_cache_dict,
+            )
+            if isinstance(pred_noise, tuple):
+                raise RuntimeError("LongCat transformer returned a tuple "
+                                   "when return_kv=False")
+        return pred_noise.permute(0, 2, 1, 3, 4)
+
+    def _empty_kv_cache_inputs(
+        self,
+        *,
+        transformer: torch.nn.Module,
+        batch_size: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        base_transformer = getattr(transformer, "module", transformer)
+        config = getattr(base_transformer, "config", None)
+        caption_dim = int(getattr(config, "caption_channels", 4096))
+        text_len = self._get_text_len(default=512)
+        return torch.zeros(
+            batch_size,
+            text_len,
+            caption_dim,
+            device=device,
+            dtype=dtype,
+        )
+
+    def _get_text_len(self, *, default: int) -> int:
+        pipeline_config = getattr(self.training_config, "pipeline_config", None)
+        text_configs = getattr(pipeline_config, "text_encoder_configs", None)
+        if text_configs:
+            arch_config = getattr(text_configs[0], "arch_config", None)
+            value = getattr(arch_config, "text_len", None)
+            if value is not None:
+                return int(value)
+        return int(default)
+
+    def _merge_kv_cache_dicts(
+        self,
+        existing: dict[int, tuple[torch.Tensor, torch.Tensor]] | None,
+        new: dict[int, tuple[torch.Tensor, torch.Tensor]],
+    ) -> dict[int, tuple[torch.Tensor, torch.Tensor]]:
+        if not existing:
+            return dict(new)
+
+        merged: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+        for idx in sorted(set(existing) | set(new)):
+            if idx not in existing:
+                merged[idx] = new[idx]
+                continue
+            if idx not in new:
+                merged[idx] = existing[idx]
+                continue
+
+            prev_k, prev_v = existing[idx]
+            new_k, new_v = new[idx]
+            merged[idx] = (
+                torch.cat((prev_k, new_k), dim=2),
+                torch.cat((prev_v, new_v), dim=2),
+            )
+        return merged

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -1,6 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
-"""LongCat streaming model plugin for self-forcing rollouts."""
+"""LongCat streaming model plugin for self-forcing rollouts.
 
+KV cache management mirrors :class:`WanCausalModel` 's pattern: a
+fixed-size buffer per layer, pre-allocated to fit the full rollout
+(``training.data.num_frames``), with a write pointer that advances
+chunk-by-chunk via in-place ``.copy_()``. Old positions are never
+overwritten, so backward (under gradient checkpointing) can safely
+re-read the same slice even after later forwards have advanced the
+pointer — no per-forward clone of the K/V tensors is needed.
+
+Switching from a growing dict + ``torch.cat`` per chunk to a
+pre-allocated buffer keeps peak memory constant at
+``num_frames * tokens_per_frame * 2 (K+V) * num_layers`` instead of
+growing linearly with the number of chunks.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -19,10 +32,20 @@ if TYPE_CHECKING:
 
 @dataclass(slots=True)
 class _LongCatStreamingCache:
-    kv_cache: dict[int, tuple[torch.Tensor, torch.Tensor]]
-    start_frame: int
-    cached_frames: int
+    """Pre-allocated KV cache buffer for one ``cache_tag``.
+
+    Mirrors the ``WanCausalModel`` pattern: each transformer layer
+    gets a fixed-size ``[B, H, max_tokens, D]`` buffer, and a single
+    ``write_idx`` (0-d long tensor, like Wan's ``global_end_index``)
+    tracks the next write position.
+    """
+
+    # layer_idx -> {"k": [B, H, max_tokens, D], "v": [B, H, max_tokens, D]}
+    buffers: dict[int, dict[str, torch.Tensor]]
+    # Next write position, in tokens. 0-d tensor for cheap snapshotting.
+    write_idx: torch.Tensor
     tokens_per_frame: int
+    max_tokens: int
 
 
 class LongCatCausalModel(LongCatModel, CausalModelBase):
@@ -38,7 +61,6 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         flow_shift: float = 12.0,
         enable_gradient_checkpointing_type: str | None = None,
         transformer_override_safetensor: str | None = None,
-        max_kv_cache_frames: int | None = None,
     ) -> None:
         super().__init__(
             init_from=init_from,
@@ -49,12 +71,7 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
             enable_gradient_checkpointing_type=enable_gradient_checkpointing_type,
             transformer_override_safetensor=transformer_override_safetensor,
         )
-        if max_kv_cache_frames is None:
-            self._max_kv_cache_frames = int(training_config.data.num_frames)
-        else:
-            if int(max_kv_cache_frames) <= 0:
-                raise ValueError("max_kv_cache_frames must be > 0")
-            self._max_kv_cache_frames = int(max_kv_cache_frames)
+        # Lazy-allocated per cache_tag on the first store_kv call.
         self._streaming_caches: dict[str, _LongCatStreamingCache] = {}
 
     def clear_caches(self, *, cache_tag: str = "pos") -> None:
@@ -76,7 +93,8 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         if attn_kind not in {"dense", "vsa"}:
             raise ValueError(f"Unknown attn_kind: {attn_kind!r}")
         # SelfForcingMethod passes "vsa" for student rollout, but LongCat
-        # selects sparse behavior through its native BSA config, not VSA metadata.
+        # selects sparse behavior through its native BSA config, not VSA
+        # metadata.
         cache_tag = str(cache_tag)
         cur_start_frame = int(cur_start_frame)
         if cur_start_frame < 0:
@@ -87,24 +105,20 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
             if text_dict is None:
                 raise RuntimeError("Missing conditional_dict in TrainingBatch")
         else:
-            text_dict = self._get_uncond_text_dict(batch, cfg_uncond=cfg_uncond)
+            text_dict = self._get_uncond_text_dict(
+                batch, cfg_uncond=cfg_uncond)
 
         transformer = self.transformer
         dtype = noisy_latents.dtype
+
         cache_state = self._streaming_caches.get(cache_tag)
-        kv_cache_dict = cache_state.kv_cache if cache_state is not None else None
-        kv_cache_start_frame = (
-            cache_state.start_frame if cache_state is not None else 0
-        )
-        cached_frames = cache_state.cached_frames if cache_state is not None else 0
+        kv_cache_view, cached_frames = self._cache_view(cache_state)
 
-        if self._should_snapshot_streaming_cache() and torch.is_grad_enabled():
-            kv_cache_dict = self._snapshot_kv_cache_dict(kv_cache_dict)
-
-        with torch.autocast(self.device.type, dtype=dtype), set_forward_context(
-            current_timestep=batch.timesteps,
-            attn_metadata=None,
-        ):
+        with torch.autocast(self.device.type,
+                            dtype=dtype), set_forward_context(
+                                current_timestep=batch.timesteps,
+                                attn_metadata=None,
+                            ):
             if store_kv:
                 empty_embeds = self._empty_kv_cache_inputs(
                     transformer=transformer,
@@ -112,7 +126,7 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                     device=noisy_latents.device,
                     dtype=dtype,
                 )
-                _, new_cache = transformer(
+                _, new_chunk = transformer(
                     hidden_states=noisy_latents.permute(0, 2, 1, 3, 4),
                     encoder_hidden_states=empty_embeds,
                     timestep=timestep,
@@ -120,13 +134,16 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                     return_kv=True,
                     skip_crs_attn=True,
                 )
-                if new_cache is None:
-                    raise RuntimeError("LongCat transformer returned no KV cache")
-                self._streaming_caches[cache_tag] = self._merge_kv_cache_state(
-                    existing=cache_state,
-                    new=new_cache,
-                    new_frames=int(noisy_latents.shape[1]),
-                )
+                if new_chunk is None:
+                    raise RuntimeError(
+                        "LongCat transformer returned no KV cache")
+                self._streaming_caches[cache_tag] = (
+                    self._write_chunk_to_buffer(
+                        cache_state=cache_state,
+                        new_chunk=new_chunk,
+                        new_frames=int(noisy_latents.shape[1]),
+                        device=noisy_latents.device,
+                    ))
                 return None
 
             pred_noise = transformer(
@@ -135,13 +152,160 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                 encoder_attention_mask=text_dict["encoder_attention_mask"],
                 timestep=timestep,
                 num_cond_latents=cached_frames,
-                kv_cache_dict=kv_cache_dict,
-                kv_cache_start_frame=kv_cache_start_frame,
+                kv_cache_dict=kv_cache_view,
+                # Buffer never evicts; cached frames always start at frame 0.
+                kv_cache_start_frame=0,
             )
             if isinstance(pred_noise, tuple):
                 raise RuntimeError("LongCat transformer returned a tuple "
                                    "when return_kv=False")
         return pred_noise.permute(0, 2, 1, 3, 4)
+
+    # ------------------------------------------------------------------
+    # KV cache buffer
+    # ------------------------------------------------------------------
+
+    def _cache_view(
+        self,
+        cache_state: _LongCatStreamingCache | None,
+    ) -> tuple[dict[int, tuple[torch.Tensor, torch.Tensor]] | None, int]:
+        """Return ``(kv_cache_dict view, cached_frames)`` for the transformer.
+
+        The slice ``buf[..., :write_idx, :]`` is a view into the
+        pre-allocated buffer. Because positions ``[0, write_idx)`` are
+        never overwritten, this view stays valid across later writes —
+        which is what makes the buffer pattern grad-checkpoint safe
+        without cloning the full K/V every forward.
+        """
+        if cache_state is None:
+            return None, 0
+
+        widx = int(cache_state.write_idx.item())
+        if widx == 0:
+            return None, 0
+
+        view = {
+            idx: (buf["k"][:, :, :widx, :], buf["v"][:, :, :widx, :])
+            for idx, buf in cache_state.buffers.items()
+        }
+        cached_frames = widx // cache_state.tokens_per_frame
+        return view, cached_frames
+
+    def _write_chunk_to_buffer(
+        self,
+        *,
+        cache_state: _LongCatStreamingCache | None,
+        new_chunk: dict[int, tuple[torch.Tensor, torch.Tensor]],
+        new_frames: int,
+        device: torch.device,
+    ) -> _LongCatStreamingCache:
+        """Copy the new chunk's K/V into the pre-allocated buffer.
+
+        Lazy-allocates the buffer on the first call from the first
+        chunk's K/V shape and ``training_config.data.num_frames``.
+        Subsequent calls are pure in-place ``.copy_()`` into the next
+        slot, plus an advance of ``write_idx`` — no allocation, no
+        ``torch.cat``, no eviction.
+        """
+        if int(new_frames) <= 0:
+            raise ValueError("new_frames must be > 0")
+        if not new_chunk:
+            raise ValueError("LongCat transformer returned an empty KV cache")
+
+        sample_k, _ = next(iter(new_chunk.values()))
+        if sample_k.ndim != 4:
+            raise ValueError(
+                "Unexpected LongCat KV cache shape; expected [B, H, N, D], "
+                f"got ndim={sample_k.ndim}")
+        new_tokens = int(sample_k.shape[2])
+        if new_tokens % new_frames != 0:
+            raise ValueError(
+                "LongCat KV cache token count is not divisible by the "
+                "number of frames in the cached chunk: "
+                f"{new_tokens} vs {new_frames}")
+        tokens_per_frame = new_tokens // new_frames
+
+        if cache_state is None:
+            # First chunk: allocate a fixed-size buffer sized for the
+            # full rollout. We use training_config.data.num_frames as
+            # the upper bound.
+            tc = self.training_config
+            assert tc is not None
+            total_frames = int(tc.data.num_frames)
+            if total_frames <= 0:
+                raise ValueError(
+                    "training.num_frames must be > 0 for streaming "
+                    f"KV cache; got {total_frames}")
+            max_tokens = tokens_per_frame * total_frames
+            B = int(sample_k.shape[0])
+            H = int(sample_k.shape[1])
+            D = int(sample_k.shape[3])
+
+            buffers: dict[int, dict[str, torch.Tensor]] = {}
+            for idx, (k, v) in new_chunk.items():
+                if (k.shape[0] != B or k.shape[1] != H or k.shape[3] != D):
+                    raise ValueError(
+                        "LongCat KV cache shape mismatch across layers: "
+                        f"layer {idx} has {tuple(k.shape)}, expected "
+                        f"({B}, {H}, *, {D})")
+                buffers[idx] = {
+                    "k":
+                    torch.zeros(
+                        (B, H, max_tokens, D),
+                        dtype=k.dtype,
+                        device=k.device,
+                    ),
+                    "v":
+                    torch.zeros(
+                        (B, H, max_tokens, D),
+                        dtype=v.dtype,
+                        device=v.device,
+                    ),
+                }
+
+            cache_state = _LongCatStreamingCache(
+                buffers=buffers,
+                write_idx=torch.zeros((), dtype=torch.long, device=device),
+                tokens_per_frame=tokens_per_frame,
+                max_tokens=max_tokens,
+            )
+        else:
+            if cache_state.tokens_per_frame != tokens_per_frame:
+                raise ValueError(
+                    "LongCat KV cache token density changed between chunks: "
+                    f"{cache_state.tokens_per_frame} vs {tokens_per_frame}")
+
+        widx = int(cache_state.write_idx.item())
+        new_widx = widx + new_tokens
+        if new_widx > cache_state.max_tokens:
+            raise ValueError(
+                "LongCat KV cache buffer overflow: tried to write up to "
+                f"{new_widx} tokens, buffer capacity is "
+                f"{cache_state.max_tokens} "
+                f"({cache_state.max_tokens // cache_state.tokens_per_frame} "
+                "frames). Increase training.data.num_frames or reduce "
+                "the rollout length.")
+
+        for idx, (k, v) in new_chunk.items():
+            buf = cache_state.buffers.get(idx)
+            if buf is None:
+                raise ValueError(
+                    f"LongCat returned new K/V for layer {idx} not present "
+                    "in the pre-allocated buffer; the layer set must be "
+                    "consistent across chunks")
+            # In-place write into the next slot. .detach() ensures the
+            # buffer is a constant from the next chunk's perspective —
+            # gradients flow through the live transformer call, not back
+            # through previously-cached K/V (matches WanCausalModel).
+            buf["k"][:, :, widx:new_widx, :].copy_(k.detach())
+            buf["v"][:, :, widx:new_widx, :].copy_(v.detach())
+
+        cache_state.write_idx.fill_(new_widx)
+        return cache_state
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
 
     def _empty_kv_cache_inputs(
         self,
@@ -164,7 +328,8 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         )
 
     def _get_text_len(self, *, default: int) -> int:
-        pipeline_config = getattr(self.training_config, "pipeline_config", None)
+        pipeline_config = getattr(self.training_config, "pipeline_config",
+                                  None)
         text_configs = getattr(pipeline_config, "text_encoder_configs", None)
         if text_configs:
             arch_config = getattr(text_configs[0], "arch_config", None)
@@ -172,123 +337,3 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
             if value is not None:
                 return int(value)
         return int(default)
-
-    def _should_use_checkpoint_safe_kv_cache(self) -> bool:
-        tc = getattr(self, "training_config", None)
-        checkpointing_type = (
-            tc.model.enable_gradient_checkpointing_type
-            if tc is not None else None
-        )
-        return bool(checkpointing_type) and bool(self._trainable)
-
-    def _should_snapshot_streaming_cache(self) -> bool:
-        return self._should_use_checkpoint_safe_kv_cache()
-
-    def _snapshot_kv_cache_dict(
-        self,
-        kv_cache_dict: dict[int, tuple[torch.Tensor, torch.Tensor]] | None,
-    ) -> dict[int, tuple[torch.Tensor, torch.Tensor]] | None:
-        if kv_cache_dict is None:
-            return None
-
-        return {
-            idx: (k.detach().clone(), v.detach().clone())
-            for idx, (k, v) in kv_cache_dict.items()
-        }
-
-    def _merge_kv_cache_state(
-        self,
-        existing: _LongCatStreamingCache | None,
-        new: dict[int, tuple[torch.Tensor, torch.Tensor]],
-        new_frames: int,
-    ) -> _LongCatStreamingCache:
-        if int(new_frames) <= 0:
-            raise ValueError("new_frames must be > 0")
-
-        tokens_per_frame = self._infer_tokens_per_frame(
-            cache_dict=new,
-            num_frames=int(new_frames),
-        )
-
-        if existing is None:
-            merged = {
-                idx: (k.contiguous(), v.contiguous())
-                for idx, (k, v) in new.items()
-            }
-            start_frame = 0
-            cached_frames = int(new_frames)
-        else:
-            if existing.tokens_per_frame != tokens_per_frame:
-                raise ValueError(
-                    "LongCat KV cache token density changed between chunks: "
-                    f"{existing.tokens_per_frame} vs {tokens_per_frame}"
-                )
-            merged = {}
-            for idx in sorted(set(existing.kv_cache) | set(new)):
-                if idx not in existing.kv_cache:
-                    merged[idx] = new[idx]
-                    continue
-                if idx not in new:
-                    merged[idx] = existing.kv_cache[idx]
-                    continue
-
-                prev_k, prev_v = existing.kv_cache[idx]
-                new_k, new_v = new[idx]
-                merged[idx] = (
-                    torch.cat((prev_k, new_k), dim=2),
-                    torch.cat((prev_v, new_v), dim=2),
-                )
-            start_frame = int(existing.start_frame)
-            cached_frames = int(existing.cached_frames + new_frames)
-
-        max_cache_frames = min(
-            self._max_kv_cache_frames,
-            int(self.training_config.data.num_frames),
-        )
-        if cached_frames > max_cache_frames:
-            frames_to_drop = int(cached_frames - max_cache_frames)
-            tokens_to_drop = int(frames_to_drop * tokens_per_frame)
-            for idx, (k, v) in merged.items():
-                if k.shape[2] < tokens_to_drop or v.shape[2] < tokens_to_drop:
-                    raise ValueError(
-                        "LongCat KV cache eviction would drop more tokens "
-                        "than are present in the cache"
-                    )
-                merged[idx] = (
-                    k[:, :, tokens_to_drop:, :].contiguous(),
-                    v[:, :, tokens_to_drop:, :].contiguous(),
-                )
-            start_frame += frames_to_drop
-            cached_frames = max_cache_frames
-
-        return _LongCatStreamingCache(
-            kv_cache=merged,
-            start_frame=start_frame,
-            cached_frames=cached_frames,
-            tokens_per_frame=tokens_per_frame,
-        )
-
-    def _infer_tokens_per_frame(
-        self,
-        *,
-        cache_dict: dict[int, tuple[torch.Tensor, torch.Tensor]],
-        num_frames: int,
-    ) -> int:
-        if not cache_dict:
-            raise ValueError("LongCat returned an empty KV cache")
-        if num_frames <= 0:
-            raise ValueError("num_frames must be > 0")
-
-        sample_k, _ = next(iter(cache_dict.values()))
-        if sample_k.ndim != 4:
-            raise ValueError(
-                "Unexpected LongCat KV cache shape; expected [B, H, N, D], "
-                f"got ndim={sample_k.ndim}"
-            )
-        num_tokens = int(sample_k.shape[2])
-        if num_tokens % num_frames != 0:
-            raise ValueError(
-                "LongCat KV cache token count is not divisible by the number "
-                f"of frames in the cached chunk: {num_tokens} vs {num_frames}"
-            )
-        return num_tokens // num_frames

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -26,7 +26,7 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         training_config: TrainingConfig,
         trainable: bool = True,
         disable_custom_init_weights: bool = False,
-        flow_shift: float = 0.0,
+        flow_shift: float = 12.0,
         enable_gradient_checkpointing_type: str | None = None,
         transformer_override_safetensor: str | None = None,
     ) -> None:

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Literal, TYPE_CHECKING
 
 import torch
@@ -14,6 +15,14 @@ from fastvideo.train.models.longcat.longcat import LongCatModel
 if TYPE_CHECKING:
     from fastvideo.pipelines import TrainingBatch
     from fastvideo.train.utils.training_config import TrainingConfig
+
+
+@dataclass(slots=True)
+class _LongCatStreamingCache:
+    kv_cache: dict[int, tuple[torch.Tensor, torch.Tensor]]
+    start_frame: int
+    cached_frames: int
+    tokens_per_frame: int
 
 
 class LongCatCausalModel(LongCatModel, CausalModelBase):
@@ -29,6 +38,7 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         flow_shift: float = 12.0,
         enable_gradient_checkpointing_type: str | None = None,
         transformer_override_safetensor: str | None = None,
+        max_kv_cache_frames: int | None = None,
     ) -> None:
         super().__init__(
             init_from=init_from,
@@ -39,7 +49,13 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
             enable_gradient_checkpointing_type=enable_gradient_checkpointing_type,
             transformer_override_safetensor=transformer_override_safetensor,
         )
-        self._streaming_caches: dict[str, dict[int, tuple[torch.Tensor, torch.Tensor]]] = {}
+        if max_kv_cache_frames is None:
+            self._max_kv_cache_frames = int(training_config.data.num_frames)
+        else:
+            if int(max_kv_cache_frames) <= 0:
+                raise ValueError("max_kv_cache_frames must be > 0")
+            self._max_kv_cache_frames = int(max_kv_cache_frames)
+        self._streaming_caches: dict[str, _LongCatStreamingCache] = {}
 
     def clear_caches(self, *, cache_tag: str = "pos") -> None:
         self._streaming_caches.pop(str(cache_tag), None)
@@ -75,7 +91,15 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
 
         transformer = self.transformer
         dtype = noisy_latents.dtype
-        kv_cache_dict = self._streaming_caches.get(cache_tag)
+        cache_state = self._streaming_caches.get(cache_tag)
+        kv_cache_dict = cache_state.kv_cache if cache_state is not None else None
+        kv_cache_start_frame = (
+            cache_state.start_frame if cache_state is not None else 0
+        )
+        cached_frames = cache_state.cached_frames if cache_state is not None else 0
+
+        if self._should_snapshot_streaming_cache() and torch.is_grad_enabled():
+            kv_cache_dict = self._snapshot_kv_cache_dict(kv_cache_dict)
 
         with torch.autocast(self.device.type, dtype=dtype), set_forward_context(
             current_timestep=batch.timesteps,
@@ -92,15 +116,16 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                     hidden_states=noisy_latents.permute(0, 2, 1, 3, 4),
                     encoder_hidden_states=empty_embeds,
                     timestep=timestep,
-                    num_cond_latents=cur_start_frame,
+                    num_cond_latents=cached_frames,
                     return_kv=True,
                     skip_crs_attn=True,
                 )
                 if new_cache is None:
                     raise RuntimeError("LongCat transformer returned no KV cache")
-                self._streaming_caches[cache_tag] = self._merge_kv_cache_dicts(
-                    kv_cache_dict,
-                    new_cache,
+                self._streaming_caches[cache_tag] = self._merge_kv_cache_state(
+                    existing=cache_state,
+                    new=new_cache,
+                    new_frames=int(noisy_latents.shape[1]),
                 )
                 return None
 
@@ -109,8 +134,9 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                 encoder_hidden_states=text_dict["encoder_hidden_states"],
                 encoder_attention_mask=text_dict["encoder_attention_mask"],
                 timestep=timestep,
-                num_cond_latents=cur_start_frame,
+                num_cond_latents=cached_frames,
                 kv_cache_dict=kv_cache_dict,
+                kv_cache_start_frame=kv_cache_start_frame,
             )
             if isinstance(pred_noise, tuple):
                 raise RuntimeError("LongCat transformer returned a tuple "
@@ -147,27 +173,122 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                 return int(value)
         return int(default)
 
-    def _merge_kv_cache_dicts(
+    def _should_use_checkpoint_safe_kv_cache(self) -> bool:
+        tc = getattr(self, "training_config", None)
+        checkpointing_type = (
+            tc.model.enable_gradient_checkpointing_type
+            if tc is not None else None
+        )
+        return bool(checkpointing_type) and bool(self._trainable)
+
+    def _should_snapshot_streaming_cache(self) -> bool:
+        return self._should_use_checkpoint_safe_kv_cache()
+
+    def _snapshot_kv_cache_dict(
         self,
-        existing: dict[int, tuple[torch.Tensor, torch.Tensor]] | None,
+        kv_cache_dict: dict[int, tuple[torch.Tensor, torch.Tensor]] | None,
+    ) -> dict[int, tuple[torch.Tensor, torch.Tensor]] | None:
+        if kv_cache_dict is None:
+            return None
+
+        return {
+            idx: (k.detach().clone(), v.detach().clone())
+            for idx, (k, v) in kv_cache_dict.items()
+        }
+
+    def _merge_kv_cache_state(
+        self,
+        existing: _LongCatStreamingCache | None,
         new: dict[int, tuple[torch.Tensor, torch.Tensor]],
-    ) -> dict[int, tuple[torch.Tensor, torch.Tensor]]:
-        if not existing:
-            return dict(new)
+        new_frames: int,
+    ) -> _LongCatStreamingCache:
+        if int(new_frames) <= 0:
+            raise ValueError("new_frames must be > 0")
 
-        merged: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
-        for idx in sorted(set(existing) | set(new)):
-            if idx not in existing:
-                merged[idx] = new[idx]
-                continue
-            if idx not in new:
-                merged[idx] = existing[idx]
-                continue
+        tokens_per_frame = self._infer_tokens_per_frame(
+            cache_dict=new,
+            num_frames=int(new_frames),
+        )
 
-            prev_k, prev_v = existing[idx]
-            new_k, new_v = new[idx]
-            merged[idx] = (
-                torch.cat((prev_k, new_k), dim=2),
-                torch.cat((prev_v, new_v), dim=2),
+        if existing is None:
+            merged = {
+                idx: (k.contiguous(), v.contiguous())
+                for idx, (k, v) in new.items()
+            }
+            start_frame = 0
+            cached_frames = int(new_frames)
+        else:
+            if existing.tokens_per_frame != tokens_per_frame:
+                raise ValueError(
+                    "LongCat KV cache token density changed between chunks: "
+                    f"{existing.tokens_per_frame} vs {tokens_per_frame}"
+                )
+            merged = {}
+            for idx in sorted(set(existing.kv_cache) | set(new)):
+                if idx not in existing.kv_cache:
+                    merged[idx] = new[idx]
+                    continue
+                if idx not in new:
+                    merged[idx] = existing.kv_cache[idx]
+                    continue
+
+                prev_k, prev_v = existing.kv_cache[idx]
+                new_k, new_v = new[idx]
+                merged[idx] = (
+                    torch.cat((prev_k, new_k), dim=2),
+                    torch.cat((prev_v, new_v), dim=2),
+                )
+            start_frame = int(existing.start_frame)
+            cached_frames = int(existing.cached_frames + new_frames)
+
+        max_cache_frames = min(
+            self._max_kv_cache_frames,
+            int(self.training_config.data.num_frames),
+        )
+        if cached_frames > max_cache_frames:
+            frames_to_drop = int(cached_frames - max_cache_frames)
+            tokens_to_drop = int(frames_to_drop * tokens_per_frame)
+            for idx, (k, v) in merged.items():
+                if k.shape[2] < tokens_to_drop or v.shape[2] < tokens_to_drop:
+                    raise ValueError(
+                        "LongCat KV cache eviction would drop more tokens "
+                        "than are present in the cache"
+                    )
+                merged[idx] = (
+                    k[:, :, tokens_to_drop:, :].contiguous(),
+                    v[:, :, tokens_to_drop:, :].contiguous(),
+                )
+            start_frame += frames_to_drop
+            cached_frames = max_cache_frames
+
+        return _LongCatStreamingCache(
+            kv_cache=merged,
+            start_frame=start_frame,
+            cached_frames=cached_frames,
+            tokens_per_frame=tokens_per_frame,
+        )
+
+    def _infer_tokens_per_frame(
+        self,
+        *,
+        cache_dict: dict[int, tuple[torch.Tensor, torch.Tensor]],
+        num_frames: int,
+    ) -> int:
+        if not cache_dict:
+            raise ValueError("LongCat returned an empty KV cache")
+        if num_frames <= 0:
+            raise ValueError("num_frames must be > 0")
+
+        sample_k, _ = next(iter(cache_dict.values()))
+        if sample_k.ndim != 4:
+            raise ValueError(
+                "Unexpected LongCat KV cache shape; expected [B, H, N, D], "
+                f"got ndim={sample_k.ndim}"
             )
-        return merged
+        num_tokens = int(sample_k.shape[2])
+        if num_tokens % num_frames != 0:
+            raise ValueError(
+                "LongCat KV cache token count is not divisible by the number "
+                f"of frames in the cached chunk: {num_tokens} vs {num_frames}"
+            )
+        return num_tokens // num_frames

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -178,7 +178,8 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
             if isinstance(pred_noise, tuple):
                 raise RuntimeError("LongCat transformer returned a tuple "
                                    "when return_kv=False")
-        return -pred_noise.permute(0, 2, 1, 3, 4)
+        return self._to_training_velocity(
+            pred_noise).permute(0, 2, 1, 3, 4)
 
     # ------------------------------------------------------------------
     # KV cache buffer

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -2,8 +2,8 @@
 """LongCat streaming model plugin for self-forcing rollouts.
 
 KV cache management mirrors :class:`WanCausalModel` 's pattern: a
-fixed-size buffer per layer, pre-allocated to fit the full rollout
-(``training.data.num_frames``), with a write pointer that advances
+fixed-size buffer per layer, pre-allocated to fit the latent rollout,
+with a write pointer that advances
 chunk-by-chunk via in-place ``.copy_()``. Old positions are never
 overwritten, so backward (under gradient checkpointing) can safely
 re-read the same slice even after later forwards have advanced the
@@ -11,7 +11,7 @@ pointer — no per-forward clone of the K/V tensors is needed.
 
 Switching from a growing dict + ``torch.cat`` per chunk to a
 pre-allocated buffer keeps peak memory constant at
-``num_frames * tokens_per_frame * 2 (K+V) * num_layers`` instead of
+``num_latent_frames * tokens_per_frame * 2 (K+V) * num_layers`` instead of
 growing linearly with the number of chunks.
 """
 from __future__ import annotations
@@ -162,6 +162,7 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                         cache_state=cache_state,
                         new_chunk=new_chunk,
                         new_frames=num_chunk_frames,
+                        num_frames_total=int(batch.latents.shape[1]),
                         device=noisy_latents.device,
                     ))
                 return None
@@ -219,12 +220,13 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         cache_state: _LongCatStreamingCache | None,
         new_chunk: dict[int, tuple[torch.Tensor, torch.Tensor]],
         new_frames: int,
+        num_frames_total: int,
         device: torch.device,
     ) -> _LongCatStreamingCache:
         """Copy the new chunk's K/V into the pre-allocated buffer.
 
         Lazy-allocates the buffer on the first call from the first
-        chunk's K/V shape and ``training_config.data.num_frames``.
+        chunk's K/V shape and the latent rollout length.
         Subsequent calls are pure in-place ``.copy_()`` into the next
         slot, plus an advance of ``write_idx`` — no allocation, no
         ``torch.cat``, no eviction.
@@ -248,18 +250,12 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         tokens_per_frame = new_tokens // new_frames
 
         if cache_state is None:
-            # First chunk: allocate a fixed-size buffer sized for the
-            # full rollout. We use training_config.data.num_frames as
-            # the upper bound.
-            tc = self.training_config
-            if tc is None:
-                raise RuntimeError(
-                    "training_config is required for LongCat streaming "
-                    "KV cache allocation")
-            total_frames = int(tc.data.num_frames)
+            # First chunk: allocate a fixed-size buffer for the latent
+            # rollout, not the source video's pixel-frame count.
+            total_frames = int(num_frames_total)
             if total_frames <= 0:
                 raise ValueError(
-                    "training.num_frames must be > 0 for streaming "
+                    "num_frames_total must be > 0 for streaming "
                     f"KV cache; got {total_frames}")
             max_tokens = tokens_per_frame * total_frames
             B = int(sample_k.shape[0])

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -148,6 +148,8 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                     encoder_hidden_states=empty_embeds,
                     timestep=timestep,
                     num_cond_latents=cached_frames,
+                    kv_cache_dict=kv_cache_view,
+                    kv_cache_start_frame=0,
                     return_kv=True,
                     causal_block_size=self._causal_block_size,
                     skip_crs_attn=True,

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -77,9 +77,38 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         self._causal_block_size = int(causal_block_size)
         if self._causal_block_size <= 0:
             raise ValueError("causal_block_size must be > 0")
+        # DFSFT's chunk-size guard reads ``transformer.num_frame_per_block``;
+        # expose it so a mismatched method ``chunk_size`` errors loudly instead
+        # of silently training with the wrong block size. Harmless if FSDP
+        # later hides it (the guard just falls back to ``None``).
+        try:
+            self.transformer.num_frame_per_block = self._causal_block_size
+        except AttributeError:
+            pass
 
     def clear_caches(self, *, cache_tag: str = "pos") -> None:
         self._streaming_caches.pop(str(cache_tag), None)
+
+    def _build_distill_input_kwargs(
+        self,
+        noise_input: torch.Tensor,
+        timestep: torch.Tensor,
+        text_dict: dict[str, torch.Tensor] | None,
+    ) -> dict[str, Any]:
+        """Route the non-streaming training forward through the block-causal mask.
+
+        ``LongCatModel._build_distill_input_kwargs`` leaves ``causal_block_size``
+        unset, so the inherited ``predict_noise`` (used by ``FineTuneMethod`` and
+        ``DiffusionForcingSFTMethod``) runs the LongCat DiT with *full
+        bidirectional* attention. Causal training (DFSFT) needs the same
+        block-causal mask the streaming rollout and self-forcing paths apply.
+        Inject ``causal_block_size`` here so ``predict_noise`` -> transformer
+        builds and applies the mask during the training forward.
+        """
+        kwargs = super()._build_distill_input_kwargs(
+            noise_input, timestep, text_dict)
+        kwargs["causal_block_size"] = self._causal_block_size
+        return kwargs
 
     def predict_noise_streaming(
         self,

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -61,6 +61,7 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         flow_shift: float = 12.0,
         enable_gradient_checkpointing_type: str | None = None,
         transformer_override_safetensor: str | None = None,
+        causal_block_size: int = 3,
     ) -> None:
         super().__init__(
             init_from=init_from,
@@ -73,6 +74,9 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         )
         # Lazy-allocated per cache_tag on the first store_kv call.
         self._streaming_caches: dict[str, _LongCatStreamingCache] = {}
+        self._causal_block_size = int(causal_block_size)
+        if self._causal_block_size <= 0:
+            raise ValueError("causal_block_size must be > 0")
 
     def clear_caches(self, *, cache_tag: str = "pos") -> None:
         self._streaming_caches.pop(str(cache_tag), None)
@@ -132,6 +136,7 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                     timestep=timestep,
                     num_cond_latents=cached_frames,
                     return_kv=True,
+                    causal_block_size=self._causal_block_size,
                     skip_crs_attn=True,
                 )
                 if new_chunk is None:
@@ -155,11 +160,12 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                 kv_cache_dict=kv_cache_view,
                 # Buffer never evicts; cached frames always start at frame 0.
                 kv_cache_start_frame=0,
+                causal_block_size=self._causal_block_size,
             )
             if isinstance(pred_noise, tuple):
                 raise RuntimeError("LongCat transformer returned a tuple "
                                    "when return_kv=False")
-        return pred_noise.permute(0, 2, 1, 3, 4)
+        return -pred_noise.permute(0, 2, 1, 3, 4)
 
     # ------------------------------------------------------------------
     # KV cache buffer

--- a/fastvideo/train/models/longcat/longcat_causal.py
+++ b/fastvideo/train/models/longcat/longcat_causal.py
@@ -96,6 +96,11 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
     ) -> torch.Tensor | None:
         if attn_kind not in {"dense", "vsa"}:
             raise ValueError(f"Unknown attn_kind: {attn_kind!r}")
+        if noisy_latents.ndim != 5:
+            raise ValueError(
+                "LongCatCausalModel.predict_noise_streaming expects "
+                "BTCHW latents [B, T, C, H, W], got "
+                f"shape={tuple(noisy_latents.shape)}")
         # SelfForcingMethod passes "vsa" for student rollout, but LongCat
         # selects sparse behavior through its native BSA config, not VSA
         # metadata.
@@ -115,8 +120,16 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
         transformer = self.transformer
         dtype = noisy_latents.dtype
 
+        # Layout is intentionally BTCHW here. The transformer boundary below
+        # converts to the package-wide BCTHW convention.
+        num_chunk_frames = int(noisy_latents.shape[1])
         cache_state = self._streaming_caches.get(cache_tag)
         kv_cache_view, cached_frames = self._cache_view(cache_state)
+        if cur_start_frame != cached_frames:
+            raise ValueError(
+                "cur_start_frame must match the number of cached frames "
+                "because LongCat streaming cache does not evict yet: "
+                f"{cur_start_frame} vs {cached_frames}")
 
         with torch.autocast(self.device.type,
                             dtype=dtype), set_forward_context(
@@ -146,7 +159,7 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
                     self._write_chunk_to_buffer(
                         cache_state=cache_state,
                         new_chunk=new_chunk,
-                        new_frames=int(noisy_latents.shape[1]),
+                        new_frames=num_chunk_frames,
                         device=noisy_latents.device,
                     ))
                 return None
@@ -236,7 +249,10 @@ class LongCatCausalModel(LongCatModel, CausalModelBase):
             # full rollout. We use training_config.data.num_frames as
             # the upper bound.
             tc = self.training_config
-            assert tc is not None
+            if tc is None:
+                raise RuntimeError(
+                    "training_config is required for LongCat streaming "
+                    "KV cache allocation")
             total_frames = int(tc.data.num_frames)
             if total_frames <= 0:
                 raise ValueError(

--- a/fastvideo/train/models/wan/wan.py
+++ b/fastvideo/train/models/wan/wan.py
@@ -4,8 +4,7 @@
 from __future__ import annotations
 
 import copy
-import gc
-from typing import Any, ClassVar, Literal, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING
 
 import torch
 
@@ -19,10 +18,6 @@ from fastvideo.forward_context import set_forward_context
 from fastvideo.models.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler, )
 from fastvideo.pipelines import TrainingBatch
-from fastvideo.pipelines.basic.wan.wan_pipeline import (
-    WanPipeline, )
-from fastvideo.pipelines.pipeline_batch_info import (
-    ForwardBatch, )
 from fastvideo.training.activation_checkpoint import (
     apply_activation_checkpointing, )
 from fastvideo.training.training_utils import (
@@ -41,6 +36,7 @@ from fastvideo.train.utils.module_state import (
     apply_trainable, )
 from fastvideo.train.utils.moduleloader import (
     load_module_from_path, )
+from fastvideo.train.utils.negative_prompt import encode_negative_prompt
 
 if TYPE_CHECKING:
     from fastvideo.train.utils.training_config import (
@@ -60,7 +56,6 @@ class WanModel(ModelBase):
     """Wan per-role model: owns transformer + noise_scheduler."""
 
     _transformer_cls_name: str = "WanTransformer3DModel"
-    _prompt_pipeline_cls: ClassVar[type[WanPipeline]] = WanPipeline
 
     def __init__(
         self,
@@ -342,98 +337,15 @@ class WanModel(ModelBase):
 
         assert self.training_config is not None
         tc = self.training_config
-        world_group = self.world_group
-        device = self.device
-        dtype = self._get_training_dtype()
-
-        from fastvideo.train.utils.moduleloader import (
-            make_inference_args, )
-
-        neg_embeds: torch.Tensor | None = None
-        neg_mask: torch.Tensor | None = None
-
-        if world_group.rank_in_group == 0:
-            sampling_param = SamplingParam.from_pretrained(tc.model_path)
-            negative_prompt = sampling_param.negative_prompt
-
-            inference_args = make_inference_args(tc, model_path=tc.model_path)
-
-            prompt_pipeline = self._prompt_pipeline_cls.from_pretrained(
-                tc.model_path,
-                args=inference_args,
-                inference_mode=True,
-                loaded_modules={"transformer": self.transformer},
-                tp_size=tc.distributed.tp_size,
-                sp_size=tc.distributed.sp_size,
-                num_gpus=tc.distributed.num_gpus,
-                pin_cpu_memory=(tc.distributed.pin_cpu_memory),
-                dit_cpu_offload=True,
-            )
-
-            batch_negative = ForwardBatch(
-                data_type="video",
-                prompt=negative_prompt,
-                prompt_embeds=[],
-                prompt_attention_mask=[],
-            )
-            result_batch = prompt_pipeline.prompt_encoding_stage(  # type: ignore[attr-defined]
-                batch_negative,
-                inference_args,
-            )
-
-            neg_embeds = result_batch.prompt_embeds[0].to(device=device, dtype=dtype)
-            neg_mask = (result_batch.prompt_attention_mask[0].to(device=device, dtype=dtype))
-
-            del prompt_pipeline
-            gc.collect()
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()
-
-        meta = torch.zeros((2, ), device=device, dtype=torch.int64)
-        if world_group.rank_in_group == 0:
-            assert neg_embeds is not None
-            assert neg_mask is not None
-            meta[0] = neg_embeds.ndim
-            meta[1] = neg_mask.ndim
-        world_group.broadcast(meta, src=0)
-        embed_ndim, mask_ndim = (
-            int(meta[0].item()),
-            int(meta[1].item()),
+        sampling_param = SamplingParam.from_pretrained(tc.model_path)
+        embeds, mask = encode_negative_prompt(
+            tc,
+            prompt=sampling_param.negative_prompt,
+            device=self.device,
+            dtype=self._get_training_dtype(),
         )
-
-        max_ndim = 8
-        embed_shape = torch.full((max_ndim, ), -1, device=device, dtype=torch.int64)
-        mask_shape = torch.full((max_ndim, ), -1, device=device, dtype=torch.int64)
-        if world_group.rank_in_group == 0:
-            assert neg_embeds is not None
-            assert neg_mask is not None
-            embed_shape[:embed_ndim] = torch.tensor(
-                list(neg_embeds.shape),
-                device=device,
-                dtype=torch.int64,
-            )
-            mask_shape[:mask_ndim] = torch.tensor(
-                list(neg_mask.shape),
-                device=device,
-                dtype=torch.int64,
-            )
-        world_group.broadcast(embed_shape, src=0)
-        world_group.broadcast(mask_shape, src=0)
-
-        embed_sizes = tuple(int(x) for x in embed_shape[:embed_ndim].tolist())
-        mask_sizes = tuple(int(x) for x in mask_shape[:mask_ndim].tolist())
-
-        if world_group.rank_in_group != 0:
-            neg_embeds = torch.empty(embed_sizes, device=device, dtype=dtype)
-            neg_mask = torch.empty(mask_sizes, device=device, dtype=dtype)
-        assert neg_embeds is not None
-        assert neg_mask is not None
-
-        world_group.broadcast(neg_embeds, src=0)
-        world_group.broadcast(neg_mask, src=0)
-
-        self.negative_prompt_embeds = neg_embeds
-        self.negative_prompt_attention_mask = neg_mask
+        self.negative_prompt_embeds = embeds
+        self.negative_prompt_attention_mask = mask
 
     def _sample_timesteps(
         self,

--- a/fastvideo/train/models/wan/wan.py
+++ b/fastvideo/train/models/wan/wan.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Literal, TYPE_CHECKING
+import gc
+from typing import Any, ClassVar, Literal, TYPE_CHECKING
 
 import torch
 
@@ -18,6 +19,10 @@ from fastvideo.forward_context import set_forward_context
 from fastvideo.models.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler, )
 from fastvideo.pipelines import TrainingBatch
+from fastvideo.pipelines.basic.wan.wan_pipeline import (
+    WanPipeline, )
+from fastvideo.pipelines.pipeline_batch_info import (
+    ForwardBatch, )
 from fastvideo.training.activation_checkpoint import (
     apply_activation_checkpointing, )
 from fastvideo.training.training_utils import (
@@ -36,7 +41,6 @@ from fastvideo.train.utils.module_state import (
     apply_trainable, )
 from fastvideo.train.utils.moduleloader import (
     load_module_from_path, )
-from fastvideo.train.utils.negative_prompt import encode_negative_prompt
 
 if TYPE_CHECKING:
     from fastvideo.train.utils.training_config import (
@@ -56,6 +60,7 @@ class WanModel(ModelBase):
     """Wan per-role model: owns transformer + noise_scheduler."""
 
     _transformer_cls_name: str = "WanTransformer3DModel"
+    _prompt_pipeline_cls: ClassVar[type[WanPipeline]] = WanPipeline
 
     def __init__(
         self,
@@ -337,15 +342,98 @@ class WanModel(ModelBase):
 
         assert self.training_config is not None
         tc = self.training_config
-        sampling_param = SamplingParam.from_pretrained(tc.model_path)
-        embeds, mask = encode_negative_prompt(
-            tc,
-            prompt=sampling_param.negative_prompt,
-            device=self.device,
-            dtype=self._get_training_dtype(),
+        world_group = self.world_group
+        device = self.device
+        dtype = self._get_training_dtype()
+
+        from fastvideo.train.utils.moduleloader import (
+            make_inference_args, )
+
+        neg_embeds: torch.Tensor | None = None
+        neg_mask: torch.Tensor | None = None
+
+        if world_group.rank_in_group == 0:
+            sampling_param = SamplingParam.from_pretrained(tc.model_path)
+            negative_prompt = sampling_param.negative_prompt
+
+            inference_args = make_inference_args(tc, model_path=tc.model_path)
+
+            prompt_pipeline = self._prompt_pipeline_cls.from_pretrained(
+                tc.model_path,
+                args=inference_args,
+                inference_mode=True,
+                loaded_modules={"transformer": self.transformer},
+                tp_size=tc.distributed.tp_size,
+                sp_size=tc.distributed.sp_size,
+                num_gpus=tc.distributed.num_gpus,
+                pin_cpu_memory=(tc.distributed.pin_cpu_memory),
+                dit_cpu_offload=True,
+            )
+
+            batch_negative = ForwardBatch(
+                data_type="video",
+                prompt=negative_prompt,
+                prompt_embeds=[],
+                prompt_attention_mask=[],
+            )
+            result_batch = prompt_pipeline.prompt_encoding_stage(  # type: ignore[attr-defined]
+                batch_negative,
+                inference_args,
+            )
+
+            neg_embeds = result_batch.prompt_embeds[0].to(device=device, dtype=dtype)
+            neg_mask = (result_batch.prompt_attention_mask[0].to(device=device, dtype=dtype))
+
+            del prompt_pipeline
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+        meta = torch.zeros((2, ), device=device, dtype=torch.int64)
+        if world_group.rank_in_group == 0:
+            assert neg_embeds is not None
+            assert neg_mask is not None
+            meta[0] = neg_embeds.ndim
+            meta[1] = neg_mask.ndim
+        world_group.broadcast(meta, src=0)
+        embed_ndim, mask_ndim = (
+            int(meta[0].item()),
+            int(meta[1].item()),
         )
-        self.negative_prompt_embeds = embeds
-        self.negative_prompt_attention_mask = mask
+
+        max_ndim = 8
+        embed_shape = torch.full((max_ndim, ), -1, device=device, dtype=torch.int64)
+        mask_shape = torch.full((max_ndim, ), -1, device=device, dtype=torch.int64)
+        if world_group.rank_in_group == 0:
+            assert neg_embeds is not None
+            assert neg_mask is not None
+            embed_shape[:embed_ndim] = torch.tensor(
+                list(neg_embeds.shape),
+                device=device,
+                dtype=torch.int64,
+            )
+            mask_shape[:mask_ndim] = torch.tensor(
+                list(neg_mask.shape),
+                device=device,
+                dtype=torch.int64,
+            )
+        world_group.broadcast(embed_shape, src=0)
+        world_group.broadcast(mask_shape, src=0)
+
+        embed_sizes = tuple(int(x) for x in embed_shape[:embed_ndim].tolist())
+        mask_sizes = tuple(int(x) for x in mask_shape[:mask_ndim].tolist())
+
+        if world_group.rank_in_group != 0:
+            neg_embeds = torch.empty(embed_sizes, device=device, dtype=dtype)
+            neg_mask = torch.empty(mask_sizes, device=device, dtype=dtype)
+        assert neg_embeds is not None
+        assert neg_mask is not None
+
+        world_group.broadcast(neg_embeds, src=0)
+        world_group.broadcast(neg_mask, src=0)
+
+        self.negative_prompt_embeds = neg_embeds
+        self.negative_prompt_attention_mask = neg_mask
 
     def _sample_timesteps(
         self,


### PR DESCRIPTION
Draft follow-up for causal / self-forcing LongCat work. The bidirectional LongCat fine-tuning base from #1244 has merged, and this branch is focused on causal DFSFT / self-forcing support.

Current contents:
- `LongCatCausalModel` training wrapper
- LongCat causal DMD and multi-step inference pipelines/stages
- `self_forcing_t2v.yaml` config
- KV-cache buffering, RoPE temporal-offset plumbing, and block-causal LongCat self-attention mask support
- Regression coverage for causal masking, chunk/block mismatch, chunked rollout vs full-prefix behavior, and `forward_with_kv_cache`

Validation completed:
- Targeted LongCat causal / KV-cache regression tests passed.
- 1-step training smoke on 4x B200 passed.
- 5-step training smoke on 4x B200 passed.
- 21-frame causal rollout with `chunk_size=3` passed.
- 100-step self-forcing run on 4x B200 with real preprocessed video/text data completed.
- Student and critic optimizer updates ran.
- Validation video generation ran at steps 0/50/100.
- W&B evidence: https://wandb.ai/aryan5v-san-jose-state-university/self-forcing-longcat/runs/3k7mqmqx
- CI fastcheck / targeted Buildkite contexts passed on the PR branch.
- Local `python3 -m py_compile ...` passed for changed LongCat files.
- Local `git diff --check` passed.

Remaining notes:
- The generated validation videos are not visually coherent yet, so follow-up quality work may still be needed after the scaffold is reviewed.
- PR still needs reviewer approval and required merge checks.

Linked base PR: #1244