### PR TITLE
[ci] mergify: accept [skill]/[skills] and [infra] PR title tags

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,8 @@
 PR TITLE: Must start with a type tag, e.g.:
   [feat] Add new model       [bugfix] Fix VAE tiling      [refactor] Restructure pipeline
   [perf] Optimize kernel     [ci] Update tests             [docs] Add guide
-  [misc] Cleanup configs     [new-model] Port Flux2
+  [misc] Cleanup configs     [new-model] Port Flux2        [infra] Add trace hooks
+  [skill] Add agent skill
 
 MERGE WORKFLOW:
   1. Ensure pre-commit passes and you have at least 1 approval

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,7 @@ merge_protections:
     if:
       - base = main
     success_conditions:
-      - "title~=(?i)^\\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model)\\]"
+      - "title~=(?i)^\\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model|skill|skills|infra)\\]"
       - "#approved-reviews-by>=1"
       - check-success~=pre-commit
       - check-success=fastcheck-passed
@@ -78,6 +78,22 @@ pull_request_rules:
     actions:
       label:
         add: ["type: new-model"]
+
+  - name: "label type: infra"
+    conditions:
+      - "title~=(?i)^\\[infra\\]"
+      - -closed
+    actions:
+      label:
+        add: ["type: infra"]
+
+  - name: "label type: skill"
+    conditions:
+      - "title~=(?i)^\\[skills?\\]"
+      - -closed
+    actions:
+      label:
+        add: ["type: skill"]
 
   # ============================================================
   # Scope labels (from changed files)
@@ -262,7 +278,7 @@ pull_request_rules:
   - name: auto-merge when ready and all checks pass
     conditions:
       - label=ready
-      - "title~=(?i)^\\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model)\\]"
+      - "title~=(?i)^\\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model|skill|skills|infra)\\]"
       - "#approved-reviews-by>=1"
       - check-success~=pre-commit
       - check-success=fastcheck-passed
@@ -292,7 +308,7 @@ pull_request_rules:
     conditions:
       - -closed
       - -draft
-      - "-title~=(?i)^\\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model)\\]"
+      - "-title~=(?i)^\\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model|skill|skills|infra)\\]"
     actions:
       comment:
         message: |
@@ -304,11 +320,13 @@ pull_request_rules:
           - `[refactor] Restructure training pipeline`
           - `[perf] Optimize attention kernel`
           - `[ci] Update test infrastructure`
+          - `[infra] Add activation trace hooks`
           - `[docs] Add inference guide`
           - `[misc] Clean up configs`
           - `[new-model] Port Flux2 to FastVideo`
+          - `[skill] Add add-model agent skill`
 
-          Valid tags: `feat`, `feature`, `bugfix`, `fix`, `refactor`, `perf`, `ci`, `doc`, `docs`, `misc`, `chore`, `kernel`, `new-model`
+          Valid tags: `feat`, `feature`, `bugfix`, `fix`, `refactor`, `perf`, `ci`, `infra`, `doc`, `docs`, `misc`, `chore`, `kernel`, `new-model`, `skill`, `skills`
 
           Please update your PR title and the merge protection check will pass automatically.
 

--- a/docs/contributing/pull_requests.md
+++ b/docs/contributing/pull_requests.md
@@ -25,10 +25,12 @@ Mergify before any merge is allowed.
 | `[refactor]` | Code restructuring with no behavior change |
 | `[perf]` | Performance improvement |
 | `[ci]` | CI/CD or build tooling changes |
+| `[infra]` | Repo infrastructure: agent tooling, debug hooks, conversion scripts, dev infra |
 | `[doc]` or `[docs]` | Documentation only |
 | `[misc]` or `[chore]` | Housekeeping, dependency bumps, minor cleanup |
 | `[kernel]` | CUDA kernel changes in `fastvideo-kernel/` |
 | `[new-model]` | Adding a new model or pipeline |
+| `[skill]` or `[skills]` | Agent skills under `.agents/skills/` or `.claude/skills/` |
 
 **Examples:**
 
@@ -38,6 +40,8 @@ Mergify before any merge is allowed.
 [refactor] Restructure distributed attention dispatch
 [docs] Add LoRA finetuning guide
 [new-model] Port HunyuanVideo 1.5 to FastVideo
+[infra] Add activation trace hooks for pipeline debugging
+[skill] Add add-model agent skill
 ```
 
 If your title is missing the tag, Mergify will post a comment listing the valid formats.
@@ -51,8 +55,8 @@ Labels are applied automatically based on your PR title and the files you change
 need to set them manually.
 
 **Type label** — set from the `[tag]` in your title:
-`type: feat`, `type: bugfix`, `type: refactor`, `type: perf`, `type: ci`, `type: docs`,
-`type: misc`, `type: new-model`
+`type: feat`, `type: bugfix`, `type: refactor`, `type: perf`, `type: ci`, `type: infra`,
+`type: docs`, `type: misc`, `type: new-model`, `type: skill`
 
 **Scope labels** — set from which files you modified (multiple labels can apply):
 `scope: training`, `scope: inference`, `scope: attention`, `scope: kernel`, `scope: data`,
@@ -187,8 +191,8 @@ Common quick fixes:
 Update your title to start with a valid type tag. The Mergify merge protection check
 re-evaluates automatically after you save the title.
 
-Valid tags: `feat`, `feature`, `bugfix`, `fix`, `refactor`, `perf`, `ci`, `doc`, `docs`,
-`misc`, `chore`, `kernel`, `new-model`
+Valid tags: `feat`, `feature`, `bugfix`, `fix`, `refactor`, `perf`, `ci`, `infra`, `doc`,
+`docs`, `misc`, `chore`, `kernel`, `new-model`, `skill`, `skills`
 
 ### My PR has merge conflicts (`needs-rebase` label)
 


### PR DESCRIPTION
## Purpose

Adds `[skill]` / `[skills]` and `[infra]` to the Mergify merge-protection allowlist for PR titles. All three forms are already in active use on `main` but currently fail the title regex and trigger the *PR title format required* comment:

- [#1293](https://github.com/hao-ai-lab/FastVideo/pull/1293) `[infra]: Add activation trace hooks for pipeline debugging`
- [#1303](https://github.com/hao-ai-lab/FastVideo/pull/1303) `[skills]: New skill - decompose-pipeline-pr`
- pre-merge stack: `[infra]: Loader umbrella-repo support…`, `[infra]: MagiHuman checkpoint conversion…`, `[skill] Add add-model and review-add-model-pr skills`, etc.

Without this PR, future skill / repo-infra changes have to be retitled to `[misc]` or `[ci]` to clear merge protection, which loses semantic meaning in the auto-applied type labels.

## Changes

### `.github/mergify.yml`
- Append `|skill|skills|infra` to the title regex in all three places:
  - `merge_protections.success_conditions`
  - `auto-merge when ready` rule
  - `comment on invalid PR title format` rule
- Add two new label rules following the existing per-tag pattern:
  - `label type: infra` → matches `^\[infra\]`
  - `label type: skill` → matches `^\[skills?\]` (single rule for both singular + plural, mirroring how `label type: feat` matches `^\[(feat|feature)\]`)
- Refresh the help comment posted to invalid-title PRs (examples + valid-tag list).

### `.github/PULL_REQUEST_TEMPLATE.md`
- Extend the example list with `[infra]` and `[skill]`.

### `docs/contributing/pull_requests.md`
- Tag table: add `[infra]` and `[skill]` / `[skills]` rows.
- Examples block: add `[infra]` and `[skill]` examples.
- Type-label list: add `type: infra`, `type: skill`.
- Troubleshooting valid-tag list: add `infra`, `skill`, `skills`.

### Tag semantics

| Tag | When to use |
|-----|-------------|
| `[infra]` | Repo infrastructure: agent tooling, debug hooks, conversion scripts, dev infra |
| `[skill]` or `[skills]` | Agent skills under `.agents/skills/` or `.claude/skills/` |

`[skill]` / `[skills]` is the plural-form convention already used by `feat`/`feature` and `doc`/`docs`. Singular is preferred in the example block; plural is accepted because it's already in commit history.

## Test Plan

```bash
# YAML still parses
python3 -c "import yaml; yaml.safe_load(open('.github/mergify.yml'))"

# Pre-commit on changed files
pre-commit run --files .github/mergify.yml .github/PULL_REQUEST_TEMPLATE.md docs/contributing/pull_requests.md

# Regex sanity check (mirrors Mergify's (?i) ^\[(...)\] regex)
python3 - <<'PY'
import re
top = re.compile(r'(?i)^\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model|skill|skills|infra)\]')
label_skill = re.compile(r'(?i)^\[skills?\]')
for s, want in [('[feat] x', True), ('[infra] x', True), ('[Infra] x', True),
                ('[skill] x', True), ('[skills] x', True), ('[Skills] x', True),
                ('[new-model] x', True), ('[new model] x', True), ('[newmodel] x', True),
                ('[noTag]', False), ('[infrastructure] x', False), ('[skillss] x', False),
                ('no brackets', False)]:
    print(f"top={bool(top.match(s))}/want{want}  label-skill={bool(label_skill.match(s))}: {s}")
PY
```

## Test Results

<details>
<summary>Test output</summary>

```
YAML OK

yapf.................................................(no files to check)Skipped
ruff (legacy alias)..................................(no files to check)Skipped
codespell................................................................Passed
PyMarkdown...............................................................Passed
Lint GitHub Actions workflow files...................(no files to check)Skipped
mypy.................................................(no files to check)Skipped
Check for spaces in all filenames........................................Passed
Suggestion...............................................................Passed

top=True/wantTrue   label-skill=False : [feat] x
top=True/wantTrue   label-skill=False : [infra] x
top=True/wantTrue   label-skill=False : [Infra] x
top=True/wantTrue   label-skill=True  : [skill] x
top=True/wantTrue   label-skill=True  : [skills] x
top=True/wantTrue   label-skill=True  : [Skills] x
top=True/wantTrue   label-skill=False : [new-model] x
top=True/wantTrue   label-skill=False : [new model] x
top=True/wantTrue   label-skill=False : [newmodel] x
top=False/wantFalse label-skill=False : [noTag]
top=False/wantFalse label-skill=False : [infrastructure] x   # closing-bracket anchor prevents over-match
top=False/wantFalse label-skill=False : [skillss] x
top=False/wantFalse label-skill=False : no brackets
```

</details>

## Notes

- This PR uses `[ci]` instead of `[infra]` because Mergify reads its config from `main`'s default branch, so `[infra]` is not a valid title tag until *after* this PR merges (chicken-and-egg).
- No existing labels are removed; no scope rules change.
- New `type: skill` / `type: infra` labels need to exist on the repo for the new label rules to apply (otherwise Mergify will create them on first use, depending on org settings).

## Checklist

- [x] I ran `pre-commit run --files <changed paths>` and fixed all issues
- [x] I added or updated tests for my changes (regex unit-check above)
- [x] I updated documentation if needed (`docs/contributing/pull_requests.md`, `.github/PULL_REQUEST_TEMPLATE.md`)
- [x] I considered GPU memory impact of my changes (n/a — config + docs only)