### PR TITLE
[ci] Ci/perf env capture and docs

### DIFF
--- a/docs/contributing/ci_architecture.md
+++ b/docs/contributing/ci_architecture.md
@@ -99,7 +99,7 @@ failing test's output.
 | LoRA Training Tests | `training_lora` | 15 min |
 | Training Tests VSA | `training_vsa` | 15 min |
 | Inference Tests VMoBA | `inference_vmoba` | 15 min |
-| Performance Tests | `performance` | 30 min |
+| [Performance Tests](performance_benchmarks.md) | `performance` | 30 min |
 | API Server Tests | `api_server` | 30 min |
 
 If a Full Suite test fails, check the Buildkite build log for the failing step's output.

--- a/docs/contributing/performance_benchmarks.md
+++ b/docs/contributing/performance_benchmarks.md
@@ -1,0 +1,302 @@
+# Performance Benchmarks
+
+FastVideo's performance benchmark suite measures end-to-end inference latency,
+throughput, and peak GPU memory for representative pipeline configurations,
+and tracks them over time against a rolling baseline stored on the Hugging
+Face Hub.
+
+It serves three audiences:
+
+* **CI** — gates pull requests against a per-GPU static threshold and a
+  rolling-median regression check.
+* **Maintainers** — surfaces regressions in a Markdown summary on every
+  performance build and a long-form Plotly dashboard.
+* **Local developers** — lets you run the same benchmark on your own machine,
+  with environment-aware comparison so a different GPU or torch build doesn't
+  produce misleading "regressions".
+
+## Quick start (local)
+
+```bash
+# Run all benchmarks; writes raw perf_*.json under
+# fastvideo/tests/performance/results/
+pytest fastvideo/tests/performance/ -vs
+
+# Optional: compare against the rolling HF baseline (read-only outside CI).
+# By default this compares your record against records from any environment.
+python fastvideo/tests/performance/compare_baseline.py
+
+# Only compare against records produced on a matching environment
+# (same GPU model, torch major.minor, CUDA major, attention backend):
+PERF_STRICT_ENV=1 python fastvideo/tests/performance/compare_baseline.py
+```
+
+The pytest run never uploads anything. `compare_baseline.py` only writes to
+the HF dataset when `TEST_SCOPE=full` *and* `BUILDKITE_BRANCH=main`, so local
+runs are always read-only.
+
+## Architecture
+
+```
+.buildkite/performance-benchmarks/tests/*.json
+    └── per-benchmark configs: model, gen kwargs, per-GPU thresholds
+
+fastvideo/tests/performance/
+    ├── env_capture.py            # runtime env metadata + compare-tuple helpers
+    ├── test_inference_performance.py
+    │       └── pytest test that runs each config, writes perf_*.json
+    ├── compare_baseline.py
+    │       └── normalizes raw results, compares against HF rolling baseline,
+    │           writes Markdown summary + (optionally) uploads new records
+    ├── dashboard.py
+    │       └── builds time-series Plotly HTML from HF history
+    └── hf_store.py               # shared HF I/O + DataFrame helpers
+```
+
+The HF dataset (`FastVideo/performance-tracking` by default) holds one
+normalized JSON per `(model_id, gpu_type, run)` tuple. The rolling baseline is
+the median of the last 5 successful records for that model+GPU.
+
+## The two gates
+
+There are **two independent regression gates** — they protect against
+different failure modes and are not redundant.
+
+### Static thresholds (per-GPU)
+
+Defined in `.buildkite/performance-benchmarks/tests/<benchmark>.json` under
+`thresholds`. Example:
+
+```json
+"thresholds": {
+  "L40S":    { "max_generation_time_s": 34.0, "max_peak_memory_mb": 11000.0 },
+  "default": { "max_generation_time_s": 120.0, "max_peak_memory_mb": 30000.0 }
+}
+```
+
+Selection: `_get_thresholds(cfg)` matches the current GPU name (substring
+match) against keys; falls back to `default` if no GPU matches.
+
+These are **fail-safes** — they catch order-of-magnitude regressions and
+unrealistic memory growth even when the rolling baseline is empty. They are
+hand-set with generous headroom and almost never need touching.
+
+### Rolling baseline (per `(model_id, gpu_type)`)
+
+`compare_baseline.py` loads the last 5 successful records for the same
+`(model_id, gpu_type)` from the HF dataset, computes the median for each
+metric, and fails if the current run regresses by more than
+`PERF_MAX_REGRESSION` (default 5%).
+
+This is the **drift detector** — it catches sub-threshold regressions that
+slowly add up. It only persists new records when running the full suite on
+`main`.
+
+When the baseline shifts for a legitimate reason (torch upgrade, kernel
+change, etc.) and CI starts failing, use the
+[`reseed-performance-baseline`](https://github.com/hao-ai-lab/FastVideo/blob/main/.agents/skills/reseed-performance-baseline/SKILL.md)
+agent skill to advance the rolling median.
+
+## Environment-aware comparison
+
+Every record carries an `env` block describing the runtime — GPU model and
+count, CUDA toolkit, PyTorch version, attention backend, key package
+versions, container image. The comparator can use this to decide whether two
+records are "comparable".
+
+### Default mode (env-tuple as metadata)
+
+By default the comparator filters baselines only by `(model_id, gpu_type)`.
+The env tuple is captured and surfaced in the Markdown summary and the
+dashboard, but does not affect baseline selection.
+
+This is the right default for CI on a fixed machine image — the env tuple
+rarely changes, and any change is a deliberate operator action.
+
+### Strict mode (`PERF_STRICT_ENV=1`)
+
+When the environment variable is set, baseline records are additionally
+filtered to those whose env tuple matches the current run on the keys
+returned by `env_capture.get_compare_keys()`. The default tuple is:
+
+```
+(gpu.name, gpu.count, torch.version_major_minor, cuda.runtime_major,
+ attention_backend)
+```
+
+Override via `PERF_COMPARE_KEYS` (comma-separated dotted paths into the `env`
+block):
+
+```bash
+PERF_STRICT_ENV=1 \
+PERF_COMPARE_KEYS="gpu.name,torch.version_major_minor" \
+python fastvideo/tests/performance/compare_baseline.py
+```
+
+When strict mode finds zero matching records, it logs `no env-comparable
+records on <model_id>` and skips the regression check (the run still passes).
+This is the correct behavior for local dev on a non-CI GPU — you get a clear
+"no comparable baseline" message instead of a false-positive failure against
+a different machine's median.
+
+## Schemas
+
+### Raw record (`results/perf_*.json`)
+
+Written by `test_inference_performance.py`. One file per benchmark run.
+
+```jsonc
+{
+  "schema_version": 1,
+  "benchmark_id": "wan-t2v-1.3b-2gpu",
+  "model_short_name": "Wan2.1-T2V-1.3B-Diffusers",
+  "device": "NVIDIA L40S",
+  "num_gpus": 2,
+  "num_warmup_runs": 1,
+  "num_measurement_runs": 3,
+  "avg_generation_time_s": 28.4,
+  "individual_times_s": [28.5, 28.3, 28.4],
+  "throughput_fps": 1.58,
+  "max_peak_memory_mb": 10840.0,
+  "individual_peak_memories_mb": [10840.0, 10822.0, 10833.0],
+  "thresholds": { "max_generation_time_s": 34.0, "max_peak_memory_mb": 11000.0 },
+  "commit": "<full sha>",
+  "pr_number": "1234",
+  "timestamp": "2026-05-08T22:00:00+00:00",
+  "env": {
+    "schema_version": 1,
+    "gpu":   { "name": "NVIDIA L40S", "count": 2, "compute_capability": "8.9",
+               "memory_total_mb": 46068.0, "driver_version": "550.54.15",
+               "uuids": ["GPU-...", "GPU-..."] },
+    "cuda":  { "runtime": "12.4", "runtime_major": "12" },
+    "torch": { "version": "2.5.1+cu124", "version_major_minor": "2.5",
+               "built_with_cuda": "12.4" },
+    "python": "3.12.3",
+    "os":    { "system": "Linux", "release": "6.5.0-x", "machine": "x86_64" },
+    "attention_backend": "FLASH_ATTN",
+    "key_packages": { "torch": "2.5.1+cu124", "transformers": "...", ... },
+    "container_image": "<modal image digest, when on Modal>"
+  }
+}
+```
+
+### Normalized record (HF dataset, also dumped as `normalized_perf_*.json`)
+
+Written by `compare_baseline.py:_normalize_record`. One file per benchmark
+result, used as the rolling-baseline source of truth.
+
+```jsonc
+{
+  "schema_version": 1,
+  "model_id": "wan-t2v-1.3b-2gpu",
+  "timestamp": "2026-05-08T22:00:00+00:00",
+  "commit_sha": "<full sha>",
+  "gpu_type": "NVIDIA L40S",
+  "latency": 28.4,
+  "throughput": 1.58,
+  "memory": 10840.0,
+  "env": { ...same as raw.env... },
+  "success": true
+}
+```
+
+### Compatibility with legacy records
+
+Records produced before `schema_version: 1` exist in the HF dataset with no
+`env` block. The comparator and dashboard treat them as having
+`extract_compare_tuple(...) == (None, None, None, ...)`. In default mode they
+participate in the rolling median normally; in strict mode they only match
+*other* legacy records, which is the conservative behavior.
+
+## Environment variable reference
+
+| Variable | Default | Used by | Purpose |
+|---|---|---|---|
+| `PERF_MAX_REGRESSION` | `0.05` | `compare_baseline.py` | Per-metric regression fraction that fails the build. |
+| `PERF_STRICT_ENV` | unset | `compare_baseline.py` | When `1`/`true`/`yes`, filter baseline records by env-tuple equality. |
+| `PERF_COMPARE_KEYS` | `gpu.name,gpu.count,torch.version_major_minor,cuda.runtime_major,attention_backend` | `compare_baseline.py`, `dashboard.py` | Comma-separated dotted paths into `env` for strict-mode filtering and dashboard grouping. |
+| `PERFORMANCE_TRACKING_ROOT` | `/tmp/perf-tracking` | `compare_baseline.py` | Local directory the HF dataset is synced to. |
+| `PERF_REPORTS_DIR` | `/root/data/perf_reports` | `compare_baseline.py`, `dashboard.py` | Where the Markdown summary and Plotly HTML get written for Buildkite to pick up. |
+| `HF_REPO_ID` | `FastVideo/performance-tracking` | `hf_store.py` | HF dataset repo holding rolling-baseline records. |
+| `HF_API_KEY` | unset | `hf_store.py` | Required for upload (main-branch full-suite only); reads work without it. |
+| `TEST_SCOPE` | unset | `compare_baseline.py` | Set to `full` together with `BUILDKITE_BRANCH=main` to enable HF persistence. |
+| `BUILDKITE_BRANCH`, `BUILDKITE_COMMIT`, `BUILDKITE_PULL_REQUEST` | unset | `compare_baseline.py`, `test_inference_performance.py` | CI metadata stamped into records. |
+| `DASHBOARD_DAYS` | `30` | `dashboard.py` | Lookback window for the Plotly trend pages. |
+| `FASTVIDEO_ATTENTION_BACKEND` | unset | `env_capture.py` | Captured into `env.attention_backend` for env-tuple comparison. |
+| `MODAL_IMAGE_DIGEST`, `DOCKER_IMAGE_DIGEST`, `DOCKER_IMAGE` | unset | `env_capture.py` | First non-empty value is captured into `env.container_image`. |
+
+## CI integration
+
+The performance step runs in the Full Suite (see
+[CI Architecture](ci_architecture.md)). The Modal entry point is
+`fastvideo/tests/modal/pr_test.py:run_performance_tests` and the Buildkite
+artifact upload is in `.buildkite/scripts/pr_test.sh:upload_performance_artifacts`.
+
+Each performance build produces:
+
+* **Markdown summary** — appended to `$GITHUB_STEP_SUMMARY` and uploaded as
+  `perf_<sha>_<ts>.md`. Contains the env tuple banner and a per-benchmark row
+  with current vs. baseline.
+* **Plotly dashboard** — `dashboard_<sha>_<ts>.html` showing time-series for
+  each `(model_id, gpu_type, torch_version, cuda_runtime, attention_backend)`
+  bucket.
+* **Normalized records** — `normalized_perf_*.json`, one per benchmark.
+  Useful as input to the
+  [`reseed-performance-baseline`](https://github.com/hao-ai-lab/FastVideo/blob/main/.agents/skills/reseed-performance-baseline/SKILL.md)
+  skill.
+
+## Adding a new benchmark
+
+1. Drop a new JSON config into
+   `.buildkite/performance-benchmarks/tests/<name>.json`. Required keys:
+
+   ```json
+   {
+     "benchmark_id": "<unique-id>",
+     "model": { "model_path": "...", "model_short_name": "..." },
+     "init_kwargs": { "num_gpus": 1, ... },
+     "generation_kwargs": { "num_frames": 45, ... },
+     "test_prompts": ["..."],
+     "run_config": { "required_gpus": 1,
+                     "num_warmup_runs": 1, "num_measurement_runs": 3 },
+     "thresholds": {
+       "L40S":    { "max_generation_time_s": 34.0, "max_peak_memory_mb": 11000.0 },
+       "default": { "max_generation_time_s": 120.0, "max_peak_memory_mb": 30000.0 }
+     }
+   }
+   ```
+
+2. The pytest test auto-discovers all configs — no test code needed. CI
+   picks it up on the next `/test performance` run.
+
+3. The first run with no HF history initializes the baseline (passes
+   automatically). Subsequent runs compare against it.
+
+4. If the benchmark targets a GPU not currently in `thresholds`, either add
+   that GPU as a key or rely on the `default` block. Note that `default` is
+   intended for slower fallback GPUs, so its values should be relaxed
+   relative to the fastest entry.
+
+## Troubleshooting
+
+**"No baseline for ... Initializing"** — first run for this `(model_id,
+gpu_type)`, or strict env mode and no env-comparable history. Run will
+pass and (if persisting) seed the first record.
+
+**Persistent failure right after a torch / kernel / image upgrade** —
+genuine regression *or* baseline drift. Read the `env` block of the failing
+record and the most recent baseline record in the HF dataset to compare. If
+the env shifted and the metric shift is within the upgrade's expected cost,
+use the `reseed-performance-baseline` skill.
+
+**Local strict-mode comparison returns 0 records** — your local env
+(GPU/torch/CUDA/backend) doesn't match any historical record. This is
+expected — the comparator skips with a clear log line. Either disable strict
+mode (`PERF_STRICT_ENV=` ) to compare against the closest available history
+on the same model+GPU, or build a local baseline by running a few times with
+`PERFORMANCE_TRACKING_ROOT=/some/local/dir` against itself.
+
+**Markdown summary `Env` column shows mostly `None=`** — records lack the
+`env` block (legacy `schema_version=0`). Re-run the benchmark to produce a
+new record on the current schema, or accept the legacy bucket until enough
+new records accumulate.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -9,6 +9,7 @@ This guide explains how to add and run tests in FastVideo. The testing suite is 
 * **SSIM Tests**: Located in `fastvideo/tests/ssim`. These are regression tests that compare generated videos against reference videos using the Structural Similarity Index Measure (SSIM) to detect quality degradation.
 * **Training Tests**: Located in `fastvideo/tests/training`. These validate training loops, loss calculations, and specific training techniques like LoRA, Distillation, and VSA.
 * **Inference Tests**: Located in `fastvideo/tests/inference`. These test specialized inference pipelines and optimizations (e.g., VSA, V-MoBA).
+* **Performance Tests**: Located in `fastvideo/tests/performance`. End-to-end latency, throughput, and peak-memory benchmarks gated against per-GPU static thresholds and a rolling Hugging Face baseline. See [Performance Benchmarks](performance_benchmarks.md) for the full workflow, schema, and environment-aware comparison flags.
 
 For now, we will focus on **SSIM Tests**.
 

--- a/fastvideo/tests/AGENTS.md
+++ b/fastvideo/tests/AGENTS.md
@@ -24,7 +24,7 @@ tests/
 ├── modal/                 # Modal CI orchestrators (ssim_test.py, nightly_test.py)
 ├── nightly/               # Long-running suites (gated)
 ├── ops/                   # Custom kernel / op tests
-├── performance/           # Throughput / memory benchmarks (informational)
+├── performance/           # Throughput / memory benchmarks (informational) — see docs/contributing/performance_benchmarks.md
 ├── ssim/                  # GPU SSIM regressions — see ssim/AGENTS.md
 ├── stages/                # Per-stage unit tests
 ├── train/                 # New modular trainer tests

--- a/fastvideo/tests/performance/compare_baseline.py
+++ b/fastvideo/tests/performance/compare_baseline.py
@@ -20,6 +20,13 @@ import sys
 from datetime import datetime, timezone
 from typing import Any
 
+from env_capture import (
+    PERF_RECORD_SCHEMA_VERSION,
+    describe_compare_tuple,
+    extract_compare_tuple,
+    get_compare_keys,
+    strict_env_mode,
+)
 from hf_store import (
     load_records_for_model,
     safe_float,
@@ -68,6 +75,7 @@ def _normalize_record(result: dict[str, Any]) -> dict[str, Any]:
     memory = safe_float(result.get("max_peak_memory_mb"))
 
     return {
+        "schema_version": result.get("schema_version", PERF_RECORD_SCHEMA_VERSION),
         "model_id": model_id,
         "timestamp": timestamp,
         "commit_sha": commit_sha,
@@ -75,6 +83,7 @@ def _normalize_record(result: dict[str, Any]) -> dict[str, Any]:
         "latency": latency,
         "throughput": throughput,
         "memory": memory,
+        "env": result.get("env"),
         "success": True,
     }
 
@@ -173,9 +182,14 @@ def _build_summary_row(
     regressions = [v for v in (latency_reg, throughput_reg, memory_reg) if v is not None]
     worst_regression_pct = max(regressions) if regressions else None
 
+    compare_keys = get_compare_keys()
+    env_tuple = extract_compare_tuple(record, compare_keys)
+    env_summary = describe_compare_tuple(env_tuple, compare_keys)
+
     return {
         "model_id": record["model_id"],
         "gpu_type": record["gpu_type"],
+        "env_summary": env_summary,
         "baseline_n": len(baseline_records),
         "latency_curr": safe_float(record.get("latency")),
         "latency_base": latency_base,
@@ -192,15 +206,21 @@ def _build_markdown_summary(
     summary_rows: list[dict[str, Any]],
     max_regression: float,
 ) -> str:
+    compare_keys = get_compare_keys()
+    strict = strict_env_mode()
+
     lines = [
         "## Performance Baseline Comparison",
         "",
         f"Threshold: regressions greater than {max_regression * 100:.1f}% fail",
+        f"Env compare keys: {', '.join(compare_keys)}",
+        f"Strict env mode: {'ON' if strict else 'OFF'} "
+        "(set `PERF_STRICT_ENV=1` to require env-tuple match for baseline records)",
         "",
-        ("| Model | GPU | Baseline N | Latency (curr/base) | "
+        ("| Model | GPU | Env | Baseline N | Latency (curr/base) | "
          "Throughput (curr/base) | Memory (curr/base) | "
          "Worst Regression | Status |"),
-        "|---|---|---:|---|---|---|---:|---|",
+        "|---|---|---|---:|---|---|---|---:|---|",
     ]
 
     for row in summary_rows:
@@ -213,8 +233,10 @@ def _build_markdown_summary(
 
         worst_reg = ("n/a" if row["worst_regression_pct"] is None else f"{row['worst_regression_pct']:.1f}%")
         status = "FAIL" if row["failed"] else "PASS"
+        env_summary = row.get("env_summary") or "n/a"
 
         lines.append(f"| {row['model_id']} | {row['gpu_type']} | "
+                     f"{env_summary} | "
                      f"{row['baseline_n']} | "
                      f"{latency} | {throughput} | {memory} | "
                      f"{worst_reg} | {status} |")
@@ -265,8 +287,20 @@ def main() -> int:
         print("Tracking persistence disabled: "
               "only full-suite runs on main branch are persisted")
 
+    strict = strict_env_mode()
+    compare_keys = get_compare_keys()
+    if strict:
+        print(f"PERF_STRICT_ENV=1 — baselines filtered to records matching "
+              f"current env on keys: {', '.join(compare_keys)}")
+
     for raw in current_results:
         record = _normalize_record(raw)
+
+        env_filter = None
+        if strict:
+            current_tuple = extract_compare_tuple(record, compare_keys)
+            env_filter = (lambda r, t=current_tuple:
+                          extract_compare_tuple(r, compare_keys) == t)
 
         baseline_records = load_records_for_model(
             TRACKING_ROOT,
@@ -274,10 +308,13 @@ def main() -> int:
             record["gpu_type"],
             last_n=5,
             successful_only=True,
+            extra_filter=env_filter,
         )
 
         if not baseline_records:
-            print(f"No baseline for {record['model_id']} on "
+            reason = ("no env-comparable records on "
+                      if strict else "no baseline for ")
+            print(f"{reason}{record['model_id']} on "
                   f"{record['gpu_type']}. Initializing...")
             failures: list[str] = []
             record["success"] = True

--- a/fastvideo/tests/performance/dashboard.py
+++ b/fastvideo/tests/performance/dashboard.py
@@ -7,27 +7,50 @@ import pandas as pd
 
 from hf_store import sync_from_hf, load_as_dataframe
 
-# -----------------------------
-# 1. Grouping
-# -----------------------------
+# Grouping keys for time-series plots. Adding env-derived columns
+# (torch_version, cuda_runtime, attention_backend) prevents pre-/post-upgrade
+# records from being averaged into the same line, which would otherwise
+# silently smear environment-driven shifts across the trend.
+_GROUP_KEYS = (
+    "model_id",
+    "gpu_type",
+    "torch_version",
+    "cuda_runtime",
+    "attention_backend",
+)
+
+
 def group_data(df: pd.DataFrame):
-    # Group only by model+GPU so each group produces a time-series line.
-    # config_id (commit SHA) is carried as a column for hover/color use.
-    keys = ["model_id", "gpu_type"]
+    keys = [k for k in _GROUP_KEYS if k in df.columns]
     return df.groupby(keys, dropna=False)
 
-# -----------------------------
-# 2. Plot builder
-# -----------------------------
+
+def _format_group_label(key_values: tuple, key_names: list[str]) -> str:
+    parts = []
+    for name, value in zip(key_names, key_values, strict=False):
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            display = "n/a"
+        else:
+            display = str(value)
+        parts.append(f"{name}={display}")
+    return " | ".join(parts)
+
+
 def build_plots(df: pd.DataFrame) -> list:
     figs = []
 
-    for (model_id, gpu_type), g in group_data(df):
+    grouped = group_data(df)
+    key_names = list(grouped.keys) if hasattr(grouped, "keys") else list(_GROUP_KEYS)
+
+    for key_values, g in grouped:
+        if not isinstance(key_values, tuple):
+            key_values = (key_values, )
         g = g.sort_values("timestamp")
+        label = _format_group_label(key_values, key_names)
 
         # One chart per metric so the y-axes aren't on wildly different scales
         for metric in ("latency", "throughput", "memory"):
-            if g[metric].isna().all():
+            if metric not in g.columns or g[metric].isna().all():
                 continue
 
             fig = px.line(
@@ -36,7 +59,7 @@ def build_plots(df: pd.DataFrame) -> list:
                 y=metric,
                 markers=True,
                 hover_data=["config_id", "commit_sha"],
-                title=f"{model_id} | {gpu_type} | {metric}",
+                title=f"{label} | {metric}",
                 labels={"timestamp": "Time", metric: metric},
             )
             figs.append(fig)

--- a/fastvideo/tests/performance/env_capture.py
+++ b/fastvideo/tests/performance/env_capture.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capture runtime environment metadata for performance benchmark records.
+
+The returned dict is embedded under the ``env`` key of each ``perf_*.json``
+record. All sub-fields are best-effort: capture must NEVER raise. Missing
+data is reported as ``None`` (or empty list/dict) so that older records and
+records produced on partial environments still load and compare.
+
+Two consumers care about this data:
+
+* The Markdown summary and dashboard surface it for human inspection.
+* :func:`compare_baseline._check_regressions` optionally filters the rolling
+  baseline window to records whose ``env`` matches the current run, so that a
+  torch/CUDA/attention-backend swap does not silently shift the median.
+
+The set of ``env`` keys used for comparison is intentionally short
+(``DEFAULT_COMPARE_KEYS``) and configurable via the ``PERF_COMPARE_KEYS``
+environment variable. Everything else captured here is metadata.
+"""
+from __future__ import annotations
+
+import os
+import platform
+import re
+import shutil
+import subprocess
+from importlib import metadata
+from typing import Any
+
+import torch
+
+# Bump when fields are added/removed/renamed in a way that downstream
+# consumers must adapt to. Older records without the field are treated as
+# schema_version=0.
+PERF_RECORD_SCHEMA_VERSION = 1
+
+# Packages whose installed version is most likely to influence inference
+# performance numbers. Missing packages produce None instead of raising.
+_KEY_PACKAGES = (
+    "torch",
+    "transformers",
+    "diffusers",
+    "huggingface_hub",
+    "fastvideo",
+    "fastvideo-kernel",
+    "flash-attn",
+    "sage-attention",
+    "xformers",
+    "triton",
+    "vllm",
+)
+
+# Default tuple of dotted ``env``-record keys used to decide whether two
+# records are "comparable" for rolling-baseline / dashboard-grouping
+# purposes. The tuple is intentionally short — finer-grained fields (CUDA
+# patch, torch patch, kernel build hash) live in ``env`` for human
+# inspection but are not enforced. Override via ``PERF_COMPARE_KEYS``
+# (comma-separated dotted paths).
+DEFAULT_COMPARE_KEYS: tuple[str, ...] = (
+    "gpu.name",
+    "gpu.count",
+    "torch.version_major_minor",
+    "cuda.runtime_major",
+    "attention_backend",
+)
+
+
+def capture_env() -> dict[str, Any]:
+    """Return a metadata dict describing the runtime."""
+    return {
+        "schema_version": PERF_RECORD_SCHEMA_VERSION,
+        "gpu": _capture_gpu(),
+        "cuda": _capture_cuda(),
+        "torch": _capture_torch(),
+        "python": platform.python_version(),
+        "os": _capture_os(),
+        "attention_backend": _capture_attention_backend(),
+        "key_packages": _capture_packages(),
+        "container_image": _capture_container_image(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-section capture helpers
+# ---------------------------------------------------------------------------
+
+
+def _capture_gpu() -> dict[str, Any]:
+    if not torch.cuda.is_available():
+        return {
+            "name": None,
+            "count": 0,
+            "compute_capability": None,
+            "memory_total_mb": None,
+            "driver_version": None,
+            "uuids": [],
+        }
+    count = torch.cuda.device_count()
+    name: str | None
+    compute_capability: str | None
+    memory_total_mb: float | None
+    try:
+        props = torch.cuda.get_device_properties(0)
+        name = props.name
+        compute_capability = f"{props.major}.{props.minor}"
+        memory_total_mb = round(props.total_memory / (1024 * 1024), 1)
+    except Exception:
+        name = None
+        compute_capability = None
+        memory_total_mb = None
+
+    return {
+        "name": name,
+        "count": count,
+        "compute_capability": compute_capability,
+        "memory_total_mb": memory_total_mb,
+        "driver_version": _nvidia_smi_query("driver_version"),
+        "uuids": _nvidia_smi_query("uuid", multi=True),
+    }
+
+
+def _capture_cuda() -> dict[str, Any]:
+    runtime = getattr(torch.version, "cuda", None)
+    runtime_major: str | None
+    if isinstance(runtime, str):
+        runtime_major = runtime.split(".")[0]
+    else:
+        runtime_major = None
+    return {
+        "runtime": runtime,
+        "runtime_major": runtime_major,
+    }
+
+
+def _capture_torch() -> dict[str, Any]:
+    version = getattr(torch, "__version__", None)
+    major_minor: str | None = None
+    if isinstance(version, str):
+        match = re.match(r"(\d+\.\d+)", version)
+        if match is not None:
+            major_minor = match.group(1)
+    return {
+        "version": version,
+        "version_major_minor": major_minor,
+        "built_with_cuda": getattr(torch.version, "cuda", None),
+    }
+
+
+def _capture_os() -> dict[str, Any]:
+    return {
+        "system": platform.system(),
+        "release": platform.release(),
+        "machine": platform.machine(),
+    }
+
+
+def _capture_attention_backend() -> str | None:
+    # FASTVIDEO_ATTENTION_BACKEND is the user-visible knob. Empty string is
+    # treated the same as unset.
+    value = os.environ.get("FASTVIDEO_ATTENTION_BACKEND")
+    return value if value else None
+
+
+def _capture_packages() -> dict[str, str | None]:
+    out: dict[str, str | None] = {}
+    for pkg in _KEY_PACKAGES:
+        try:
+            out[pkg] = metadata.version(pkg)
+        except metadata.PackageNotFoundError:
+            out[pkg] = None
+    return out
+
+
+def _capture_container_image() -> str | None:
+    return (os.environ.get("MODAL_IMAGE_DIGEST")
+            or os.environ.get("DOCKER_IMAGE_DIGEST")
+            or os.environ.get("DOCKER_IMAGE")
+            or None)
+
+
+def _nvidia_smi_query(field: str, *, multi: bool = False) -> Any:
+    """Best-effort ``nvidia-smi`` field query. Returns None / [] on failure."""
+    if shutil.which("nvidia-smi") is None:
+        return [] if multi else None
+    try:
+        proc = subprocess.run(
+            ["nvidia-smi", f"--query-gpu={field}", "--format=csv,noheader"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return [] if multi else None
+    values = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    if multi:
+        return values
+    return values[0] if values else None
+
+
+# ---------------------------------------------------------------------------
+# Compare-tuple helpers (used by compare_baseline.py / dashboard.py)
+# ---------------------------------------------------------------------------
+
+
+def get_compare_keys() -> tuple[str, ...]:
+    """Return the dotted env-keys used for comparable-record bucketing.
+
+    Override the default by setting ``PERF_COMPARE_KEYS`` to a
+    comma-separated list of dotted paths into the ``env`` block, e.g.
+    ``gpu.name,torch.version_major_minor``.
+    """
+    raw = os.environ.get("PERF_COMPARE_KEYS")
+    if not raw:
+        return DEFAULT_COMPARE_KEYS
+    parts = tuple(part.strip() for part in raw.split(",") if part.strip())
+    return parts or DEFAULT_COMPARE_KEYS
+
+
+def extract_compare_tuple(
+    record: dict[str, Any],
+    keys: tuple[str, ...] | None = None,
+) -> tuple:
+    """Extract a comparable tuple from *record* using dotted *keys*.
+
+    Records that predate ``schema_version=1`` (no ``env`` block) yield a
+    tuple of ``None``. Comparator code should treat such records as
+    incomparable when strict-env mode is on, and surface a clear note.
+    """
+    if keys is None:
+        keys = get_compare_keys()
+    env = record.get("env") or {}
+    return tuple(_dot_get(env, key) for key in keys)
+
+
+def describe_compare_tuple(
+    values: tuple,
+    keys: tuple[str, ...] | None = None,
+) -> str:
+    """Render a compare-tuple as a human-readable ``k=v, k=v`` string."""
+    if keys is None:
+        keys = get_compare_keys()
+    return ", ".join(f"{key}={value}" for key, value in zip(keys, values, strict=False))
+
+
+def _dot_get(obj: Any, dotted: str) -> Any:
+    cur: Any = obj
+    for part in dotted.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+        if cur is None:
+            return None
+    return cur
+
+
+# ---------------------------------------------------------------------------
+# Strict-env mode
+# ---------------------------------------------------------------------------
+
+
+def strict_env_mode() -> bool:
+    """Return True if comparator should require env-tuple equality.
+
+    Controlled by ``PERF_STRICT_ENV``. Truthy values: ``1``, ``true``,
+    ``yes`` (case-insensitive). Default: off.
+    """
+    raw = os.environ.get("PERF_STRICT_ENV", "").strip().lower()
+    return raw in ("1", "true", "yes", "on")

--- a/fastvideo/tests/performance/hf_store.py
+++ b/fastvideo/tests/performance/hf_store.py
@@ -13,6 +13,7 @@ import glob
 import json
 import os
 import re
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -190,6 +191,7 @@ def load_records_for_model(
     *,
     last_n: int | None = None,
     successful_only: bool = True,
+    extra_filter: Callable[[dict[str, Any]], bool] | None = None,
 ) -> list[dict[str, Any]]:
     """Return records for a specific *model_id*, optionally filtered by GPU.
 
@@ -200,6 +202,9 @@ def load_records_for_model(
         last_n: When set, return only the most recent *n* records (after all
             other filters). Useful for sliding-window baseline calculations.
         successful_only: Passed through to :func:`load_records`.
+        extra_filter: Optional predicate applied AFTER ``gpu_type`` and BEFORE
+            ``last_n``. Used by ``compare_baseline`` for env-aware filtering
+            without coupling this module to the env-tuple schema.
 
     Returns:
         List of matching dicts sorted by timestamp ascending.
@@ -213,6 +218,9 @@ def load_records_for_model(
     if gpu_type is not None:
         records = [r for r in records if r.get("gpu_type") == gpu_type]
 
+    if extra_filter is not None:
+        records = [r for r in records if extra_filter(r)]
+
     if last_n is not None:
         records = records[-last_n:]
 
@@ -225,6 +233,26 @@ def load_records_for_model(
 
 _NUMERIC_COLS = ("latency", "throughput", "memory")
 
+_ENV_FLAT_COLS: tuple[tuple[str, str], ...] = (
+    ("torch_version", "torch.version_major_minor"),
+    ("cuda_runtime", "cuda.runtime_major"),
+    ("attention_backend", "attention_backend"),
+    ("gpu_count", "gpu.count"),
+)
+
+
+def _env_dot_get(env: Any, dotted: str) -> Any:
+    if not isinstance(env, dict):
+        return None
+    cur: Any = env
+    for part in dotted.split("."):
+        if not isinstance(cur, dict):
+            return None
+        cur = cur.get(part)
+        if cur is None:
+            return None
+    return cur
+
 
 def normalize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     """Apply standard type coercions to a raw records DataFrame.
@@ -232,6 +260,10 @@ def normalize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     - Parses ``timestamp`` to UTC-aware datetime.
     - Coerces ``latency``, ``throughput``, ``memory`` to float.
     - Adds a ``config_id`` column (first 7 chars of ``commit_sha``).
+    - Flattens selected ``env.*`` fields into top-level columns
+      (``torch_version``, ``cuda_runtime``, ``attention_backend``,
+      ``gpu_count``) so dashboard grouping does not need to know about
+      the nested ``env`` schema.
 
     Returns the mutated DataFrame (also modifies in place for efficiency).
     """
@@ -244,6 +276,12 @@ def normalize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     for col in _NUMERIC_COLS:
         if col in df.columns:
             df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    env_series = (df["env"]
+                  if "env" in df.columns
+                  else pd.Series([None] * len(df), index=df.index))
+    for col_name, dotted in _ENV_FLAT_COLS:
+        df[col_name] = env_series.apply(lambda e, d=dotted: _env_dot_get(e, d))
 
     return df
 

--- a/fastvideo/tests/performance/test_inference_performance.py
+++ b/fastvideo/tests/performance/test_inference_performance.py
@@ -17,6 +17,10 @@ import pytest
 
 from fastvideo import VideoGenerator
 from fastvideo.logger import init_logger
+from fastvideo.tests.performance.env_capture import (
+    PERF_RECORD_SCHEMA_VERSION,
+    capture_env,
+)
 from fastvideo.worker.multiproc_executor import MultiprocExecutor
 
 logger = init_logger(__name__)
@@ -170,6 +174,7 @@ def test_inference_performance(cfg):
         throughput_fps = num_frames / avg_time
 
     results = {
+        "schema_version": PERF_RECORD_SCHEMA_VERSION,
         "benchmark_id": cfg["benchmark_id"],
         "model_short_name": model_info.get("model_short_name", ""),
         "device": device_name,
@@ -186,6 +191,7 @@ def test_inference_performance(cfg):
         "commit": os.environ.get("BUILDKITE_COMMIT", ""),
         "pr_number": os.environ.get("BUILDKITE_PULL_REQUEST", ""),
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        "env": capture_env(),
     }
 
     logger.info(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,6 +170,7 @@ nav:
     - Pull Requests: contributing/pull_requests.md
     - CI Architecture: contributing/ci_architecture.md
     - Testing: contributing/testing.md
+    - Performance Benchmarks: contributing/performance_benchmarks.md
     - Profiling: contributing/profiling.md
     - Coding Agents: contributing/coding_agents.md
     - Attention Backend Development: contributing/attention_backend.md


### PR DESCRIPTION
<!--
PR TITLE: Must start with a type tag, e.g.:
  [feat] Add new model       [bugfix] Fix VAE tiling      [refactor] Restructure pipeline
  [perf] Optimize kernel     [ci] Update tests             [docs] Add guide
  [misc] Cleanup configs     [new-model] Port Flux2        [infra] Add trace hooks
  [skill] Add agent skill

MERGE WORKFLOW:
  1. Ensure pre-commit passes and you have at least 1 approval
  2. Comment /merge (or add the "ready" label) to enter the Merge Queue
  3. Full Test Suite runs automatically on a staging branch → auto-merge on success

ON-DEMAND TESTING (write access required):
  /test full       — Full Test Suite        /test ssim        — SSIM regression
  /test training   — Training pipeline      /test encoder     — Encoder tests
  /test transformer — Transformer tests     /test vae         — VAE tests
  /test kernel     — CUDA kernel tests      /test unit        — Unit tests
  See docs/contributing/pull_requests.md for all 17 test commands
-->

## Purpose

<!-- What does this PR do? Link the related issue if applicable. -->

Fixes #

## Changes

<!-- Describe your changes concisely. What approach did you take? -->

-

## Test Plan

<!-- How did you verify your changes? Paste exact commands and output. -->

```bash
# Commands you ran
```

## Test Results

<!-- Paste test output, before/after comparisons, or SSIM scores for model changes. -->

<details>
<summary>Test output</summary>

```
# Paste output here
```

</details>

## Checklist

- [ ] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [ ] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model


### What it adds

**1. New `fastvideo/tests/performance/env_capture.py`** — captures into every `perf_*.json` record (under a new `env` block, `schema_version: 1`):
- GPU: name, count, compute capability, driver version, total memory, UUIDs (via `nvidia-smi`)
- CUDA: runtime version + major
- PyTorch: version, `version_major_minor`, `built_with_cuda`
- Python, OS (system/release/machine)
- `FASTVIDEO_ATTENTION_BACKEND`
- Versions for: torch, transformers, diffusers, huggingface_hub, fastvideo, fastvideo-kernel, flash-attn, sage-attention, xformers, triton, vllm
- Container image (Modal/Docker digest when present)

All capture is best-effort — never raises, missing fields become `None`.

**2. Env-aware baseline filtering** in `compare_baseline.py`:
- Default mode (off): captured env is metadata only; surfaced in markdown, dashboard, and HF records, but doesn't affect baseline selection (preserves current behavior).
- Strict mode (`PERF_STRICT_ENV=1`): rolling baseline is filtered to records whose env tuple matches the current run on `(gpu.name, gpu.count, torch.version_major_minor, cuda.runtime_major, attention_backend)`. Override the tuple via `PERF_COMPARE_KEYS=…`. When zero records match, the comparator logs `no env-comparable records on …` and skips the regression check rather than firing a false-positive against an unrelated environment. **This is the bit that makes the workflow usable for local dev on non-CI GPUs / different torch builds.**

**3. Dashboard env-aware grouping** in `dashboard.py`:
- Time-series now buckets on `(model_id, gpu_type, torch_version, cuda_runtime, attention_backend)` so a torch upgrade no longer silently smears across the trend line. Legacy records (no `env`) get an `n/a` bucket.

**4. Markdown summary** carries an env-keys banner, a strict-mode indicator, and a per-row `Env` column.

**5. New docs page**: [`docs/contributing/performance_benchmarks.md`](https://github.com/hao-ai-lab/FastVideo/blob/ci/perf-env-capture-and-docs/docs/contributing/performance_benchmarks.md) covering the local-dev workflow, the two gates (static thresholds vs rolling baseline), strict-env mode, raw vs normalized schemas, full env-var reference, CI integration, adding a new benchmark, and troubleshooting. Linked from `mkdocs.yml` nav, `docs/contributing/ci_architecture.md`, `docs/contributing/testing.md`, and `fastvideo/tests/AGENTS.md`.

### Smoke tested

| Check | Result |
|---|---|
| `env_capture.capture_env()` on this host (B200 / torch 2.11 / CUDA 12.8) | All fields populated incl. driver_version + UUIDs from `nvidia-smi` |
| `compare_baseline.main()` end-to-end with synthetic baseline | 4.8% regression detected, env tuple shown in markdown |
| `PERF_STRICT_ENV=1` with matching torch version | 5 baselines used, regression check ran |
| `PERF_STRICT_ENV=1` with mismatched torch version | 0 baselines, "no env-comparable records" logged, run still passes |
| `dashboard.build_plots` with synthetic mixed-env data | 4 records → 3 distinct env buckets, 9 plots (3 × 3 metrics) |
| `pre-commit run --files …` on changed files | clean (perf tests excluded from yapf/ruff/mypy per existing repo config; codespell + PyMarkdown pass) |

