### PR TITLE
[feat] Dreamverse 3/5: standardize backend host env

### DIFF
--- a/apps/dreamverse/scripts/smoke_local.sh
+++ b/apps/dreamverse/scripts/smoke_local.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-HOST="${DREAMVERSE_HOST:-127.0.0.1}"
-PORT="${DREAMVERSE_PORT:-8009}"
-BASE_URL="http://${HOST}:${PORT}"
+HOST="${BACKEND_HOST:-127.0.0.1}"
+PORT="${BACKEND_PORT:-8009}"
+BACKEND_ORIGIN="http://${HOST}:${PORT}"
 TIMEOUT_SECONDS="${DREAMVERSE_SMOKE_TIMEOUT_SECONDS:-240}"
 POLL_INTERVAL_SECONDS="${DREAMVERSE_SMOKE_POLL_SECONDS:-2}"
 BACKEND_LOG_PATH="${DREAMVERSE_SMOKE_LOG_PATH:-${ROOT_DIR}/outputs/smoke-local-backend.log}"
@@ -31,7 +31,7 @@ require_command() {
 
 probe_json() {
   local path="$1"
-  curl --silent --show-error --fail "${BASE_URL}${path}"
+  curl --silent --show-error --fail "${BACKEND_ORIGIN}${path}"
 }
 
 wait_for_endpoint() {
@@ -44,7 +44,7 @@ wait_for_endpoint() {
     fi
     sleep "${POLL_INTERVAL_SECONDS}"
   done
-  echo "Timed out waiting for ${label} at ${BASE_URL}${path}" >&2
+  echo "Timed out waiting for ${label} at ${BACKEND_ORIGIN}${path}" >&2
   return 1
 }
 
@@ -54,13 +54,13 @@ mkdir -p "$(dirname "${BACKEND_LOG_PATH}")"
 
 if ! probe_json "/healthz" >/dev/null 2>&1; then
   if [[ "${START_BACKEND}" != "1" ]]; then
-    echo "Dreamverse backend is not reachable at ${BASE_URL} and auto-start is disabled." >&2
+    echo "Dreamverse backend is not reachable at ${BACKEND_ORIGIN} and auto-start is disabled." >&2
     exit 1
   fi
 
   require_command dreamverse-server
 
-  echo "Starting Dreamverse backend on ${BASE_URL}..."
+  echo "Starting Dreamverse backend on ${BACKEND_ORIGIN}..."
   (
     cd "${ROOT_DIR}"
     exec dreamverse-server --host "${HOST}" --port "${PORT}"
@@ -68,7 +68,7 @@ if ! probe_json "/healthz" >/dev/null 2>&1; then
   backend_pid=$!
   started_backend=1
 else
-  echo "Dreamverse backend already running on ${BASE_URL}."
+  echo "Dreamverse backend already running on ${BACKEND_ORIGIN}."
 fi
 
 echo "Waiting for /healthz..."
@@ -78,7 +78,7 @@ wait_for_endpoint "/readyz" "readyz"
 
 status_payload="$(probe_json "/status")"
 echo "Dreamverse local smoke check passed."
-echo "Backend URL: ${BASE_URL}"
+echo "Backend URL: ${BACKEND_ORIGIN}"
 echo "Status: ${status_payload}"
 
 if [[ "${started_backend}" == "1" ]]; then
@@ -87,9 +87,9 @@ if [[ "${started_backend}" == "1" ]]; then
   echo "Backend log: ${BACKEND_LOG_PATH}"
   echo "Backend is still running so you can launch the frontend:"
   echo "  cd ${ROOT_DIR}/web"
-  echo "  BACKEND_PORT=${PORT} pnpm run dev"
+  echo "  BACKEND_HOST=${HOST} BACKEND_PORT=${PORT} pnpm run dev"
 else
   echo "You can now launch the frontend:"
   echo "  cd ${ROOT_DIR}/web"
-  echo "  BACKEND_PORT=${PORT} pnpm run dev"
+  echo "  BACKEND_HOST=${HOST} BACKEND_PORT=${PORT} pnpm run dev"
 fi

--- a/apps/dreamverse/web/e2e/long-running-segments.spec.ts
+++ b/apps/dreamverse/web/e2e/long-running-segments.spec.ts
@@ -13,7 +13,8 @@ import { test, expect, type WebSocket as PWWebSocket } from '@playwright/test';
  *     ./.agents/skills/dreamverse-deploy/scripts/dreamverse-deploy.sh \
  *         --warmup --torch-compile 4
  *     PLAYWRIGHT_SKIP_WEBSERVER=1 \
- *         BACKEND_URL=http://127.0.0.1:8009 \
+ *         BACKEND_HOST=127.0.0.1 \
+ *         BACKEND_PORT=8009 \
  *         PLAYWRIGHT_BASE_URL=http://127.0.0.1:5274 \
  *         NEXT_PUBLIC_INCLUDE_DEVTOOLS=1 \
  *         PLAYWRIGHT_LONG_RUNNING=1 \

--- a/apps/dreamverse/web/e2e/preset-prompt-generation.spec.ts
+++ b/apps/dreamverse/web/e2e/preset-prompt-generation.spec.ts
@@ -12,7 +12,7 @@ import { test, expect } from '@playwright/test';
  * Devtools mode is required because the Run button only renders when
  * NEXT_PUBLIC_INCLUDE_DEVTOOLS=1 (the production product surface
  * keeps preset selection inside the floating composer). Set
- * BACKEND_URL + NEXT_PUBLIC_INCLUDE_DEVTOOLS=1 before running.
+ * BACKEND_HOST + BACKEND_PORT + NEXT_PUBLIC_INCLUDE_DEVTOOLS=1 before running.
  */
 test.describe('preset prompt generation', () => {
   test.beforeEach(async ({ request }) => {

--- a/apps/dreamverse/web/next.config.ts
+++ b/apps/dreamverse/web/next.config.ts
@@ -2,9 +2,9 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { NextConfig } from 'next';
 
-const backendUrl =
-   process.env.BACKEND_URL ||
-  `http://${process.env.BACKEND_HOST || 'localhost'}:${Number(process.env.BACKEND_PORT) || 8009}`;
+const backendHost = process.env.BACKEND_HOST || 'localhost';
+const backendPort = Number(process.env.BACKEND_PORT) || 8009;
+const backendUrl = `http://${backendHost}:${backendPort}`;
 const configDir = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {

--- a/apps/dreamverse/web/next.config.ts
+++ b/apps/dreamverse/web/next.config.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { NextConfig } from 'next';
 
-const backendHost = process.env.BACKEND_HOST || 'localhost';
+const backendHost = process.env.BACKEND_HOST || '127.0.0.1';
 const backendPort = Number(process.env.BACKEND_PORT) || 8009;
 const backendUrl = `http://${backendHost}:${backendPort}`;
 const configDir = path.dirname(fileURLToPath(import.meta.url));

--- a/apps/dreamverse/web/playwright.config.ts
+++ b/apps/dreamverse/web/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
  * Playwright config for Dreamverse end-to-end tests.
  *
  * Tests assume the Dreamverse Python server is reachable at
- * BACKEND_HOST:BACKEND_PORT (default localhost:8009) and the Next.js frontend
+ * BACKEND_HOST:BACKEND_PORT (default 127.0.0.1:8009) and the Next.js frontend
  * runs on port 5274. The webServer block boots `pnpm run dev` if no
  * server is already listening so tests work both locally and in CI.
  */
@@ -41,8 +41,8 @@ export default defineConfig({
         reuseExistingServer: true,
         timeout: 120_000,
         env: {
-          BACKEND_HOST: process.env.BACKEND_HOST ?? '127.0.0.1',
-          BACKEND_PORT: process.env.BACKEND_PORT ?? '8009',
+          BACKEND_HOST: process.env.BACKEND_HOST || '127.0.0.1',
+          BACKEND_PORT: process.env.BACKEND_PORT || '8009',
         },
       },
 });

--- a/apps/dreamverse/web/playwright.config.ts
+++ b/apps/dreamverse/web/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from '@playwright/test';
  * Playwright config for Dreamverse end-to-end tests.
  *
  * Tests assume the Dreamverse Python server is reachable at
- * BACKEND_URL (default http://localhost:8009) and the Next.js frontend
+ * BACKEND_HOST:BACKEND_PORT (default localhost:8009) and the Next.js frontend
  * runs on port 5274. The webServer block boots `pnpm run dev` if no
  * server is already listening so tests work both locally and in CI.
  */
@@ -41,7 +41,8 @@ export default defineConfig({
         reuseExistingServer: true,
         timeout: 120_000,
         env: {
-          BACKEND_URL: process.env.BACKEND_URL ?? 'http://127.0.0.1:8009',
+          BACKEND_HOST: process.env.BACKEND_HOST ?? '127.0.0.1',
+          BACKEND_PORT: process.env.BACKEND_PORT ?? '8009',
         },
       },
 });


### PR DESCRIPTION
## Summary

This is PR 3 of 5 splitting #1312 into smaller review slices.

- Standardizes Dreamverse frontend and local smoke configuration on `BACKEND_HOST` plus `BACKEND_PORT`.
- Removes the `BACKEND_URL` fallback from Next.js proxy config.
- Updates Playwright config and E2E run comments to match the new env contract.

## Stack

1. #1313 Package backend as installable module
2. #1314 Launch backend through installed CLI
3. Standardize backend host env
4. Add Docker runtime packaging
5. Document Docker setup workflow

Base: `feat/dreamverse-stack-02-launch`
Source: #1312 at `f5c537f5e030427bbeedfa8ae403c9a539815907`

## Validation

- Pre-commit hooks passed during commit.
- `bash -n apps/dreamverse/scripts/smoke_local.sh`
- Final 5-PR stack diff was verified to exactly match #1312 from `upstream/will/dreamverse-monorepo`.

Dreamverse-Stack: 3/5