### PR TITLE
[docs] Dreamverse 5/5: document Docker setup workflow

### DIFF
--- a/apps/dreamverse/README.md
+++ b/apps/dreamverse/README.md
@@ -122,7 +122,7 @@ curl http://localhost:8009/readyz
 You can also run the same readiness path with:
 
 ```bash
-BACKEND_HOST=localhost BACKEND_PORT=8010 apps/dreamverse/scripts/smoke_local.sh
+BACKEND_HOST=localhost BACKEND_PORT=8009 apps/dreamverse/scripts/smoke_local.sh
 ```
 
 If a backend is already running and you only want the script to probe it:

--- a/apps/dreamverse/README.md
+++ b/apps/dreamverse/README.md
@@ -1,28 +1,66 @@
 # Dreamverse
 
-Dreamverse is the FastVideo realtime video product. It lives in this
-monorepo under `apps/dreamverse/`. The backend runtime under
-`apps/dreamverse/dreamverse/` is product-local; do not replace it with public
-`fastvideo.entrypoints.streaming.*` shims until a future promotion phase makes
-those public surfaces drop-in compatible.
+Dreamverse is the FastVideo realtime video generation & editing platform. It lives in this monorepo under `apps/dreamverse/`.
 
-The migration source of truth is
-`.agents/memory/dreamverse-integration/integration-plan.md`.
+## Install Dreamverse
 
-## Install From FastVideo
+You can install Dreamverse using one of the methods below.
 
-Install the Dreamverse runtime dependencies with the FastVideo extra:
+### Method 1: With uv pip
 
 ```bash
-pip install "fastvideo[dreamverse]"
-dreamverse-server --port 8009
+pip install --upgrade pip
+pip install uv
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install "fastvideo[dreamverse]"
 ```
 
-The base `pip install fastvideo` package still includes the Dreamverse Python
-package and `dreamverse-server` / `dreamverse-mock-server` commands. Running
-those commands without the `[dreamverse]` extra exits immediately with a message
-to install `fastvideo[dreamverse]`, because the cloud prompt runtime
-dependencies are intentionally gated by the extra.
+### Method 2: From source
+
+```bash
+git clone https://github.com/hao-ai-lab/FastVideo.git
+cd FastVideo
+
+pip install --upgrade pip
+pip install uv
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install -e ".[dreamverse]"
+```
+
+### Method 3: Using Docker
+
+```bash
+git clone https://github.com/hao-ai-lab/FastVideo.git
+cd FastVideo
+
+apps/dreamverse/docker/docker_build.sh
+```
+
+See `apps/dreamverse/docker/README.md` for Docker build and run option details.
+
+## Optional: Building FFmpeg For Better Performance
+
+For full streaming performance in a non-Docker install, build a custom FFmpeg
+binary:
+
+```bash
+bash apps/dreamverse/scripts/install_native_ffmpeg.sh
+```
+
+This builds and installs into `~/opt/ffmpeg-native/` and writes
+`apps/dreamverse/scripts/ffmpeg-env.sh`. Source it before starting the backend
+so Dreamverse uses the custom FFmpeg binary:
+
+```bash
+source apps/dreamverse/scripts/ffmpeg-env.sh
+dreamverse-server
+```
+
+Docker images already run this FFmpeg build during image creation and source the
+generated environment file at container startup. The installer supports Linux
+`x86_64` and `aarch64`.
 
 ## Launch Dreamverse
 
@@ -32,3 +70,165 @@ Start the backend with the installed Dreamverse commands:
 dreamverse-server --port 8009
 dreamverse-mock-server --port 8009
 ```
+
+## Frontend Setup
+
+Install the web dependencies once from the FastVideo checkout:
+
+```bash
+cd apps/dreamverse/web
+pnpm install --frozen-lockfile
+```
+
+The frontend package also has an npm lockfile, but the bundled launch scripts
+use `pnpm`.
+
+## Quick Start: Local GPU
+
+### Start Backend
+
+Export the API keys used for prompt rewrite and prompt enhancement:
+
+```bash
+export CEREBRAS_API_KEY=...
+export GROQ_API_KEY=...
+```
+
+If you built the optional native FFmpeg binary above, source its environment
+file in the same shell before starting the backend:
+
+```bash
+source apps/dreamverse/scripts/ffmpeg-env.sh
+dreamverse-server --host 0.0.0.0 --port 8009
+```
+
+The Dreamverse backend defaults to `0.0.0.0:8009` and starts one GPU worker on
+the first visible GPU by default.
+
+### Check Readiness
+
+In another shell, verify that the backend process is alive:
+
+```bash
+curl http://localhost:8009/healthz
+```
+
+Then wait for GPU workers and startup warmup to finish:
+
+```bash
+curl http://localhost:8009/readyz
+```
+
+You can also run the same readiness path with:
+
+```bash
+BACKEND_HOST=localhost BACKEND_PORT=8010 apps/dreamverse/scripts/smoke_local.sh
+```
+
+If a backend is already running and you only want the script to probe it:
+
+```bash
+DREAMVERSE_SMOKE_START_BACKEND=0 apps/dreamverse/scripts/smoke_local.sh
+```
+
+### Start Frontend
+
+Start the frontend:
+
+```bash
+cd apps/dreamverse/web
+BACKEND_HOST=localhost BACKEND_PORT=8009 pnpm run dev
+```
+
+Open `http://localhost:5299`.
+
+## Quick Start: Mock Backend (For UI development)
+
+The mock server emulates the Dreamverse backend protocol and streams a
+synthetic FFmpeg-generated fMP4 clip, so the frontend can run without a GPU.
+
+```bash
+dreamverse-mock-server --latency 200 --port 8009
+```
+
+## Tests
+
+Run the focused backend tests that validate local startup wiring, config, GPU
+selection, and mock-server behavior:
+
+```bash
+pytest apps/dreamverse/dreamverse/tests/test_config.py \
+  apps/dreamverse/dreamverse/tests/test_entrypoints.py \
+  apps/dreamverse/dreamverse/tests/test_gpu_pool.py \
+  apps/dreamverse/dreamverse/tests/test_mock_server.py -q
+```
+
+Run the broader Dreamverse backend suite:
+
+```bash
+pytest apps/dreamverse/dreamverse/tests -q
+```
+
+Run the frontend tests:
+
+```bash
+cd apps/dreamverse/web
+pnpm test
+```
+
+Run the frontend e2e tests:
+
+```bash
+cd apps/dreamverse/web
+pnpm run e2e
+```
+
+## Troubleshooting
+
+`dreamverse-server` exits with an install hint
+
+- install the Dreamverse extra with `uv pip install -e ".[dreamverse]"` from a
+  source checkout, or `uv pip install "fastvideo[dreamverse]"` from PyPI.
+
+Prompt-provider environment variable errors
+
+- set `CEREBRAS_API_KEY`
+- set `GROQ_API_KEY`
+- direct `dreamverse-server` launches do not source `~/.env`; export the keys
+  in the shell or use the bundled launch scripts, which source `~/.env`.
+
+`/readyz` stays at `503`
+
+- wait for model loading and startup warmup to finish
+- confirm a compatible CUDA GPU is visible to the process
+- check backend logs for worker startup or warmup failures
+- for a startup/debug pass without warmup, set
+  `FASTVIDEO_ENABLE_STARTUP_WARMUP=0` before starting the backend
+
+Only one GPU is used
+
+- this is the default local behavior
+- set `FASTVIDEO_GPU_COUNT=<N>` to start N GPU worker subprocesses inside one
+  backend instance
+- set `FASTVIDEO_GPU_COUNT=all` to start one worker for every visible GPU
+- use `CUDA_VISIBLE_DEVICES` first if you need to pin the visible GPU set
+
+Frontend cannot connect to backend
+
+- confirm the backend is running on `8009`; if not, point the frontend at it
+  with `BACKEND_HOST=<host> BACKEND_PORT=<port> pnpm run dev`
+- confirm `http://localhost:8009/healthz` responds before starting the frontend
+- confirm `http://localhost:8009/readyz` returns `200` before clicking Generate
+- use `apps/dreamverse/scripts/smoke_local.sh` for a repeatable local startup
+  check
+
+Mock backend fails during startup
+
+- install FFmpeg or set `FASTVIDEO_FFMPEG_BIN` to an FFmpeg binary
+- for non-mock local GPU streaming performance, use the native FFmpeg installer
+  described above
+
+## Notes
+
+Dreamverse owns its backend app under `apps/dreamverse/dreamverse/`. It expects
+`dreamverse-server`, not `fastvideo serve`.

--- a/apps/dreamverse/design.md
+++ b/apps/dreamverse/design.md
@@ -317,12 +317,12 @@ Required outcome:
 Expected shape:
 
 ```bash
-uv sync --extra server
+uv pip install -e ".[dreamverse]"
 dreamverse-server --host 0.0.0.0 --port 8009
 
 cd apps/dreamverse/web
 npm ci
-BACKEND_PORT=8009 npm run dev
+BACKEND_HOST=localhost BACKEND_PORT=8009 npm run dev
 ```
 
 Optional but useful:
@@ -459,7 +459,7 @@ Add or tighten tests for:
 
 - connection failure UX when backend is down
 - readiness failure UX when backend returns non-ready status
-- backend URL configuration through `BACKEND_URL` and `BACKEND_PORT`
+- backend routing configuration through `BACKEND_HOST` and `BACKEND_PORT`
 
 ### Manual smoke path
 

--- a/apps/dreamverse/scripts/launch/README.md
+++ b/apps/dreamverse/scripts/launch/README.md
@@ -1,0 +1,36 @@
+# Dreamverse Launch Scripts
+
+These scripts are convenience wrappers for local demos and lower-level backend
+checks. The main Dreamverse README documents the normal manual startup path.
+
+## One-Command Demo
+
+From the FastVideo checkout:
+
+```bash
+apps/dreamverse/scripts/launch/launch_demo.sh
+```
+
+The launcher starts the Dreamverse backend and frontend, polls readiness, and
+prints the active URLs. It defaults to `dreamverse-server` on backend port
+`8009` and frontend port `5274`.
+
+Useful overrides:
+
+```bash
+BE_PORT=8010 FE_PORT=5274 apps/dreamverse/scripts/launch/launch_demo.sh
+NO_FRONTEND=1 apps/dreamverse/scripts/launch/launch_demo.sh
+NO_BROWSER=1 apps/dreamverse/scripts/launch/launch_demo.sh
+```
+
+## Individual Scripts
+
+`launch_backend_dreamverse.sh` starts the full Dreamverse backend path used by
+the web app.
+
+`launch_frontend.sh` starts the Next.js frontend and installs `pnpm`
+dependencies when `node_modules/` is missing.
+
+`launch_backend_fastvideo.sh` starts the typed `fastvideo serve --config` path
+for lower-level serve-config checks. It is not a full Dreamverse app replacement
+because the current frontend still depends on Dreamverse-specific routes.

--- a/apps/dreamverse/serve_configs/streaming_demo.yaml
+++ b/apps/dreamverse/serve_configs/streaming_demo.yaml
@@ -1,5 +1,9 @@
 # Dreamverse streaming demo — fastvideo serve --config target.
 #
+# This config is for testing Dreamverse-like streaming through the lower-level
+# `fastvideo serve --config` entrypoint. Use `dreamverse-server` for the full
+# Dreamverse web app.
+#
 # Mirrors ../FastVideo-internal/ui/ltx2-streaming/server/config.py
 # defaults so the public typed surface produces the same runtime
 # behavior as the internal UI's GPU pool. Sources of each setting are


### PR DESCRIPTION
## Summary

This is PR 5 of 5 splitting #1312 into smaller review slices.

- Expands Dreamverse setup documentation for installed CLI usage, Docker workflows, and local launch paths.
- Adds launch script documentation.
- Clarifies the streaming demo config as a lower-level `fastvideo serve --config` target.

## Stack

1. #1313 Package backend as installable module
2. #1314 Launch backend through installed CLI
3. #1315 Standardize backend host env
4. #1316 Add Docker runtime packaging
5. Document Docker setup workflow

Base: `feat/dreamverse-stack-04-docker`
Source: #1312 at `f5c537f5e030427bbeedfa8ae403c9a539815907`

## Validation

- Pre-commit hooks passed during commit.
- Final 5-PR stack diff was verified to exactly match #1312 from `upstream/will/dreamverse-monorepo`.
- Exact diff files compared: `/tmp/pr-1312-source.diff` and `/tmp/dreamverse-stack.diff`.
- Exact file lists compared: `/tmp/pr-1312-source.name-status` and `/tmp/dreamverse-stack.name-status`.

Dreamverse-Stack: 5/5