### PR TITLE
[feat] eval: async VideoPool + metric streamlines

### DIFF
--- a/examples/inference/eval/eval_ltx2_vbench.py
+++ b/examples/inference/eval/eval_ltx2_vbench.py
@@ -127,7 +127,7 @@ def evaluate_video(video_path: Path, prompt: str, fps: float,
     print(f"[eval] running ({video.shape[1]} frames @ {fps} fps)...")
     results = evaluator.evaluate(
         video=video,
-        text_prompt=[prompt],
+        text_prompt=prompt,
         fps=fps,
     )
 

--- a/fastvideo/entrypoints/cli/eval.py
+++ b/fastvideo/entrypoints/cli/eval.py
@@ -128,8 +128,7 @@ def _cmd_run(args: argparse.Namespace) -> None:
             ref = ref_paths[i] if i < len(ref_paths) else ref_paths[0]
             kwargs["reference"] = load_video(ref)
         if args.text_prompt is not None:
-            prompt = (args.text_prompt[i] if i < len(args.text_prompt) else args.text_prompt[0])
-            kwargs["text_prompt"] = [prompt]
+            kwargs["text_prompt"] = (args.text_prompt[i] if i < len(args.text_prompt) else args.text_prompt[0])
         if args.fps is not None:
             kwargs["fps"] = args.fps
 

--- a/fastvideo/eval/__init__.py
+++ b/fastvideo/eval/__init__.py
@@ -21,7 +21,7 @@ def _redirect_third_party_caches() -> None:
 
 _redirect_third_party_caches()
 
-from fastvideo.eval.types import MetricResult  # noqa: E402
+from fastvideo.eval.types import MetricResult, Video  # noqa: E402
 from fastvideo.eval.metrics.base import BaseMetric  # noqa: E402
 from fastvideo.eval.registry import register, list_metrics, get_metric  # noqa: E402
 from fastvideo.eval.api import evaluate  # noqa: E402
@@ -35,6 +35,7 @@ __all__ = [
     "Evaluator",
     "create_evaluator",
     "MetricResult",
+    "Video",
     "BaseMetric",
     "register",
     "list_metrics",

--- a/fastvideo/eval/__init__.py
+++ b/fastvideo/eval/__init__.py
@@ -21,7 +21,7 @@ def _redirect_third_party_caches() -> None:
 
 _redirect_third_party_caches()
 
-from fastvideo.eval.types import MetricResult, Video  # noqa: E402
+from fastvideo.eval.types import EvalResults, MetricResult, Video  # noqa: E402
 from fastvideo.eval.metrics.base import BaseMetric  # noqa: E402
 from fastvideo.eval.registry import register, list_metrics, get_metric  # noqa: E402
 from fastvideo.eval.api import evaluate  # noqa: E402
@@ -34,6 +34,7 @@ __all__ = [
     "evaluate",
     "Evaluator",
     "create_evaluator",
+    "EvalResults",
     "MetricResult",
     "Video",
     "BaseMetric",

--- a/fastvideo/eval/evaluator.py
+++ b/fastvideo/eval/evaluator.py
@@ -3,19 +3,21 @@
 Layering (mirrors FastVideo's VideoGenerator → Worker pattern, but
 in-process)::
 
-    Evaluator               ← user-facing; round-robins samples across workers
+    Evaluator               ← user-facing
       └── EvalWorker × N    ← single-GPU; owns metric replicas
+      └── VideoPool         ← async path-→-tensor prefetch (per evaluate call)
 
 The constructor builds one :class:`EvalWorker` per GPU and loads every
 metric on every worker eagerly. :meth:`evaluate` is the single entry
 point: pass kwargs for one sample, or pass a list of sample dicts to
-fan-out across GPU replicas — same method, return type follows the
-input shape.
+fan-out across GPU replicas with pipelined decoding — same method,
+return type follows the input shape.
 """
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor
+import threading
 from collections.abc import Iterable
+from typing import Any
 
 from fastvideo.eval.registry import (list_metrics, missing_dependencies, resolve_group)
 from fastvideo.eval.types import MetricResult
@@ -38,6 +40,22 @@ class Evaluator:
         Number of GPU replicas. Each gets its own :class:`EvalWorker`.
     compile : bool
         Apply :func:`torch.compile` to each metric's ``_model``.
+    loader_threads : int
+        Background decode threads in the :class:`VideoPool`. Default 1
+        (hide decode behind compute). Bump for I/O-heavy benchmark sets
+        where one loader can't keep up with the workers.
+    prefetch_factor : int
+        ``pool max_size = prefetch_factor * num_workers``. Default 2 —
+        one sample being consumed, one prefetched per worker.
+    pre_upload : bool
+        When ``True`` (default), the worker performs a single
+        host→device upload of ``video`` / ``reference`` per sample
+        before the metric loop, and every metric reads from that
+        shared GPU-resident tensor. Without it, each metric pays its
+        own ``.to(self.device)`` — N transfers of the same clip for N
+        metrics, which dominates at high resolution. Set ``False`` for
+        training-time eval, where keeping a clip resident on GPU
+        across the metric loop would fight the training step for VRAM.
     """
 
     def __init__(
@@ -46,13 +64,20 @@ class Evaluator:
         device: str = "cuda:0",
         num_gpus: int = 1,
         compile: bool = False,
+        *,
+        loader_threads: int = 1,
+        prefetch_factor: int = 2,
+        pre_upload: bool = True,
     ) -> None:
         names = _resolve_metric_names(metrics)
         if num_gpus > 1:
-            self._workers = [EvalWorker(names, f"cuda:{i}", compile=compile) for i in range(num_gpus)]
+            self._workers = [
+                EvalWorker(names, f"cuda:{i}", compile=compile, pre_upload=pre_upload) for i in range(num_gpus)
+            ]
         else:
-            self._workers = [EvalWorker(names, device, compile=compile)]
-        self._pool = (ThreadPoolExecutor(max_workers=num_gpus) if num_gpus > 1 else None)
+            self._workers = [EvalWorker(names, device, compile=compile, pre_upload=pre_upload)]
+        self._loader_threads = max(1, loader_threads)
+        self._prefetch_factor = max(1, prefetch_factor)
 
     @property
     def num_gpus(self) -> int:
@@ -71,17 +96,16 @@ class Evaluator:
 
         ``video`` and ``reference`` may be either a pre-loaded
         ``(T, C, H, W)`` tensor or a path-like (``str`` / ``Path``).
-        Paths are decoded inside the worker thread that picks up the
-        sample, so memory stays bounded by ``num_gpus`` even when
-        thousands of paths are queued — see ``score_folder.py`` for
-        the canonical pattern.
+        Paths in the list form are decoded asynchronously by a
+        :class:`VideoPool` that runs alongside metric compute, hiding
+        decode latency behind GPU work.
 
         One sample::
 
             ev.evaluate(video=tensor, text_prompt="...", fps=24.0)
             ev.evaluate(video="path/to/clip.mp4", fps=24.0)
 
-        Many samples — fan out across GPU replicas, results in input order::
+        Many samples — pipelined decode + work-stealing across replicas::
 
             ev.evaluate(samples=[
                 {"video": "a.mp4", "reference": "ref_a.mp4"},
@@ -89,23 +113,59 @@ class Evaluator:
                 ...
             ])
 
-        Multi-GPU dispatch fires automatically iff ``num_gpus > 1`` *and*
-        the list form is used. The kwargs form always runs on worker 0;
-        if you have a single sample but multiple GPUs, wrap it in a
-        one-element list to use the pool, or just accept that a single
-        call uses one GPU — that's fine.
+        Multi-GPU dispatch fires automatically when ``num_gpus > 1`` and
+        the list form is used: every worker runs a consumer thread,
+        pulling decoded samples from the shared pool as it frees up.
+        The kwargs form always runs on worker 0 with no pool overhead.
         """
         if samples is None:
             return self._workers[0].evaluate(**kwargs)
 
         samples = list(samples)
-        if self._pool is None or len(samples) <= 1:
-            return [self._workers[0].evaluate(**s) for s in samples]
+        if not samples:
+            return []
+        return self._evaluate_with_pool(samples)
 
-        n = len(self._workers)
-        # Round-robin: worker i handles samples i, i+n, i+2n, ...
-        futures = [self._pool.submit(self._workers[idx % n].evaluate, **sample) for idx, sample in enumerate(samples)]
-        return [f.result() for f in futures]
+    def _evaluate_with_pool(self, samples: list[dict]) -> list[dict[str, MetricResult]]:
+        """Run samples through a :class:`VideoPool`, writing results in input order."""
+        from fastvideo.eval.pool import VideoPool
+
+        n_workers = len(self._workers)
+        max_size = self._prefetch_factor * n_workers
+        results: list[Any] = [None] * len(samples)
+
+        with VideoPool(samples, loader_threads=self._loader_threads, max_size=max_size) as pool:
+            if n_workers == 1:
+                while True:
+                    item = pool.get()
+                    if item is None:
+                        break
+                    idx, decoded = item
+                    results[idx] = self._workers[0].evaluate(**decoded)
+            else:
+                # Multi-GPU: every worker drains the shared pool (work-stealing).
+                threads: list[threading.Thread] = []
+                for w in self._workers:
+                    t = threading.Thread(
+                        target=self._consumer_loop,
+                        args=(w, pool, results),
+                        daemon=True,
+                    )
+                    t.start()
+                    threads.append(t)
+                for t in threads:
+                    t.join()
+
+        return results
+
+    @staticmethod
+    def _consumer_loop(worker: EvalWorker, pool: Any, results: list) -> None:
+        while True:
+            item = pool.get()
+            if item is None:
+                return
+            idx, decoded = item
+            results[idx] = worker.evaluate(**decoded)
 
     def release_cuda_memory(self) -> None:
         """Free CUDA caches on every replica without dropping models."""
@@ -123,10 +183,7 @@ class Evaluator:
             w.reload()
 
     def shutdown(self) -> None:
-        """Tear down the worker thread pool. Idempotent."""
-        if self._pool is not None:
-            self._pool.shutdown(wait=True)
-            self._pool = None
+        """No-op; kept for API compatibility with older callers."""
 
 
 def create_evaluator(

--- a/fastvideo/eval/evaluator.py
+++ b/fastvideo/eval/evaluator.py
@@ -20,7 +20,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from fastvideo.eval.registry import (list_metrics, missing_dependencies, resolve_group)
-from fastvideo.eval.types import MetricResult
+from fastvideo.eval.types import EvalResults, MetricResult
 from fastvideo.eval.worker import EvalWorker
 from fastvideo.logger import init_logger
 
@@ -91,19 +91,19 @@ class Evaluator:
         self,
         samples: Iterable[dict] | None = None,
         **kwargs,
-    ) -> dict[str, MetricResult] | list[dict[str, MetricResult]]:
+    ) -> dict[str, MetricResult] | EvalResults:
         """Score one sample (kwargs form) or many samples (list form).
 
-        ``video`` and ``reference`` may be either a pre-loaded
-        ``(T, C, H, W)`` tensor or a path-like (``str`` / ``Path``).
-        Paths in the list form are decoded asynchronously by a
-        :class:`VideoPool` that runs alongside metric compute, hiding
-        decode latency behind GPU work.
+        Both forms go through the same :class:`VideoPool` pipeline;
+        ``video`` / ``reference`` paths are decoded asynchronously,
+        ``(1, T, C, H, W)`` tensors are squeezed.
 
         One sample::
 
             ev.evaluate(video=tensor, text_prompt="...", fps=24.0)
             ev.evaluate(video="path/to/clip.mp4", fps=24.0)
+
+        Returns a ``dict[str, MetricResult]``.
 
         Many samples — pipelined decode + work-stealing across replicas::
 
@@ -113,26 +113,34 @@ class Evaluator:
                 ...
             ])
 
-        Multi-GPU dispatch fires automatically when ``num_gpus > 1`` and
-        the list form is used: every worker runs a consumer thread,
-        pulling decoded samples from the shared pool as it frees up.
-        The kwargs form always runs on worker 0 with no pool overhead.
+        Returns an :class:`EvalResults` (list-of-dict subclass): per-sample
+        dicts in input order, with set-metric scores under ``.corpus``.
         """
-        if samples is None:
-            return self._workers[0].evaluate(**kwargs)
+        single = samples is None
+        sample_list: list[dict] = [kwargs] if samples is None else list(samples)
+        if not sample_list:
+            return EvalResults(samples=[], corpus={})
 
-        samples = list(samples)
-        if not samples:
-            return []
-        return self._evaluate_with_pool(samples)
+        per_sample, corpus = self._run(sample_list)
 
-    def _evaluate_with_pool(self, samples: list[dict]) -> list[dict[str, MetricResult]]:
-        """Run samples through a :class:`VideoPool`, writing results in input order."""
+        if single:
+            return per_sample[0]
+        return EvalResults(samples=per_sample, corpus=corpus)
+
+    def _run(self, samples: list[dict]) -> tuple[list[dict[str, MetricResult]], dict[str, MetricResult]]:
+        """Pool-driven sample pipeline + set-metric finalize.
+
+        Returns ``(per_sample_results, corpus_results)``.
+        """
         from fastvideo.eval.pool import VideoPool
+
+        # Reset every worker's set-metric buffers — per-call isolation.
+        for w in self._workers:
+            w.reset_set_metrics()
 
         n_workers = len(self._workers)
         max_size = self._prefetch_factor * n_workers
-        results: list[Any] = [None] * len(samples)
+        per_sample: list[Any] = [None] * len(samples)
 
         with VideoPool(samples, loader_threads=self._loader_threads, max_size=max_size) as pool:
             if n_workers == 1:
@@ -141,31 +149,43 @@ class Evaluator:
                     if item is None:
                         break
                     idx, decoded = item
-                    results[idx] = self._workers[0].evaluate(**decoded)
+                    per_sample[idx] = self._workers[0].evaluate(**decoded)
             else:
                 # Multi-GPU: every worker drains the shared pool (work-stealing).
+                errors: list[BaseException] = []
                 threads: list[threading.Thread] = []
                 for w in self._workers:
-                    t = threading.Thread(
-                        target=self._consumer_loop,
-                        args=(w, pool, results),
-                        daemon=True,
-                    )
+                    t = threading.Thread(target=self._consumer_loop, args=(w, pool, per_sample, errors), daemon=True)
                     t.start()
                     threads.append(t)
                 for t in threads:
                     t.join()
+                if errors:
+                    raise errors[0]
 
-        return results
+        # Finalize set metrics. With multiple workers, fold per-worker
+        # accumulator state into worker 0 first, then finalize once.
+        corpus: dict[str, MetricResult] = {}
+        base_set = self._workers[0].set_metrics()
+        if base_set:
+            for w in self._workers[1:]:
+                for name, m in w.set_metrics().items():
+                    base_set[name].merge_from(m)
+            corpus = {name: m.finalize() for name, m in base_set.items()}
+
+        return per_sample, corpus
 
     @staticmethod
-    def _consumer_loop(worker: EvalWorker, pool: Any, results: list) -> None:
-        while True:
-            item = pool.get()
-            if item is None:
-                return
-            idx, decoded = item
-            results[idx] = worker.evaluate(**decoded)
+    def _consumer_loop(worker: EvalWorker, pool: Any, results: list, errors: list) -> None:
+        try:
+            while True:
+                item = pool.get()
+                if item is None:
+                    return
+                idx, decoded = item
+                results[idx] = worker.evaluate(**decoded)
+        except BaseException as e:  # noqa: BLE001 — surface to parent thread via shared list
+            errors.append(e)
 
     def release_cuda_memory(self) -> None:
         """Free CUDA caches on every replica without dropping models."""

--- a/fastvideo/eval/evaluator.py
+++ b/fastvideo/eval/evaluator.py
@@ -121,6 +121,15 @@ class Evaluator:
         if not sample_list:
             return EvalResults(samples=[], corpus={})
 
+        if single and any(m.is_set_metric for m in self._workers[0].set_metrics().values()):
+            # Set metrics need a population. A single sample can't produce a
+            # meaningful corpus result, and silently discarding it (return
+            # ``per_sample[0]`` only) hides the no-op. Force the list form.
+            raise ValueError("Set-vs-set metrics require samples=[...] with >=2 entries; "
+                             "the kwargs form (single sample) cannot produce a corpus "
+                             "result. Registered set metrics: "
+                             f"{sorted(self._workers[0].set_metrics())}")
+
         per_sample, corpus = self._run(sample_list)
 
         if single:

--- a/fastvideo/eval/io/paths.py
+++ b/fastvideo/eval/io/paths.py
@@ -45,8 +45,10 @@ def build_eval_kwargs(row: dict, video_path: Path, *, fps: float = 24.0) -> dict
     """Build evaluator kwargs from a sample row + a video on disk.
 
     Loads the video as ``(T,C,H,W)`` and adds the leading batch dim.
-    Forwards ``prompt`` (as ``text_prompt=[prompt]``) and
-    ``auxiliary_info`` (as ``[aux]``) when present on the row.
+    Forwards ``prompt`` (as scalar ``text_prompt``) and
+    ``auxiliary_info`` (as scalar dict) when present on the row —
+    matches the one-sample-per-call contract that the evaluator and
+    every metric assume.
     """
     from fastvideo.eval.io.video import load_video
 
@@ -56,8 +58,8 @@ def build_eval_kwargs(row: dict, video_path: Path, *, fps: float = 24.0) -> dict
         "fps": fps,
     }
     if "prompt" in row:
-        kwargs["text_prompt"] = [row["prompt"]]
+        kwargs["text_prompt"] = row["prompt"]
     aux = row.get("auxiliary_info")
     if aux:
-        kwargs["auxiliary_info"] = [aux]
+        kwargs["auxiliary_info"] = aux
     return kwargs

--- a/fastvideo/eval/metrics/base.py
+++ b/fastvideo/eval/metrics/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import ABC
 
 import torch
 
@@ -10,14 +10,24 @@ from fastvideo.eval.types import MetricResult
 class BaseMetric(ABC):
     """Abstract base class for all eval metrics.
 
-    Subclasses must implement :meth:`compute`. Optionally override
-    :meth:`setup` to eagerly load models.
+    Two execution shapes:
 
-    Metrics that need to chunk along the time dimension (frames or frame
-    pairs) for memory reasons should hardcode their own chunk size in
-    ``__init__`` (see ``optical_flow`` for the canonical example). Eval
-    always processes one video per :meth:`Evaluator.evaluate` call;
-    ``compute`` therefore receives a single sample, not a batch.
+    * **Per-sample** (``is_set_metric=False``, default) — implement
+      :meth:`compute`. The Evaluator calls it once per input sample and
+      returns one :class:`MetricResult` per sample.
+
+    * **Set-vs-set** (``is_set_metric=True``) — implement
+      :meth:`accumulate` (called once per sample to buffer features)
+      and :meth:`finalize` (called once after all samples to compute
+      the corpus-level result). Use :meth:`reset` to clear buffers and
+      :meth:`merge_from` to fold multi-GPU per-worker state together.
+
+    Optionally override :meth:`setup` to eagerly load models. Metrics
+    that chunk along the time dim for memory hardcode their own chunk
+    size in ``__init__`` (see ``optical_flow`` for the canonical
+    example). Eval always processes one video per
+    :meth:`Evaluator.evaluate` call; ``compute`` / ``accumulate``
+    receive a single sample, not a batch.
     """
 
     name: str = ""
@@ -26,6 +36,7 @@ class BaseMetric(ABC):
     dependencies: list[str] = []
     needs_gpu: bool = False
     backbone: str | None = None
+    is_set_metric: bool = False
 
     # Default time-dim chunk size for metrics that batch internally over
     # frames or frame-pairs. Override in subclass __init__ if needed
@@ -56,14 +67,27 @@ class BaseMetric(ABC):
         """Return a skipped result (``score=None`` + reason in details)."""
         return MetricResult(name=self.name, score=None, details={"skipped": reason})
 
-    @abstractmethod
     def compute(self, sample: dict) -> MetricResult:
-        """Compute the metric on a single sample.
+        """Per-sample metrics: compute the score for one sample.
 
         ``sample["video"]`` is ``(T, C, H, W)`` float in ``[0, 1]``.
-        ``sample["reference"]`` (if used) has the same shape.
-
-        If required inputs are missing, return ``self._skip(sample, reason)``
-        instead of raising.
+        ``sample["reference"]`` (if used) has the same shape. Return
+        ``self._skip(sample, reason)`` for missing inputs.
         """
-        ...
+        raise NotImplementedError(f"{type(self).__name__}.compute is not implemented")
+
+    # --- set-vs-set protocol (only invoked when is_set_metric=True) ---
+
+    def reset(self) -> None:  # noqa: B027 - intentionally optional override
+        """Clear accumulator state at the start of each evaluate() call."""
+
+    def accumulate(self, sample: dict) -> None:
+        """Buffer per-sample features for a corpus-level metric."""
+        raise NotImplementedError(f"{type(self).__name__}.accumulate is not implemented")
+
+    def finalize(self) -> MetricResult:
+        """Compute the corpus-level result from buffered state."""
+        raise NotImplementedError(f"{type(self).__name__}.finalize is not implemented")
+
+    def merge_from(self, other: BaseMetric) -> None:  # noqa: B027 - intentionally optional override
+        """Multi-GPU: fold another worker's accumulator state into this one."""

--- a/fastvideo/eval/metrics/base.py
+++ b/fastvideo/eval/metrics/base.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from abc import ABC
-
 import torch
 
 from fastvideo.eval.types import MetricResult
 
 
-class BaseMetric(ABC):
+class BaseMetric:
     """Abstract base class for all eval metrics.
 
     Two execution shapes:

--- a/fastvideo/eval/metrics/common/lpips/metric.py
+++ b/fastvideo/eval/metrics/common/lpips/metric.py
@@ -17,9 +17,12 @@ class LPIPSMetric(BaseMetric):
     needs_gpu = True
     dependencies = ["lpips"]
 
-    def __init__(self, net: str = "alex") -> None:
+    def __init__(self, net: str = "alex", chunk_size: int = 8) -> None:
         super().__init__()
         self.net = net
+        # Chunk the per-frame forward: AlexNet feature maps at 1080p
+        # peak ~60 GB on a 121-frame clip; chunk=8 caps it at ~5 GB.
+        self._chunk_size = chunk_size
         self._model: Any = None
 
     def to(self, device: str | torch.device) -> LPIPSMetric:
@@ -39,8 +42,9 @@ class LPIPSMetric(BaseMetric):
         if self._model is None:
             self.setup()
 
-        gen = sample["video"].float().to(self.device)  # (T, C, H, W)
-        ref = sample["reference"].float().to(self.device)
+        gen = sample["video"].float().to(self.device, non_blocking=True)
+        ref = sample["reference"].float().to(self.device, non_blocking=True)
+
         n = min(gen.shape[0], ref.shape[0])
         gen, ref = gen[:n] * 2.0 - 1.0, ref[:n] * 2.0 - 1.0
 

--- a/fastvideo/eval/metrics/common/psnr/metric.py
+++ b/fastvideo/eval/metrics/common/psnr/metric.py
@@ -12,20 +12,29 @@ class PSNRMetric(BaseMetric):
     name = "common.psnr"
     requires_reference = True
     higher_is_better = True
-    needs_gpu = False
+    # On CPU the squared-diff is memory-bandwidth-bound at 1080p and
+    # fights the loader for the host bus; trivial on GPU.
+    needs_gpu = True
 
-    def __init__(self, max_val: float = 1.0) -> None:
+    def __init__(self, max_val: float = 1.0, chunk_size: int = 32) -> None:
         super().__init__()
         self.max_val = max_val
+        # Keeps the (gen - ref)**2 intermediate under ~800 MB at 1080p.
+        self._chunk_size = chunk_size
 
     def compute(self, sample: dict) -> MetricResult:
-        gen = sample["video"].float()  # (T, C, H, W)
-        ref = sample["reference"].float()
+        gen = sample["video"].float().to(self.device)  # (T, C, H, W)
+        ref = sample["reference"].float().to(self.device)
         n = min(gen.shape[0], ref.shape[0])
         gen, ref = gen[:n], ref[:n]
 
-        # Per-frame MSE → PSNR.
-        mse = ((gen - ref)**2).mean(dim=(1, 2, 3))  # (T,)
+        chunk = self._chunk_size or n
+        mse_parts = []
+        for i in range(0, n, chunk):
+            g = gen[i:i + chunk]
+            r = ref[i:i + chunk]
+            mse_parts.append(((g - r)**2).mean(dim=(1, 2, 3)))
+        mse = torch.cat(mse_parts)  # (T,)
         psnr = 10.0 * torch.log10(self.max_val**2 / mse.clamp(min=1e-10))
 
         return MetricResult(

--- a/fastvideo/eval/metrics/common/ssim/metric.py
+++ b/fastvideo/eval/metrics/common/ssim/metric.py
@@ -51,15 +51,19 @@ class SSIMMetric(BaseMetric):
     name = "common.ssim"
     requires_reference = True
     higher_is_better = True
-    needs_gpu = False
+    # Five depthwise conv2d's per chunk — GPU is ~100× the CPU path at
+    # 1080p, and it frees the host bus for the loader thread.
+    needs_gpu = True
 
-    def __init__(self, window_size: int = 11) -> None:
+    def __init__(self, window_size: int = 11, chunk_size: int = 16) -> None:
         super().__init__()
         self.window_size = window_size
+        # Caps the ~5-7 conv intermediates at ~4 GB on a 1080p clip.
+        self._chunk_size = chunk_size
 
     def compute(self, sample: dict) -> MetricResult:
-        gen = sample["video"].float()  # (T, C, H, W)
-        ref = sample["reference"].float()
+        gen = sample["video"].float().to(self.device)  # (T, C, H, W)
+        ref = sample["reference"].float().to(self.device)
         n = min(gen.shape[0], ref.shape[0])
         gen, ref = gen[:n], ref[:n]
 

--- a/fastvideo/eval/metrics/optical_flow/_shared.py
+++ b/fastvideo/eval/metrics/optical_flow/_shared.py
@@ -232,13 +232,14 @@ def aggregate_temporal(per_frame: list[dict[str, float]], ) -> dict[str, float |
 
 
 def tensor_to_bgr_list(video: torch.Tensor) -> list[np.ndarray]:
-    """Convert ``(T, C, H, W)`` float [0,1] to a list of HWC BGR uint8 frames."""
-    frames = []
-    for t in range(video.shape[0]):
-        rgb = (video[t].permute(1, 2, 0).cpu().numpy() * 255).astype(np.uint8)
-        bgr = rgb[:, :, ::-1].copy()
-        frames.append(bgr)
-    return frames
+    """Convert ``(T, C, H, W)`` float [0,1] to a list of HWC BGR uint8 frames.
+
+    Casts + permutes + BGR-swaps on-device and transfers once, instead
+    of T per-frame ``.cpu()`` round-trips.
+    """
+    bgr_u8 = (video.float() * 255.0).clamp(0, 255).to(torch.uint8).permute(0, 2, 3, 1).flip(-1).contiguous()
+    arr = bgr_u8.cpu().numpy()
+    return [arr[t] for t in range(arr.shape[0])]
 
 
 def load_ptlflow_model(model_name: str, ckpt: str, device: torch.device):

--- a/fastvideo/eval/metrics/optical_flow/gt_optical_flow/metric.py
+++ b/fastvideo/eval/metrics/optical_flow/gt_optical_flow/metric.py
@@ -53,7 +53,9 @@ class GtOpticalFlowMetric(BaseMetric):
         self.max_mag_pct = max_mag_pct
         self.grid_size = grid_size
         self._model = None
-        self._chunk_size = 16
+        # One frame-pair per DPFlow forward: the cost volume is ~4 GB
+        # per pair at 1080p, so batching OOMs. Bump for low-res inputs.
+        self._chunk_size = 1
 
     def to(self, device: str | torch.device) -> GtOpticalFlowMetric:
         super().to(device)

--- a/fastvideo/eval/metrics/optical_flow/synthetic_optical_flow/metric.py
+++ b/fastvideo/eval/metrics/optical_flow/synthetic_optical_flow/metric.py
@@ -94,7 +94,8 @@ class SyntheticOpticalFlowMetric(BaseMetric):
         self._calibration: ThirdPersonCalibration | None = (_resolve_calibration(calibration_path)
                                                             if calibration_path else None)
         self._model = None
-        self._chunk_size = 16
+        # One frame-pair per DPFlow forward; see ``gt_optical_flow``.
+        self._chunk_size = 1
 
     def to(self, device: str | torch.device) -> SyntheticOpticalFlowMetric:
         super().to(device)
@@ -114,10 +115,6 @@ class SyntheticOpticalFlowMetric(BaseMetric):
         actions = sample.get("actions")
         if actions is None:
             return self._skip(sample, "missing 'actions' (keyboard + mouse)")
-        if isinstance(actions, list):
-            actions = actions[0] if actions else None
-            if actions is None:
-                return self._skip(sample, "empty 'actions' list")
 
         cal_obj = sample.get("calibration")
         cal = self._calibration if cal_obj is None else _resolve_calibration(cal_obj)

--- a/fastvideo/eval/metrics/physics_iq/metric.py
+++ b/fastvideo/eval/metrics/physics_iq/metric.py
@@ -16,7 +16,6 @@ from fastvideo.eval.metrics.physics_iq.utils import (
     mean,
     prepare_pair_inputs,
     prepare_triplet_inputs,
-    unpack_batch_value,
 )
 from fastvideo.eval.registry import register
 from fastvideo.eval.types import MetricResult
@@ -172,22 +171,15 @@ class PhysicsIQMetric(BaseMetric):
         if take2_key is None:
             raise KeyError("PhysicsIQMetric requires sample['reference_take2'] or an alias.")
 
-        # Polymorphic input handling: tensors / ndarrays / file paths / list-of-one.
-        # ``unpack_batch_value`` always yields a list; with B=1 we take element 0.
-        [video] = unpack_batch_value(sample["video"])
-        [reference] = unpack_batch_value(sample["reference"])
-        [reference_take2] = unpack_batch_value(sample[take2_key])
-        generated_mask = unpack_batch_value(sample["video_mask"])[0] if "video_mask" in sample else None
-        reference_mask = unpack_batch_value(sample["reference_mask"])[0] if "reference_mask" in sample else None
-        reference_take2_mask = (unpack_batch_value(sample["reference_take2_mask"])[0]
-                                if "reference_take2_mask" in sample else None)
+        video = sample["video"]
+        reference = sample["reference"]
+        reference_take2 = sample[take2_key]
+        generated_mask = sample.get("video_mask")
+        reference_mask = sample.get("reference_mask")
+        reference_take2_mask = sample.get("reference_take2_mask")
 
         scenario = sample.get("scenario")
-        if isinstance(scenario, list):
-            scenario = scenario[0] if scenario else None
         view = sample.get("view")
-        if isinstance(view, list):
-            view = view[0] if view else None
 
         details = self.compute_single(
             video,

--- a/fastvideo/eval/metrics/physics_iq/mse/metric.py
+++ b/fastvideo/eval/metrics/physics_iq/mse/metric.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastvideo.eval.metrics.base import BaseMetric
 from fastvideo.eval.registry import register
 from fastvideo.eval.types import MetricResult
-from fastvideo.eval.metrics.physics_iq.utils import compute_mse, prepare_pair_batch
+from fastvideo.eval.metrics.physics_iq.utils import compute_mse, prepare_pair
 
 
 @register("physics_iq.mse")
@@ -19,7 +19,7 @@ class PhysicsIQMSEMetric(BaseMetric):
         self._kwargs = kwargs
 
     def compute(self, sample: dict) -> MetricResult:
-        [prepared] = prepare_pair_batch(sample, prep_kwargs=self._kwargs)
+        prepared = prepare_pair(sample, prep_kwargs=self._kwargs)
         per_frame = compute_mse(prepared.reference_quarter, prepared.generated_quarter)
         score = sum(per_frame) / len(per_frame)
         return MetricResult(name=self.name, score=score, details={"per_frame": per_frame})

--- a/fastvideo/eval/metrics/physics_iq/spatial_iou/metric.py
+++ b/fastvideo/eval/metrics/physics_iq/spatial_iou/metric.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastvideo.eval.metrics.base import BaseMetric
 from fastvideo.eval.registry import register
 from fastvideo.eval.types import MetricResult
-from fastvideo.eval.metrics.physics_iq.utils import compute_spatial_iou, prepare_pair_batch
+from fastvideo.eval.metrics.physics_iq.utils import compute_spatial_iou, prepare_pair
 
 
 @register("physics_iq.spatial_iou")
@@ -19,6 +19,6 @@ class SpatialIoUMetric(BaseMetric):
         self._kwargs = kwargs
 
     def compute(self, sample: dict) -> MetricResult:
-        [prepared] = prepare_pair_batch(sample, prep_kwargs=self._kwargs)
+        prepared = prepare_pair(sample, prep_kwargs=self._kwargs)
         score = compute_spatial_iou(prepared.reference_masks, prepared.generated_masks)
         return MetricResult(name=self.name, score=score, details={})

--- a/fastvideo/eval/metrics/physics_iq/spatiotemporal_iou/metric.py
+++ b/fastvideo/eval/metrics/physics_iq/spatiotemporal_iou/metric.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastvideo.eval.metrics.base import BaseMetric
 from fastvideo.eval.registry import register
 from fastvideo.eval.types import MetricResult
-from fastvideo.eval.metrics.physics_iq.utils import compute_spatiotemporal_iou, prepare_pair_batch
+from fastvideo.eval.metrics.physics_iq.utils import compute_spatiotemporal_iou, prepare_pair
 
 
 @register("physics_iq.spatiotemporal_iou")
@@ -19,7 +19,7 @@ class SpatiotemporalIoUMetric(BaseMetric):
         self._kwargs = kwargs
 
     def compute(self, sample: dict) -> MetricResult:
-        [prepared] = prepare_pair_batch(sample, prep_kwargs=self._kwargs)
+        prepared = prepare_pair(sample, prep_kwargs=self._kwargs)
         per_frame = compute_spatiotemporal_iou(prepared.reference_masks, prepared.generated_masks)
         score = sum(per_frame) / len(per_frame)
         return MetricResult(name=self.name, score=score, details={"per_frame": per_frame})

--- a/fastvideo/eval/metrics/physics_iq/utils.py
+++ b/fastvideo/eval/metrics/physics_iq/utils.py
@@ -103,13 +103,15 @@ def prepare_pair(
     if "reference" not in sample:
         raise KeyError("Physics-IQ pair metrics require sample['reference'].")
 
-    return prepare_pair_inputs(
+    prepared = prepare_pair_inputs(
         sample["video"],
         sample["reference"],
         generated_mask=sample.get("video_mask"),
         reference_mask=sample.get("reference_mask"),
         **(prep_kwargs or {}),
     )
+    sample["_physics_iq_pair"] = prepared
+    return prepared
 
 
 def select_window(frames: np.ndarray, *, target_frames: int, selection: str = "first") -> np.ndarray:

--- a/fastvideo/eval/metrics/physics_iq/utils.py
+++ b/fastvideo/eval/metrics/physics_iq/utils.py
@@ -86,63 +86,30 @@ def as_numpy_video(source: Any) -> tuple[np.ndarray, str]:
     raise TypeError(f"Unsupported Physics-IQ video source type: {type(source)!r}")
 
 
-def unpack_batch_value(value: Any) -> list[Any]:
-    if isinstance(value, torch.Tensor):
-        if value.ndim == 4:
-            return [value]
-        if value.ndim == 5:
-            return [value[idx] for idx in range(value.shape[0])]
-        raise ValueError(f"Unsupported tensor rank for Physics-IQ metric: {value.ndim}")
-    if isinstance(value, np.ndarray):
-        if value.ndim == 4:
-            return [value]
-        if value.ndim == 5:
-            return [value[idx] for idx in range(value.shape[0])]
-        raise ValueError(f"Unsupported ndarray rank for Physics-IQ metric: {value.ndim}")
-    if isinstance(value, str | Path):
-        return [value]
-    if isinstance(value, list):
-        return value
-    raise TypeError(f"Unsupported batched Physics-IQ value type: {type(value)!r}")
-
-
-def prepare_pair_batch(
+def prepare_pair(
     sample: dict[str, Any],
     *,
     prep_kwargs: dict[str, Any] | None = None,
-) -> list[PreparedPhysicsIQPair]:
+) -> PreparedPhysicsIQPair:
+    """Resolve a sample into a prepared (gen, ref) pair.
+
+    Caches the result on ``sample['_physics_iq_pair']`` so other physics_iq
+    sub-metrics on the same sample reuse it instead of re-decoding.
+    """
     prepared = sample.get("_physics_iq_pair")
     if prepared is not None:
-        return [prepared]
+        return prepared
 
     if "reference" not in sample:
         raise KeyError("Physics-IQ pair metrics require sample['reference'].")
 
-    videos = unpack_batch_value(sample["video"])
-    references = unpack_batch_value(sample["reference"])
-    generated_masks = unpack_batch_value(sample["video_mask"]) if "video_mask" in sample else [None] * len(videos)
-    reference_masks = unpack_batch_value(
-        sample["reference_mask"]) if "reference_mask" in sample else [None] * len(videos)
-
-    if not (len(videos) == len(references) == len(generated_masks) == len(reference_masks)):
-        raise ValueError("Physics-IQ pair metric inputs must have the same batch size.")
-
-    prep_kwargs = prep_kwargs or {}
-    return [
-        prepare_pair_inputs(
-            video,
-            reference,
-            generated_mask=generated_mask,
-            reference_mask=reference_mask,
-            **prep_kwargs,
-        ) for video, reference, generated_mask, reference_mask in zip(
-            videos,
-            references,
-            generated_masks,
-            reference_masks,
-            strict=False,
-        )
-    ]
+    return prepare_pair_inputs(
+        sample["video"],
+        sample["reference"],
+        generated_mask=sample.get("video_mask"),
+        reference_mask=sample.get("reference_mask"),
+        **(prep_kwargs or {}),
+    )
 
 
 def select_window(frames: np.ndarray, *, target_frames: int, selection: str = "first") -> np.ndarray:

--- a/fastvideo/eval/metrics/physics_iq/weighted_spatial_iou/metric.py
+++ b/fastvideo/eval/metrics/physics_iq/weighted_spatial_iou/metric.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastvideo.eval.metrics.base import BaseMetric
 from fastvideo.eval.registry import register
 from fastvideo.eval.types import MetricResult
-from fastvideo.eval.metrics.physics_iq.utils import compute_weighted_spatial_iou, prepare_pair_batch
+from fastvideo.eval.metrics.physics_iq.utils import compute_weighted_spatial_iou, prepare_pair
 
 
 @register("physics_iq.weighted_spatial_iou")
@@ -19,6 +19,6 @@ class WeightedSpatialIoUMetric(BaseMetric):
         self._kwargs = kwargs
 
     def compute(self, sample: dict) -> MetricResult:
-        [prepared] = prepare_pair_batch(sample, prep_kwargs=self._kwargs)
+        prepared = prepare_pair(sample, prep_kwargs=self._kwargs)
         score = compute_weighted_spatial_iou(prepared.reference_masks, prepared.generated_masks)
         return MetricResult(name=self.name, score=score, details={})

--- a/fastvideo/eval/metrics/vbench/appearance_style/metric.py
+++ b/fastvideo/eval/metrics/vbench/appearance_style/metric.py
@@ -69,8 +69,6 @@ class AppearanceStyleMetric(BaseMetric):
         text_prompt = sample.get("text_prompt")
         if text_prompt is None:
             return self._skip(sample, "missing text_prompt")
-        if isinstance(text_prompt, list):
-            text_prompt = text_prompt[0]
 
         frames = _clip_transform(video.to(self.device))
 

--- a/fastvideo/eval/metrics/vbench/color/metric.py
+++ b/fastvideo/eval/metrics/vbench/color/metric.py
@@ -55,17 +55,11 @@ class ColorMetric(BaseMetric):
         from fastvideo.eval.metrics.vbench._grit_helper import prepare_frames
 
         video = sample["video"]  # (T, C, H, W)
-        aux = sample.get("auxiliary_info")
-        if isinstance(aux, list):
-            aux = aux[0] if aux else None
-        if not aux or "color" not in aux:
+        aux = sample.get("auxiliary_info") or {}
+        if "color" not in aux:
             return self._skip(sample, "missing 'color' in auxiliary_info")
 
-        text_prompt = sample.get("text_prompt")
-        if isinstance(text_prompt, list):
-            text_prompt = text_prompt[0] if text_prompt else ""
-        prompt = text_prompt or ""
-
+        prompt = sample.get("text_prompt") or ""
         color_key = aux["color"]
         # Parse object name: remove "a ", "an ", and the color word
         object_key = prompt.replace("a ", "").replace("an ", "").replace(color_key, "").strip()

--- a/fastvideo/eval/metrics/vbench/human_action/metric.py
+++ b/fastvideo/eval/metrics/vbench/human_action/metric.py
@@ -101,8 +101,6 @@ class HumanActionMetric(BaseMetric):
         text_prompt = sample.get("text_prompt")
         if text_prompt is None:
             return self._skip(sample, "missing text_prompt with action labels")
-        if isinstance(text_prompt, list):
-            text_prompt = text_prompt[0]
 
         cat_dict = _load_cat_dict()
 

--- a/fastvideo/eval/metrics/vbench/multiple_objects/metric.py
+++ b/fastvideo/eval/metrics/vbench/multiple_objects/metric.py
@@ -38,10 +38,8 @@ class MultipleObjectsMetric(BaseMetric):
         from fastvideo.eval.metrics.vbench._grit_helper import prepare_frames, detect_frames
 
         video = sample["video"]  # (T, C, H, W)
-        aux = sample.get("auxiliary_info")
-        if isinstance(aux, list):
-            aux = aux[0] if aux else None
-        if not aux or "object" not in aux:
+        aux = sample.get("auxiliary_info") or {}
+        if "object" not in aux:
             return self._skip(sample, "missing 'object' in auxiliary_info")
 
         object_info = aux["object"]

--- a/fastvideo/eval/metrics/vbench/object_class/metric.py
+++ b/fastvideo/eval/metrics/vbench/object_class/metric.py
@@ -38,10 +38,8 @@ class ObjectClassMetric(BaseMetric):
         from fastvideo.eval.metrics.vbench._grit_helper import prepare_frames, detect_frames
 
         video = sample["video"]  # (T, C, H, W)
-        aux = sample.get("auxiliary_info")
-        if isinstance(aux, list):
-            aux = aux[0] if aux else None
-        if not aux or "object" not in aux:
+        aux = sample.get("auxiliary_info") or {}
+        if "object" not in aux:
             return self._skip(sample, "missing 'object' in auxiliary_info")
 
         object_key = aux["object"]

--- a/fastvideo/eval/metrics/vbench/overall_consistency/metric.py
+++ b/fastvideo/eval/metrics/vbench/overall_consistency/metric.py
@@ -80,8 +80,6 @@ class OverallConsistencyMetric(BaseMetric):
         text_prompt = sample.get("text_prompt")
         if text_prompt is None:
             return self._skip(sample, "missing text_prompt")
-        if isinstance(text_prompt, list):
-            text_prompt = text_prompt[0]
 
         frames = _clip_transform(extract_frames(video, 8))  # (8, C, H, W)
         clip_in = frames.unsqueeze(0).to(self.device)  # (1, 8, C, H, W)

--- a/fastvideo/eval/metrics/vbench/scene/metric.py
+++ b/fastvideo/eval/metrics/vbench/scene/metric.py
@@ -142,10 +142,8 @@ class SceneMetric(BaseMetric):
     @torch.no_grad()
     def compute(self, sample: dict) -> MetricResult:
         video = sample["video"]  # (T, C, H, W)
-        aux = sample.get("auxiliary_info")
-        if isinstance(aux, list):
-            aux = aux[0] if aux else None
-        if aux is None or "scene" not in aux:
+        aux = sample.get("auxiliary_info") or {}
+        if "scene" not in aux:
             return self._skip(sample, "missing 'scene' in auxiliary_info")
 
         scene_keywords = aux["scene"]

--- a/fastvideo/eval/metrics/vbench/spatial_relationship/metric.py
+++ b/fastvideo/eval/metrics/vbench/spatial_relationship/metric.py
@@ -77,10 +77,8 @@ class SpatialRelationshipMetric(BaseMetric):
         from fastvideo.eval.metrics.vbench._grit_helper import prepare_frames
 
         video = sample["video"]  # (T, C, H, W)
-        aux = sample.get("auxiliary_info")
-        if isinstance(aux, list):
-            aux = aux[0] if aux else None
-        if not aux or "spatial_relationship" not in aux:
+        aux = sample.get("auxiliary_info") or {}
+        if "spatial_relationship" not in aux:
             return self._skip(sample, "missing 'spatial_relationship' in auxiliary_info")
 
         sp_info = aux["spatial_relationship"]

--- a/fastvideo/eval/pool.py
+++ b/fastvideo/eval/pool.py
@@ -16,9 +16,25 @@ import threading
 from pathlib import Path
 from typing import Any
 
+import torch
+
 from fastvideo.eval.types import Video
 
 _SENTINEL = object()
+
+
+class _DecodeError:
+    """Marker pushed onto the ready queue when a loader thread raises.
+
+    The consumer re-raises in its own thread, surfacing the error to
+    the caller of ``Evaluator.evaluate`` instead of hanging on
+    ``_ready_q.get()`` forever.
+    """
+
+    __slots__ = ("exc", )
+
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
 
 
 class VideoPool:
@@ -82,6 +98,8 @@ class VideoPool:
         """Pop the next decoded ``(idx, sample)``.
 
         Returns ``None`` when all input samples have been consumed.
+        Re-raises any exception caught in a loader thread on the
+        consumer's stack so callers don't hang on a dead loader.
         Thread-safe: multiple consumer threads may share one pool.
         """
         with self._consume_lock:
@@ -93,6 +111,9 @@ class VideoPool:
             return None
         with self._consume_lock:
             self._consumed += 1
+        idx, payload = item
+        if isinstance(payload, _DecodeError):
+            raise payload.exc
         return item
 
     def _loader_loop(self) -> None:
@@ -101,18 +122,26 @@ class VideoPool:
             if item is _SENTINEL:
                 return
             idx, sample = item
-            decoded = self._decode(sample)
+            try:
+                decoded: Any = self._decode(sample)
+            except BaseException as exc:  # noqa: BLE001 — forward to consumer
+                self._ready_q.put((idx, _DecodeError(exc)))
+                continue
             # Blocking put: under normal flow the consumer drains the
             # queue; under shutdown ``__exit__`` drains it for us. A
             # timeout would silently drop samples and hang the consumer.
             self._ready_q.put((idx, decoded))
 
     def _decode(self, sample: dict) -> dict:
-        """Materialize any path-shaped video values in *sample*.
+        """Materialize and normalize ``video`` / ``reference`` entries.
 
-        Recognises ``Video`` instances (populates ``.frames``) and bare
-        path strings under ``video`` / ``reference``. Other entries pass
-        through unchanged.
+        * ``Video`` instance → populate ``.frames`` via decode.
+        * ``str`` / ``Path`` under ``video`` / ``reference`` → decoded
+          ``(T, C, H, W)`` tensor.
+        * ``(1, T, C, H, W)`` tensor under ``video`` / ``reference`` →
+          squeezed to ``(T, C, H, W)`` (back-compat with callers that
+          still pass a leading batch dim).
+        * Everything else passes through unchanged.
         """
         from fastvideo.eval.io.video import load_video
 
@@ -122,6 +151,9 @@ class VideoPool:
                 if val.frames is None and val.source is not None:
                     val.frames = load_video(val.source)
                 out[key] = val
-            elif key in ("video", "reference") and isinstance(val, str | Path):
-                out[key] = load_video(str(val))
+            elif key in ("video", "reference"):
+                if isinstance(val, str | Path):
+                    out[key] = load_video(str(val))
+                elif isinstance(val, torch.Tensor) and val.dim() == 5 and val.shape[0] == 1:
+                    out[key] = val.squeeze(0)
         return out

--- a/fastvideo/eval/pool.py
+++ b/fastvideo/eval/pool.py
@@ -102,10 +102,10 @@ class VideoPool:
                 return
             idx, sample = item
             decoded = self._decode(sample)
-            try:
-                self._ready_q.put((idx, decoded), timeout=10.0)
-            except queue.Full:
-                return
+            # Blocking put: under normal flow the consumer drains the
+            # queue; under shutdown ``__exit__`` drains it for us. A
+            # timeout would silently drop samples and hang the consumer.
+            self._ready_q.put((idx, decoded))
 
     def _decode(self, sample: dict) -> dict:
         """Materialize any path-shaped video values in *sample*.

--- a/fastvideo/eval/pool.py
+++ b/fastvideo/eval/pool.py
@@ -1,0 +1,127 @@
+"""Async path-→-tensor prefetcher for the Evaluator.
+
+Hides video-decode latency behind metric compute by running a small
+thread pool of decoders that fill a bounded queue. One :class:`VideoPool`
+is owned by the Evaluator per ``evaluate(samples=...)`` call; workers
+consume via :meth:`VideoPool.get`. Decode order is non-deterministic;
+each yielded item carries its original input index so consumers can
+write back into a result list in input order.
+
+Pool sizing: ``max_size = prefetch_factor * num_workers``.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+from pathlib import Path
+from typing import Any
+
+from fastvideo.eval.types import Video
+
+_SENTINEL = object()
+
+
+class VideoPool:
+    """Bounded prefetch queue feeding decoded samples to consumers.
+
+    Use as a context manager so loader threads are always cleaned up::
+
+        with VideoPool(samples, loader_threads=1, max_size=4) as pool:
+            while True:
+                item = pool.get()
+                if item is None:
+                    break
+                idx, decoded = item
+                results[idx] = worker.evaluate(**decoded)
+    """
+
+    def __init__(
+        self,
+        samples: list[dict],
+        *,
+        loader_threads: int = 1,
+        max_size: int = 4,
+    ) -> None:
+        if loader_threads < 1:
+            raise ValueError("loader_threads must be >= 1")
+        self._samples = samples
+        self._loader_threads_n = loader_threads
+        self._max_size = max(max_size, 1)
+
+        self._task_q: queue.Queue = queue.Queue()
+        self._ready_q: queue.Queue = queue.Queue(maxsize=self._max_size)
+        self._loaders: list[threading.Thread] = []
+        self._stop = threading.Event()
+
+        self._consumed = 0
+        self._consume_lock = threading.Lock()
+
+    def __enter__(self) -> VideoPool:
+        for idx, sample in enumerate(self._samples):
+            self._task_q.put((idx, sample))
+        for _ in range(self._loader_threads_n):
+            self._task_q.put(_SENTINEL)
+        for _ in range(self._loader_threads_n):
+            t = threading.Thread(target=self._loader_loop, daemon=True)
+            t.start()
+            self._loaders.append(t)
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self._stop.set()
+        # Drain ready queue so any blocked-on-put loader unblocks.
+        while True:
+            try:
+                self._ready_q.get_nowait()
+            except queue.Empty:
+                break
+        for t in self._loaders:
+            t.join(timeout=5.0)
+
+    def get(self, timeout: float | None = None) -> tuple[int, dict] | None:
+        """Pop the next decoded ``(idx, sample)``.
+
+        Returns ``None`` when all input samples have been consumed.
+        Thread-safe: multiple consumer threads may share one pool.
+        """
+        with self._consume_lock:
+            if self._consumed >= len(self._samples):
+                return None
+        try:
+            item = self._ready_q.get(timeout=timeout)
+        except queue.Empty:
+            return None
+        with self._consume_lock:
+            self._consumed += 1
+        return item
+
+    def _loader_loop(self) -> None:
+        while not self._stop.is_set():
+            item = self._task_q.get()
+            if item is _SENTINEL:
+                return
+            idx, sample = item
+            decoded = self._decode(sample)
+            try:
+                self._ready_q.put((idx, decoded), timeout=10.0)
+            except queue.Full:
+                return
+
+    def _decode(self, sample: dict) -> dict:
+        """Materialize any path-shaped video values in *sample*.
+
+        Recognises ``Video`` instances (populates ``.frames``) and bare
+        path strings under ``video`` / ``reference``. Other entries pass
+        through unchanged.
+        """
+        from fastvideo.eval.io.video import load_video
+
+        out = dict(sample)
+        for key, val in sample.items():
+            if isinstance(val, Video):
+                if val.frames is None and val.source is not None:
+                    val.frames = load_video(val.source)
+                out[key] = val
+            elif key in ("video", "reference") and isinstance(val, str | Path):
+                out[key] = load_video(str(val))
+        return out

--- a/fastvideo/eval/pool.py
+++ b/fastvideo/eval/pool.py
@@ -94,27 +94,33 @@ class VideoPool:
         for t in self._loaders:
             t.join(timeout=5.0)
 
-    def get(self, timeout: float | None = None) -> tuple[int, dict] | None:
+    def get(self) -> tuple[int, dict] | None:
         """Pop the next decoded ``(idx, sample)``.
 
         Returns ``None`` when all input samples have been consumed.
-        Re-raises any exception caught in a loader thread on the
-        consumer's stack so callers don't hang on a dead loader.
-        Thread-safe: multiple consumer threads may share one pool.
+        Polls in 0.1 s slices so extra consumer threads (when
+        ``len(samples) < num_workers``) wake up periodically to
+        re-check ``_consumed`` and exit cleanly — without the poll,
+        a blocking ``_ready_q.get(timeout=None)`` deadlocks because
+        the loaders are already done. Re-raises any exception caught
+        in a loader thread on the consumer's stack so callers don't
+        hang on a dead loader. Thread-safe: multiple consumer threads
+        may share one pool.
         """
-        with self._consume_lock:
-            if self._consumed >= len(self._samples):
-                return None
-        try:
-            item = self._ready_q.get(timeout=timeout)
-        except queue.Empty:
-            return None
-        with self._consume_lock:
-            self._consumed += 1
-        idx, payload = item
-        if isinstance(payload, _DecodeError):
-            raise payload.exc
-        return item
+        while True:
+            with self._consume_lock:
+                if self._consumed >= len(self._samples):
+                    return None
+            try:
+                item = self._ready_q.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            with self._consume_lock:
+                self._consumed += 1
+            idx, payload = item
+            if isinstance(payload, _DecodeError):
+                raise payload.exc
+            return item
 
     def _loader_loop(self) -> None:
         while not self._stop.is_set():

--- a/fastvideo/eval/types.py
+++ b/fastvideo/eval/types.py
@@ -17,6 +17,25 @@ class MetricResult:
     details: dict[str, Any] = field(default_factory=dict)
 
 
+class EvalResults(list):
+    """Return type for :meth:`Evaluator.evaluate` with ``samples=...``.
+
+    Behaves like a ``list[dict[str, MetricResult]]`` — one dict per
+    input sample, in input order — so existing iteration and indexing
+    keeps working. The ``corpus`` attribute carries set-metric results
+    (FAD, IS, …) that are properties of the whole input set, not of
+    any individual sample. Empty dict when no set metric ran.
+    """
+
+    def __init__(
+        self,
+        samples: list[dict[str, MetricResult]] | None = None,
+        corpus: dict[str, MetricResult] | None = None,
+    ) -> None:
+        super().__init__(samples or [])
+        self.corpus: dict[str, MetricResult] = corpus or {}
+
+
 @dataclass
 class Video:
     """Path-backed media handle. The :class:`VideoPool` populates

--- a/fastvideo/eval/types.py
+++ b/fastvideo/eval/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 
@@ -14,3 +15,27 @@ class MetricResult:
     name: str
     score: float | None
     details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Video:
+    """Path-backed media handle. The :class:`VideoPool` populates
+    ``frames`` (and optionally ``audio``) before the metric loop sees
+    the sample.
+    """
+
+    source: Any
+    fps: float | None = None
+    frames: Any = None
+    audio: Any = None
+    audio_sr: int | None = None
+
+    def has_frames(self) -> bool:
+        return self.frames is not None
+
+    def has_audio(self) -> bool:
+        return self.audio is not None
+
+    def __post_init__(self) -> None:
+        if isinstance(self.source, Path):
+            self.source = str(self.source)

--- a/fastvideo/eval/worker.py
+++ b/fastvideo/eval/worker.py
@@ -60,6 +60,10 @@ class EvalWorker:
             if self._compile and getattr(m, "_model", None) is not None:
                 m._model = torch.compile(m._model)
             self._metrics[name] = m
+        # Skip pre_upload when no loaded metric actually runs on GPU
+        # (e.g. an all-physics_iq run) — it would just pay a wasted
+        # host→device→host round-trip per sample.
+        self._any_needs_gpu = any(m.needs_gpu for m in self._metrics.values())
         self._unloaded = False
 
     def evaluate(self, **kwargs) -> dict[str, MetricResult]:
@@ -74,7 +78,7 @@ class EvalWorker:
             raise RuntimeError("EvalWorker was unloaded; call reload() before evaluating.")
 
         sample = dict(kwargs)
-        if self._pre_upload:
+        if self._pre_upload and self._any_needs_gpu:
             sample["video"] = _to_device(sample.get("video"), self._device)
             if "reference" in sample:
                 sample["reference"] = _to_device(sample["reference"], self._device)

--- a/fastvideo/eval/worker.py
+++ b/fastvideo/eval/worker.py
@@ -13,6 +13,7 @@ unnecessary overhead.
 """
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import Any
 
@@ -21,16 +22,21 @@ import torch
 from fastvideo.eval.memory import clear_cache
 from fastvideo.eval.registry import get_metric
 from fastvideo.eval.types import MetricResult
-import contextlib
 
 
 class EvalWorker:
-    """Owns metric replicas on one device. Single-GPU, single-sample."""
+    """Owns metric replicas on one device. Single-GPU, single-sample.
 
-    def __init__(self, metric_names: list[str], device: str, *, compile: bool = False) -> None:
+    Metrics receive one sample per ``compute(sample)`` call: scalar
+    values, not list-wrapped or batch-dim-prefixed. See
+    :class:`Evaluator` for ``pre_upload`` semantics.
+    """
+
+    def __init__(self, metric_names: list[str], device: str, *, compile: bool = False, pre_upload: bool = True) -> None:
         self._names = list(metric_names)
         self._device = device
         self._compile = compile
+        self._pre_upload = pre_upload
         self._metrics: dict = {}
         self._unloaded = False
         self._load()
@@ -57,13 +63,10 @@ class EvalWorker:
     def evaluate(self, **kwargs) -> dict[str, MetricResult]:
         """Score one sample.
 
-        ``video`` may be a ``(T, C, H, W)`` tensor or a path-like
-        (``str`` / ``Path``) — paths are loaded inside this method so
-        the dispatcher can hold a queue of cheap path strings instead
-        of fully-decoded tensors. ``reference`` follows the same rule.
-
-        A ``(1, T, C, H, W)`` tensor is also accepted for back-compat
-        and gets unwrapped to ``(T, C, H, W)`` before reaching metrics.
+        ``video`` / ``reference`` may be a ``(T, C, H, W)`` tensor or a
+        path-like (``str`` / ``Path``). Paths are decoded here so the
+        dispatcher can queue cheap strings. A ``(1, T, C, H, W)`` tensor
+        is unwrapped to ``(T, C, H, W)`` for back-compat.
         """
         if self._unloaded:
             raise RuntimeError("EvalWorker was unloaded; call reload() before evaluating.")
@@ -72,6 +75,10 @@ class EvalWorker:
         sample["video"] = _resolve_video_input(sample.get("video"))
         if "reference" in sample:
             sample["reference"] = _resolve_video_input(sample["reference"])
+        if self._pre_upload:
+            sample["video"] = _to_device(sample.get("video"), self._device)
+            if "reference" in sample:
+                sample["reference"] = _to_device(sample["reference"], self._device)
 
         results: dict[str, MetricResult] = {}
         for name, m in self._metrics.items():
@@ -97,16 +104,21 @@ class EvalWorker:
             self._load()
 
 
+def _to_device(value: Any, device: str | torch.device) -> Any:
+    """Move *value* to *device* if it's a tensor not already there."""
+    if value is None or not isinstance(value, torch.Tensor):
+        return value
+    target = torch.device(device)
+    if value.device == target:
+        return value
+    return value.to(target, non_blocking=True)
+
+
 def _resolve_video_input(value: Any) -> Any:
     """Normalize a sample's ``video`` / ``reference`` field for metrics.
 
-    * ``str`` / ``Path`` → decoded ``(T, C, H, W)`` tensor via
-      :func:`fastvideo.eval.io.video.load_video`. Decoding happens in
-      the worker thread so the dispatcher can keep paths queued
-      instead of full tensors.
-    * ``(1, T, C, H, W)`` tensor → squeezed to ``(T, C, H, W)``
-      (back-compat with callers that still pass the leading batch dim).
-    * anything else → returned untouched.
+    Paths → decoded ``(T, C, H, W)`` tensor; ``(1, T, C, H, W)`` →
+    squeezed to ``(T, C, H, W)``; everything else returned untouched.
     """
     if value is None:
         return None

--- a/fastvideo/eval/worker.py
+++ b/fastvideo/eval/worker.py
@@ -14,12 +14,12 @@ unnecessary overhead.
 from __future__ import annotations
 
 import contextlib
-from pathlib import Path
 from typing import Any
 
 import torch
 
 from fastvideo.eval.memory import clear_cache
+from fastvideo.eval.metrics.base import BaseMetric
 from fastvideo.eval.registry import get_metric
 from fastvideo.eval.types import MetricResult
 
@@ -27,9 +27,11 @@ from fastvideo.eval.types import MetricResult
 class EvalWorker:
     """Owns metric replicas on one device. Single-GPU, single-sample.
 
-    Metrics receive one sample per ``compute(sample)`` call: scalar
-    values, not list-wrapped or batch-dim-prefixed. See
-    :class:`Evaluator` for ``pre_upload`` semantics.
+    Per-sample metrics (``is_set_metric=False``) return one
+    :class:`MetricResult` per ``evaluate`` call. Set metrics
+    (``is_set_metric=True``) accumulate state on the worker's own
+    instance and contribute nothing to the per-sample return — the
+    Evaluator finalizes them after the pool drains.
     """
 
     def __init__(self, metric_names: list[str], device: str, *, compile: bool = False, pre_upload: bool = True) -> None:
@@ -37,7 +39,7 @@ class EvalWorker:
         self._device = device
         self._compile = compile
         self._pre_upload = pre_upload
-        self._metrics: dict = {}
+        self._metrics: dict[str, BaseMetric] = {}
         self._unloaded = False
         self._load()
 
@@ -61,20 +63,17 @@ class EvalWorker:
         self._unloaded = False
 
     def evaluate(self, **kwargs) -> dict[str, MetricResult]:
-        """Score one sample.
+        """Score one already-decoded sample.
 
-        ``video`` / ``reference`` may be a ``(T, C, H, W)`` tensor or a
-        path-like (``str`` / ``Path``). Paths are decoded here so the
-        dispatcher can queue cheap strings. A ``(1, T, C, H, W)`` tensor
-        is unwrapped to ``(T, C, H, W)`` for back-compat.
+        Inputs (``video`` / ``reference`` paths, 5-D tensors) are
+        decoded and normalized upstream by the :class:`VideoPool`. The
+        worker only handles the optional pre-upload to its device and
+        dispatches to each metric's ``compute`` or ``accumulate``.
         """
         if self._unloaded:
             raise RuntimeError("EvalWorker was unloaded; call reload() before evaluating.")
 
         sample = dict(kwargs)
-        sample["video"] = _resolve_video_input(sample.get("video"))
-        if "reference" in sample:
-            sample["reference"] = _resolve_video_input(sample["reference"])
         if self._pre_upload:
             sample["video"] = _to_device(sample.get("video"), self._device)
             if "reference" in sample:
@@ -82,8 +81,21 @@ class EvalWorker:
 
         results: dict[str, MetricResult] = {}
         for name, m in self._metrics.items():
-            results[name] = m.compute(sample)
+            if m.is_set_metric:
+                m.accumulate(sample)
+            else:
+                results[name] = m.compute(sample)
         return results
+
+    def set_metrics(self) -> dict[str, BaseMetric]:
+        """Return ``{name: instance}`` for set metrics on this worker."""
+        return {n: m for n, m in self._metrics.items() if m.is_set_metric}
+
+    def reset_set_metrics(self) -> None:
+        """Clear accumulator state on every set metric."""
+        for m in self._metrics.values():
+            if m.is_set_metric:
+                m.reset()
 
     def release_cuda_memory(self) -> None:
         """Free CUDA caches without dropping models."""
@@ -112,19 +124,3 @@ def _to_device(value: Any, device: str | torch.device) -> Any:
     if value.device == target:
         return value
     return value.to(target, non_blocking=True)
-
-
-def _resolve_video_input(value: Any) -> Any:
-    """Normalize a sample's ``video`` / ``reference`` field for metrics.
-
-    Paths → decoded ``(T, C, H, W)`` tensor; ``(1, T, C, H, W)`` →
-    squeezed to ``(T, C, H, W)``; everything else returned untouched.
-    """
-    if value is None:
-        return None
-    if isinstance(value, str | Path):
-        from fastvideo.eval.io.video import load_video
-        return load_video(str(value))
-    if isinstance(value, torch.Tensor) and value.dim() == 5 and value.shape[0] == 1:
-        return value.squeeze(0)
-    return value


### PR DESCRIPTION
# Async VideoPool + GPU-side common metrics + safe optical-flow chunks

## Summary

- New `VideoPool`: async path → tensor prefetcher behind the
  `Evaluator`. One pool is built per `evaluate(samples=…)` call;
  workers pull from a bounded queue while loader threads decode the
  next clip — decode is hidden behind compute.
- `EvalWorker` pre-uploads `video` / `reference` once per sample so the
  per-sample metric loop shares a single GPU-resident tensor instead of
  every metric paying its own host→device transfer. Toggle with
  `Evaluator(pre_upload=…)`.
- `common.{psnr, ssim}` move to GPU (`needs_gpu=True`) — at 1080p the
  CPU paths were memory-bandwidth-bound and competed with the loader.
- Memory-safe chunking: `common.lpips` adds `chunk_size=8` (was peaking
  ~60 GB on a 121-frame clip → ~5 GB); `optical_flow.{gt,synthetic}`
  drop `chunk_size` to 1 (was OOMing on H200; DPFlow's cost volume is
  ~4 GB per frame pair at 1080p).
- Contract tightening: metrics receive one sample per `compute()`
  call. List/B-dim unwrap shims removed from `physics_iq` and the
  affected `vbench` metrics. `physics_iq.utils.prepare_pair_batch` →
  `prepare_pair` (singular).

Scores are bit-identical across baseline and pool in every benchmarked
configuration.

## End-to-end speedup

All tests are done with 121-frame 1080p videos on a single H200.

| group | N | baseline (s) | pool (s) | speedup |
|---|---:|---:|---:|---:|
| common (psnr+ssim+lpips) | 4 | 18.27 | 14.94 | **1.22×** |
| common (psnr+ssim+lpips) | 16 | 75.33 | 57.64 | **1.31×** |
| vbench (6 metrics) | 4 | 20.68 | 17.87 | **1.16×** |
| vbench (6 metrics) | 16 | 82.54 | 63.84 | **1.29×** |
| optical_flow.gt | 4 | 414.70 | — | — *(compute-bound; pool can't hide ~100 s/sample)* |


## Peak GPU memory

Changed chunk size for optical flow metric to 1 to save memory on large videos.

| metric set | peak GPU (GB) | notes |
|---|---:|---|
| common (psnr + ssim + lpips) | 15.3 | lpips pre-chunk peak was 60+ GB on this clip |
| vbench (6 metrics) | 9.9 | |
| optical_flow.gt_optical_flow | 14.6 | pre-fix: 63 GB → OOM on H200 |
