### PR TITLE
[feat] Dreamverse 07/14: Add frontend session UI

### DIFF
--- a/.agents/memory/dreamverse-integration/open-threads.md
+++ b/.agents/memory/dreamverse-integration/open-threads.md
@@ -6,7 +6,8 @@ recommended next action.
 For why each item is open see [decisions-log.md](decisions-log.md). For
 PR-level context see [pr-roadmap.md](pr-roadmap.md).
 
-**Last updated:** 2026-05-05 (D-20 broken-pipe root cause + fix landed on
+**Last updated:** 2026-05-12 (added DR-4 follow-up for PR #1330's skipped
+`App websocket integration` suite. Earlier: 2026-05-05 D-20 broken-pipe root cause + fix landed on
 `will/dreamverse-monorepo` @ `5eaf0a13`; added new thread D-20-CP for
 cherry-picking the public-API audio routing fix to `will/ltx2_sr_port`
 so it lands in PR #1288. Earlier: strategy reversal — PR #1287 CLOSED,
@@ -32,6 +33,7 @@ different vehicle.).
 | **DR-1** | High | Dreamverse: create `prompting/_internal_compat.py` shim + replace local `prompt_enhancer.py` (1933 LOC) — **PR #1258 has merged (`f673423b`); now actionable** | M (~150-200 LOC shim, replace upstream wiring) | Lets Dreamverse stop carrying a 1933-LOC fork |
 | **DR-2** | Med | Decide `cerebras_ifm` provider path: (a) public Literal + `CerebrasIFMProvider` shipped, OR (b) Dreamverse-side custom provider via `enhancer.register_provider(...)` | S (decision) + S-M (impl) | Resolves the cerebras_ifm gap left by PR #1258. Same item as legacy #3 below; DR-2 is the Dreamverse-side framing. |
 | **DR-3** | Low | Replace Dreamverse `PromptEnhancer._run_blocking_request` manual thread/queue polling with `asyncio.to_thread` after the PR #1327 prompt-enhancer compatibility surface is retired or isolated | S | Review comment #1327 (`prompt_enhancer.py`) is valid, but deferred to avoid patching the local fork in this PR. |
+| **DR-4** | Low | Investigate unskipping PR #1330's skipped public `App websocket integration` suite | S-M | Public PR #1330 has `describe.skip(...)` around 27 websocket tests while the internal equivalent suite is active with 25 tests. The 2 public-only tests cover backend unreachable / GPU workers not ready. Not blocking while skipped, but stale assertions may need safe refresh before unskip. |
 | **3** | Med | Add `cerebras_ifm` to `PromptEnhancerConfig.provider` Literal + provider | S-M | Public-side resolution if DR-2 picks (a) |
 | **4** | Med | Expose `layer_profile` on typed `engine.quantization` | M | Removes Dreamverse's `experimental["pipeline_config"]` dodge for stage profiles |
 | **5** | Med | Design typed `dit_config.quant_config` carrier | L design + L impl | Removes broader `experimental["pipeline_config"]` escape hatch |
@@ -399,6 +401,25 @@ to `CerebrasProvider` / `GroqProvider` constructors and pass through to
 **Effort:** Small.
 
 **Dependencies:** None blocking; only act on real perf data.
+
+### Item DR-4: Unskip PR #1330 `App websocket integration` suite safely
+
+**Why:** Public PR #1330 currently wraps `App websocket integration` in
+`describe.skip(...)`, so the 27-test websocket integration suite does not
+run. The internal repo has the equivalent suite active via `describe(...)`
+with 25 tests. The two public-only cases cover backend unreachable and GPU
+workers not ready readiness/reachability behavior.
+
+**Action:** Later, investigate whether the public suite can be unskipped and
+refresh any stale assertions without changing the intended websocket contract.
+Because the suite is skipped today, this is not blocking the current stack or
+current PR #1330 review.
+
+**Effort:** Small-Medium.
+
+**Dependencies:** Best handled when someone can run the frontend integration
+stack end-to-end and compare the public assertions against the internal active
+suite.
 
 ### Item D-12-C: Avoid locking `PoolAssignment.gpu_id: int` as public
 

--- a/apps/dreamverse/web/src/app/internal/f8a3991c/replica-monitor/page.tsx
+++ b/apps/dreamverse/web/src/app/internal/f8a3991c/replica-monitor/page.tsx
@@ -1,0 +1,5 @@
+import MonitorPage from '@/components/MonitorPage';
+
+export default function ReplicaMonitorPage() {
+  return <MonitorPage />;
+}

--- a/apps/dreamverse/web/src/app/page.integration.test.tsx
+++ b/apps/dreamverse/web/src/app/page.integration.test.tsx
@@ -1,0 +1,1921 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Server } from 'mock-socket';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const avPipelineMockState = vi.hoisted(() => ({
+  useNativePlaybackFallback: false,
+}));
+
+const projectStorageMockState = vi.hoisted(() => {
+  const state = {
+    projects: [] as any[],
+    clips: [] as any[],
+    commitSave: async (project: any, clips: any[]) => {
+      state.projects = [
+        project,
+        ...state.projects.filter((entry) => entry.id !== project.id),
+      ];
+      state.clips = [
+        ...state.clips.filter((clip) => clip.projectId !== project.id),
+        ...clips.map((clip) => ({ ...clip })),
+      ];
+    },
+    saveProject: vi.fn(async (project: any, clips: any[]) => {
+      await state.commitSave(project, clips);
+    }),
+    saveProjectMetadata: vi.fn(async (project: any) => {
+      state.projects = [
+        project,
+        ...state.projects.filter((entry) => entry.id !== project.id),
+      ];
+    }),
+    listProjects: vi.fn(async () => [...state.projects]),
+    loadProjectClips: vi.fn(async (projectId: string) =>
+      state.clips
+        .filter((clip) => clip.projectId === projectId)
+        .map((clip) => ({ ...clip })),
+    ),
+    deleteProject: vi.fn(async (projectId: string) => {
+      state.projects = state.projects.filter((project) => project.id !== projectId);
+      state.clips = state.clips.filter((clip) => clip.projectId !== projectId);
+    }),
+    pruneOldProjects: vi.fn(async () => {}),
+    reset() {
+      state.projects = [];
+      state.clips = [];
+      state.saveProject.mockReset();
+      state.saveProject.mockImplementation(async (project: any, clips: any[]) => {
+        await state.commitSave(project, clips);
+      });
+      state.saveProjectMetadata.mockReset();
+      state.saveProjectMetadata.mockImplementation(async (project: any) => {
+        state.projects = [
+          project,
+          ...state.projects.filter((entry) => entry.id !== project.id),
+        ];
+      });
+      state.listProjects.mockClear();
+      state.loadProjectClips.mockClear();
+      state.deleteProject.mockClear();
+      state.pruneOldProjects.mockClear();
+    },
+  };
+
+  return state;
+});
+
+vi.mock('../lib/storyPresetsData', () => ({
+  default: [
+    {
+      id: 'test_preset',
+      label: 'Test Preset',
+      segment_prompts: ['segment one', 'segment two'],
+    },
+  ],
+}));
+
+vi.mock('../lib/media/avPipeline', () => ({
+  DEFAULT_AV_MIME: 'video/mp4',
+  createAvPipeline: vi.fn(({ onPlaybackStarted = () => {} }) => {
+    let archivedChunks: any[] = [];
+    let archivedSegments: any[] = [];
+    let activeSegmentKey = '';
+
+    function cloneChunk(chunk: any) {
+      if (chunk instanceof ArrayBuffer) {
+        return chunk.slice(0);
+      }
+      if (ArrayBuffer.isView(chunk)) {
+        return chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength);
+      }
+      return chunk;
+    }
+
+    return {
+      reset: vi.fn(() => {
+        archivedChunks = [];
+        archivedSegments = [];
+        activeSegmentKey = '';
+      }),
+      enqueueChunk: vi.fn((chunk: any) => {
+        const clonedChunk = cloneChunk(chunk);
+        archivedChunks = [...archivedChunks, clonedChunk];
+        if (!activeSegmentKey) {
+          const key = `implicit-${archivedSegments.length + 1}`;
+          activeSegmentKey = key;
+          archivedSegments = [
+            ...archivedSegments,
+            {
+              key,
+              segmentIdx: null,
+              streamId: key,
+              mime: 'video/mp4',
+              completed: false,
+              chunks: [],
+            },
+          ];
+        }
+        const target = archivedSegments.find((segment) => segment.key === activeSegmentKey);
+        if (target) {
+          target.chunks.push(clonedChunk);
+        }
+      }),
+      ensurePipeline: vi.fn(async () => {}),
+      maybeStartPlayback: vi.fn(() => {
+        onPlaybackStarted();
+      }),
+      tryEndStream: vi.fn(() => {}),
+      setStreamCompleted: vi.fn(() => {}),
+      noteSegmentInit: vi.fn(({ segmentIdx = null, streamId = '', mime = 'video/mp4' } = {}) => {
+        const normalizedStreamId = streamId || `stream-${archivedSegments.length + 1}`;
+        const key = `${segmentIdx !== null ? segmentIdx : 'na'}:${normalizedStreamId}`;
+        const existing = archivedSegments.find((segment) => segment.key === key);
+        if (existing) {
+          existing.completed = false;
+          existing.mime = mime || existing.mime;
+        } else {
+          archivedSegments = [
+            ...archivedSegments,
+            {
+              key,
+              segmentIdx,
+              streamId: normalizedStreamId,
+              mime: mime || 'video/mp4',
+              completed: false,
+              chunks: [],
+            },
+          ];
+        }
+        activeSegmentKey = key;
+      }),
+      noteSegmentComplete: vi.fn(({ segmentIdx = null, streamId = '' } = {}) => {
+        let target = null as any;
+        if (streamId) {
+          target = archivedSegments.find(
+            (segment) => segment.streamId === streamId && (segmentIdx === null || segment.segmentIdx === segmentIdx),
+          ) || null;
+        }
+        if (!target && activeSegmentKey) {
+          target = archivedSegments.find((segment) => segment.key === activeSegmentKey) || null;
+        }
+        if (target) {
+          target.completed = true;
+          if (target.key === activeSegmentKey) {
+            activeSegmentKey = '';
+          }
+        }
+      }),
+      markStreamStarting: vi.fn(() => {
+        archivedChunks = [];
+        archivedSegments = [];
+        activeSegmentKey = '';
+      }),
+      hasArchivedChunks: vi.fn(() => {
+        return archivedChunks.length > 0;
+      }),
+      hasArchivedCompletedSegments: vi.fn(() => {
+        return archivedSegments.some((segment) => segment.completed && segment.chunks.length > 0);
+      }),
+      buildArchivedStreamChunks: vi.fn(() => archivedChunks.map((chunk) => {
+        if (chunk instanceof ArrayBuffer) {
+          return chunk.slice(0);
+        }
+        return chunk;
+      })),
+      buildArchivedSegmentSnapshots: vi.fn(({ includeInProgress = true } = {}) => archivedSegments
+        .filter((segment) => segment.chunks.length > 0 && (includeInProgress || segment.completed))
+        .map((segment) => ({
+          ...segment,
+          chunks: segment.chunks.map((chunk: any) => cloneChunk(chunk)),
+        }))),
+      buildArchivedStreamBlob: vi.fn(() => {
+        return new Blob(archivedChunks, { type: 'video/mp4' });
+      }),
+      takeArchivedStreamChunks: vi.fn(() => {
+        const chunks = archivedChunks.map((chunk) => {
+          if (chunk instanceof ArrayBuffer) {
+            return chunk.slice(0);
+          }
+          return chunk;
+        });
+        archivedChunks = [];
+        archivedSegments = [];
+        activeSegmentKey = '';
+        return chunks;
+      }),
+      takeArchivedSegmentSnapshots: vi.fn(({ includeInProgress = true } = {}) => {
+        const snapshots = archivedSegments
+          .filter((segment) => segment.chunks.length > 0 && (includeInProgress || segment.completed))
+          .map((segment) => ({
+            ...segment,
+            chunks: segment.chunks.map((chunk: any) => cloneChunk(chunk)),
+          }));
+        if (includeInProgress) {
+          archivedSegments = [];
+          activeSegmentKey = '';
+        } else {
+          archivedSegments = archivedSegments.filter((segment) => !segment.completed);
+          if (activeSegmentKey && !archivedSegments.some((segment) => segment.key === activeSegmentKey)) {
+            activeSegmentKey = '';
+          }
+        }
+        return snapshots;
+      }),
+      takeArchivedStreamBlob: vi.fn(() => {
+        const blob = new Blob(archivedChunks, { type: 'video/mp4' });
+        archivedChunks = [];
+        archivedSegments = [];
+        activeSegmentKey = '';
+        return blob;
+      }),
+      usesNativePlaybackFallback() {
+        return avPipelineMockState.useNativePlaybackFallback;
+      },
+    };
+  }),
+}));
+
+vi.mock('../lib/projectStorage', () => ({
+  saveProject: projectStorageMockState.saveProject,
+  saveProjectMetadata: projectStorageMockState.saveProjectMetadata,
+  listProjects: projectStorageMockState.listProjects,
+  loadProjectClips: projectStorageMockState.loadProjectClips,
+  deleteProject: projectStorageMockState.deleteProject,
+  pruneOldProjects: projectStorageMockState.pruneOldProjects,
+}));
+
+import Page from './page';
+import { createAvPipeline } from '../lib/media/avPipeline';
+
+function getWsUrl() {
+  const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${wsProtocol}//${window.location.host}/ws`;
+}
+
+describe.skip('App websocket integration', () => {
+  let server: Server;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    avPipelineMockState.useNativePlaybackFallback = false;
+    projectStorageMockState.reset();
+    window.history.pushState({}, '', '/');
+    server = new Server(getWsUrl());
+    fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      if (url.endsWith('/healthz')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            status: 'ok',
+            service: 'ltx2-streaming-backend',
+          }),
+        };
+      }
+      if (url.endsWith('/readyz')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            status: 'ready',
+            service: 'ltx2-streaming-backend',
+            ready_gpu_workers: 1,
+            total_gpus: 1,
+            available_gpus: 1,
+            warmup_successful_gpus: 1,
+            warmup_failed_gpus: 0,
+            queue_size: 0,
+          }),
+        };
+      }
+      if (url.endsWith('/status')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            total_gpus: 1,
+            available_gpus: 1,
+            queue_size: 0,
+            warmup_enabled: true,
+            warmup_successful_gpus: 1,
+            warmup_failed_gpus: 0,
+          }),
+        };
+      }
+      throw new Error(`Unhandled fetch request in test: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    server.stop();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the streaming chat workspace and hides advanced panels', async () => {
+    render(<Page />);
+
+    expect(await screen.findByRole('heading', { name: 'Realtime streaming video workspace' }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'History' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Collapse history sidebar' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Main chat' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Story preset')).toBeInTheDocument();
+    expect(screen.getByLabelText('Continuation prompt')).toBeEnabled();
+    expect(screen.queryByRole('button', { name: 'Guide next segment' })).not.toBeInTheDocument();
+    expect(screen.getByText('Video replies')).toBeInTheDocument();
+    expect(screen.queryByText('Session setup')).not.toBeInTheDocument();
+
+    expect(screen.queryByText('Live Prompt Input')).not.toBeInTheDocument();
+    expect(screen.queryByText('Prompt Window')).not.toBeInTheDocument();
+    expect(screen.queryByText('Editable Prompt Segments')).not.toBeInTheDocument();
+    expect(screen.queryByText('Depth Mode: System Prompt Editor')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Prompt count')).not.toBeInTheDocument();
+  });
+
+  it('collapses and re-expands the history sidebar', async () => {
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Collapse history sidebar' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Expand history sidebar' })).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'History' })).not.toBeInTheDocument();
+      expect(screen.getByText('Clips')).toBeInTheDocument();
+      expect(screen.getByText('Prompts')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Expand history sidebar' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'History' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Collapse history sidebar' })).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the session timer visible and pauses session playback while viewing a saved project', async () => {
+    projectStorageMockState.projects = [
+      {
+        id: 'saved_project_1',
+        label: 'Saved Project',
+        originalLabel: 'Saved History Project',
+        presetId: 'saved_preset',
+        createdAt: Date.now() - 60_000,
+        lastThumbnail: null,
+        promptEvents: [],
+      },
+    ];
+    projectStorageMockState.clips = [
+      {
+        id: 'saved_clip_1',
+        projectId: 'saved_project_1',
+        label: 'Saved Clip',
+        prompt: 'saved prompt',
+        mime: 'video/mp4',
+        blob: new Blob([new Uint8Array([9, 9, 9])], { type: 'video/mp4' }),
+        createdAt: Date.now() - 60_000,
+      },
+    ];
+
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Time left:/i)).toBeInTheDocument();
+    });
+
+    const sessionVideos = Array.from(container.querySelectorAll('video'));
+    const liveSessionVideo = sessionVideos[1] as HTMLVideoElement;
+    expect(liveSessionVideo).toBeTruthy();
+
+    const playbackState = { paused: false };
+    Object.defineProperty(liveSessionVideo, 'paused', {
+      configurable: true,
+      get: () => playbackState.paused,
+    });
+    Object.defineProperty(liveSessionVideo, 'ended', {
+      configurable: true,
+      get: () => false,
+    });
+    Object.defineProperty(liveSessionVideo, 'readyState', {
+      configurable: true,
+      get: () => 4,
+    });
+
+    const pauseSpy = vi.spyOn(liveSessionVideo, 'pause').mockImplementation(() => {
+      playbackState.paused = true;
+    });
+    const playSpy = vi.spyOn(liveSessionVideo, 'play').mockImplementation(async () => {
+      playbackState.paused = false;
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Toggle sidebar' }));
+    await user.click(await screen.findByRole('button', { name: 'Saved History Project' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('View-only project')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Time left:/i)).toBeInTheDocument();
+    expect(pauseSpy).toHaveBeenCalledTimes(1);
+    expect(playbackState.paused).toBe(true);
+
+    playSpy.mockClear();
+
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('View-only project')).not.toBeInTheDocument();
+    });
+
+    expect(playSpy).toHaveBeenCalledTimes(1);
+    expect(playbackState.paused).toBe(false);
+  });
+
+  it('does not resume session playback after leaving a saved project if it was already paused', async () => {
+    projectStorageMockState.projects = [
+      {
+        id: 'saved_project_1',
+        label: 'Saved Project',
+        originalLabel: 'Saved History Project',
+        presetId: 'saved_preset',
+        createdAt: Date.now() - 60_000,
+        lastThumbnail: null,
+        promptEvents: [],
+      },
+    ];
+    projectStorageMockState.clips = [
+      {
+        id: 'saved_clip_1',
+        projectId: 'saved_project_1',
+        label: 'Saved Clip',
+        prompt: 'saved prompt',
+        mime: 'video/mp4',
+        blob: new Blob([new Uint8Array([9, 9, 9])], { type: 'video/mp4' }),
+        createdAt: Date.now() - 60_000,
+      },
+    ];
+
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    const sessionVideos = Array.from(container.querySelectorAll('video'));
+    const liveSessionVideo = sessionVideos[1] as HTMLVideoElement;
+    expect(liveSessionVideo).toBeTruthy();
+
+    const playbackState = { paused: true };
+    Object.defineProperty(liveSessionVideo, 'paused', {
+      configurable: true,
+      get: () => playbackState.paused,
+    });
+    Object.defineProperty(liveSessionVideo, 'ended', {
+      configurable: true,
+      get: () => false,
+    });
+    Object.defineProperty(liveSessionVideo, 'readyState', {
+      configurable: true,
+      get: () => 4,
+    });
+
+    const pauseSpy = vi.spyOn(liveSessionVideo, 'pause').mockImplementation(() => {
+      playbackState.paused = true;
+    });
+    const playSpy = vi.spyOn(liveSessionVideo, 'play').mockImplementation(async () => {
+      playbackState.paused = false;
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Toggle sidebar' }));
+    await user.click(await screen.findByRole('button', { name: 'Saved History Project' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('View-only project')).toBeInTheDocument();
+    });
+
+    expect(pauseSpy).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('View-only project')).not.toBeInTheDocument();
+    });
+
+    expect(playSpy).not.toHaveBeenCalled();
+    expect(playbackState.paused).toBe(true);
+  });
+
+  it('keeps the active prompt window collapsed by default and expands it on toggle', async () => {
+    const user = userEvent.setup();
+    render(<Page />);
+
+    expect(await screen.findByRole('button', { name: 'Show prompts' })).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '2 prompts in the active window. Expand when you want to inspect the full rollout context.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Window 1')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Show prompts' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Hide prompts' })).toBeInTheDocument();
+      expect(screen.getByText('Window 1')).toBeInTheDocument();
+      expect(screen.getByText('Window 2')).toBeInTheDocument();
+    });
+  });
+
+  it('sends session_init_v2 payload when Generate is clicked', async () => {
+    const outbound: any[] = [];
+    server.on('connection', (socket) => {
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    const generateButton = await screen.findByRole('button', { name: 'Generate' });
+    await waitFor(() => expect(generateButton).toBeEnabled());
+    await user.click(generateButton);
+
+    await waitFor(() => {
+      expect(outbound.some((message) => message.type === 'session_init_v2')).toBe(true);
+    });
+
+    const initMessage = outbound.find((message) => message.type === 'session_init_v2');
+    expect(initMessage.preset_id).toBe('test_preset');
+    expect(initMessage.curated_prompts).toEqual(['segment one', 'segment two']);
+    expect(initMessage.enhancement_enabled).toBe(true);
+    expect(initMessage.auto_extension_enabled).toBe(false);
+    expect(initMessage.loop_generation_enabled).toBe(false);
+    expect(initMessage.initial_rollout_prompt).toBe('');
+  });
+
+  it('starts a streaming session from a custom initial prompt without using curated prompts', async () => {
+    const outbound: any[] = [];
+    server.on('connection', (socket) => {
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(
+      continuationInput,
+      'A lone astronaut walks through a flooded moonbase corridor lit by failing red alarms',
+    );
+
+    const generateButton = await screen.findByRole('button', { name: 'Generate' });
+    await waitFor(() => expect(generateButton).toBeEnabled());
+    await user.click(generateButton);
+
+    await waitFor(() => {
+      expect(outbound.some((message) => message.type === 'session_init_v2')).toBe(true);
+    });
+
+    const initMessage = outbound.find((message) => message.type === 'session_init_v2');
+    expect(initMessage.preset_id).toBe('custom_editable');
+    expect(initMessage.preset_label).toBe('Custom rollout');
+    expect(initMessage.curated_prompts).toEqual([]);
+    expect(initMessage.initial_rollout_prompt)
+      .toBe(
+        'A lone astronaut walks through a flooded moonbase corridor lit by failing red alarms',
+      );
+  });
+
+  it('shows a specific notice when a second websocket from the same IP is rejected', async () => {
+    const outbound: any[] = [];
+    const sockets: any[] = [];
+    server.on('connection', (socket) => {
+      sockets.push(socket);
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+
+      if (sockets.length === 2) {
+        socket.send(JSON.stringify({
+          type: 'error',
+          error_code: 'ip_session_limit',
+          message: 'Only one active websocket session is allowed per IP. Close the other session and retry.',
+        }));
+        socket.close();
+      }
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+    render(<Page />);
+
+    const generateButtons = await screen.findAllByRole('button', { name: 'Generate' });
+    await user.click(generateButtons[0]);
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+      expect(outbound.filter((message) => message.type === 'session_init_v2')).toHaveLength(1);
+    });
+
+    await user.click(generateButtons[1]);
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(2);
+      expect(outbound.filter((message) => message.type === 'session_init_v2')).toHaveLength(2);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(
+        'Only one active websocket session is allowed per IP. Close the other session and click Run to retry.',
+      )).toBeInTheDocument();
+    });
+  });
+
+  it('shows a clear notice when the backend is not reachable before session start', async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      if (url.endsWith('/healthz')) {
+        throw new Error('network down');
+      }
+      throw new Error(`Unhandled fetch request in test: ${url}`);
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(continuationInput, 'A neon city skyline in the rain');
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    expect(await screen.findByText(
+      'Dreamverse backend is not reachable. Start uv run dreamverse-server and wait for /readyz to return 200 before retrying.',
+    )).toBeInTheDocument();
+    expect(screen.getByLabelText('Continuation prompt')).toHaveValue('A neon city skyline in the rain');
+  });
+
+  it('shows a readiness notice when GPU workers are not ready yet', async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      if (url.endsWith('/healthz')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ status: 'ok' }),
+        };
+      }
+      if (url.endsWith('/readyz')) {
+        return {
+          ok: false,
+          status: 503,
+          json: async () => ({ detail: 'No ready GPU worker processes.' }),
+        };
+      }
+      if (url.endsWith('/status')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            total_gpus: 1,
+            available_gpus: 0,
+            queue_size: 0,
+            warmup_enabled: true,
+            warmup_successful_gpus: 0,
+            warmup_failed_gpus: 0,
+          }),
+        };
+      }
+      throw new Error(`Unhandled fetch request in test: ${url}`);
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(continuationInput, 'A cathedral drifting through clouds');
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    expect(await screen.findByText(
+      'Dreamverse backend is running, but GPU workers are not ready yet. Wait for startup warmup to finish and retry.',
+    )).toBeInTheDocument();
+    expect(screen.getByLabelText('Continuation prompt')).toHaveValue('A cathedral drifting through clouds');
+  });
+
+  it('submits rewrite requests from the chat composer', async () => {
+    const outbound: any[] = [];
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await waitFor(() => expect(continuationInput).toBeEnabled());
+    await user.type(
+      continuationInput,
+      'Make the mood more ominous and push closer to the subject',
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Rewrite rollout' }));
+
+    await waitFor(() => {
+      expect(outbound.some((message) => message.type === 'rewrite_seed_prompts')).toBe(true);
+    });
+
+    const rewriteMessage = outbound.find((message) => message.type === 'rewrite_seed_prompts');
+    expect(rewriteMessage.rewrite_instruction)
+      .toBe('Make the mood more ominous and push closer to the subject');
+    expect(Array.isArray(rewriteMessage.prompt_window_prompts)).toBe(true);
+  });
+
+  it('sends rewrite requests from the continuation composer', async () => {
+    const outbound: any[] = [];
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await waitFor(() => expect(continuationInput).toBeEnabled());
+    await user.type(continuationInput, 'A dramatic reveal');
+
+    const rewriteButton = screen.getByRole('button', { name: 'Rewrite rollout' });
+    await waitFor(() => expect(rewriteButton).toBeEnabled());
+    await user.click(rewriteButton);
+
+    await waitFor(() => {
+      expect(outbound.some((message) => message.type === 'rewrite_seed_prompts')).toBe(true);
+    });
+
+    const rewriteMessage = outbound.find((message) => message.type === 'rewrite_seed_prompts');
+    expect(rewriteMessage.rewrite_instruction).toBe('A dramatic reveal');
+    expect(Array.isArray(rewriteMessage.prompt_window_prompts)).toBe(true);
+  });
+
+  it('uses the selected archived version as the next rewrite source', async () => {
+    const outbound: any[] = [];
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'segment two',
+      source: 'curated',
+      seed_prompt_index: 1,
+    }));
+    clientSocket.send(new Uint8Array([4, 5, 6]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 2 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(continuationInput, 'Turn it into a desert');
+    await user.click(screen.getByRole('button', { name: 'Rewrite rollout' }));
+
+    await waitFor(() => {
+      expect(outbound.filter((message) => message.type === 'rewrite_seed_prompts')).toHaveLength(1);
+    });
+
+    clientSocket.send(JSON.stringify({ type: 'rewrite_seed_prompts_started' }));
+    clientSocket.send(JSON.stringify({
+      type: 'seed_prompts_updated',
+      reason: 'rewrite',
+      prompts: [
+        'desert one',
+        'desert two',
+      ],
+    }));
+    clientSocket.send(JSON.stringify({ type: 'rewrite_seed_prompts_complete' }));
+    clientSocket.send(JSON.stringify({ type: 'seed_prompts_reset_applied' }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_stream_start',
+      total_segments: 2,
+      loop_generation_enabled: false,
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'desert one',
+      source: 'rewrite',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([7, 8, 9]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'desert two',
+      source: 'rewrite',
+      seed_prompt_index: 1,
+    }));
+    clientSocket.send(new Uint8Array([10, 11, 12]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 2 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await screen.findByText('Turn it into a desert');
+
+    await user.click(screen.getByText('Original'));
+
+    const freshContinuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(freshContinuationInput, 'Add snowfall');
+    await user.click(screen.getByRole('button', { name: 'Rewrite rollout' }));
+
+    await waitFor(() => {
+      expect(outbound.filter((message) => message.type === 'rewrite_seed_prompts')).toHaveLength(2);
+    });
+
+    const secondRewrite = outbound
+      .filter((message) => message.type === 'rewrite_seed_prompts')
+      .at(-1);
+    expect(secondRewrite.prompt_window_prompts.slice(0, 2)).toEqual([
+      'segment one',
+      'segment two',
+    ]);
+  });
+
+  it('highlights the selected edit history item and rewrites from that selected version', async () => {
+    const outbound: any[] = [];
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'segment two',
+      source: 'curated',
+      seed_prompt_index: 1,
+    }));
+    clientSocket.send(new Uint8Array([4, 5, 6]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 2 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(continuationInput, 'Turn it into a desert');
+    await user.click(screen.getByRole('button', { name: 'Rewrite rollout' }));
+
+    await waitFor(() => {
+      expect(outbound.filter((message) => message.type === 'rewrite_seed_prompts')).toHaveLength(1);
+    });
+
+    clientSocket.send(JSON.stringify({ type: 'rewrite_seed_prompts_started' }));
+    clientSocket.send(JSON.stringify({
+      type: 'seed_prompts_updated',
+      reason: 'rewrite',
+      prompts: [
+        'desert one',
+        'desert two',
+      ],
+    }));
+    clientSocket.send(JSON.stringify({ type: 'rewrite_seed_prompts_complete' }));
+    clientSocket.send(JSON.stringify({ type: 'seed_prompts_reset_applied' }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_stream_start',
+      total_segments: 2,
+      loop_generation_enabled: false,
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'desert one',
+      source: 'rewrite',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([7, 8, 9]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'desert two',
+      source: 'rewrite',
+      seed_prompt_index: 1,
+    }));
+    clientSocket.send(new Uint8Array([10, 11, 12]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 2 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await screen.findByText('Turn it into a desert');
+
+    const secondContinuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(secondContinuationInput, 'Add snowfall');
+    await user.click(screen.getByRole('button', { name: 'Rewrite rollout' }));
+
+    await waitFor(() => {
+      expect(outbound.filter((message) => message.type === 'rewrite_seed_prompts')).toHaveLength(2);
+    });
+
+    clientSocket.send(JSON.stringify({ type: 'rewrite_seed_prompts_started' }));
+    clientSocket.send(JSON.stringify({
+      type: 'seed_prompts_updated',
+      reason: 'rewrite',
+      prompts: [
+        'snow one',
+        'snow two',
+      ],
+    }));
+    clientSocket.send(JSON.stringify({ type: 'rewrite_seed_prompts_complete' }));
+    clientSocket.send(JSON.stringify({ type: 'seed_prompts_reset_applied' }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_stream_start',
+      total_segments: 2,
+      loop_generation_enabled: false,
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'snow one',
+      source: 'rewrite',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([13, 14, 15]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'snow two',
+      source: 'rewrite',
+      seed_prompt_index: 1,
+    }));
+    clientSocket.send(new Uint8Array([16, 17, 18]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 2 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    const currentHistoryRow = await screen.findByText('Add snowfall');
+    await waitFor(() => {
+      expect(currentHistoryRow.closest('[data-selected]')).toHaveAttribute('data-selected', 'true');
+    });
+
+    const olderHistoryRow = screen.getByText('Turn it into a desert');
+    await user.click(olderHistoryRow);
+
+    await waitFor(() => {
+      expect(olderHistoryRow.closest('[data-selected]')).toHaveAttribute('data-selected', 'true');
+      expect(currentHistoryRow.closest('[data-selected]')).toHaveAttribute('data-selected', 'false');
+    });
+
+    const thirdContinuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(thirdContinuationInput, 'Make it rainy');
+    await user.click(screen.getByRole('button', { name: 'Rewrite rollout' }));
+
+    await waitFor(() => {
+      expect(outbound.filter((message) => message.type === 'rewrite_seed_prompts')).toHaveLength(3);
+    });
+
+    const thirdRewrite = outbound
+      .filter((message) => message.type === 'rewrite_seed_prompts')
+      .at(-1);
+    expect(thirdRewrite.prompt_window_prompts.slice(0, 2)).toEqual([
+      'desert one',
+      'desert two',
+    ]);
+  });
+
+  it('submits the rewrite-only continuation composer with Enter', async () => {
+    const outbound: any[] = [];
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await waitFor(() => expect(continuationInput).toBeEnabled());
+    await user.type(continuationInput, 'A dramatic reveal{Enter}');
+
+    await waitFor(() => {
+      expect(outbound.some((message) => message.type === 'rewrite_seed_prompts')).toBe(true);
+    });
+
+    const rewriteMessage = outbound.find((message) => message.type === 'rewrite_seed_prompts');
+    expect(rewriteMessage.rewrite_instruction).toBe('A dramatic reveal');
+    expect(continuationInput).toHaveValue('');
+  });
+
+  it('submits rewrite requests with Enter from the composer', async () => {
+    const outbound: any[] = [];
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await waitFor(() => expect(continuationInput).toBeEnabled());
+    await user.type(
+      continuationInput,
+      'Make the mood more ominous and push closer to the subject{Enter}',
+    );
+
+    await waitFor(() => {
+      expect(outbound.some((message) => message.type === 'rewrite_seed_prompts')).toBe(true);
+    });
+
+    const rewriteMessage = outbound.find((message) => message.type === 'rewrite_seed_prompts');
+    expect(rewriteMessage.rewrite_instruction)
+      .toBe('Make the mood more ominous and push closer to the subject');
+    expect(continuationInput).toHaveValue('');
+  });
+
+  it('keeps the completed 30s rollout in the main player and adds one video-reply card', async () => {
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'segment two',
+      source: 'curated',
+      seed_prompt_index: 1,
+    }));
+    clientSocket.send(new Uint8Array([4, 5, 6]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 2 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.gallery-card')).toHaveLength(1);
+    });
+    expect(container.querySelector('.stage-copy h2')?.textContent).toBe('Test Preset');
+    expect(screen.getByRole('button', { name: /Test Preset/i })).toBeInTheDocument();
+    expect(container.querySelector('.gallery-card.is-active')).toBeNull();
+  });
+
+  it('keeps prior clips available while a rewrite-driven restart is underway', async () => {
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'segment two',
+      source: 'curated',
+      seed_prompt_index: 1,
+    }));
+    clientSocket.send(new Uint8Array([4, 5, 6]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 2 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.gallery-card')).toHaveLength(1);
+    });
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(continuationInput, 'The camera cuts to a rooftop chase');
+    await user.click(screen.getByRole('button', { name: 'Rewrite rollout' }));
+
+    clientSocket.send(JSON.stringify({
+      type: 'rewrite_seed_prompts_started',
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'seed_prompts_updated',
+      reason: 'rewrite',
+      prompts: [
+        'The camera cuts to a rooftop chase',
+        'A wider aerial view of the rooftop pursuit',
+      ],
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'rewrite_seed_prompts_complete',
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'seed_prompts_reset_applied',
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_stream_start',
+      total_segments: 2,
+      loop_generation_enabled: false,
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'The camera cuts to a rooftop chase',
+      source: 'rewrite',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([4, 5, 6]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.gallery-card')).toHaveLength(1);
+    });
+    expect(container.textContent).toContain('The camera cuts to a rooftop chase');
+    expect(container.querySelector('.stage-copy h2')?.textContent).toBe('Cuts 2');
+
+    const galleryLabelsBeforeSelection = Array.from<Element>(
+      container.querySelectorAll('.gallery-card .gallery-card-label'),
+    ).map((node: Element) => node.textContent || '');
+    expect(galleryLabelsBeforeSelection).toEqual(['Test Preset']);
+
+    await user.click(screen.getByRole('button', { name: /Test Preset/i }));
+
+    await waitFor(() => {
+      expect(container.querySelector('.stage-copy h2')?.textContent).toBe('Test Preset');
+    });
+
+    const galleryLabelsAfterSelection = Array.from<Element>(
+      container.querySelectorAll('.gallery-card .gallery-card-label'),
+    ).map((node: Element) => node.textContent || '');
+    expect(galleryLabelsAfterSelection).toEqual(['Test Preset']);
+  });
+
+  it('shows a timeout popup with repo and blog links when the session expires', async () => {
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'session_timeout',
+    }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Session ended' });
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText(/5-minute session limit/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open repo' })).toHaveAttribute('href', 'https://github.com/hao-ai-lab/FastVideo');
+    expect(screen.getByRole('link', { name: 'Read blog' })).toHaveAttribute('href', 'https://hao-ai-lab.github.io/blogs/fastvideo/');
+  });
+
+  it('recreates the live media pipeline when a rewrite restarts mid-generation', async () => {
+    const outbound: any[] = [];
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_stream_start',
+      total_segments: 2,
+      generation_segment_cap: 6,
+      loop_generation_enabled: false,
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'segment two',
+      source: 'curated',
+      seed_prompt_index: 1,
+    }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Rewrite rollout' })).toBeEnabled();
+    });
+
+    const continuationInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(continuationInput, 'Restart from a stormy street chase');
+    await user.click(screen.getByRole('button', { name: 'Rewrite rollout' }));
+
+    await waitFor(() => {
+      expect(outbound.some((message) => message.type === 'rewrite_seed_prompts')).toBe(true);
+    });
+
+    const livePipeline = (createAvPipeline as ReturnType<typeof vi.fn>).mock.results[0]?.value;
+    expect(livePipeline).toBeTruthy();
+    const resetsBeforeRestart = livePipeline.reset.mock.calls.length;
+
+    clientSocket.send(JSON.stringify({ type: 'rewrite_seed_prompts_started' }));
+    clientSocket.send(JSON.stringify({
+      type: 'seed_prompts_updated',
+      reason: 'rewrite',
+      prompts: [
+        'Restart from a stormy street chase',
+        'The chase cuts through a wet neon alley',
+      ],
+    }));
+    clientSocket.send(JSON.stringify({ type: 'rewrite_seed_prompts_complete' }));
+    clientSocket.send(JSON.stringify({
+      type: 'seed_prompts_reset_applied',
+      reason: 'rewrite_during_generation',
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_stream_start',
+      total_segments: 2,
+      generation_segment_cap: 6,
+      loop_generation_enabled: false,
+    }));
+
+    await waitFor(() => {
+      expect(livePipeline.reset.mock.calls.length).toBeGreaterThan(resetsBeforeRestart);
+    });
+    expect(livePipeline.markStreamStarting).not.toHaveBeenCalled();
+  });
+
+  it('switches the stage to the archived final clip when segment cap is reached', async () => {
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 1,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    expect(screen.queryByText(/Reached max number of segments supported/i)).not.toBeInTheDocument();
+    clientSocket.send(JSON.stringify({
+      type: 'generation_cap_reached',
+      cap_segments: 1,
+      generated_segments: 1,
+      message: 'Reached max number of segments supported (1). Click Restart to continue.',
+    }));
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.gallery-card')).toHaveLength(1);
+    });
+
+    expect(container.querySelector('.stage-copy h2')?.textContent).toBe('Test Preset');
+    expect(container.querySelector('.gallery-card.is-active')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Restart' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Reached max number of segments supported/i)).not.toBeInTheDocument();
+  });
+
+  it('replays completed 30s video replies from the archived blob when available', async () => {
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'segment two',
+      source: 'curated',
+      seed_prompt_index: 1,
+    }));
+    clientSocket.send(new Uint8Array([4, 5, 6]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 2 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.gallery-card')).toHaveLength(1);
+    });
+
+    const archivedReplayPipeline = (createAvPipeline as ReturnType<typeof vi.fn>).mock.results[1]?.value;
+    expect(archivedReplayPipeline).toBeTruthy();
+    expect(archivedReplayPipeline.ensurePipeline).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /Test Preset/i }));
+
+    await waitFor(() => {
+      expect(container.querySelector('video')?.getAttribute('src')).toBe('blob:mock-url');
+    });
+    expect(archivedReplayPipeline.ensurePipeline).not.toHaveBeenCalled();
+    expect(archivedReplayPipeline.enqueueChunk).not.toHaveBeenCalled();
+  });
+
+  it('keeps the archived rollout selected while the next rollout starts on Apple fallback', async () => {
+    avPipelineMockState.useNativePlaybackFallback = true;
+
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: 'Generate' }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 2,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 2,
+      total_segments: 2,
+      prompt: 'segment two',
+      source: 'curated',
+      seed_prompt_index: 1,
+    }));
+    clientSocket.send(new Uint8Array([4, 5, 6]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 2 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await waitFor(() => {
+      expect(container.querySelector('.gallery-card.is-active')).not.toBeNull();
+    });
+    expect(container.querySelector('.stage-copy h2')?.textContent).toBe('Test Preset');
+
+    const promptInput = await screen.findByLabelText('Continuation prompt');
+    await user.type(promptInput, 'The hero escapes into the rain');
+    await user.click(screen.getByRole('button', { name: 'Rewrite rollout' }));
+
+    clientSocket.send(JSON.stringify({
+      type: 'rewrite_seed_prompts_started',
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_stream_start',
+      total_segments: 2,
+      loop_generation_enabled: false,
+    }));
+    clientSocket.send(JSON.stringify({
+      type: 'media_init',
+      mime: 'video/mp4',
+      stream_id: 'rewrite_stream',
+    }));
+
+    await waitFor(() => {
+      expect(container.querySelector('.gallery-card.is-active')).not.toBeNull();
+    });
+    expect(container.querySelector('.stage-copy h2')?.textContent).toBe('Test Preset');
+  });
+
+  it('saves the first completed clip when the user leaves the session without edits', async () => {
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    const { container } = render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: /Test Preset/i }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 1,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('.gallery-card')).toHaveLength(1);
+    });
+
+    await user.click(screen.getByLabelText('Leave'));
+
+    await waitFor(() => {
+      expect(projectStorageMockState.saveProject).toHaveBeenCalled();
+    });
+
+    expect(projectStorageMockState.projects).toHaveLength(1);
+    expect(projectStorageMockState.clips).toHaveLength(1);
+    expect(projectStorageMockState.clips[0].projectId).toBe(projectStorageMockState.projects[0].id);
+    expect(projectStorageMockState.clips[0].blob).toBeInstanceOf(Blob);
+    expect(projectStorageMockState.clips[0].label).toBe('Test Preset');
+  });
+
+  it('starts the next project on the same websocket after New project and keeps both archives', async () => {
+    const sockets: any[] = [];
+    const outbound: any[] = [];
+    server.on('connection', (socket) => {
+      sockets.push(socket);
+      socket.on('message', (rawMessage) => {
+        outbound.push(JSON.parse(rawMessage as string));
+      });
+    });
+
+    let releaseFirstSave = () => {};
+    let firstSaveBlocked = false;
+    projectStorageMockState.saveProject.mockImplementation(async (project: any, clips: any[]) => {
+      if (!firstSaveBlocked) {
+        firstSaveBlocked = true;
+        await new Promise<void>((resolve) => {
+          releaseFirstSave = resolve;
+        });
+      }
+      await projectStorageMockState.commitSave(project, clips);
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: /Test Preset/i }));
+
+    await waitFor(() => {
+      expect(sockets[0]).toBeTruthy();
+    });
+
+    sockets[0].send(JSON.stringify({
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 90,
+    }));
+    sockets[0].send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 1,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    sockets[0].send(new Uint8Array([1, 2, 3]).buffer);
+    sockets[0].send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    sockets[0].send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Leave')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'New project' }));
+
+    expect(screen.getByLabelText('Leave')).toBeInTheDocument();
+    expect(outbound.some((message) => message.type === 'end_project_keep_session')).toBe(true);
+    expect(sockets).toHaveLength(1);
+
+    sockets[0].send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+    sockets[0].send(JSON.stringify({ type: 'project_idle' }));
+
+    releaseFirstSave();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Test Preset/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /Test Preset/i }));
+
+    await waitFor(() => {
+      expect(outbound.some((message) => message.type === 'project_init_v1')).toBe(true);
+    });
+
+    expect(sockets).toHaveLength(1);
+
+    sockets[0].send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 1,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    sockets[0].send(new Uint8Array([4, 5, 6]).buffer);
+    sockets[0].send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    sockets[0].send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Leave')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText('Leave'));
+
+    await waitFor(() => {
+      expect(projectStorageMockState.projects).toHaveLength(2);
+    });
+
+    expect(new Set(projectStorageMockState.projects.map((project) => project.id)).size).toBe(2);
+    expect(new Set(projectStorageMockState.clips.map((clip) => clip.projectId)).size).toBe(2);
+    expect(outbound.filter((message) => message.type === 'session_init_v2')).toHaveLength(1);
+    expect(outbound.filter((message) => message.type === 'project_init_v1')).toHaveLength(1);
+    const clipCountsByProject = projectStorageMockState.clips.reduce((counts: Record<string, number>, clip) => {
+      counts[clip.projectId] = (counts[clip.projectId] || 0) + 1;
+      return counts;
+    }, {});
+    expect(Object.values(clipCountsByProject).sort()).toEqual([1, 1]);
+  });
+
+  it('prunes older archives and retries when project save hits storage pressure', async () => {
+    projectStorageMockState.projects = [
+      { id: 'old-1', label: 'Old 1', presetId: '', originalLabel: 'Old 1', createdAt: 400, lastThumbnail: null, promptEvents: [] },
+      { id: 'old-2', label: 'Old 2', presetId: '', originalLabel: 'Old 2', createdAt: 300, lastThumbnail: null, promptEvents: [] },
+      { id: 'old-3', label: 'Old 3', presetId: '', originalLabel: 'Old 3', createdAt: 200, lastThumbnail: null, promptEvents: [] },
+      { id: 'old-4', label: 'Old 4', presetId: '', originalLabel: 'Old 4', createdAt: 100, lastThumbnail: null, promptEvents: [] },
+    ];
+    projectStorageMockState.clips = projectStorageMockState.projects.map((project, index) => ({
+      id: `clip-${index + 1}`,
+      projectId: project.id,
+      label: project.label,
+      prompt: project.label,
+      mime: 'video/mp4',
+      blob: new Blob([String(index + 1)], { type: 'video/mp4' }),
+      createdAt: project.createdAt,
+    }));
+
+    let failedOnce = false;
+    projectStorageMockState.saveProject.mockImplementation(async (project: any, clips: any[]) => {
+      if (!failedOnce) {
+        failedOnce = true;
+        throw new DOMException('Quota exceeded', 'QuotaExceededError');
+      }
+      await projectStorageMockState.commitSave(project, clips);
+    });
+
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: /Test Preset/i }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 1,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([7, 8, 9]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Leave')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText('Leave'));
+
+    await waitFor(() => {
+      expect(projectStorageMockState.saveProject).toHaveBeenCalledTimes(2);
+    });
+
+    expect(projectStorageMockState.deleteProject).toHaveBeenCalled();
+    expect(projectStorageMockState.projects.some((project) => project.id === 'old-4')).toBe(false);
+    expect(projectStorageMockState.projects.some((project) => project.label === 'Test Preset')).toBe(true);
+  });
+
+  it('preserves the existing archive when later saves fall back to metadata only', async () => {
+    let clientSocket: any;
+    server.on('connection', (socket) => {
+      clientSocket = socket;
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    await user.click(await screen.findByRole('button', { name: /Test Preset/i }));
+
+    await waitFor(() => {
+      expect(clientSocket).toBeTruthy();
+    });
+
+    clientSocket.send(JSON.stringify({
+      type: 'ltx2_segment_start',
+      segment_idx: 1,
+      total_segments: 1,
+      prompt: 'segment one',
+      source: 'curated',
+      seed_prompt_index: 0,
+    }));
+    clientSocket.send(new Uint8Array([1, 2, 3]).buffer);
+    clientSocket.send(JSON.stringify({ type: 'media_segment_complete', segment_idx: 1 }));
+    clientSocket.send(JSON.stringify({ type: 'ltx2_stream_complete' }));
+
+    await waitFor(() => {
+      expect(projectStorageMockState.projects).toHaveLength(1);
+      expect(projectStorageMockState.clips).toHaveLength(1);
+    });
+
+    const projectId = projectStorageMockState.projects[0].id;
+    projectStorageMockState.saveProject.mockImplementation(async () => {
+      throw new DOMException('Quota exceeded', 'QuotaExceededError');
+    });
+
+    await user.click(screen.getByLabelText('Leave'));
+
+    await waitFor(() => {
+      expect(projectStorageMockState.saveProjectMetadata).toHaveBeenCalled();
+    });
+
+    expect(projectStorageMockState.projects).toHaveLength(1);
+    expect(projectStorageMockState.projects[0].id).toBe(projectId);
+    expect(projectStorageMockState.clips.filter((clip) => clip.projectId === projectId)).toHaveLength(1);
+  });
+
+});

--- a/apps/dreamverse/web/src/app/page.monitor.test.tsx
+++ b/apps/dreamverse/web/src/app/page.monitor.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ReplicaMonitorPage from './internal/f8a3991c/replica-monitor/page';
+
+describe('Monitor route', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders monitor page instead of the regular app shell and polls every 15 seconds', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          replicas: [
+            {
+              url: 'http://r1:8009',
+              healthy: true,
+              active_sessions: 2,
+              pending_sessions: 1,
+              max_available_sessions: 4,
+              prompt_provider_success_counts: {
+                cerebras_ifm: 9,
+                cerebras: 2,
+                groq: 1,
+              },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          replicas: [
+            {
+              url: 'http://r1:8009',
+              healthy: true,
+              active_sessions: 3,
+              pending_sessions: 0,
+              max_available_sessions: 4,
+              prompt_provider_success_counts: {
+                cerebras_ifm: 10,
+                cerebras: 2,
+                groq: 1,
+              },
+            },
+          ],
+        }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+    const intervalCallbacks: Array<() => void | Promise<void>> = [];
+    vi.spyOn(globalThis, 'setInterval').mockImplementation(
+      ((callback: TimerHandler) => {
+        intervalCallbacks.push(callback as () => void | Promise<void>);
+        return 1 as unknown as ReturnType<typeof setInterval>;
+      }) as unknown as typeof setInterval,
+    );
+    vi.spyOn(globalThis, 'clearInterval').mockImplementation(
+      (() => {}) as typeof clearInterval,
+    );
+
+    render(<ReplicaMonitorPage />);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Replica Session Monitor' }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('http://r1:8009')).toBeInTheDocument();
+    expect(await screen.findByText('4')).toBeInTheDocument();
+    expect(
+      await screen.findByText('IFM 9 / Cerebras 2 / Groq 1'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Preset-driven video continuation' }),
+    ).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await intervalCallbacks[0]?.();
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('renders error state when monitor fetch fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ detail: 'boom' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<ReplicaMonitorPage />);
+
+    expect(
+      await screen.findByText('boom'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/dreamverse/web/src/app/page.startup.test.tsx
+++ b/apps/dreamverse/web/src/app/page.startup.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const projectStorageMockState = vi.hoisted(() => ({
+  saveProject: vi.fn(),
+  saveProjectMetadata: vi.fn(),
+  listProjects: vi.fn(async () => []),
+  loadProjectClips: vi.fn(async () => []),
+  deleteProject: vi.fn(async () => {}),
+  pruneOldProjects: vi.fn(async () => {}),
+  reset() {
+    this.saveProject.mockReset();
+    this.saveProjectMetadata.mockReset();
+    this.listProjects.mockClear();
+    this.loadProjectClips.mockClear();
+    this.deleteProject.mockClear();
+    this.pruneOldProjects.mockClear();
+  },
+}));
+
+vi.mock('../lib/storyPresetsData', () => ({
+  default: [
+    {
+      id: 'test_preset',
+      label: 'Test Preset',
+      segment_prompts: ['segment one', 'segment two'],
+    },
+  ],
+}));
+
+vi.mock('../lib/projectStorage', () => ({
+  saveProject: projectStorageMockState.saveProject,
+  saveProjectMetadata: projectStorageMockState.saveProjectMetadata,
+  listProjects: projectStorageMockState.listProjects,
+  loadProjectClips: projectStorageMockState.loadProjectClips,
+  deleteProject: projectStorageMockState.deleteProject,
+  pruneOldProjects: projectStorageMockState.pruneOldProjects,
+}));
+
+vi.mock('../lib/media/avPipeline', () => ({
+  DEFAULT_AV_MIME: 'video/mp4',
+  createAvPipeline: vi.fn(() => ({
+    reset() {},
+    enqueueChunk() {},
+    ensurePipeline: async () => {},
+    maybeStartPlayback() {},
+    tryEndStream() {},
+    setStreamCompleted() {},
+    noteSegmentInit() {},
+    noteSegmentComplete() {},
+    markStreamStarting() {},
+    hasArchivedChunks() {
+      return false;
+    },
+    hasArchivedCompletedSegments() {
+      return false;
+    },
+    buildArchivedStreamChunks() {
+      return [];
+    },
+    buildArchivedSegmentSnapshots() {
+      return [];
+    },
+    buildArchivedStreamBlob() {
+      return new Blob([], { type: 'video/mp4' });
+    },
+    takeArchivedStreamChunks() {
+      return [];
+    },
+    takeArchivedSegmentSnapshots() {
+      return [];
+    },
+    takeArchivedStreamBlob() {
+      return new Blob([], { type: 'video/mp4' });
+    },
+    usesNativePlaybackFallback() {
+      return false;
+    },
+  })),
+}));
+
+import Page from './page';
+
+describe('Page startup readiness UX', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    projectStorageMockState.reset();
+    window.history.pushState({}, '', '/');
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('shows a clear notice when the backend is not reachable before session start', async () => {
+    fetchMock.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    const promptInput = screen.getByRole('textbox', { name: 'Continuation prompt' });
+    await user.type(promptInput, 'A fox surfing through neon rain');
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(
+      await screen.findByText(
+        'Dreamverse backend is not reachable. Start uv run dreamverse-server and wait for /readyz to return 200 before retrying.',
+      ),
+    ).toBeInTheDocument();
+    expect(promptInput).toHaveValue('A fox surfing through neon rain');
+  });
+
+  it('shows a readiness notice when GPU workers are not ready yet', async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (url.endsWith('/healthz')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ status: 'ok', service: 'ltx2-streaming-backend' }),
+        };
+      }
+
+      if (url.endsWith('/readyz')) {
+        return {
+          ok: false,
+          status: 503,
+          json: async () => ({
+            detail: 'No ready GPU worker processes.',
+          }),
+        };
+      }
+
+      if (url.endsWith('/status')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            total_gpus: 1,
+            available_gpus: 0,
+            queue_size: 0,
+            warmup_enabled: true,
+            warmup_successful_gpus: 0,
+            warmup_failed_gpus: 0,
+          }),
+        };
+      }
+
+      throw new Error(`Unhandled fetch request in test: ${url}`);
+    });
+
+    const user = userEvent.setup();
+    render(<Page />);
+
+    const promptInput = screen.getByRole('textbox', { name: 'Continuation prompt' });
+    await user.type(promptInput, 'A fox surfing through neon rain');
+    await user.click(screen.getByRole('button', { name: 'Generate' }));
+
+    expect(
+      await screen.findByText(
+        'Dreamverse backend is running, but GPU workers are not ready yet. Wait for startup warmup to finish and retry.',
+      ),
+    ).toBeInTheDocument();
+    expect(promptInput).toHaveValue('A fox surfing through neon rain');
+  });
+});

--- a/apps/dreamverse/web/src/app/page.tsx
+++ b/apps/dreamverse/web/src/app/page.tsx
@@ -1,0 +1,2801 @@
+"use client";
+import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Download, Share2 } from "lucide-react";
+import DevtoolsShell from "@/components/devtools/DevtoolsShell";
+import MonitorPage from "@/components/MonitorPage";
+import ChatBar from "@/components/ChatBar";
+import SessionTimeoutModal from "@/components/SessionTimeoutModal";
+import Sidebar from "@/components/Sidebar";
+import Header from "@/components/Header";
+import VideoPlayer from "@/components/VideoPlayer";
+import Workspace from "@/components/Workspace";
+import { saveProject, saveProjectMetadata, listProjects, loadProjectClips, deleteProject, pruneOldProjects, type StoredProject, type StoredClip } from "@/lib/projectStorage";
+import { isInfrastructureError } from "@/lib/ws/reducer";
+import { useStore } from "@/hooks/useStore";
+import { resolveDevtoolsMode } from "@/lib/devtoolsMode";
+import { createAvPipeline, DEFAULT_AV_MIME } from "@/lib/media/avPipeline";
+import { remuxArchivedFmp4Segments } from "@/lib/media/fmp4Remux";
+import { DEFAULT_CUSTOM_PRESET_ID, parseStoryPresets, sanitizePresetId } from "@/lib/presets";
+import {
+	buildRewritePromptWindowSnapshot,
+	buildRewritePromptWindowSnapshotFromPrompts,
+	normalizePromptWindowSnapshot,
+} from "@/lib/prompts/promptWindowSnapshot";
+import rawPresets from "@/lib/storyPresetsData";
+import { cn } from "@/lib/utils";
+import { createWebSocketConnection, detachAndCloseWebSocket } from "@/lib/ws/client";
+import { decodeWebSocketEvent } from "@/lib/ws/handlers";
+import { normalizeSocketMessage } from "@/lib/ws/protocol";
+import { applyNormalizedSocketEvent } from "@/lib/ws/reducer";
+import { createPromptWindowStore } from "@/stores/promptWindow";
+import { createRewriteStore } from "@/stores/rewrite";
+import { createSessionStore } from "@/stores/session";
+import { createStreamStore } from "@/stores/stream";
+import { createUiStore } from "@/stores/ui";
+import { Button } from "@/components/ui/button";
+
+const DEFAULT_CUSTOM_PRESET_LABEL = "Custom Editable Preset";
+const FIXED_REWRITE_MODEL = "gpt-oss-120b";
+const DEFAULT_CURATED_PROMPT_LIMIT = 2;
+const MONITOR_ROUTE_PATH = "/internal/f8a3991c/replica-monitor";
+const MAX_ARCHIVED_PROJECTS = 10;
+const STORAGE_RECOVERY_PREVIOUS_PROJECT_COUNTS = [6, 3, 1, 0];
+const FASTVIDEO_REPO_URL = "https://haoailab.com/blogs/dreamverse/";
+const FASTVIDEO_BLOG_URL = "https://haoailab.com/blogs/fastvideo_realtime_1080p_part2/";
+const BACKEND_PROBE_TIMEOUT_MS = 4000;
+
+interface PageStores {
+	sessionStore: ReturnType<typeof createSessionStore>;
+	promptWindowStore: ReturnType<typeof createPromptWindowStore>;
+	rewriteStore: ReturnType<typeof createRewriteStore>;
+	streamStore: ReturnType<typeof createStreamStore>;
+	uiStore: ReturnType<typeof createUiStore>;
+}
+
+interface ArchivedSegmentLike {
+	key: string;
+	segmentIdx: number | null;
+	streamId: string;
+	mime: string;
+	completed: boolean;
+	chunks: ArrayBuffer[];
+}
+
+interface BackendProbeResponse {
+	ok: boolean;
+	status: number;
+	payload: any;
+	errorMessage: string;
+}
+
+interface BackendReadinessProbe {
+	ok: boolean;
+	notice: string;
+}
+
+function yieldToEventLoop(): Promise<void> {
+	return new Promise((r) => setTimeout(r, 0));
+}
+
+const HERO_WAVE_LIGHT = ["#2A4A98", "#4878E5", "#6FA0F2", "#B0BCC8", "#E8D99E", "#D8C844", "#C2A620"];
+const HERO_WAVE_DARK = ["#143468", "#1E58B8", "#3892F0", "#80B8E8", "#B8D0EA", "#E2D498", "#DABB50"];
+const HERO_TEXT = "Direct scenes in seconds";
+
+function HeroTagline() {
+	const ref = useRef<HTMLHeadingElement>(null);
+
+	useEffect(() => {
+		const el = ref.current;
+		if (!el) return;
+
+		let rafId = 0;
+
+		function play() {
+			const chars = el!.querySelectorAll<HTMLSpanElement>("[data-char]");
+			if (!chars.length) return;
+			cancelAnimationFrame(rafId);
+
+			const isDark = document.documentElement.classList.contains("dark");
+			const colors = isDark ? HERO_WAVE_DARK : HERO_WAVE_LIGHT;
+			const waveLen = 10;
+			const total = chars.length + waveLen;
+			const duration = 1200;
+			const maxBlur = 3.5;
+			const start = performance.now();
+
+			function tick() {
+				const t = Math.min((performance.now() - start) / duration, 1);
+				const pos = t * total;
+				chars.forEach((ch, i) => {
+					const rel = pos - i;
+					if (rel >= 0 && rel < waveLen) {
+						const norm = rel / waveLen;
+						const ci = Math.floor(norm * colors.length);
+						ch.style.color = colors[Math.min(colors.length - 1, ci)];
+
+						let blur = 0;
+						if (norm < 0.25) {
+							blur = maxBlur * (1 - norm / 0.25);
+						} else if (norm > 0.75) {
+							blur = maxBlur * ((norm - 0.75) / 0.25);
+						}
+						ch.style.filter = blur > 0.1 ? `blur(${blur.toFixed(1)}px)` : "";
+					} else {
+						ch.style.color = "";
+						ch.style.filter = "";
+					}
+				});
+				if (t < 1) {
+					rafId = requestAnimationFrame(tick);
+				} else {
+					chars.forEach((ch) => {
+						ch.style.color = "";
+						ch.style.filter = "";
+					});
+				}
+			}
+
+			rafId = requestAnimationFrame(tick);
+		}
+
+		const initialDelay = setTimeout(play, 400);
+		const interval = setInterval(play, 5000);
+		return () => {
+			clearTimeout(initialDelay);
+			clearInterval(interval);
+			cancelAnimationFrame(rafId);
+		};
+	}, []);
+
+	return (
+		<h1 ref={ref} className="text-center text-3xl font-medium text-[#343537] dark:text-[#FAFAFB] sm:text-4xl">
+			{HERO_TEXT.split(" ").map((word, wi) => (
+				<Fragment key={wi}>
+					{wi > 0 && (
+						<span data-char className="transition-[color,filter] duration-150">
+							{" "}
+						</span>
+					)}
+					<span className="inline-flex">
+						{word.split("").map((char, ci) => (
+							<span key={ci} data-char className="inline-block transition-[color,filter] duration-150">
+								{char}
+							</span>
+						))}
+					</span>
+				</Fragment>
+			))}
+		</h1>
+	);
+}
+
+export default function Page() {
+	const storesRef = useRef<PageStores | null>(null);
+	if (!storesRef.current) {
+		const nextStoryPresets = parseStoryPresets(rawPresets);
+		const nextSimpleMode = false;
+		const nextDevtoolsMode = resolveDevtoolsModeFromRuntime();
+		const nextDemoMode = nextDevtoolsMode ? false : resolveDemoModeFromRuntime();
+		const nextEditableMode = nextDevtoolsMode;
+		const nextIsMonitorRoute = typeof window !== "undefined" && window.location.pathname === MONITOR_ROUTE_PATH;
+
+		const nextSessionStore = createSessionStore({
+			enhancementEnabled: true,
+			autoExtensionEnabled: false,
+			loopGenerationEnabled: false,
+			livePromptRewriteMode: !nextSimpleMode && !nextDevtoolsMode && !nextDemoMode,
+		});
+		const nextPromptWindowStore = createPromptWindowStore({
+			curatedPromptLimit: DEFAULT_CURATED_PROMPT_LIMIT,
+			storyPresets: nextStoryPresets as Record<string, unknown>[],
+			simpleMode: nextSimpleMode,
+			editableMode: nextEditableMode,
+		});
+		const nextRewriteStore = createRewriteStore();
+		const nextStreamStore = createStreamStore();
+		const nextUiStore = createUiStore({
+			isMonitorRoute: nextIsMonitorRoute,
+			simpleMode: nextSimpleMode,
+			devtoolsMode: nextDevtoolsMode,
+			demoMode: nextDemoMode,
+			editableMode: nextEditableMode,
+		});
+
+		if (nextEditableMode) {
+			nextPromptWindowStore.seedEditableFromPreset((nextStoryPresets[0] ?? null) as Record<string, unknown> | null, {
+				defaultCustomPresetId: DEFAULT_CUSTOM_PRESET_ID,
+				defaultCustomPresetLabel: DEFAULT_CUSTOM_PRESET_LABEL,
+			});
+		}
+
+		storesRef.current = {
+			sessionStore: nextSessionStore,
+			promptWindowStore: nextPromptWindowStore,
+			rewriteStore: nextRewriteStore,
+			streamStore: nextStreamStore,
+			uiStore: nextUiStore,
+		};
+	}
+
+	const { sessionStore, promptWindowStore, rewriteStore, streamStore, uiStore } = storesRef.current;
+
+	const sessionState = useStore(sessionStore);
+	const promptWindowState = useStore(promptWindowStore);
+	const rewriteState = useStore(rewriteStore);
+	const streamState = useStore(streamStore);
+	const uiState = useStore(uiStore);
+
+	const {
+		connected,
+		connecting,
+		sessionStarted,
+		sessionTimeout,
+		timeLeft,
+		queuePosition,
+		gpuAssigned,
+		enhancementEnabled,
+		promptExtensionError,
+		autoExtensionEnabled,
+		autoExtensionTimeoutHint,
+		loopGenerationEnabled,
+		generationPaused,
+		livePromptDraft,
+		sessionNotice,
+		generationCapReached,
+		generationSegmentCap,
+		generatedSegmentCount,
+		preservePlaybackOnClose,
+		livePromptRewriteMode,
+		sessionExpired,
+		projectResetPending,
+	} = sessionState;
+
+	const {
+		storyPresets,
+		selectedPresetId,
+		selectedPreset,
+		previewSegments,
+		maxCuratedPromptCount,
+		curatedPromptLimit,
+		outboundCuratedPrompts,
+		seedPrompts,
+		currentPromptWindowPrompts,
+		outboundSessionPrompts,
+		canJoinSession,
+		editableSegments,
+		sanitizedEditableSegments,
+		editableCanJoin,
+		editableDirty,
+		customPresetId,
+		customPresetLabel,
+	} = promptWindowState;
+
+	const { rewritingSeedPrompts, promptEvents, lastPromptSource, pendingSegmentSource } = rewriteState;
+
+	const {
+		playingSeedPromptIndex,
+		generatingSeedPromptIndex,
+		seedPromptIndexBySegment,
+		currentSegmentNumber,
+		promptHistory,
+		selectedHistoryId,
+		selectedHistoryEntry,
+		completedClips,
+		activeClipId,
+		activeClip,
+		activePlaybackStartTime,
+		pendingClip,
+		liveClip,
+		loadingAnimation,
+		avPlaybackStarted,
+		mediaAppendError,
+		lastVideoCompletedAtMs,
+		timeBetweenVideosMs,
+	} = streamState;
+
+	const {
+		isMonitorRoute,
+		demoMode,
+		devtoolsMode,
+		editableMode,
+		appendingPromptWindow,
+		appendPromptWindowStatus,
+		appendPromptWindowError,
+		promptConfigEditorOpen,
+		promptConfigLoading,
+		promptConfigSaving,
+		promptConfigLoaded,
+		promptConfigError,
+		promptConfigStatus,
+		nextSegmentPromptEditorOpen,
+		autoExtensionPromptEditorOpen,
+		rewriteWindowPromptEditorOpen,
+		nextSegmentSystemPromptDraft,
+		autoExtensionSystemPromptDraft,
+		rewriteWindowSystemPromptDraft,
+	} = uiState;
+
+	const wsRef = useRef<WebSocket | null>(null);
+	const [runtimeReady, setRuntimeReady] = useState(false);
+	const countdownIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const ttffStartAtMsRef = useRef<number | null>(null);
+	const [ttffValueMs, setTtffValueMs] = useState<number | null>(null);
+	const ttffIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const pendingInitialPromptRef = useRef("");
+	const lastArchivedReplayKeyRef = useRef("");
+	const [sidebarOpen, setSidebarOpen] = useState(false);
+	const [currentThumbnail, setCurrentThumbnail] = useState<string | null>(null);
+	const currentProjectIdRef = useRef("");
+	const currentProjectCreatedAtRef = useRef(0);
+	const [savedProjects, setSavedProjects] = useState<StoredProject[]>([]);
+	const [viewingProject, setViewingProject] = useState<{
+		project: StoredProject;
+		clips: { id: string; label: string; prompt: string; mime: string; objectUrl: string; blob: Blob; createdAt: number }[];
+	} | null>(null);
+	const viewingProjectRef = useRef(viewingProject);
+	viewingProjectRef.current = viewingProject;
+	const saveQueueRef = useRef<Promise<void>>(Promise.resolve());
+	const downloadInFlightRef = useRef(false);
+	const wsMessageQueueRef = useRef<Promise<void>>(Promise.resolve());
+	const [isMobileShareCapable, setIsMobileShareCapable] = useState(false);
+	const [videoMuted, setVideoMuted] = useState(true);
+	const [timeoutModalOpen, setTimeoutModalOpen] = useState(false);
+	useEffect(() => {
+		setIsMobileShareCapable(typeof navigator.canShare === "function" && window.matchMedia("(pointer: coarse)").matches);
+	}, []);
+
+	const videoElRef = useRef<HTMLVideoElement | null>(null);
+	const archivedPlaybackElRef = useRef<HTMLVideoElement | null>(null);
+	const viewingModePlaybackStateRef = useRef<{
+		liveWasPlaying: boolean;
+		archivedWasPlaying: boolean;
+	}>({
+		liveWasPlaying: false,
+		archivedWasPlaying: false,
+	});
+	const previousViewingModeRef = useRef(false);
+
+	const avPipelineRef = useRef(
+		createAvPipeline({
+			getVideoEl: () => videoElRef.current,
+			onAppendError: (message: string, error: unknown) => {
+				streamStore.patch({ mediaAppendError: message });
+				console.error("media append failed:", error);
+			},
+			onPlaybackStarted: () => {
+				streamStore.patch({ avPlaybackStarted: true, loadingAnimation: false });
+			},
+		}),
+	);
+
+	const archivedPlaybackPipelineRef = useRef(
+		createAvPipeline({
+			getVideoEl: () => archivedPlaybackElRef.current,
+			onAppendError: (_message: string, error: unknown) => {
+				console.error("archived playback failed:", error);
+			},
+		}),
+	);
+
+	const avPipeline = avPipelineRef.current;
+	const archivedPlaybackPipeline = archivedPlaybackPipelineRef.current;
+
+	const videoRefCallback = useCallback((el: HTMLVideoElement | null) => {
+		videoElRef.current = el;
+	}, []);
+
+	const archivedPlaybackRefCallback = useCallback((el: HTMLVideoElement | null) => {
+		archivedPlaybackElRef.current = el;
+	}, []);
+
+	// --- Derived values ---
+
+	const canStartSession = !projectResetPending && (canJoinSession || Boolean(normalizeInitialPrompt(livePromptDraft as string)));
+
+	const currentClipLabel = useMemo(() => {
+		if ((activeClip as Record<string, any>)?.label) return (activeClip as Record<string, any>).label;
+		if ((pendingClip as Record<string, any>)?.label) return (pendingClip as Record<string, any>).label;
+		if ((liveClip as Record<string, any>)?.label) return (liveClip as Record<string, any>).label;
+		const initLabel = getInitialPresetLabel(pendingInitialPromptRef.current || (livePromptDraft as string));
+		if (initLabel) return initLabel;
+		if ((selectedPreset as Record<string, any>)?.label) return (selectedPreset as Record<string, any>).label;
+		return "Video player";
+	}, [activeClip, pendingClip, liveClip, livePromptDraft, selectedPreset, customPresetLabel, selectedPresetId]);
+
+	const currentClipPrompt = useMemo(() => {
+		if ((activeClip as Record<string, any>)?.prompt) return (activeClip as Record<string, any>).prompt;
+		if ((pendingClip as Record<string, any>)?.prompt) return (pendingClip as Record<string, any>).prompt;
+		if ((liveClip as Record<string, any>)?.prompt) return (liveClip as Record<string, any>).prompt;
+		const initPrompt = normalizeInitialPrompt(pendingInitialPromptRef.current || (livePromptDraft as string));
+		if (initPrompt) return initPrompt;
+		const presetPrompts = (selectedPreset as Record<string, any>)?.segment_prompts;
+		return Array.isArray(presetPrompts) ? presetPrompts[0] || "" : "";
+	}, [activeClip, pendingClip, liveClip, livePromptDraft, selectedPreset, outboundSessionPrompts]);
+
+	const currentProjectTitle = useMemo(() => {
+		const presetLabel = (selectedPreset as Record<string, any>)?.label;
+		if (presetLabel) return presetLabel;
+		const events = promptEvents as Record<string, any>[];
+		for (let i = events.length - 1; i >= 0; i--) {
+			const e = events[i];
+			if (String(e?.source || "") === "user_rewrite" && typeof e?.text === "string" && e.text.trim()) {
+				return e.text.trim();
+			}
+		}
+		return "Untitled project";
+	}, [selectedPreset, promptEvents]);
+
+	const canSubmitContinuation = sessionStarted && connected && gpuAssigned && !projectResetPending && Boolean((livePromptDraft as string).trim());
+
+	const showLivePlayback = !activeClip;
+	const canDownloadVideo = useMemo(() => {
+		const currentActiveClip = activeClip as Record<string, any> | null;
+		if (currentActiveClip?.blob instanceof Blob) return true;
+		return (completedClips as Record<string, any>[]).some((clip) => clip?.blob instanceof Blob);
+	}, [activeClip, completedClips]);
+
+	const hasEdits = useMemo(
+		() => Boolean(sessionStarted) && (promptEvents as Record<string, any>[]).some((e) => typeof e?.text === "string" && e.text.trim() && String(e?.source || "").trim() === "user_rewrite"),
+		[sessionStarted, promptEvents],
+	);
+
+	// Viewing mode: track which clip is selected (defaults to last clip)
+	const [viewingSelectedClipId, setViewingSelectedClipId] = useState<string>("");
+	const viewingSelectedClip = useMemo(() => {
+		if (!viewingProject) return null;
+		const lastClip = viewingProject.clips[viewingProject.clips.length - 1] ?? null;
+		if (viewingSelectedClipId) {
+			return viewingProject.clips.find((c) => c.id === viewingSelectedClipId) ?? lastClip;
+		}
+		return lastClip;
+	}, [viewingProject, viewingSelectedClipId]);
+
+	const activeReplayKey = useMemo(() => {
+		if (!activeClip) return "";
+		const clip = activeClip as Record<string, any>;
+		return [clip.id || "", activePlaybackStartTime || 0, Array.isArray(clip.chunks) ? clip.chunks.length : 0, clip.objectUrl || ""].join(":");
+	}, [activeClip, activePlaybackStartTime]);
+	const isViewingMode = Boolean(viewingProject);
+
+	// --- Reactive effect: archived playback ---
+
+	useEffect(() => {
+		if (showLivePlayback || !activeReplayKey || !archivedPlaybackElRef.current) {
+			if (lastArchivedReplayKeyRef.current) {
+				lastArchivedReplayKeyRef.current = "";
+				archivedPlaybackPipeline.reset();
+			}
+		} else if (activeReplayKey !== lastArchivedReplayKeyRef.current) {
+			lastArchivedReplayKeyRef.current = activeReplayKey;
+			void restoreArchivedPlayback(activeClip as Record<string, any>, activePlaybackStartTime as number);
+		}
+	}, [showLivePlayback, activeReplayKey]);
+
+	useLayoutEffect(() => {
+		const wasViewingMode = previousViewingModeRef.current;
+		const liveEl = videoElRef.current;
+		const archivedEl = archivedPlaybackElRef.current;
+
+		if (!wasViewingMode && isViewingMode) {
+			viewingModePlaybackStateRef.current = {
+				liveWasPlaying: Boolean(liveEl && !liveEl.paused && !liveEl.ended),
+				archivedWasPlaying: Boolean(archivedEl && !archivedEl.paused && !archivedEl.ended),
+			};
+			if (liveEl && !liveEl.paused) {
+				liveEl.pause();
+			}
+			if (archivedEl && !archivedEl.paused) {
+				archivedEl.pause();
+			}
+		} else if (wasViewingMode && !isViewingMode) {
+			const { liveWasPlaying, archivedWasPlaying } = viewingModePlaybackStateRef.current;
+			const activeEl = showLivePlayback ? videoElRef.current : archivedPlaybackElRef.current;
+			const shouldResume = showLivePlayback ? liveWasPlaying : archivedWasPlaying;
+			if (shouldResume && activeEl && activeEl.paused && activeEl.readyState >= 2) {
+				const playPromise = activeEl.play();
+				if (playPromise?.catch) playPromise.catch(() => {});
+			}
+			viewingModePlaybackStateRef.current = {
+				liveWasPlaying: false,
+				archivedWasPlaying: false,
+			};
+		}
+
+		previousViewingModeRef.current = isViewingMode;
+	}, [isViewingMode, showLivePlayback]);
+
+	useEffect(() => {
+		if (sessionExpired && Number(timeLeft) === 0) {
+			setTimeoutModalOpen(true);
+		}
+	}, [sessionExpired, timeLeft]);
+
+	useEffect(() => {
+		if (!sessionExpired) {
+			setTimeoutModalOpen(false);
+		}
+	}, [sessionExpired]);
+
+	// --- Initialization ---
+
+	const initializedRef = useRef(false);
+	useEffect(() => {
+		setRuntimeReady(true);
+	}, []);
+
+	useEffect(() => {
+		if (!runtimeReady || initializedRef.current) return;
+		initializedRef.current = true;
+
+		if (uiStore.get().devtoolsMode) {
+			Promise.resolve().then(() => loadStoryPresetsFromServer());
+		}
+		if (!uiStore.get().devtoolsMode) {
+			void refreshSavedProjects().then(() => {
+				try {
+					const lastId = localStorage.getItem("fastvideo-active-project");
+					if (lastId) {
+						localStorage.removeItem("fastvideo-active-project");
+						void viewSavedProject(lastId);
+					}
+				} catch (_) {
+					/* private browsing */
+				}
+			});
+		}
+	}, [runtimeReady, uiStore]);
+
+	// --- Save project on page unload ---
+
+	useEffect(() => {
+		function triggerSaveIfActive() {
+			if (currentProjectIdRef.current && sessionStore.get().sessionStarted) {
+				void saveCurrentProject();
+			}
+		}
+		function handleBeforeUnload() {
+			triggerSaveIfActive();
+		}
+		function handleVisibilityChange() {
+			if (document.visibilityState === "hidden") {
+				triggerSaveIfActive();
+			} else if (document.visibilityState === "visible") {
+				if (viewingProjectRef.current) {
+					return;
+				}
+				// Mobile browsers pause <video> when the page is backgrounded.
+				// Resume playback on the active video element when returning.
+				const hasActiveClip = Boolean(streamStore.get().activeClipId);
+				const activeEl = hasActiveClip ? archivedPlaybackElRef.current : videoElRef.current;
+				if (activeEl && activeEl.paused && activeEl.readyState >= 2) {
+					const p = activeEl.play();
+					if (p?.catch) p.catch(() => {});
+				}
+			}
+		}
+		window.addEventListener("beforeunload", handleBeforeUnload);
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+		return () => {
+			window.removeEventListener("beforeunload", handleBeforeUnload);
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, []);
+
+	// --- Periodic auto-save as safety net ---
+
+	useEffect(() => {
+		const AUTO_SAVE_INTERVAL_MS = 30_000;
+		const interval = setInterval(() => {
+			if (currentProjectIdRef.current && sessionStore.get().sessionStarted) {
+				void saveCurrentProject();
+			}
+		}, AUTO_SAVE_INTERVAL_MS);
+		return () => clearInterval(interval);
+	}, []);
+
+	// --- Cleanup on unmount ---
+
+	useEffect(() => {
+		return () => {
+
+			clearCountdownInterval();
+			clearTtffInterval();
+			if (wsRef.current) {
+				detachAndCloseWebSocket(wsRef.current);
+				wsRef.current = null;
+			}
+			resetPlaybackState();
+			revokeCompletedClipUrls();
+			if (viewingProjectRef.current) {
+				viewingProjectRef.current.clips.forEach((clip) => URL.revokeObjectURL(clip.objectUrl));
+			}
+		};
+	}, []);
+
+	// --- Helper functions ---
+
+	function resolveDevtoolsModeFromRuntime() {
+		return resolveDevtoolsMode({
+			buildEnabled: Boolean(process.env.NEXT_PUBLIC_INCLUDE_DEVTOOLS),
+			search: typeof window === "undefined" ? "" : window.location.search,
+		});
+	}
+
+	function resolveDemoModeFromRuntime() {
+		const search = typeof window === "undefined" ? "" : window.location.search;
+		const params = new URLSearchParams(search || "");
+		if (!params.has("demo")) return false;
+		const value = String(params.get("demo") || "")
+			.trim()
+			.toLowerCase();
+		return value === "" || value === "1" || value === "true" || value === "yes" || value === "on";
+	}
+
+	async function fetchBackendProbe(path: string): Promise<BackendProbeResponse> {
+		const controller = typeof AbortController !== "undefined"
+			? new AbortController()
+			: null;
+		const timeoutId = controller
+			? window.setTimeout(() => controller.abort(), BACKEND_PROBE_TIMEOUT_MS)
+			: null;
+
+		try {
+			const response = await fetch(path, {
+				headers: { Accept: "application/json" },
+				cache: "no-store",
+				signal: controller?.signal,
+			});
+			let payload: any = null;
+			try {
+				payload = await response.json();
+			} catch (_) {
+				payload = null;
+			}
+			const fallbackMessage = typeof payload?.detail === "string"
+				? payload.detail
+				: `Request failed with status ${response.status}.`;
+			return {
+				ok: response.ok,
+				status: response.status,
+				payload,
+				errorMessage: fallbackMessage,
+			};
+		} catch (error: any) {
+			const message = error?.name === "AbortError"
+				? "Backend probe timed out."
+				: error?.message || String(error);
+			return {
+				ok: false,
+				status: 0,
+				payload: null,
+				errorMessage: message,
+			};
+		} finally {
+			if (timeoutId !== null) {
+				window.clearTimeout(timeoutId);
+			}
+		}
+	}
+
+	function resolveBackendUnavailableNotice(): string {
+		return "Dreamverse backend is not reachable. Start uv run dreamverse-server and wait for /readyz to return 200 before retrying.";
+	}
+
+	function resolveBackendNotReadyNotice(detail: string, statusPayload: any): string {
+		const totalGpus = Number(statusPayload?.total_gpus);
+		const warmupFailures = Number(statusPayload?.warmup_failed_gpus);
+		if (Number.isFinite(totalGpus) && totalGpus <= 0) {
+			return "Dreamverse backend is running, but no GPUs were detected. Confirm that your local GPU is visible to FastVideo, then retry.";
+		}
+		if (Number.isFinite(warmupFailures) && warmupFailures > 0) {
+			return `Dreamverse backend is running, but GPU warmup failed on ${warmupFailures} worker${warmupFailures === 1 ? "" : "s"}. Check the backend logs and FastVideo/model runtime setup, then retry.`;
+		}
+		if (detail === "Prompt enhancer not initialized.") {
+			return "Dreamverse backend is still initializing prompt services. Wait for /readyz to return 200 and retry.";
+		}
+		if (detail === "No ready GPU worker processes.") {
+			return "Dreamverse backend is running, but GPU workers are not ready yet. Wait for startup warmup to finish and retry.";
+		}
+		return `Dreamverse backend is not ready yet: ${detail}`;
+	}
+
+	async function probeBackendReadiness(): Promise<BackendReadinessProbe> {
+		const health = await fetchBackendProbe("/healthz");
+		if (!health.ok) {
+			return {
+				ok: false,
+				notice: resolveBackendUnavailableNotice(),
+			};
+		}
+
+		const ready = await fetchBackendProbe("/readyz");
+		if (ready.ok) {
+			return {
+				ok: true,
+				notice: "",
+			};
+		}
+
+		const status = await fetchBackendProbe("/status");
+		const detail = typeof ready.payload?.detail === "string" && ready.payload.detail.trim()
+			? ready.payload.detail.trim()
+			: ready.errorMessage;
+		return {
+			ok: false,
+			notice: resolveBackendNotReadyNotice(detail, status.payload),
+		};
+	}
+
+	function clearPendingProjectPointers() {
+		clearSessionArchivedClips();
+		currentProjectIdRef.current = "";
+		currentProjectCreatedAtRef.current = 0;
+		markActiveProjectId(null);
+		setCurrentThumbnail(null);
+	}
+
+	function showPreSessionNotice(notice: string) {
+		sessionStore.patch({
+			connected: false,
+			connecting: false,
+			gpuAssigned: false,
+			sessionNotice: notice,
+			sessionExpired: false,
+		});
+	}
+
+	function recoverFailedSessionStart(notice: string) {
+		const restoredDraft = normalizeInitialPrompt(pendingInitialPromptRef.current);
+		resetToLobbyState();
+		clearPendingProjectPointers();
+		pendingInitialPromptRef.current = "";
+		sessionStore.patch({
+			connected: false,
+			connecting: false,
+			gpuAssigned: false,
+			livePromptDraft: restoredDraft,
+			sessionNotice: notice,
+			sessionExpired: false,
+		});
+	}
+
+	async function loadStoryPresetsFromServer() {
+		if (!uiStore.get().devtoolsMode) return;
+		try {
+			const response = await fetch("/curated-presets");
+			const payload = await response.json();
+			if (!response.ok) {
+				throw new Error(payload.detail || "Failed to load curated presets.");
+			}
+			const nextStoryPresets = parseStoryPresets(payload.presets);
+			if (nextStoryPresets.length === 0) return;
+			promptWindowStore.setStoryPresets(nextStoryPresets);
+			const nextSelectedPreset = nextStoryPresets.find((preset: any) => preset.id === promptWindowStore.get().selectedPresetId) || nextStoryPresets[0];
+			promptWindowStore.setSelectedPresetId(nextSelectedPreset.id);
+			const pwState = promptWindowStore.get();
+			if (uiStore.get().editableMode && !pwState.editableDirty) {
+				seedEditableFromPreset(nextSelectedPreset);
+			}
+		} catch (error) {
+			console.error("Failed to load curated presets:", error);
+		}
+	}
+
+	function seedEditableFromPreset(preset: any) {
+		promptWindowStore.seedEditableFromPreset(preset, {
+			defaultCustomPresetId: DEFAULT_CUSTOM_PRESET_ID,
+			defaultCustomPresetLabel: DEFAULT_CUSTOM_PRESET_LABEL,
+		});
+	}
+
+	// --- Preset & prompt handlers ---
+
+	function handlePresetSelectionChange(event: any) {
+		const nextPresetId = event.currentTarget.value;
+		if (nextPresetId === promptWindowStore.get().selectedPresetId) return;
+		const pwState = promptWindowStore.get();
+		if (uiStore.get().editableMode && pwState.editableDirty) {
+			const shouldOverwrite = window.confirm("Switching presets will replace your edited segments. Continue?");
+			if (!shouldOverwrite) {
+				event.currentTarget.value = promptWindowStore.get().selectedPresetId;
+				return;
+			}
+		}
+		promptWindowStore.setSelectedPresetId(nextPresetId);
+		if (uiStore.get().editableMode) {
+			const nextPreset = (promptWindowStore.get().storyPresets as any[]).find((preset: any) => preset.id === nextPresetId) || null;
+			seedEditableFromPreset(nextPreset);
+		}
+	}
+
+	function handlePresetGenerate(presetId: string) {
+		if (sessionStore.get().sessionStarted || sessionStore.get().projectResetPending) return;
+		promptWindowStore.setSelectedPresetId(presetId);
+		joinSession({ force: true });
+	}
+
+	function normalizeInitialPrompt(value: unknown): string {
+		return typeof value === "string" ? value.trim() : "";
+	}
+
+	function shouldStartFromCustomPrompt(prompt?: string): boolean {
+		const p = prompt ?? (pendingInitialPromptRef.current || (sessionStore.get().livePromptDraft as string));
+		const normalizedPrompt = normalizeInitialPrompt(p);
+		return Boolean(normalizeInitialPrompt(pendingInitialPromptRef.current) || (!sessionStore.get().sessionStarted && normalizedPrompt));
+	}
+
+	function getInitialPresetId(prompt?: string): string {
+		if (shouldStartFromCustomPrompt(prompt)) {
+			return sanitizePresetId(promptWindowStore.get().customPresetId as string) || DEFAULT_CUSTOM_PRESET_ID;
+		}
+		return (promptWindowStore.get().selectedPresetId as string) || sanitizePresetId(promptWindowStore.get().customPresetId as string);
+	}
+
+	function getInitialPresetLabel(prompt?: string): string {
+		if (shouldStartFromCustomPrompt(prompt)) {
+			return String(promptWindowStore.get().customPresetLabel || "").trim() || "Custom rollout";
+		}
+		const sp = promptWindowStore.get().selectedPreset as Record<string, any> | null;
+		return sp?.label || String(promptWindowStore.get().customPresetLabel || "").trim() || "Current rollout";
+	}
+
+	function getSessionInitPrompts(): string[] {
+		if (shouldStartFromCustomPrompt()) return [];
+		return promptWindowStore.get().outboundSessionPrompts as string[];
+	}
+
+	// --- Playback & clip management ---
+
+	function makePromptId(): string {
+		if (typeof crypto !== "undefined" && crypto.randomUUID) {
+			return crypto.randomUUID();
+		}
+		return `prompt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+	}
+
+	function resetPlaybackState() {
+		avPipeline.reset();
+		archivedPlaybackPipeline.reset();
+		lastArchivedReplayKeyRef.current = "";
+		streamStore.patch({
+			loadingAnimation: false,
+			mediaAppendError: null,
+			avPlaybackStarted: false,
+		});
+	}
+
+	function clearCountdownInterval() {
+		if (countdownIntervalRef.current) {
+			clearInterval(countdownIntervalRef.current);
+			countdownIntervalRef.current = null;
+		}
+	}
+
+	function clearTtffInterval() {
+		if (ttffIntervalRef.current) {
+			clearInterval(ttffIntervalRef.current);
+			ttffIntervalRef.current = null;
+		}
+	}
+
+	function resetTtffTimer() {
+		clearTtffInterval();
+		ttffStartAtMsRef.current = null;
+		setTtffValueMs(null);
+	}
+
+	function startTtffTimer() {
+		clearTtffInterval();
+		ttffStartAtMsRef.current = performance.now();
+		setTtffValueMs(0);
+		ttffIntervalRef.current = setInterval(() => {
+			if (ttffStartAtMsRef.current !== null) {
+				setTtffValueMs(performance.now() - ttffStartAtMsRef.current);
+			}
+		}, 16);
+	}
+
+	function markFirstFrameRendered() {
+		const now = performance.now();
+		if (ttffStartAtMsRef.current !== null && ttffIntervalRef.current) {
+			setTtffValueMs(now - ttffStartAtMsRef.current);
+			clearTtffInterval();
+		}
+		if (streamStore.get().lastVideoCompletedAtMs !== null) {
+			streamStore.patch({
+				timeBetweenVideosMs: now - (streamStore.get().lastVideoCompletedAtMs as number),
+				lastVideoCompletedAtMs: null,
+			});
+		}
+		setTimeout(() => {
+			if (!showLivePlayback) return;
+			const thumb = captureVideoThumbnail();
+			if (thumb) {
+				setCurrentThumbnail(thumb);
+				const events = rewriteStore.get().promptEvents as Record<string, any>[];
+				const latest = events.find((e) => String(e?.source || "") === "user_rewrite");
+				if (latest?.promptId) {
+					rewriteStore.trackPromptEvent(latest.promptId, { resultThumbnail: thumb });
+				}
+				void saveCurrentProject();
+			}
+		}, 500);
+	}
+
+	function startSessionCountdown() {
+		clearCountdownInterval();
+		countdownIntervalRef.current = setInterval(() => {
+			const currentTimeLeft = sessionStore.get().timeLeft as number;
+			if (typeof currentTimeLeft === "number" && currentTimeLeft > 0) {
+				sessionStore.patch({ timeLeft: currentTimeLeft - 1 });
+			} else {
+				clearCountdownInterval();
+			}
+		}, 1000);
+	}
+
+	function shouldUseArchivedPlaybackFallback(): boolean {
+		return typeof avPipeline.usesNativePlaybackFallback === "function" && avPipeline.usesNativePlaybackFallback();
+	}
+
+	function shouldPreferArchivedBlobPlayback(clip: any): boolean {
+		return Boolean(clip?.objectUrl && clip?.blob instanceof Blob);
+	}
+
+	function cloneArchivedChunk(chunk: any): any {
+		if (chunk instanceof ArrayBuffer) return chunk.slice(0);
+		if (ArrayBuffer.isView(chunk)) {
+			return chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength);
+		}
+		return chunk;
+	}
+
+	function normalizeArchivedSegments(rawSegments: any): ArchivedSegmentLike[] {
+		if (!Array.isArray(rawSegments)) return [];
+		const normalized: ArchivedSegmentLike[] = [];
+		rawSegments.forEach((segment: any, index: number) => {
+			const rawChunks = Array.isArray(segment?.chunks) ? segment.chunks : [];
+			const chunks = rawChunks
+				.map((chunk: any) => {
+					const cloned = cloneArchivedChunk(chunk);
+					return cloned instanceof ArrayBuffer ? cloned : null;
+				})
+				.filter((chunk: ArrayBuffer | null): chunk is ArrayBuffer => chunk instanceof ArrayBuffer);
+			if (chunks.length === 0) return;
+			const streamId = typeof segment?.streamId === "string" && segment.streamId.trim() ? segment.streamId.trim() : `segment-${index + 1}`;
+			const segmentIdx = Number.isInteger(segment?.segmentIdx) ? Number(segment.segmentIdx) : null;
+			normalized.push({
+				key: typeof segment?.key === "string" && segment.key.trim() ? segment.key.trim() : `${segmentIdx ?? "na"}:${streamId}`,
+				segmentIdx,
+				streamId,
+				mime: typeof segment?.mime === "string" && segment.mime.trim() ? segment.mime.trim() : DEFAULT_AV_MIME,
+				completed: Boolean(segment?.completed),
+				chunks,
+			});
+		});
+		return normalized;
+	}
+
+	async function remuxArchivedSegmentsBestEffort(segments: ArchivedSegmentLike[], label: string): Promise<Blob | null> {
+		const normalizedSegments = normalizeArchivedSegments(segments);
+		if (normalizedSegments.length === 0) return null;
+
+		try {
+			return await remuxArchivedFmp4Segments(normalizedSegments, {
+				includeInProgress: true,
+				mimeType: "video/mp4",
+			});
+		} catch (error) {
+			try {
+				return await remuxArchivedFmp4Segments(normalizedSegments, {
+					includeInProgress: false,
+					mimeType: "video/mp4",
+				});
+			} catch (fallbackError) {
+				console.warn("Unable to remux archived segments:", {
+					error,
+					fallbackError,
+					label,
+				});
+				return null;
+			}
+		}
+	}
+
+	async function archiveCompletedClip() {
+		const lrc = streamStore.get().liveClip as Record<string, any> | null;
+		if (!lrc || !avPipeline.hasArchivedChunks()) return null;
+		const previewBlob = avPipeline.buildArchivedStreamBlob();
+		const archivedSegments = normalizeArchivedSegments(typeof avPipeline.takeArchivedSegmentSnapshots === "function" ? avPipeline.takeArchivedSegmentSnapshots({ includeInProgress: true }) : []);
+		const chunks = avPipeline.takeArchivedStreamChunks();
+		const rawBlob =
+			previewBlob instanceof Blob && previewBlob.size > 0
+				? new Blob(chunks, {
+						type: previewBlob.type || DEFAULT_AV_MIME,
+					})
+				: null;
+		if (!(rawBlob instanceof Blob) || rawBlob.size === 0) return null;
+
+		let blob = rawBlob;
+		let remuxed = false;
+		if (archivedSegments.length > 0) {
+			const remuxedBlob = await remuxArchivedSegmentsBestEffort(archivedSegments, lrc.label || "Generated clip");
+			if (remuxedBlob instanceof Blob && remuxedBlob.size > 0) {
+				blob = remuxedBlob;
+				remuxed = true;
+			}
+		}
+		const objectUrl = URL.createObjectURL(blob);
+		const archivedClip = {
+			id: makePromptId(),
+			label: lrc.label || "Generated clip",
+			prompt: lrc.prompt || "",
+			promptWindowPrompts: clonePromptWindowPrompts(lrc.promptWindowPrompts),
+			mime: blob.type || DEFAULT_AV_MIME,
+			blob,
+			objectUrl,
+			chunks: chunks.map((chunk: any) => cloneArchivedChunk(chunk)),
+			archivedSegments,
+			remuxed,
+			createdAt: Date.now(),
+		};
+		streamStore.addCompletedClip(archivedClip);
+
+		// Link this archived clip to the most recent unlinked user_rewrite prompt event
+		const events = rewriteStore.get().promptEvents as Record<string, any>[];
+		const unlinkedEvent = events.find(
+			(e) => String(e?.source || "") === "user_rewrite" && !e.clipId
+		);
+		if (unlinkedEvent?.promptId) {
+			rewriteStore.trackPromptEvent(unlinkedEvent.promptId, { clipId: archivedClip.id });
+		}
+
+		return archivedClip;
+	}
+
+	function revokeCompletedClipUrls() {
+		(streamStore.get().completedClips as any[]).forEach((clip: any) => {
+			if (clip?.objectUrl) URL.revokeObjectURL(clip.objectUrl);
+		});
+	}
+
+	function clearSessionArchivedClips() {
+		revokeCompletedClipUrls();
+		streamStore.patch({
+			completedSimpleClips: [],
+			completedClips: [],
+		});
+	}
+
+	function selectClip(clipId: string, playbackStartTime = 0) {
+		const clip = (streamStore.get().completedClips as any[]).find((item: any) => item.id === clipId) || null;
+		if (!clip) return;
+		streamStore.selectClip(clip.id, playbackStartTime);
+	}
+
+	async function playArchivedObjectUrl(clip: any, playbackStartTime = 0) {
+		const el = archivedPlaybackElRef.current;
+		if (!el || !clip?.objectUrl) return;
+		el.src = clip.objectUrl;
+		el.load();
+		try {
+			if (Number.isFinite(playbackStartTime) && playbackStartTime > 0) {
+				el.currentTime = playbackStartTime;
+			}
+		} catch (_) {
+			/* noop */
+		}
+		const playPromise = el.play();
+		if (playPromise?.catch) playPromise.catch(() => {});
+	}
+
+	async function restoreArchivedPlayback(clip: any, playbackStartTime = 0) {
+		if (!clip || !archivedPlaybackElRef.current) return;
+		if (shouldUseArchivedPlaybackFallback() || shouldPreferArchivedBlobPlayback(clip)) {
+			archivedPlaybackPipeline.reset();
+			await yieldToEventLoop();
+			await playArchivedObjectUrl(clip, playbackStartTime);
+			return;
+		}
+		const clipChunks = Array.isArray(clip.chunks) ? clip.chunks : [];
+		archivedPlaybackPipeline.reset();
+		await yieldToEventLoop();
+		if (!archivedPlaybackElRef.current) return;
+		if (clipChunks.length === 0) {
+			await playArchivedObjectUrl(clip, playbackStartTime);
+			return;
+		}
+		try {
+			await archivedPlaybackPipeline.ensurePipeline(clip.mime || DEFAULT_AV_MIME, true);
+			clipChunks.forEach((chunk: any) => {
+				archivedPlaybackPipeline.enqueueChunk(cloneArchivedChunk(chunk));
+			});
+			archivedPlaybackPipeline.setStreamCompleted(true);
+			archivedPlaybackPipeline.tryEndStream();
+			try {
+				const el = archivedPlaybackElRef.current;
+				if (el && Number.isFinite(playbackStartTime) && playbackStartTime > 0) {
+					el.currentTime = playbackStartTime;
+				}
+			} catch (_) {
+				/* noop */
+			}
+			archivedPlaybackPipeline.maybeStartPlayback();
+		} catch (error) {
+			console.error("Failed to restore archived playback:", error);
+			archivedPlaybackPipeline.reset();
+			await playArchivedObjectUrl(clip, playbackStartTime);
+		}
+	}
+
+	async function finalizeStreamCompletion({ isFallback = false } = {}) {
+		avPipeline.setStreamCompleted(true);
+		avPipeline.maybeStartPlayback();
+		avPipeline.tryEndStream();
+		streamStore.patch({
+			loadingAnimation: false,
+			avPlaybackStarted: false,
+			generatingSeedPromptIndex: null,
+			lastVideoCompletedAtMs: performance.now(),
+		});
+		if (shouldUseArchivedPlaybackFallback()) {
+			// Native fallback path: must await archive because the blob
+			// is the only way to display the video.
+			const archivedClip = await archiveCompletedClip();
+			if (archivedClip) {
+				streamStore.selectClip(archivedClip.id, 0);
+				streamStore.patch({
+					pendingClip: null,
+					avPlaybackStarted: true,
+					loadingAnimation: false,
+				});
+			} else {
+				streamStore.patch({
+					activeClipId: "",
+					activePlaybackStartTime: 0,
+					pendingClip: null,
+				});
+			}
+		} else {
+			// MSE path (desktop, iOS Safari 17+): archive in background
+			// so the message queue isn't blocked by slow remuxing.
+			// archiveCompletedClip takes data from the pipeline
+			// synchronously before its first await, so it's safe even
+			// if markStreamStarting() runs before the remux finishes.
+			streamStore.patch({
+				activeClipId: "",
+				activePlaybackStartTime: 0,
+				pendingClip: null,
+			});
+			void archiveCompletedClip().then(() => {
+				void saveCurrentProject({ refreshList: true });
+			});
+		}
+		if (isFallback) {
+			console.log("All segments complete (fallback)");
+		} else {
+			console.log("All segments complete");
+		}
+		void saveCurrentProject({ refreshList: true });
+	}
+
+	// --- Session controls ---
+
+	function handleEnhancementToggle(event: any) {
+		sessionStore.patch({
+			enhancementEnabled: Boolean(event.currentTarget.checked),
+			promptExtensionError: "",
+		});
+	}
+
+	function handleCuratedPromptLimitChange(event: any) {
+		const nextValue = Number.parseInt(event.currentTarget.value, 10);
+		if (Number.isNaN(nextValue)) return;
+		promptWindowStore.setCuratedPromptLimit(nextValue);
+	}
+
+	function setSeedPrompts(nextPrompts: string[]) {
+		promptWindowStore.setSeedPrompts(nextPrompts);
+	}
+
+	function addEditableSegment() {
+		promptWindowStore.addEditableSegment();
+	}
+
+	function removeEditableSegment(index: number) {
+		promptWindowStore.removeEditableSegment(index);
+	}
+
+	function updateEditableSegment(index: number, value: string) {
+		promptWindowStore.updateEditableSegment(index, value);
+	}
+
+	function handleCustomPresetIdInput(event: any) {
+		promptWindowStore.setCustomPresetId(event.currentTarget.value);
+	}
+
+	function handleCustomPresetLabelInput(event: any) {
+		promptWindowStore.setCustomPresetLabel(event.currentTarget.value);
+	}
+
+	function resetEditableToPreset() {
+		seedEditableFromPreset(promptWindowStore.get().selectedPreset);
+	}
+
+	function exportEditablePreset() {
+		const segs = promptWindowStore.get().sanitizedEditableSegments as string[];
+		if (segs.length < 2) {
+			window.alert("Please provide at least 2 non-empty segments before exporting.");
+			return;
+		}
+		const pw = promptWindowStore.get();
+		const label = String(pw.customPresetLabel || "").trim() || DEFAULT_CUSTOM_PRESET_LABEL;
+		const id = sanitizePresetId(pw.customPresetId as string);
+		const payload = { id, label, segment_prompts: segs };
+		const blob = new Blob([JSON.stringify(payload, null, 2)], {
+			type: "application/json",
+		});
+		const objectUrl = URL.createObjectURL(blob);
+		const anchor = document.createElement("a");
+		anchor.href = objectUrl;
+		anchor.download = `${id}.json`;
+		document.body.appendChild(anchor);
+		anchor.click();
+		anchor.remove();
+		URL.revokeObjectURL(objectUrl);
+	}
+
+	async function appendPromptWindowToPresetsJson() {
+		const prompts = (promptWindowStore.get().currentPromptWindowPrompts as string[]).map((p) => (typeof p === "string" ? p.trim() : "")).filter((p) => p.length > 0);
+		if (prompts.length < 2) {
+			uiStore.patch({
+				appendPromptWindowError: "Need at least 2 prompts in the prompt window to append.",
+				appendPromptWindowStatus: "",
+			});
+			return;
+		}
+		const pw = promptWindowStore.get();
+		const id = sanitizePresetId(pw.customPresetId as string);
+		const label = String(pw.customPresetLabel || "").trim() || DEFAULT_CUSTOM_PRESET_LABEL;
+		uiStore.patch({
+			appendingPromptWindow: true,
+			appendPromptWindowStatus: "",
+			appendPromptWindowError: "",
+		});
+		try {
+			const response = await fetch("/curated-presets/append", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ id, label, segment_prompts: prompts }),
+			});
+			const payload = await response.json();
+			if (!response.ok) {
+				throw new Error(payload.detail || "Failed to append prompt window to presets JSON.");
+			}
+			const nextPreset = payload.preset;
+			if (nextPreset?.id && nextPreset?.label && Array.isArray(nextPreset?.segment_prompts)) {
+				promptWindowStore.appendStoryPreset(nextPreset);
+			}
+			uiStore.patch({
+				appendPromptWindowStatus: `Appended preset "${label}" to presets JSON.`,
+			});
+		} catch (error: any) {
+			uiStore.patch({
+				appendPromptWindowError: error?.message || String(error),
+			});
+		} finally {
+			uiStore.patch({ appendingPromptWindow: false });
+		}
+	}
+
+	// --- Live prompt ---
+
+	function formatPromptWindowEventText(prompts: any): string {
+		if (!Array.isArray(prompts)) return "";
+		const normalized = prompts.map((p: any) => (typeof p === "string" ? p.trim() : "")).filter((p: string) => p.length > 0);
+		return normalized.map((p: string, i: number) => `[${i + 1}] ${p}`).join("\n");
+	}
+
+	function parseLatencyMs(value: any): number | null {
+		const numericValue = Number(value);
+		return Number.isFinite(numericValue) ? numericValue : null;
+	}
+
+	function trackPromptEvent(promptId: string, update: any) {
+		rewriteStore.trackPromptEvent(promptId, update);
+	}
+
+	function addPromptEvent(event: any) {
+		rewriteStore.addPromptEvent(event);
+	}
+
+	function captureVideoThumbnail(): string | null {
+		const video = showLivePlayback ? videoElRef.current : (archivedPlaybackElRef.current || videoElRef.current);
+		if (!video || video.videoWidth === 0 || video.videoHeight === 0) return null;
+		try {
+			const canvas = document.createElement("canvas");
+			canvas.width = 160;
+			canvas.height = Math.round(160 * (video.videoHeight / video.videoWidth));
+			const ctx = canvas.getContext("2d");
+			if (!ctx) return null;
+			ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+			return canvas.toDataURL("image/jpeg", 0.7);
+		} catch {
+			return null;
+		}
+	}
+
+	function summarizePresetPrompt(prompts: any): string {
+		if (!Array.isArray(prompts)) return "";
+		return prompts
+			.map((p: any) => (typeof p === "string" ? p.trim() : ""))
+			.filter((p: string) => p.length > 0)
+			.slice(0, 2)
+			.join("\n\n");
+	}
+
+	function clonePromptWindowPrompts(prompts: any): string[] {
+		return normalizePromptWindowSnapshot(prompts);
+	}
+
+	function getSelectedEventPromptWindowPrompts(selectedClipId: string): string[] {
+		if (!selectedClipId) return [];
+		const selectedEvent = (rewriteStore.get().promptEvents as any[]).find(
+			(event: any) => event?.clipId === selectedClipId,
+		);
+		return clonePromptWindowPrompts(selectedEvent?.sourcePromptWindowPrompts);
+	}
+
+	function getSelectedClipPromptWindowPrompts(): string[] {
+		const selectedClipId = String(streamStore.get().activeClipId || "").trim();
+		if (!selectedClipId) return [];
+		const selectedClip = (streamStore.get().completedClips as any[]).find((clip: any) => clip?.id === selectedClipId) || null;
+		const clipPromptWindowPrompts = clonePromptWindowPrompts(selectedClip?.promptWindowPrompts);
+		if (clipPromptWindowPrompts.length > 0) {
+			return clipPromptWindowPrompts;
+		}
+		return getSelectedEventPromptWindowPrompts(selectedClipId);
+	}
+
+	function getActivePromptWindowPrompts(): string[] {
+		const selectedClipPrompts = getSelectedClipPromptWindowPrompts();
+		if (selectedClipPrompts.length > 0) {
+			return selectedClipPrompts;
+		}
+		return clonePromptWindowPrompts(promptWindowStore.get().currentPromptWindowPrompts);
+	}
+
+	function getRewriteSourcePromptWindowSnapshot(): string[] {
+		const selectedClipPrompts = getSelectedClipPromptWindowPrompts();
+		if (selectedClipPrompts.length > 0) {
+			return buildRewritePromptWindowSnapshotFromPrompts(selectedClipPrompts);
+		}
+		return buildRewritePromptWindowSnapshot(promptWindowStore.get());
+	}
+
+	function buildPendingStartClip(initialPrompt?: string) {
+		const p = initialPrompt ?? pendingInitialPromptRef.current;
+		const normalizedInitialPrompt = normalizeInitialPrompt(p);
+		return {
+			label: getInitialPresetLabel(p) || "Preset story",
+			prompt: normalizedInitialPrompt || summarizePresetPrompt(promptWindowStore.get().outboundSessionPrompts),
+			source: normalizedInitialPrompt ? "initial_rewrite" : "preset",
+			promptWindowPrompts: clonePromptWindowPrompts(getSessionInitPrompts()),
+		};
+	}
+
+	function buildPendingContinuationClip(prompt: string) {
+		const nextIndex = (streamStore.get().completedClips as any[]).length + 1;
+		return {
+			label: `Cuts ${nextIndex}`,
+			prompt: prompt.trim(),
+			source: "append_prompt",
+			promptWindowPrompts: getActivePromptWindowPrompts(),
+		};
+	}
+
+	function buildClipLabel({ segmentIdx = null as number | null, source = "" } = {}) {
+		const normalizedSource = String(source || "")
+			.trim()
+			.toLowerCase();
+		const sp = promptWindowStore.get().selectedPreset as Record<string, any> | null;
+		if (normalizedSource === "curated") {
+			if (segmentIdx === 1) return sp?.label || "Preset story";
+			if (Number.isInteger(segmentIdx) && (segmentIdx as number) > 1) return `${sp?.label || "Preset story"} ${segmentIdx}`;
+			return sp?.label || "Preset story";
+		}
+		if (Number.isInteger(segmentIdx) && (segmentIdx as number) > 0) {
+			return `Cuts ${segmentIdx}`;
+		}
+		return `Cuts ${(streamStore.get().completedClips as any[]).length + 1}`;
+	}
+
+	function submitLivePrompt() {
+		const ws = wsRef.current;
+		if (!ws || ws.readyState !== WebSocket.OPEN) return;
+		if (sessionStore.get().projectResetPending) return;
+		const now = Date.now();
+		if (now - lastSubmitTimeRef.current < SUBMIT_COOLDOWN_MS) return;
+		const prompt = (sessionStore.get().livePromptDraft as string).trim();
+		if (!prompt) return;
+		lastSubmitTimeRef.current = now;
+		const rCAR = !uiStore.get().devtoolsMode && !uiStore.get().demoMode;
+		if (rCAR || (sessionStore.get().livePromptRewriteMode && !uiStore.get().demoMode)) {
+			if (rewriteStore.get().rewritingSeedPrompts) return;
+			const rewriteSourcePromptWindowPrompts = getActivePromptWindowPrompts();
+			const nextPendingClip = {
+				...buildPendingContinuationClip(prompt),
+				promptWindowPrompts: rewriteSourcePromptWindowPrompts,
+			};
+			rewriteStore.patch({ rewritingSeedPrompts: true });
+			setCurrentThumbnail(null);
+			const promptId = makePromptId();
+			addPromptEvent({
+				promptId,
+				status: "rewrite_requested",
+				source: "user_rewrite",
+				text: prompt,
+				thumbnail: captureVideoThumbnail(),
+				sourcePromptWindowPrompts: rewriteSourcePromptWindowPrompts,
+			});
+			ws.send(
+				JSON.stringify({
+					type: "rewrite_seed_prompts",
+					rewrite_instruction: prompt,
+					prompt_window_prompts: buildRewritePromptWindowSnapshotFromPrompts(
+						rewriteSourcePromptWindowPrompts,
+					),
+				}),
+			);
+			streamStore.patch({
+				pendingClip: nextPendingClip,
+				activeClipId: shouldUseArchivedPlaybackFallback() ? streamStore.get().activeClipId : "",
+				activePlaybackStartTime: shouldUseArchivedPlaybackFallback() ? streamStore.get().activePlaybackStartTime : 0,
+			});
+			sessionStore.patch({ livePromptDraft: "" });
+			return;
+		}
+		const promptId = makePromptId();
+		addPromptEvent({
+			promptId,
+			status: "submitted",
+			source: "user_raw",
+			text: prompt,
+		});
+		ws.send(
+			JSON.stringify({
+				type: "append_prompt",
+				prompt_id: promptId,
+				prompt,
+			}),
+		);
+		streamStore.patch({
+			pendingClip: buildPendingContinuationClip(prompt),
+			activeClipId: shouldUseArchivedPlaybackFallback() ? streamStore.get().activeClipId : "",
+			activePlaybackStartTime: shouldUseArchivedPlaybackFallback() ? streamStore.get().activePlaybackStartTime : 0,
+		});
+		sessionStore.patch({ livePromptDraft: "" });
+	}
+
+	function setLivePromptRewriteMode(enabled: boolean) {
+		const dm = uiStore.get().demoMode;
+		if (dm) {
+			sessionStore.patch({ livePromptRewriteMode: false });
+			return;
+		}
+		const rCAR = !uiStore.get().devtoolsMode && !dm;
+		if (rCAR) {
+			sessionStore.patch({ livePromptRewriteMode: true });
+			return;
+		}
+		sessionStore.patch({ livePromptRewriteMode: Boolean(enabled) });
+	}
+
+	function handleLivePromptModeToggle(event: any) {
+		setLivePromptRewriteMode(Boolean(event.currentTarget.checked));
+	}
+
+	const PROMPT_MAX_LENGTH = 500;
+
+	function handleLivePromptInput(event: any) {
+		const value = (event.currentTarget.value as string).slice(0, PROMPT_MAX_LENGTH);
+		sessionStore.patch({ livePromptDraft: value });
+	}
+
+	const lastSubmitTimeRef = useRef(0);
+	const SUBMIT_COOLDOWN_MS = 1000;
+	const liveInterimLenRef = useRef(0);
+
+	function handleLivePromptSpeechTranscript(text: string) {
+		const current = (sessionStore.get().livePromptDraft as string) || "";
+		const base = liveInterimLenRef.current > 0 ? current.slice(0, -liveInterimLenRef.current) : current;
+		liveInterimLenRef.current = 0;
+		const separator = base && !base.endsWith(" ") ? " " : "";
+		sessionStore.patch({ livePromptDraft: base + separator + text });
+	}
+
+	function handleLivePromptSpeechInterim(text: string) {
+		const current = (sessionStore.get().livePromptDraft as string) || "";
+		const base = liveInterimLenRef.current > 0 ? current.slice(0, -liveInterimLenRef.current) : current;
+		if (!text) {
+			liveInterimLenRef.current = 0;
+			sessionStore.patch({ livePromptDraft: base });
+			return;
+		}
+		const separator = base && !base.endsWith(" ") ? " " : "";
+		const appended = separator + text;
+		liveInterimLenRef.current = appended.length;
+		sessionStore.patch({ livePromptDraft: base + appended });
+	}
+
+	function handleLivePromptKeydown(event: any) {
+		if (event.key !== "Enter" || event.isComposing) return;
+		if (event.shiftKey) return;
+		event.preventDefault();
+		submitLivePrompt();
+	}
+
+	function handleAutoExtensionToggle(event: any) {
+		sessionStore.patch({
+			autoExtensionEnabled: Boolean(event.currentTarget.checked),
+		});
+		const ws = wsRef.current;
+		if (!ws || ws.readyState !== WebSocket.OPEN) return;
+		ws.send(
+			JSON.stringify({
+				type: "set_auto_extension",
+				enabled: Boolean(event.currentTarget.checked),
+			}),
+		);
+	}
+
+	function handleLoopGenerationToggle(event: any) {
+		sessionStore.patch({
+			loopGenerationEnabled: Boolean(event.currentTarget.checked),
+		});
+		const ws = wsRef.current;
+		if (!ws || ws.readyState !== WebSocket.OPEN) return;
+		ws.send(
+			JSON.stringify({
+				type: "set_loop_generation",
+				enabled: Boolean(event.currentTarget.checked),
+			}),
+		);
+	}
+
+	function handlePauseToggle() {
+		const nextPaused = !sessionStore.get().generationPaused;
+		sessionStore.patch({ generationPaused: nextPaused });
+		const ws = wsRef.current;
+		if (!ws || ws.readyState !== WebSocket.OPEN) return;
+		ws.send(
+			JSON.stringify({
+				type: "set_generation_paused",
+				paused: nextPaused,
+			}),
+		);
+	}
+
+	function resetToSeedPrompts() {
+		const ws = wsRef.current;
+		if (!ws || ws.readyState !== WebSocket.OPEN) return;
+		ws.send(JSON.stringify({ type: "reset_to_seed_prompts" }));
+	}
+
+	function rewriteSeedPrompts() {
+		const ws = wsRef.current;
+		if (!ws || ws.readyState !== WebSocket.OPEN) return;
+		if (rewriteStore.get().rewritingSeedPrompts) return;
+		rewriteStore.patch({ rewritingSeedPrompts: true });
+		ws.send(
+			JSON.stringify({
+				type: "rewrite_seed_prompts",
+				prompt_window_prompts: getRewriteSourcePromptWindowSnapshot(),
+			}),
+		);
+	}
+
+	function restartGenerationAfterCap() {
+		const ws = wsRef.current;
+		if (!ws || ws.readyState !== WebSocket.OPEN) return;
+		ws.send(JSON.stringify({ type: "restart_generation" }));
+	}
+
+	// --- Prompt config editor ---
+
+	async function loadPromptConfig(force = false) {
+		const ui = uiStore.get();
+		if (!ui.editableMode) return;
+		if (ui.promptConfigLoading) return;
+		if (ui.promptConfigLoaded && !force) return;
+		uiStore.patch({
+			promptConfigLoading: true,
+			promptConfigError: "",
+			promptConfigStatus: "",
+		});
+		try {
+			const response = await fetch("/prompt-system-config");
+			const payload = await response.json();
+			if (!response.ok) {
+				throw new Error(payload.detail || "Failed to load prompt system config.");
+			}
+			uiStore.patch({
+				nextSegmentSystemPromptDraft: payload.next_segment_system_prompt || "",
+				autoExtensionSystemPromptDraft: payload.auto_extension_system_prompt || "",
+				rewriteWindowSystemPromptDraft: payload.rewrite_window_system_prompt || "",
+				promptConfigLoaded: true,
+				promptConfigStatus: "Loaded from disk.",
+			});
+		} catch (error: any) {
+			uiStore.patch({
+				promptConfigError: error?.message || String(error),
+			});
+		} finally {
+			uiStore.patch({ promptConfigLoading: false });
+		}
+	}
+
+	function handlePromptConfigEditorToggle(event: any) {
+		const isOpen = Boolean(event.currentTarget.open);
+		uiStore.patch({ promptConfigEditorOpen: isOpen });
+		if (isOpen) loadPromptConfig();
+	}
+
+	function handleNextSegmentSystemPromptInput(event: any) {
+		uiStore.patch({
+			nextSegmentSystemPromptDraft: event.currentTarget.value,
+		});
+	}
+
+	function handleRewriteWindowSystemPromptInput(event: any) {
+		uiStore.patch({
+			rewriteWindowSystemPromptDraft: event.currentTarget.value,
+		});
+	}
+
+	function handleAutoExtensionSystemPromptInput(event: any) {
+		uiStore.patch({
+			autoExtensionSystemPromptDraft: event.currentTarget.value,
+		});
+	}
+
+	async function savePromptConfig() {
+		const ui = uiStore.get();
+		if (!ui.editableMode || ui.promptConfigSaving) return;
+		uiStore.patch({
+			promptConfigSaving: true,
+			promptConfigError: "",
+			promptConfigStatus: "",
+		});
+		try {
+			const response = await fetch("/prompt-system-config", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					next_segment_system_prompt: ui.nextSegmentSystemPromptDraft,
+					auto_extension_system_prompt: ui.autoExtensionSystemPromptDraft,
+					rewrite_window_system_prompt: ui.rewriteWindowSystemPromptDraft,
+				}),
+			});
+			const payload = await response.json();
+			if (!response.ok) {
+				throw new Error(payload.detail || "Failed to save prompt system config.");
+			}
+			uiStore.patch({
+				nextSegmentSystemPromptDraft: payload.next_segment_system_prompt || "",
+				autoExtensionSystemPromptDraft: payload.auto_extension_system_prompt || "",
+				rewriteWindowSystemPromptDraft: payload.rewrite_window_system_prompt || "",
+				promptConfigLoaded: true,
+				promptConfigStatus: "Saved to disk.",
+			});
+		} catch (error: any) {
+			uiStore.patch({
+				promptConfigError: error?.message || String(error),
+			});
+		} finally {
+			uiStore.patch({ promptConfigSaving: false });
+		}
+	}
+
+	// --- Session lifecycle ---
+
+	function resetToLobbyState({ preserveSessionNotice = false, preservePlayback = false } = {}) {
+		setVideoMuted(true);
+		clearCountdownInterval();
+		pendingInitialPromptRef.current = "";
+		sessionStore.patch({
+			sessionStarted: false,
+			connected: false,
+			connecting: false,
+			gpuAssigned: false,
+			timeLeft: null,
+			queuePosition: 0,
+			sessionTimeout: null,
+			livePromptDraft: "",
+			autoExtensionTimeoutHint: "",
+			generationPaused: false,
+			loopGenerationEnabled: false,
+			generationCapReached: false,
+			generationSegmentCap: 0,
+			generatedSegmentCount: 0,
+			enhancementEnabled: sessionStore.get().enhancementEnabled,
+			promptExtensionError: "",
+			preservePlaybackOnClose: false,
+			sessionNotice: preserveSessionNotice ? sessionStore.get().sessionNotice : "",
+			sessionExpired: preserveSessionNotice ? sessionStore.get().sessionExpired : false,
+			projectResetPending: false,
+		});
+		rewriteStore.resetSessionState();
+		streamStore.resetSessionState();
+		promptWindowStore.resetSessionState();
+		uiStore.resetSessionState();
+		resetTtffTimer();
+		if (!preservePlayback) resetPlaybackState();
+	}
+
+	function resetToProjectLobbyState() {
+		setVideoMuted(true);
+		pendingInitialPromptRef.current = "";
+		sessionStore.patch({
+			sessionStarted: false,
+			livePromptDraft: "",
+			autoExtensionTimeoutHint: "",
+			generationPaused: false,
+			generationCapReached: false,
+			generationSegmentCap: 0,
+			generatedSegmentCount: 0,
+			promptExtensionError: "",
+			preservePlaybackOnClose: false,
+			sessionNotice: "",
+			sessionExpired: false,
+			projectResetPending: false,
+		});
+		rewriteStore.resetSessionState();
+		streamStore.resetSessionState();
+		promptWindowStore.resetSessionState();
+		uiStore.resetSessionState();
+		resetTtffTimer();
+		resetPlaybackState();
+	}
+
+	function buildProjectInitPayload(type: "session_init_v2" | "project_init_v1") {
+		const segmentPrompts = getSessionInitPrompts();
+		setSeedPrompts(segmentPrompts);
+		return {
+			type,
+			preset_id: getInitialPresetId(),
+			preset_label: getInitialPresetLabel(),
+			curated_prompts: segmentPrompts,
+			initial_rollout_prompt: normalizeInitialPrompt(pendingInitialPromptRef.current),
+			initial_image: null,
+			single_clip_mode: false,
+			enhancement_enabled: sessionStore.get().enhancementEnabled,
+			auto_extension_enabled: sessionStore.get().autoExtensionEnabled,
+			loop_generation_enabled: sessionStore.get().loopGenerationEnabled,
+		};
+	}
+
+	function sendSessionInitMessage() {
+		const ws = wsRef.current;
+		if (!ws) return;
+		ws.send(JSON.stringify(buildProjectInitPayload("session_init_v2")));
+	}
+
+	function sendProjectInitMessage() {
+		const ws = wsRef.current;
+		if (!ws || ws.readyState !== WebSocket.OPEN) return;
+		ws.send(JSON.stringify(buildProjectInitPayload("project_init_v1")));
+	}
+
+	function sendEndProjectKeepSession() {
+		const ws = wsRef.current;
+		if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+		ws.send(JSON.stringify({ type: "end_project_keep_session" }));
+		return true;
+	}
+
+	async function handleProjectIdle() {
+		await saveCurrentProject({ refreshList: true });
+		clearSessionArchivedClips();
+		currentProjectIdRef.current = "";
+		currentProjectCreatedAtRef.current = 0;
+		markActiveProjectId(null);
+		setCurrentThumbnail(null);
+		resetToProjectLobbyState();
+	}
+
+	async function handleSocketMessage(event: MessageEvent) {
+		const decoded = await decodeWebSocketEvent(event);
+		if (decoded.kind === "binary") {
+			avPipeline.enqueueChunk(decoded.data);
+			return;
+		}
+		if (decoded.kind !== "json") return;
+		if (decoded.data?.type === "error" && isInfrastructureError(decoded.data)) {
+			const message = typeof decoded.data?.message === "string" && decoded.data.message.trim()
+				? decoded.data.message.trim()
+				: "Dreamverse backend is temporarily unavailable.";
+			console.warn("[InfrastructureError]", message);
+			rewriteStore.patch({ rewritingSeedPrompts: false });
+			recoverFailedSessionStart(message);
+			return;
+		}
+		const normalizedEvent = normalizeSocketMessage(decoded.data);
+		await applyNormalizedSocketEvent(normalizedEvent, {
+			sessionStore,
+			promptWindowStore,
+			rewriteStore,
+			streamStore,
+			uiStore,
+			avPipeline,
+			tick: yieldToEventLoop,
+			defaultAvMime: DEFAULT_AV_MIME,
+			fixedRewriteModel: FIXED_REWRITE_MODEL,
+			parseLatencyMs,
+			formatPromptWindowEventText,
+			makePromptId,
+			buildClipLabel,
+			startSessionCountdown,
+			clearCountdownInterval,
+			resetTtffTimer,
+			startTtffTimer,
+			preserveArchivedPlaybackSelection: shouldUseArchivedPlaybackFallback(),
+			finalizeStreamCompletion,
+		});
+		if (normalizedEvent.type === "session/project_idle") {
+			await handleProjectIdle();
+		}
+	}
+
+	function connectWebSocket() {
+		if (wsRef.current) {
+			detachAndCloseWebSocket(wsRef.current);
+			wsRef.current = null;
+		}
+		wsMessageQueueRef.current = Promise.resolve();
+		sessionStore.patch({ connecting: true, connected: false });
+		try {
+			const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+			let opened = false;
+			wsRef.current = createWebSocketConnection({
+				url: `${wsProtocol}//${window.location.host}/ws`,
+				binaryType: "arraybuffer",
+				onOpen: () => {
+					opened = true;
+					sessionStore.patch({ connected: true, connecting: false });
+					sendSessionInitMessage();
+				},
+				onMessage: (event: MessageEvent) => {
+					wsMessageQueueRef.current = wsMessageQueueRef.current
+						.then(() => handleSocketMessage(event))
+						.catch((error) => {
+							console.error("Failed to handle websocket message:", error);
+						});
+				},
+				onError: () => {},
+				onClose: () => {
+					wsRef.current = null;
+					const ss = sessionStore.get();
+					const hadActiveStream = ss.sessionStarted && avPipeline.hasArchivedChunks();
+					rewriteStore.patch({ rewritingSeedPrompts: false });
+					if (!opened && ss.sessionStarted && !ss.sessionExpired && !hadActiveStream) {
+						if (ss.sessionNotice) {
+							recoverFailedSessionStart(ss.sessionNotice);
+							return;
+						}
+						void (async () => {
+							const probe = await probeBackendReadiness();
+							const fallbackNotice = probe.ok
+								? "Dreamverse backend closed the websocket before the session started. Retry after the backend finishes starting."
+								: probe.notice;
+							recoverFailedSessionStart(fallbackNotice);
+						})();
+						return;
+					}
+					if (ss.sessionExpired || hadActiveStream) {
+						void (async () => {
+							await wsMessageQueueRef.current;
+							await finalizeStreamCompletion();
+							const clips = streamStore.get().completedClips as any[];
+							if (clips.length > 0) {
+								streamStore.selectClip(clips[clips.length - 1].id, 0);
+							}
+							// Reuse the sessionExpired UI path: it keeps
+							// the VideoPlayer mounted and shows "Session
+							// ended" with a "New Project" button, so the
+							// user's generated video stays visible.
+
+							sessionStore.patch({
+								connected: false,
+								connecting: false,
+								gpuAssigned: false,
+								sessionExpired: true,
+								sessionNotice: "",
+							});
+							await saveCurrentProject({ refreshList: true });
+						})();
+					} else {
+						resetToLobbyState({
+							preserveSessionNotice: Boolean(ss.sessionNotice),
+							preservePlayback: Boolean(ss.preservePlaybackOnClose),
+						});
+					}
+				},
+			});
+		} catch (_) {
+			wsRef.current = null;
+			const ss = sessionStore.get();
+			if (ss.sessionExpired) {
+				sessionStore.patch({ connected: false, connecting: false, gpuAssigned: false });
+			} else {
+				resetToLobbyState({
+					preserveSessionNotice: Boolean(ss.sessionNotice),
+					preservePlayback: Boolean(ss.preservePlaybackOnClose),
+				});
+			}
+		}
+	}
+
+	function beginProjectLocally({ force = false } = {}) {
+		if (!force && !canStartSession) return;
+		if (sessionStore.get().sessionStarted || sessionStore.get().projectResetPending) return false;
+		setTimeoutModalOpen(false);
+		// Unmute during the user gesture so iOS Safari permits audio playback.
+		setVideoMuted(false);
+		if (viewingProject) closeViewingProject();
+		clearSessionArchivedClips();
+		currentProjectIdRef.current = makePromptId();
+		currentProjectCreatedAtRef.current = Date.now();
+		markActiveProjectId(currentProjectIdRef.current);
+		setCurrentThumbnail(null);
+		const initialPrompt = normalizeInitialPrompt(sessionStore.get().livePromptDraft as string);
+		pendingInitialPromptRef.current = initialPrompt;
+		const rCAR = !uiStore.get().devtoolsMode && !uiStore.get().demoMode;
+		sessionStore.patch({
+			sessionNotice: "",
+			sessionExpired: false,
+			promptExtensionError: "",
+			generationCapReached: false,
+			generationSegmentCap: 0,
+			generatedSegmentCount: 0,
+			preservePlaybackOnClose: false,
+			sessionStarted: true,
+			livePromptDraft: "",
+			livePromptRewriteMode: rCAR || Boolean(initialPrompt),
+			autoExtensionTimeoutHint: "",
+			generationPaused: false,
+			projectResetPending: false,
+		});
+		resetPlaybackState();
+		streamStore.patch({
+			loadingAnimation: true,
+			playingSeedPromptIndex: null,
+			generatingSeedPromptIndex: null,
+			seedPromptIndexBySegment: {},
+			currentSegmentNumber: 0,
+			promptHistory: [],
+			promptHistoryCounter: 0,
+			selectedHistoryId: "",
+		});
+		rewriteStore.resetSessionState();
+		if (initialPrompt) {
+			addPromptEvent({
+				promptId: makePromptId(),
+				status: "rewrite_requested",
+				source: "user_rewrite",
+				text: initialPrompt,
+			});
+		}
+		setSeedPrompts(getSessionInitPrompts());
+		const nextPendingClip = buildPendingStartClip(initialPrompt);
+		streamStore.patch({
+			pendingClip: nextPendingClip,
+			liveClip: nextPendingClip,
+			activeClipId: "",
+			activePlaybackStartTime: 0,
+		});
+		return true;
+	}
+
+	async function joinSession({ force = false } = {}) {
+		if (
+			wsRef.current
+			&& wsRef.current.readyState === WebSocket.OPEN
+			&& sessionStore.get().connected
+		) {
+			if (!beginProjectLocally({ force })) return;
+			sendProjectInitMessage();
+			return;
+		}
+		showPreSessionNotice("");
+		streamStore.patch({ loadingAnimation: true });
+		sessionStore.patch({ connecting: true });
+		const probe = await probeBackendReadiness();
+		if (!probe.ok) {
+			streamStore.patch({ loadingAnimation: false });
+			showPreSessionNotice(probe.notice);
+			return;
+		}
+		if (!beginProjectLocally({ force })) {
+			streamStore.patch({ loadingAnimation: false });
+			sessionStore.patch({ connecting: false });
+			return;
+		}
+		if (
+			wsRef.current
+			&& wsRef.current.readyState === WebSocket.OPEN
+			&& sessionStore.get().connected
+		) {
+			sendProjectInitMessage();
+			return;
+		}
+		connectWebSocket();
+	}
+
+	async function saveCurrentProject({ refreshList = false } = {}) {
+		if (!currentProjectIdRef.current) return;
+		const pw = promptWindowStore.get();
+		const project: StoredProject = {
+			id: currentProjectIdRef.current,
+			label: currentClipLabel,
+			presetId: (pw.selectedPresetId as string) || "",
+			originalLabel: pendingInitialPromptRef.current || ((pw.selectedPreset as Record<string, any>)?.label as string) || "",
+			createdAt: currentProjectCreatedAtRef.current || Date.now(),
+			lastThumbnail: currentThumbnail,
+			promptEvents: [...(rewriteStore.get().promptEvents as Record<string, unknown>[])],
+		};
+		const clips: StoredClip[] = (streamStore.get().completedClips as any[])
+			.filter((clip: any) => clip?.blob instanceof Blob)
+			.map((clip: any) => ({
+				id: clip.id,
+				projectId: project.id,
+				label: clip.label || "",
+				prompt: clip.prompt || "",
+				mime: clip.mime || "",
+				blob: clip.blob,
+				createdAt: clip.createdAt || Date.now(),
+			}));
+		const persistSnapshot = async () => {
+			try {
+				await saveProjectWithRecovery(project, clips, refreshList);
+			} catch (error) {
+				console.error("Failed to save project:", error);
+			}
+		};
+		const queuedSave = saveQueueRef.current.then(persistSnapshot, persistSnapshot);
+		saveQueueRef.current = queuedSave.catch(() => {});
+		await queuedSave;
+	}
+
+	function markActiveProjectId(id: string | null) {
+		try {
+			if (id) {
+				localStorage.setItem("fastvideo-active-project", id);
+			} else {
+				localStorage.removeItem("fastvideo-active-project");
+			}
+		} catch (_) {
+			/* private browsing */
+		}
+	}
+
+	function isLikelyProjectStoragePressure(error: unknown): boolean {
+		if (error instanceof DOMException) {
+			return [
+				"QuotaExceededError",
+				"AbortError",
+				"UnknownError",
+				"InvalidStateError",
+			].includes(error.name);
+		}
+
+		const message = String(
+			(error as { message?: unknown })?.message || error || "",
+		).toLowerCase();
+		return (
+			message.includes("quota")
+			|| message.includes("storage")
+			|| message.includes("space")
+			|| message.includes("indexeddb")
+			|| message.includes("backing store")
+			|| message.includes("transaction failed")
+			|| message.includes("transaction was aborted")
+		);
+	}
+
+	async function pruneProjectsForStorageRecovery(currentProjectId: string, retainPreviousCount: number): Promise<number> {
+		const projects = await listProjects();
+		let keptPrevious = 0;
+		let deletedCount = 0;
+
+		for (const project of projects) {
+			if (project.id === currentProjectId) {
+				continue;
+			}
+			if (keptPrevious < retainPreviousCount) {
+				keptPrevious += 1;
+				continue;
+			}
+			await deleteProject(project.id);
+			deletedCount += 1;
+		}
+
+		return deletedCount;
+	}
+
+	async function saveProjectWithRecovery(
+		project: StoredProject,
+		clips: StoredClip[],
+		refreshList: boolean,
+	): Promise<void> {
+		try {
+			await saveProject(project, clips);
+		} catch (error) {
+			if (!isLikelyProjectStoragePressure(error)) {
+				throw error;
+			}
+
+			let hasExistingSnapshot = false;
+			try {
+				const existingProjects = await listProjects();
+				hasExistingSnapshot = existingProjects.some(
+					(existingProject) => existingProject.id === project.id,
+				);
+			} catch (snapshotError) {
+				if (!isLikelyProjectStoragePressure(snapshotError)) {
+					throw snapshotError;
+				}
+				console.warn(
+					"Unable to inspect existing project snapshots before retrying save.",
+					{
+						projectId: project.id,
+						error: snapshotError,
+					},
+				);
+			}
+			let lastError: unknown = error;
+			for (const retainPreviousCount of STORAGE_RECOVERY_PREVIOUS_PROJECT_COUNTS) {
+				let deletedCount = 0;
+				try {
+					deletedCount = await pruneProjectsForStorageRecovery(
+						project.id,
+						retainPreviousCount,
+					);
+				} catch (pruneError) {
+					lastError = pruneError;
+					if (!isLikelyProjectStoragePressure(pruneError)) {
+						throw pruneError;
+					}
+					continue;
+				}
+				if (deletedCount === 0 && retainPreviousCount !== 0) {
+					continue;
+				}
+
+				try {
+					await saveProject(project, clips);
+					console.warn(
+						"Recovered project save after pruning older archives.",
+						{
+							projectId: project.id,
+							deletedCount,
+							retainPreviousCount,
+						},
+					);
+					lastError = null;
+					break;
+				} catch (retryError) {
+					lastError = retryError;
+					if (!isLikelyProjectStoragePressure(retryError)) {
+						throw retryError;
+					}
+				}
+			}
+
+			if (lastError && !hasExistingSnapshot && clips.length > 1) {
+				try {
+					await saveProject(project, clips.slice(-1));
+					console.warn(
+						"Recovered project save with only the latest archived clip.",
+						{
+							projectId: project.id,
+							savedClipCount: 1,
+							originalClipCount: clips.length,
+						},
+					);
+					lastError = null;
+				} catch (retryError) {
+					lastError = retryError;
+					if (!isLikelyProjectStoragePressure(retryError)) {
+						throw retryError;
+					}
+				}
+			}
+
+			if (lastError) {
+				try {
+					await saveProjectMetadata(project);
+					console.warn(
+						hasExistingSnapshot
+							? "Recovered project save by preserving the existing archive and updating metadata only."
+							: "Recovered project save by storing project metadata without archived clips.",
+						{
+							projectId: project.id,
+							originalClipCount: clips.length,
+							hadExistingSnapshot: hasExistingSnapshot,
+						},
+					);
+					lastError = null;
+				} catch (metadataError) {
+					lastError = metadataError;
+					if (!isLikelyProjectStoragePressure(metadataError)) {
+						throw metadataError;
+					}
+				}
+			}
+
+			if (lastError) {
+				throw lastError;
+			}
+		}
+
+		try {
+			await pruneOldProjects(MAX_ARCHIVED_PROJECTS);
+		} catch (pruneError) {
+			console.warn("Failed to prune older archived projects after save.", {
+				projectId: project.id,
+				error: pruneError,
+			});
+		}
+		if (refreshList) {
+			await refreshSavedProjects();
+		}
+	}
+
+	async function refreshSavedProjects() {
+		try {
+			const projects = await listProjects();
+			setSavedProjects(projects);
+		} catch (error) {
+			console.error("Failed to load saved projects:", error);
+		}
+	}
+
+	async function handleDeleteProject(projectId: string) {
+		try {
+			await deleteProject(projectId);
+			await refreshSavedProjects();
+			if (viewingProject?.project.id === projectId) {
+				closeViewingProject();
+			}
+		} catch (error) {
+			console.error("Failed to delete project:", error);
+		}
+	}
+
+	async function viewSavedProject(projectId: string) {
+		try {
+			const clips = await loadProjectClips(projectId);
+			const project = savedProjects.find((p) => p.id === projectId);
+			if (!project) return;
+			if (viewingProject) {
+				closeViewingProject();
+			}
+			const hydratedClips = clips.map((clip) => ({
+				id: clip.id,
+				label: clip.label,
+				prompt: clip.prompt,
+				mime: clip.mime,
+				objectUrl: URL.createObjectURL(clip.blob),
+				blob: clip.blob,
+				createdAt: clip.createdAt,
+			}));
+			setViewingProject({ project, clips: hydratedClips });
+			setViewingSelectedClipId("");
+			setSidebarOpen(false);
+		} catch (error) {
+			console.error("Failed to load project:", error);
+		}
+	}
+
+	function closeViewingProject() {
+		if (viewingProject) {
+			viewingProject.clips.forEach((clip) => URL.revokeObjectURL(clip.objectUrl));
+		}
+		setViewingProject(null);
+	}
+
+	async function leaveSession() {
+		setTimeoutModalOpen(false);
+		if (wsRef.current) {
+			detachAndCloseWebSocket(wsRef.current);
+			wsRef.current = null;
+		}
+		await finalizeStreamCompletion();
+		await saveCurrentProject({ refreshList: true });
+		clearSessionArchivedClips();
+		currentProjectIdRef.current = "";
+		currentProjectCreatedAtRef.current = 0;
+		markActiveProjectId(null);
+		resetToLobbyState();
+	}
+
+	async function handleStartNewProject() {
+		setTimeoutModalOpen(false);
+		setSidebarOpen(false);
+		if (viewingProject) {
+			closeViewingProject();
+		}
+		const ss = sessionStore.get();
+		if (ss.projectResetPending) {
+			return;
+		}
+
+		if (
+			wsRef.current
+			&& wsRef.current.readyState === WebSocket.OPEN
+			&& ss.connected
+			&& ss.sessionStarted
+		) {
+			sessionStore.patch({
+				projectResetPending: true,
+				sessionNotice: "",
+			});
+			sendEndProjectKeepSession();
+			return;
+		}
+
+		clearSessionArchivedClips();
+		currentProjectIdRef.current = "";
+		currentProjectCreatedAtRef.current = 0;
+		markActiveProjectId(null);
+		setCurrentThumbnail(null);
+		sessionStore.patch({
+			sessionNotice: "",
+			sessionExpired: false,
+			projectResetPending: false,
+		});
+
+		if (
+			wsRef.current
+			&& wsRef.current.readyState === WebSocket.OPEN
+			&& ss.connected
+		) {
+			resetToProjectLobbyState();
+			return;
+		}
+
+		resetToLobbyState();
+	}
+
+	// --- Formatting helpers ---
+
+	function formatTime(seconds: number): string {
+		const mins = Math.floor(seconds / 60);
+		const secs = seconds % 60;
+		return `${mins}:${secs.toString().padStart(2, "0")}`;
+	}
+
+	function formatDurationMs(durationMs: number): string {
+		return `${(durationMs / 1000).toFixed(3)}s`;
+	}
+
+	async function triggerBlobDownload(blob: Blob, label: string) {
+		const ext = blob.type.includes("webm") ? "webm" : "mp4";
+		const firstPrompt = (currentClipPrompt as string || "")
+			.replace(/[^a-zA-Z0-9 _-]/g, "")
+			.trim()
+			.replace(/\s+/g, "_")
+			.substring(0, 60);
+		const safeName = firstPrompt || "video";
+		const fileName = `${safeName}.${ext}`;
+		const mimeType = blob.type || `video/${ext}`;
+
+		// Use Web Share API on touch-first devices (phones/tablets) for camera-roll access.
+		// "pointer: coarse" excludes desktops where canShare exists but a share dialog is unwanted.
+		if (typeof navigator.canShare === "function" && window.matchMedia("(pointer: coarse)").matches) {
+			try {
+				const file = new File([blob], fileName, { type: mimeType });
+				if (navigator.canShare({ files: [file] })) {
+					await navigator.share({ files: [file] });
+					return;
+				}
+			} catch (err: any) {
+				if (err?.name === "AbortError") return;
+			}
+		}
+
+		const url = URL.createObjectURL(blob);
+		const anchor = document.createElement("a");
+		anchor.href = url;
+		anchor.download = fileName;
+		document.body.appendChild(anchor);
+		anchor.click();
+		anchor.remove();
+		URL.revokeObjectURL(url);
+	}
+
+	function getRemuxableSegmentsFromClip(clip: Record<string, any> | null): ArchivedSegmentLike[] {
+		if (!clip) return [];
+		const archivedSegments = normalizeArchivedSegments(clip.archivedSegments);
+		if (archivedSegments.length > 0) return archivedSegments;
+		return [];
+	}
+
+	async function handleDownloadVideo() {
+		if (downloadInFlightRef.current) return;
+		downloadInFlightRef.current = true;
+		try {
+			const liveSegments = normalizeArchivedSegments(typeof avPipeline.buildArchivedSegmentSnapshots === "function" ? avPipeline.buildArchivedSegmentSnapshots({ includeInProgress: true }) : []);
+			if (liveSegments.length > 0) {
+				const remuxedBlob = await remuxArchivedSegmentsBestEffort(liveSegments, currentClipLabel);
+				if (remuxedBlob instanceof Blob && remuxedBlob.size > 0) {
+					await triggerBlobDownload(remuxedBlob, currentClipLabel);
+				}
+				return;
+			}
+
+			const currentActiveClip = streamStore.get().activeClip as Record<string, any> | null;
+			const activeClipSegments = getRemuxableSegmentsFromClip(currentActiveClip);
+			if (activeClipSegments.length > 0) {
+				const remuxedBlob = await remuxArchivedSegmentsBestEffort(activeClipSegments, currentActiveClip?.label || currentClipLabel);
+				if (remuxedBlob instanceof Blob && remuxedBlob.size > 0) {
+					await triggerBlobDownload(remuxedBlob, currentActiveClip?.label || currentClipLabel);
+					return;
+				}
+				return;
+			}
+			if (currentActiveClip?.blob instanceof Blob) {
+				await triggerBlobDownload(currentActiveClip.blob, currentActiveClip.label || currentClipLabel);
+				return;
+			}
+
+			const clips = streamStore.get().completedClips as Record<string, any>[];
+			const latestCompletedClip = clips[clips.length - 1] || null;
+			const latestClipSegments = getRemuxableSegmentsFromClip(latestCompletedClip);
+			if (latestClipSegments.length > 0) {
+				const remuxedBlob = await remuxArchivedSegmentsBestEffort(latestClipSegments, latestCompletedClip?.label || currentClipLabel);
+				if (remuxedBlob instanceof Blob && remuxedBlob.size > 0) {
+					await triggerBlobDownload(remuxedBlob, latestCompletedClip?.label || currentClipLabel);
+					return;
+				}
+				return;
+			}
+			if (latestCompletedClip?.blob instanceof Blob) {
+				await triggerBlobDownload(latestCompletedClip.blob, latestCompletedClip.label || currentClipLabel);
+			}
+		} finally {
+			downloadInFlightRef.current = false;
+		}
+	}
+
+	async function handleDownloadViewingVideo() {
+		const lastClip = viewingProject?.clips[viewingProject.clips.length - 1];
+		if (!lastClip?.blob) return;
+		await triggerBlobDownload(lastClip.blob, viewingProject?.project.label || "video");
+	}
+
+	// --- Render ---
+
+	if (!runtimeReady) {
+		return null;
+	}
+
+	if (isMonitorRoute) {
+		return <MonitorPage />;
+	}
+
+	if (devtoolsMode) {
+		return (
+			<DevtoolsShell
+				connected={connected as boolean}
+				gpuAssigned={gpuAssigned as boolean}
+				sessionStarted={sessionStarted as boolean}
+				queuePosition={queuePosition as number}
+				connecting={connecting as boolean}
+				storyPresets={storyPresets as any[]}
+				selectedPresetId={selectedPresetId as string}
+				enhancementEnabled={enhancementEnabled as boolean}
+				autoExtensionEnabled={autoExtensionEnabled as boolean}
+				loopGenerationEnabled={loopGenerationEnabled as boolean}
+				canJoinSession={canJoinSession as boolean}
+				canSubmitContinuation={canSubmitContinuation}
+				editableMode={editableMode as boolean}
+				demoMode={demoMode as boolean}
+				editableCanJoin={editableCanJoin as boolean}
+				curatedPromptLimit={curatedPromptLimit as number}
+				maxCuratedPromptCount={maxCuratedPromptCount as number}
+				onPresetChange={handlePresetSelectionChange}
+				onEnhancementToggle={handleEnhancementToggle}
+				onCuratedPromptLimitChange={handleCuratedPromptLimitChange}
+				onAutoExtensionToggle={handleAutoExtensionToggle}
+				onLoopToggle={handleLoopGenerationToggle}
+				onJoin={joinSession}
+				onLeave={leaveSession}
+				sessionNotice={sessionNotice as string}
+				generationCapReached={generationCapReached as boolean}
+				generationSegmentCap={generationSegmentCap as number}
+				onRestartGeneration={restartGenerationAfterCap}
+				selectedPreset={selectedPreset}
+				editableSegments={editableSegments as string[]}
+				customPresetId={customPresetId as string}
+				customPresetLabel={customPresetLabel as string}
+				currentPromptWindowPrompts={currentPromptWindowPrompts as string[]}
+				appendingPromptWindow={appendingPromptWindow as boolean}
+				appendPromptWindowStatus={appendPromptWindowStatus as string}
+				appendPromptWindowError={appendPromptWindowError as string}
+				onCustomPresetIdInput={handleCustomPresetIdInput}
+				onCustomPresetLabelInput={handleCustomPresetLabelInput}
+				onAddSegment={addEditableSegment}
+				onResetToPreset={resetEditableToPreset}
+				onExport={exportEditablePreset}
+				onAppendPromptWindowToJson={appendPromptWindowToPresetsJson}
+				onRemoveSegment={removeEditableSegment}
+				onUpdateSegment={updateEditableSegment}
+				seedPrompts={seedPrompts as string[]}
+				playingSeedPromptIndex={playingSeedPromptIndex}
+				generatingSeedPromptIndex={generatingSeedPromptIndex}
+				livePromptDraft={livePromptDraft as string}
+				livePromptRewriteMode={livePromptRewriteMode as boolean}
+				rewritingSeedPrompts={rewritingSeedPrompts as boolean}
+				promptEvents={promptEvents as any[]}
+				onLivePromptInput={handleLivePromptInput}
+				onLivePromptModeToggle={handleLivePromptModeToggle}
+				onLivePromptKeydown={handleLivePromptKeydown}
+				onSubmitLivePrompt={submitLivePrompt}
+				onSpeechTranscript={handleLivePromptSpeechTranscript}
+				onSpeechInterimChange={handleLivePromptSpeechInterim}
+				promptConfigEditorOpen={promptConfigEditorOpen as boolean}
+				promptConfigLoading={promptConfigLoading as boolean}
+				promptConfigSaving={promptConfigSaving as boolean}
+				promptConfigStatus={promptConfigStatus as string}
+				promptConfigError={promptConfigError as string}
+				nextSegmentPromptEditorOpen={nextSegmentPromptEditorOpen as boolean}
+				autoExtensionPromptEditorOpen={autoExtensionPromptEditorOpen as boolean}
+				rewriteWindowPromptEditorOpen={rewriteWindowPromptEditorOpen as boolean}
+				nextSegmentSystemPromptDraft={nextSegmentSystemPromptDraft as string}
+				autoExtensionSystemPromptDraft={autoExtensionSystemPromptDraft as string}
+				rewriteWindowSystemPromptDraft={rewriteWindowSystemPromptDraft as string}
+				onPromptConfigEditorToggle={handlePromptConfigEditorToggle}
+				onReloadPromptConfig={() => loadPromptConfig(true)}
+				onNextSegmentSystemPromptInput={handleNextSegmentSystemPromptInput}
+				onAutoExtensionSystemPromptInput={handleAutoExtensionSystemPromptInput}
+				onRewriteWindowSystemPromptInput={handleRewriteWindowSystemPromptInput}
+				onSavePromptConfig={savePromptConfig}
+				autoExtensionTimeoutHint={autoExtensionTimeoutHint as string}
+				activeClip={
+					activeClip
+						? {
+								...(activeClip as Record<string, any>),
+								playbackStartTime: activePlaybackStartTime,
+							}
+						: null
+				}
+				liveClipLabel={currentClipLabel}
+				liveClipPrompt={currentClipPrompt}
+				galleryClips={completedClips as any[]}
+				activeClipId={activeClipId as string}
+				showLivePlayback={showLivePlayback}
+				onSelectClip={selectClip}
+				avPlaybackStarted={avPlaybackStarted as boolean}
+				mediaAppendError={mediaAppendError}
+				timeLeft={timeLeft}
+				ttffStartAtMs={ttffStartAtMsRef.current}
+				ttffValueMs={ttffValueMs}
+				timeBetweenVideosMs={timeBetweenVideosMs}
+				loadingAnimation={loadingAnimation as boolean}
+				formatTime={formatTime}
+				formatDurationMs={formatDurationMs}
+				onPlaying={markFirstFrameRendered}
+			/>
+		);
+	}
+
+	const viewingEvents = viewingProject?.project.promptEvents ?? [];
+	const viewingHasEdits = viewingEvents.some((e: any) => typeof e?.text === "string" && e.text.trim() && String(e?.source || "").trim() === "user_rewrite");
+	const viewingLastClip = viewingProject?.clips[viewingProject.clips.length - 1] ?? null;
+	const viewingFirstClip = viewingProject?.clips[0] ?? null;
+	const showActiveProject = (sessionStarted as boolean) || (sessionExpired as boolean);
+	const headerTimeLeft = (
+		(connected as boolean)
+		|| (connecting as boolean)
+		|| (sessionStarted as boolean)
+		|| (sessionExpired as boolean)
+	)
+		? timeLeft
+		: null;
+
+	return (
+		<main className="flex h-dvh w-full flex-col overflow-hidden bg-background text-foreground">
+			<SessionTimeoutModal
+				open={timeoutModalOpen && !isViewingMode}
+				onClose={() => setTimeoutModalOpen(false)}
+				onStartNewProject={handleStartNewProject}
+				repoUrl={FASTVIDEO_REPO_URL}
+				blogUrl={FASTVIDEO_BLOG_URL}
+			/>
+			<Sidebar
+				open={sidebarOpen}
+				currentProjectId={currentProjectIdRef.current}
+				currentProjectLabel={currentProjectTitle}
+				sessionActive={Boolean(sessionStarted) && !sessionExpired}
+				sessionExpired={sessionExpired as boolean}
+				projectResetPending={projectResetPending as boolean}
+				savedProjects={savedProjects}
+				viewingProjectId={viewingProject?.project.id ?? null}
+				isViewingPastProject={isViewingMode}
+				onClose={() => setSidebarOpen(false)}
+				onSelectProject={viewSavedProject}
+				onSelectCurrentProject={() => {
+					closeViewingProject();
+					setSidebarOpen(false);
+				}}
+				onDeleteProject={handleDeleteProject}
+				onNewProject={() => {
+					setSidebarOpen(false);
+					handleStartNewProject();
+				}}
+			/>
+			<Header timeLeft={headerTimeLeft} formatTime={formatTime} onToggleSidebar={() => setSidebarOpen((prev) => !prev)} />
+
+			<div className="relative flex flex-1 min-h-0 flex-col justify-center px-4 pb-2 sm:px-6 sm:pb-12">
+				{isViewingMode && (
+					<>
+						{viewingSelectedClip && (
+							<div className="relative z-30 w-full shrink-0">
+								<div className="relative mx-auto aspect-video w-full max-w-3xl overflow-hidden rounded-2xl border border-border bg-black">
+									<video key={viewingSelectedClip.id} src={viewingSelectedClip.objectUrl} className="h-full w-full object-contain" autoPlay loop playsInline controls />
+									<Button
+										onClick={handleDownloadViewingVideo}
+										size="icon"
+										variant="outline"
+										className="absolute top-3 right-3 z-10 bg-slate-900/60 backdrop-blur-md text-white hover:bg-slate-800/85 border-white/25"
+									>
+										{isMobileShareCapable ? <Share2 className="size-5" /> : <Download className="size-5" />}
+									</Button>
+								</div>
+							</div>
+						)}
+						<section className={cn("mx-auto w-full max-w-2xl", viewingHasEdits && "flex-1 min-h-0 overflow-y-auto")}>
+								<Workspace
+									promptEvents={viewingEvents as any[]}
+									currentThumbnail={viewingProject?.project.lastThumbnail ?? null}
+									originalLabel={viewingProject?.project.originalLabel || ""}
+									sessionStarted={true}
+									originalClipId={viewingFirstClip?.id || ""}
+									selectedClipId={viewingSelectedClip?.id || ""}
+									onSelectOriginal={() => {
+										if (viewingFirstClip) setViewingSelectedClipId(viewingFirstClip.id);
+								}}
+								onSelectEvent={(event) => {
+									const clip = viewingProject?.clips.find((c) => c.id === event.clipId);
+									if (clip) setViewingSelectedClipId(clip.id);
+								}}
+								onSelectCurrent={() => {
+									if (viewingLastClip) setViewingSelectedClipId(viewingLastClip.id);
+								}}
+							/>
+						</section>
+						<motion.div layout="position" className="mx-auto w-full max-w-2xl shrink-0" transition={{ type: "spring", stiffness: 200, damping: 25 }}>
+							<ChatBar sessionStarted={false} viewingReadOnly={true} onStartNewProject={handleStartNewProject} onBackFromViewing={closeViewingProject} />
+						</motion.div>
+					</>
+				)}
+
+				{/* Keep active session mounted (hidden when viewing past project) so the video pipeline stays alive */}
+				<div className={isViewingMode ? "hidden" : "contents"}>
+					<AnimatePresence>
+						{showActiveProject && (
+							<motion.div
+								key="video-player"
+								layout="position"
+								initial={{ opacity: 0, scale: 0.98 }}
+								animate={{ opacity: 1, scale: 1 }}
+								exit={{ opacity: 0, scale: 0.98 }}
+								transition={{
+									layout: { type: "spring", stiffness: 200, damping: 25 },
+									opacity: { duration: 0.4, ease: "easeOut" },
+									scale: { duration: 0.4, ease: "easeOut" },
+								}}
+								className="relative z-30 w-full shrink-0"
+							>
+								<VideoPlayer
+									videoRef={videoRefCallback}
+									archivedPlaybackRef={archivedPlaybackRefCallback}
+									activeClip={
+										activeClip
+											? {
+													...(activeClip as Record<string, any>),
+													playbackStartTime: activePlaybackStartTime,
+												}
+											: null
+									}
+									sessionStarted={sessionStarted as boolean}
+									avPlaybackStarted={avPlaybackStarted as boolean}
+									mediaAppendError={mediaAppendError}
+									timeLeft={timeLeft}
+									gpuAssigned={gpuAssigned as boolean}
+									connected={connected as boolean}
+									queuePosition={queuePosition as number}
+									loadingAnimation={loadingAnimation as boolean}
+									showLivePlayback={showLivePlayback}
+									defaultMuted={videoMuted}
+									canDownload={canDownloadVideo}
+									onPlaying={markFirstFrameRendered}
+									onDownload={handleDownloadVideo}
+								/>
+							</motion.div>
+						)}
+					</AnimatePresence>
+
+					<section className={cn("mx-auto w-full max-w-2xl", hasEdits && "flex-1 min-h-0 overflow-y-auto")}>
+						<Workspace
+							promptEvents={promptEvents as any[]}
+							currentThumbnail={currentThumbnail}
+							originalLabel={pendingInitialPromptRef.current || (selectedPreset as Record<string, any>)?.label || ""}
+							sessionStarted={sessionStarted as boolean}
+							originalClipId={((completedClips as any[])[0])?.id || ""}
+							selectedClipId={(activeClipId as string) || ""}
+							onSelectOriginal={() => {
+								const firstClip = (completedClips as any[])[0];
+								if (firstClip) selectClip(firstClip.id, 0);
+							}}
+							onSelectEvent={(event) => {
+								if (event.clipId) selectClip(event.clipId, 0);
+							}}
+							onSelectCurrent={() => {
+								const clips = completedClips as any[];
+								if (sessionStarted && !sessionExpired) {
+									// Return to live playback
+									streamStore.patch({ activeClipId: "", activePlaybackStartTime: 0 });
+								} else if (clips.length > 0) {
+									selectClip(clips[clips.length - 1].id, 0);
+								}
+							}}
+						/>
+					</section>
+
+					<AnimatePresence>
+						{!showActiveProject && (
+							<motion.div
+								key="hero-tagline"
+								initial={{ opacity: 0 }}
+								animate={{ opacity: 1 }}
+								exit={{ opacity: 0, transition: { duration: 0.2, ease: "easeIn" } }}
+								transition={{ duration: 0.5, ease: "easeOut" }}
+								className="pointer-events-none absolute inset-x-0 top-0 bottom-1/2 z-10 flex items-center justify-center px-4"
+							>
+								<HeroTagline />
+							</motion.div>
+						)}
+					</AnimatePresence>
+
+					<motion.div layout="position" className="mx-auto w-full max-w-2xl shrink-0" transition={{ type: "spring", stiffness: 200, damping: 25 }}>
+						<ChatBar
+							sessionStarted={sessionStarted as boolean}
+							rewritingSeedPrompts={rewritingSeedPrompts as boolean}
+							isGenerating={loadingAnimation as boolean}
+							storyPresets={storyPresets as any[]}
+							continuationDraft={livePromptDraft as string}
+							canJoinSession={canStartSession}
+							canSubmitContinuation={canSubmitContinuation}
+							sessionExpired={sessionExpired as boolean}
+							sessionNotice={sessionNotice as string}
+							projectResetPending={projectResetPending as boolean}
+							onPresetGenerate={handlePresetGenerate}
+							onContinuationInput={handleLivePromptInput}
+							onContinuationKeydown={handleLivePromptKeydown}
+							onGenerate={joinSession}
+							onSubmitContinuation={submitLivePrompt}
+							onLeave={leaveSession}
+							onStartNewProject={handleStartNewProject}
+							onSpeechTranscript={handleLivePromptSpeechTranscript}
+							onSpeechInterimChange={handleLivePromptSpeechInterim}
+						/>
+					</motion.div>
+				</div>
+			</div>
+		</main>
+	);
+}

--- a/apps/dreamverse/web/src/components/ChatBar.tsx
+++ b/apps/dreamverse/web/src/components/ChatBar.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import React, { useRef, useState, useCallback, useEffect } from "react";
+import Image from "next/image";
+import { Film, ArrowUp, X, Loader2, ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import LeaveSessionModal, { shouldShowLeaveWarning } from "@/components/LeaveSessionModal";
+import SpeechToTextButton from "@/components/SpeechToTextButton";
+import { cn } from "@/lib/utils";
+
+const PROMPT_MAX_LENGTH = 500;
+
+interface Props {
+	sessionStarted?: boolean;
+	rewritingSeedPrompts?: boolean;
+	isGenerating?: boolean;
+	storyPresets?: any[];
+	continuationDraft?: string;
+	canJoinSession?: boolean;
+	canSubmitContinuation?: boolean;
+	sessionExpired?: boolean;
+	sessionNotice?: string;
+	projectResetPending?: boolean;
+	viewingReadOnly?: boolean;
+	onPresetGenerate?: (presetId: string) => void;
+	onContinuationInput?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+	onContinuationKeydown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+	onGenerate?: () => void;
+	onSubmitContinuation?: () => void;
+	onLeave?: () => void;
+	onStartNewProject?: () => void;
+	onBackFromViewing?: () => void;
+	onSpeechTranscript?: (text: string) => void;
+	onSpeechInterimChange?: (text: string) => void;
+}
+
+export default function ChatBar({
+	sessionStarted = false,
+	rewritingSeedPrompts = false,
+	isGenerating = false,
+	storyPresets = [],
+	continuationDraft = "",
+	canJoinSession = false,
+	canSubmitContinuation = false,
+	sessionExpired = false,
+	sessionNotice = "",
+	projectResetPending = false,
+	viewingReadOnly = false,
+	onPresetGenerate = () => {},
+	onContinuationInput = () => {},
+	onContinuationKeydown = () => {},
+	onGenerate = () => {},
+	onSubmitContinuation = () => {},
+	onLeave = () => {},
+	onStartNewProject = () => {},
+	onBackFromViewing = () => {},
+	onSpeechTranscript,
+	onSpeechInterimChange,
+}: Props) {
+	const [sttBusy, setSttBusy] = useState(false);
+	const [leaveModalOpen, setLeaveModalOpen] = useState(false);
+	const showSpinner = isGenerating || rewritingSeedPrompts;
+	const isBusy = isGenerating || rewritingSeedPrompts || projectResetPending;
+	const messagePlaceholder = projectResetPending
+		? "Starting new project\u2026"
+		: isBusy
+			? "Generating video\u2026"
+			: !sessionStarted
+				? "What video are you imagining?"
+				: "What do you want to edit?";
+	const actionLabel = !sessionStarted ? "Generate" : "Rewrite rollout";
+
+	const inputRef = useRef<HTMLTextAreaElement>(null);
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const [canScrollLeft, setCanScrollLeft] = useState(false);
+	const [canScrollRight, setCanScrollRight] = useState(false);
+	const [presetRailDragging, setPresetRailDragging] = useState(false);
+	const presetDragStateRef = useRef({
+		pointerId: null as number | null,
+		startX: 0,
+		startScrollLeft: 0,
+		moved: false,
+	});
+	const suppressPresetClickRef = useRef(false);
+
+	const updateScrollState = useCallback(() => {
+		const el = scrollRef.current;
+		if (!el) return;
+		setCanScrollLeft(el.scrollLeft > 2);
+		setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 2);
+	}, []);
+
+	const handlePresetWheel = useCallback(
+		(event: React.WheelEvent<HTMLDivElement>) => {
+			const el = scrollRef.current;
+			if (!el) return;
+			if (el.scrollWidth <= el.clientWidth + 1) return;
+
+			const dominantDelta = Math.abs(event.deltaX) > Math.abs(event.deltaY)
+				? event.deltaX
+				: event.deltaY;
+			if (!dominantDelta) return;
+
+			const maxScrollLeft = Math.max(el.scrollWidth - el.clientWidth, 0);
+			const nextScrollLeft = Math.min(
+				Math.max(el.scrollLeft + dominantDelta, 0),
+				maxScrollLeft,
+			);
+			if (nextScrollLeft === el.scrollLeft) return;
+
+			event.preventDefault();
+			el.scrollLeft = nextScrollLeft;
+			updateScrollState();
+		},
+		[updateScrollState],
+	);
+
+	const finishPresetDrag = useCallback(() => {
+		presetDragStateRef.current = {
+			pointerId: null,
+			startX: 0,
+			startScrollLeft: 0,
+			moved: false,
+		};
+		setPresetRailDragging(false);
+	}, []);
+
+	const handlePresetPointerDown = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>) => {
+			const el = scrollRef.current;
+			if (!el) return;
+			if (event.pointerType !== "mouse" || event.button !== 0) return;
+			if (el.scrollWidth <= el.clientWidth + 1) return;
+
+			suppressPresetClickRef.current = false;
+			presetDragStateRef.current = {
+				pointerId: event.pointerId,
+				startX: event.clientX,
+				startScrollLeft: el.scrollLeft,
+				moved: false,
+			};
+		},
+		[],
+	);
+
+	const handlePresetPointerMove = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>) => {
+			const el = scrollRef.current;
+			const dragState = presetDragStateRef.current;
+			if (!el || dragState.pointerId !== event.pointerId) return;
+
+			const deltaX = event.clientX - dragState.startX;
+			if (!dragState.moved && Math.abs(deltaX) > 4) {
+				dragState.moved = true;
+				suppressPresetClickRef.current = true;
+				setPresetRailDragging(true);
+				el.setPointerCapture?.(event.pointerId);
+			}
+			if (!dragState.moved) return;
+
+			event.preventDefault();
+			const maxScrollLeft = Math.max(el.scrollWidth - el.clientWidth, 0);
+			el.scrollLeft = Math.min(
+				Math.max(dragState.startScrollLeft - deltaX, 0),
+				maxScrollLeft,
+			);
+			updateScrollState();
+		},
+		[updateScrollState],
+	);
+
+	const handlePresetPointerUp = useCallback(
+		(event: React.PointerEvent<HTMLDivElement>) => {
+			const el = scrollRef.current;
+			if (!el || presetDragStateRef.current.pointerId !== event.pointerId) return;
+			if (el.hasPointerCapture?.(event.pointerId)) {
+				el.releasePointerCapture(event.pointerId);
+			}
+			finishPresetDrag();
+		},
+		[finishPresetDrag],
+	);
+
+	const handlePresetClickCapture = useCallback(
+		(event: React.MouseEvent<HTMLDivElement>) => {
+			if (!suppressPresetClickRef.current) return;
+			suppressPresetClickRef.current = false;
+			event.preventDefault();
+			event.stopPropagation();
+		},
+		[],
+	);
+
+	useEffect(() => {
+		updateScrollState();
+	}, [storyPresets, updateScrollState]);
+
+	useEffect(() => {
+		if (!isBusy && !sttBusy && !window.matchMedia("(pointer: coarse)").matches) {
+			inputRef.current?.focus();
+		}
+	}, [isBusy, sttBusy, sessionStarted]);
+
+	const autoResize = useCallback(() => {
+		const el = inputRef.current;
+		if (!el) return;
+		el.style.height = "auto";
+		const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 20;
+		const maxHeight = lineHeight * 3;
+		el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+		el.style.overflowY = el.scrollHeight > maxHeight ? "auto" : "hidden";
+	}, []);
+
+	useEffect(() => {
+		autoResize();
+	}, [continuationDraft, autoResize]);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+			if (e.key === "Enter" && !e.nativeEvent.isComposing && !e.shiftKey) {
+				e.preventDefault();
+				if (!sessionStarted) {
+					if (canJoinSession && !isGenerating && continuationDraft.trim()) {
+						onGenerate();
+					}
+				} else {
+					onContinuationKeydown(e);
+				}
+				return;
+			}
+			onContinuationKeydown(e);
+		},
+		[onContinuationKeydown, sessionStarted, canJoinSession, isGenerating, continuationDraft, onGenerate],
+	);
+
+	if (viewingReadOnly) {
+		return (
+			<section className="mx-auto flex w-full max-w-2xl shrink-0 flex-col gap-4">
+				<div className="flex flex-col items-center gap-3 rounded-2xl border border-border bg-card/80 px-6 py-4 text-center shadow-md backdrop-blur-sm">
+					<div className="flex flex-col gap-1">
+						<p className="text-sm font-semibold text-foreground">View-only project</p>
+						<p className="max-w-md text-xs text-muted-foreground">Project sessions are currently limited to 5 minutes. Start a new project to create more videos.</p>
+					</div>
+					<div className="mt-1 flex items-center gap-2">
+						<Button onClick={onBackFromViewing} variant="outline" size="sm" className="gap-1.5 rounded-full px-4">
+							<ArrowLeft className="size-3.5" />
+							Back
+						</Button>
+						<Button onClick={onStartNewProject} size="sm" className="rounded-full px-5">
+							New project
+						</Button>
+					</div>
+				</div>
+			</section>
+		);
+	}
+
+	if (sessionExpired) {
+		return (
+			<section className="mx-auto flex w-full max-w-2xl shrink-0 flex-col gap-4">
+				<div className="flex flex-col items-center gap-3 rounded-2xl border border-border bg-card/80 px-8 py-5 text-center shadow-md backdrop-blur-sm">
+					<div className="flex flex-col gap-1">
+						<p className="text-sm font-semibold text-foreground">Session ended</p>
+						<p className="max-w-xs text-xs text-muted-foreground">Each project currently has a 5-minute session. Start a new project to continue creating videos.</p>
+					</div>
+					<div className="mt-1 flex items-center gap-2">
+						<Button onClick={onStartNewProject} size="sm" className="rounded-full px-5">
+							New Project
+						</Button>
+						<a href="https://docs.google.com/forms/d/e/1FAIpQLSe5zpO1iD8Ds-Ih-fOLm64qd7YZVvuvAyHuJaAfw1hkRHTe_A/viewform?usp=publish-editor" target="_blank" rel="noopener noreferrer">
+							<Button variant="outline" size="sm" className="rounded-full px-5">
+								Join Waitlist
+							</Button>
+						</a>
+					</div>
+				</div>
+			</section>
+		);
+	}
+
+	return (
+		<section className="mx-auto flex w-full max-w-2xl shrink-0 flex-col gap-4">
+			{storyPresets.length > 0 && !sessionStarted && (
+				<div className={cn("relative transition-opacity duration-200", isGenerating && "pointer-events-none opacity-40")}>
+					<div
+						ref={scrollRef}
+						onScroll={updateScrollState}
+						onWheel={handlePresetWheel}
+						onPointerDown={handlePresetPointerDown}
+						onPointerMove={handlePresetPointerMove}
+						onPointerUp={handlePresetPointerUp}
+						onPointerCancel={handlePresetPointerUp}
+						onLostPointerCapture={finishPresetDrag}
+						onClickCapture={handlePresetClickCapture}
+						className={cn(
+							"scrollbar-hidden flex gap-3 overflow-x-auto px-1 select-none",
+							presetRailDragging ? "cursor-grabbing" : "cursor-grab",
+						)}
+					>
+						{storyPresets.map((preset) => (
+							<button
+								key={preset.id}
+								type="button"
+								disabled={isGenerating}
+								onClick={() => onPresetGenerate(preset.id)}
+								className="flex flex-col sm:flex-row items-start gap-1.5 shrink-0 rounded-xl border p-2.5 text-left backdrop-blur-sm transition-colors max-w-42 sm:max-w-[215px] border-input bg-card/80 text-muted-foreground hover:bg-slate-200/60 hover:border-slate-400 hover:text-slate-700 dark:bg-slate-800/80 dark:text-slate-300 dark:hover:bg-slate-700/50 dark:hover:border-slate-500 dark:hover:text-slate-200"
+							>
+								<Film className="mt-0.5 size-4 shrink-0 opacity-60" />
+								<span className="flex flex-col gap-1 min-w-0">
+									<span className="text-[14px] font-medium line-clamp-1">{preset.label}</span>
+									{preset.description && <span className="text-xs leading-tight opacity-70 line-clamp-3 sm:line-clamp-2">{preset.description}</span>}
+								</span>
+							</button>
+						))}
+					</div>
+
+					<div
+						className={cn("pointer-events-none absolute inset-y-0 left-0 w-8 bg-background transition-opacity duration-150", canScrollLeft ? "opacity-100" : "opacity-0")}
+						style={{ maskImage: "linear-gradient(to right, black, transparent)", WebkitMaskImage: "linear-gradient(to right, black, transparent)" }}
+						aria-hidden="true"
+					/>
+					<div
+						className={cn("pointer-events-none absolute inset-y-0 right-0 w-8 bg-background transition-opacity duration-150", canScrollRight ? "opacity-100" : "opacity-0")}
+						style={{ maskImage: "linear-gradient(to left, black, transparent)", WebkitMaskImage: "linear-gradient(to left, black, transparent)" }}
+						aria-hidden="true"
+					/>
+				</div>
+			)}
+
+			{sessionNotice && (
+				<div
+					className={cn(
+						"rounded-xl px-4 py-2.5 text-center text-xs",
+						sessionStarted
+							? "border border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+							: "border border-rose-500/20 bg-rose-500/10 text-rose-700 dark:text-rose-300",
+					)}
+				>
+					{sessionNotice}
+				</div>
+			)}
+
+			{projectResetPending && sessionStarted && (
+				<div className="rounded-xl border border-sky-500/20 bg-sky-500/10 px-4 py-2.5 text-center text-xs text-sky-700 dark:text-sky-300">
+					Starting a new project after the current shot finishes. Your GPU session stays active.
+				</div>
+			)}
+
+			<div
+				className={cn(
+					"flex min-w-0 items-center gap-1.5 rounded-4xl border py-2.5 pl-5 pr-2.5 shadow-md backdrop-blur-sm transition-all duration-200",
+					isBusy ? "border-input/60 bg-card/40" : "border-input bg-card/65",
+				)}
+			>
+				<textarea
+					ref={inputRef}
+					id="continuation-prompt"
+					aria-label="Continuation prompt"
+					value={continuationDraft}
+					onChange={onContinuationInput}
+					onKeyDown={handleKeyDown}
+					placeholder={sttBusy ? "Listening\u2026" : messagePlaceholder}
+					maxLength={PROMPT_MAX_LENGTH}
+					disabled={isBusy || sttBusy}
+					rows={1}
+					className={cn(
+						"min-w-0 flex-1 resize-none bg-transparent text-foreground outline-none placeholder:text-muted-foreground transition-opacity duration-200 scrollbar-thin leading-snug",
+						(isBusy || sttBusy) && "cursor-not-allowed opacity-50",
+					)}
+				/>
+				{onSpeechTranscript && <SpeechToTextButton disabled={isBusy} onTranscript={onSpeechTranscript} onInterimChange={onSpeechInterimChange} onBusyChange={setSttBusy} />}
+				{!sessionStarted ? (
+					<Button
+						aria-label={actionLabel}
+						title={actionLabel}
+						onClick={onGenerate}
+						disabled={!canJoinSession || isGenerating || !continuationDraft.trim()}
+						size="icon-sm"
+						className="shrink-0 rounded-full"
+					>
+						{showSpinner ? <Loader2 className="size-5 animate-spin" /> : <ArrowUp className="size-5" />}
+					</Button>
+				) : (
+					<>
+						<Button
+							aria-label={actionLabel}
+							title={actionLabel}
+							onClick={onSubmitContinuation}
+							disabled={!canSubmitContinuation || showSpinner || projectResetPending || !continuationDraft.trim()}
+							size="icon-sm"
+							className="shrink-0 rounded-full"
+						>
+							{showSpinner ? <Loader2 className="size-5 animate-spin" /> : <ArrowUp className="size-5" />}
+						</Button>
+						<Button variant="outline" aria-label="Leave" title="Leave" onClick={() => { if (shouldShowLeaveWarning()) setLeaveModalOpen(true); else onLeave(); }} disabled={isGenerating || projectResetPending} size="icon-sm" className="shrink-0 rounded-full">
+							<X className="size-5" />
+						</Button>
+					</>
+				)}
+			</div>
+			<p className="px-2 text-center text-[11px] text-muted-foreground">
+				LLM powered by{" "}
+				<a
+					href="https://ifm.ai/k2/"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="inline-flex items-center gap-1 font-medium text-foreground/80 transition-colors hover:text-foreground"
+				>
+					<span>K2-V2</span>
+					<Image
+						src="/k2.png"
+						alt=""
+						aria-hidden="true"
+						width={14}
+						height={14}
+						className="h-3.5 w-auto opacity-80"
+					/>
+				</a>
+			</p>
+			<LeaveSessionModal
+				open={leaveModalOpen}
+				onClose={() => setLeaveModalOpen(false)}
+				onConfirmLeave={() => { setLeaveModalOpen(false); onLeave(); }}
+			/>
+		</section>
+	);
+}

--- a/apps/dreamverse/web/src/components/Header.tsx
+++ b/apps/dreamverse/web/src/components/Header.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React from "react";
+import { SidePanelOpenFilled } from "@carbon/icons-react";
+import { ExternalLink } from "lucide-react";
+import Image from "next/image";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/ui/theme-toggle";
+
+const FASTVIDEO_REPO_URL = "https://haoailab.com/blogs/dreamverse/";
+const FASTVIDEO_BLOG_URL = "https://haoailab.com/blogs/dreamverse/";
+
+interface Props {
+	timeLeft?: number | null;
+	formatTime?: (seconds: number) => string;
+	onToggleSidebar?: () => void;
+}
+
+export default function Header({ timeLeft = null, formatTime = (seconds) => `${seconds}`, onToggleSidebar }: Props) {
+	const timeVariant = timeLeft !== null && timeLeft <= 30 ? "warning" : "secondary";
+
+	return (
+		<header className="relative z-30 shrink-0">
+			<div className="flex flex-wrap items-center justify-between gap-y-2 px-4 pt-3 pb-2 sm:pt-4 sm:pb-3 sm:px-6">
+				<div className="flex items-center gap-3">
+					{onToggleSidebar && (
+						<Button variant="outline" size="icon" onClick={onToggleSidebar} aria-label="Toggle sidebar">
+							<SidePanelOpenFilled size={20} />
+						</Button>
+					)}
+					<a href={FASTVIDEO_REPO_URL} target="_blank" rel="noopener noreferrer" title="FastVideo on GitHub">
+						<Image src="/logo.svg" alt="FastVideo" width={32} height={32} className="h-8 w-auto sm:h-9 transition-opacity hover:opacity-70" />
+					</a>
+					<div className="hidden sm:flex items-center gap-3">
+						<a href="https://docs.google.com/forms/d/e/1FAIpQLSe5zpO1iD8Ds-Ih-fOLm64qd7YZVvuvAyHuJaAfw1hkRHTe_A/viewform?usp=publish-editor" target="_blank" rel="noopener noreferrer">
+							<Button variant="outline" size="sm" className="gap-1.5 rounded-full px-3 text-xs">
+								Join Waitlist
+								<ExternalLink className="size-3 opacity-60" />
+							</Button>
+						</a>
+					</div>
+				</div>
+
+				<div className="flex items-center gap-3">
+					{timeLeft !== null && (
+						<Badge variant={timeVariant} className="rounded-xl px-3 py-1 text-xs font-medium normal-case tracking-normal">
+							Time left: {formatTime(timeLeft)}
+						</Badge>
+					)}
+					<ThemeToggle />
+				</div>
+			</div>
+
+			<div className="flex sm:hidden items-center gap-2 px-4 pb-3">
+				<a href="https://docs.google.com/forms/d/e/1FAIpQLSe5zpO1iD8Ds-Ih-fOLm64qd7YZVvuvAyHuJaAfw1hkRHTe_A/viewform?usp=publish-editor" target="_blank" rel="noopener noreferrer">
+					<Button variant="outline" size="sm" className="gap-1.5 rounded-full px-3 text-xs">
+						Join Waitlist
+						<ExternalLink className="size-3 opacity-60" />
+					</Button>
+				</a>
+			</div>
+		</header>
+	);
+}

--- a/apps/dreamverse/web/src/components/LeaveSessionModal.tsx
+++ b/apps/dreamverse/web/src/components/LeaveSessionModal.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+
+const STORAGE_KEY = "fastvideo-suppress-leave-warning";
+
+interface LeaveSessionModalProps {
+	open?: boolean;
+	onClose?: () => void;
+	onConfirmLeave?: () => void;
+}
+
+export default function LeaveSessionModal({
+	open = false,
+	onClose = () => {},
+	onConfirmLeave = () => {},
+}: LeaveSessionModalProps) {
+	const [suppress, setSuppress] = useState(false);
+
+	useEffect(() => {
+		if (open) setSuppress(false);
+	}, [open]);
+
+	if (!open) return null;
+
+	function handleConfirm() {
+		if (suppress) {
+			try {
+				localStorage.setItem(STORAGE_KEY, "1");
+			} catch {}
+		}
+		onConfirmLeave();
+	}
+
+	return (
+		<div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/45 px-4 backdrop-blur-[3px]">
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="leave-session-title"
+				className="w-full max-w-md rounded-3xl border border-border/70 bg-card/95 p-6 shadow-2xl"
+			>
+				<div className="space-y-3">
+					<div className="space-y-1">
+						<h2 id="leave-session-title" className="text-lg font-semibold text-foreground">
+							Leave session?
+						</h2>
+						<p className="text-sm text-muted-foreground">
+							This will end your current session. You will need to queue again for a GPU to start a new project.
+						</p>
+					</div>
+					<div className="flex items-center gap-2">
+						<Checkbox
+							id="suppress-leave-warning"
+							checked={suppress}
+							onCheckedChange={(v) => setSuppress(v === true)}
+						/>
+						<Label htmlFor="suppress-leave-warning" className="text-sm text-muted-foreground cursor-pointer">
+							Do not warn again
+						</Label>
+					</div>
+				</div>
+				<div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+					<Button variant="outline" onClick={onClose}>
+						Cancel
+					</Button>
+					<Button variant="destructive" onClick={handleConfirm}>
+						Leave session
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export function shouldShowLeaveWarning(): boolean {
+	try {
+		return localStorage.getItem(STORAGE_KEY) !== "1";
+	} catch {
+		return true;
+	}
+}

--- a/apps/dreamverse/web/src/components/MonitorPage.tsx
+++ b/apps/dreamverse/web/src/components/MonitorPage.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const POLL_INTERVAL_MS = 15000;
+
+interface Replica {
+  url: string;
+  healthy: boolean;
+  active_sessions?: number;
+  pending_sessions?: number;
+  max_available_sessions?: number;
+  prompt_provider_success_counts?: Record<string, number>;
+}
+
+function formatTimestamp(value: string): string {
+  if (!value) return '';
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return '';
+  }
+}
+
+function formatProviderSuccessCounts(
+  counts: Record<string, number> | undefined,
+): string {
+  const normalized = counts || {};
+  const cerebrasIfm = normalized.cerebras_ifm ?? 0;
+  const cerebras = normalized.cerebras ?? 0;
+  const groq = normalized.groq ?? 0;
+  return `IFM ${cerebrasIfm} / Cerebras ${cerebras} / Groq ${groq}`;
+}
+
+export default function MonitorPage() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [replicas, setReplicas] = useState<Replica[]>([]);
+  const [lastUpdated, setLastUpdated] = useState('');
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    async function loadReplicaSessions() {
+      try {
+        const response = await fetch('/router/replicas/sessions');
+        const payload = await response.json();
+        if (!response.ok) {
+          throw new Error(
+            payload.detail || 'Failed to fetch replica sessions',
+          );
+        }
+        setReplicas(
+          Array.isArray(payload.replicas) ? payload.replicas : [],
+        );
+        setError('');
+        setLastUpdated(new Date().toISOString());
+      } catch (err: any) {
+        setError(err?.message || String(err));
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadReplicaSessions();
+    timerRef.current = setInterval(loadReplicaSessions, POLL_INTERVAL_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-4 px-4 py-8 text-foreground">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-foreground">
+          Replica Session Monitor
+        </h1>
+        <div className="flex flex-wrap gap-2 text-sm text-muted-foreground">
+          <Badge variant="secondary">poll interval: 15s</Badge>
+        {lastUpdated && (
+            <Badge variant="outline">
+              last updated: {formatTimestamp(lastUpdated)}
+            </Badge>
+        )}
+        </div>
+      </div>
+
+      {loading ? (
+        <Card>
+          <CardContent className="p-6 text-sm text-muted-foreground">
+            Loading monitor data...
+          </CardContent>
+        </Card>
+      ) : error ? (
+        <Card className="border-rose-500/30 bg-rose-950/45">
+          <CardContent className="p-6 text-sm text-rose-100">
+            {error}
+          </CardContent>
+        </Card>
+      ) : (
+        <Card className="overflow-hidden">
+          <CardHeader className="border-b border-border pb-4">
+            <CardTitle className="text-xl">Replica capacity</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[760px] border-collapse text-left text-sm">
+                <thead className="bg-secondary text-muted-foreground">
+                  <tr>
+                    <th className="border-b border-border px-4 py-3 font-semibold">
+                      URL
+                    </th>
+                    <th className="border-b border-border px-4 py-3 font-semibold">
+                      Healthy
+                    </th>
+                    <th className="border-b border-border px-4 py-3 font-semibold">
+                      Active WS Sessions
+                    </th>
+                    <th className="border-b border-border px-4 py-3 font-semibold">
+                      Pending Sessions
+                    </th>
+                    <th className="border-b border-border px-4 py-3 font-semibold">
+                      Max Available Sessions
+                    </th>
+                    <th className="border-b border-border px-4 py-3 font-semibold">
+                      Prompt API Successes
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {replicas.map((replica, index) => (
+                    <tr
+                      key={replica.url || index}
+                      className="border-b border-border last:border-b-0"
+                    >
+                      <td className="px-4 py-3 text-foreground">{replica.url}</td>
+                      <td className="px-4 py-3">
+                        <Badge
+                          variant={replica.healthy ? 'success' : 'destructive'}
+                        >
+                          {replica.healthy ? 'yes' : 'no'}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3 text-foreground">
+                        {replica.active_sessions ?? '-'}
+                      </td>
+                      <td className="px-4 py-3 text-foreground">
+                        {replica.pending_sessions ?? '-'}
+                      </td>
+                      <td className="px-4 py-3 text-foreground">
+                        {replica.max_available_sessions ?? '-'}
+                      </td>
+                      <td className="px-4 py-3 text-foreground">
+                        {formatProviderSuccessCounts(
+                          replica.prompt_provider_success_counts,
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </main>
+  );
+}

--- a/apps/dreamverse/web/src/components/SessionTimeoutModal.tsx
+++ b/apps/dreamverse/web/src/components/SessionTimeoutModal.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+interface SessionTimeoutModalProps {
+	open?: boolean;
+	onClose?: () => void;
+	onStartNewProject?: () => void;
+	repoUrl?: string;
+	blogUrl?: string;
+}
+
+export default function SessionTimeoutModal({
+	open = false,
+	onClose = () => {},
+	onStartNewProject = () => {},
+	repoUrl = "",
+	blogUrl = "",
+}: SessionTimeoutModalProps) {
+	if (!open) return null;
+
+	return (
+		<div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/45 px-4 backdrop-blur-[3px]">
+			<div
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="session-timeout-title"
+				className="w-full max-w-md rounded-3xl border border-border/70 bg-card/95 p-6 shadow-2xl"
+			>
+				<div className="space-y-3">
+					<div className="space-y-1">
+						<h2 id="session-timeout-title" className="text-lg font-semibold text-foreground">
+							Session ended
+						</h2>
+						<p className="text-sm text-muted-foreground">
+							This project hit the current 5-minute session limit. Your latest video stays on screen, and the project is being kept in the archive so you can come back to it.
+						</p>
+					</div>
+					<p className="text-sm text-muted-foreground">
+						Start a new project to keep creating, or keep viewing this one while you decide what to do next.
+					</p>
+					<div className="flex flex-wrap gap-2 text-sm">
+						<a
+							href={repoUrl}
+							target="_blank"
+							rel="noreferrer"
+							className="font-medium text-sky-700 underline underline-offset-4 transition-colors hover:text-sky-600 dark:text-sky-300 dark:hover:text-sky-200"
+						>
+							Open repo
+						</a>
+						<a
+							href={blogUrl}
+							target="_blank"
+							rel="noreferrer"
+							className="font-medium text-sky-700 underline underline-offset-4 transition-colors hover:text-sky-600 dark:text-sky-300 dark:hover:text-sky-200"
+						>
+							Read blog
+						</a>
+					</div>
+				</div>
+				<div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+					<Button variant="outline" onClick={onClose}>
+						Keep viewing
+					</Button>
+					<Button onClick={onStartNewProject}>New project</Button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/dreamverse/web/src/components/Sidebar.tsx
+++ b/apps/dreamverse/web/src/components/Sidebar.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import React, { useState, useRef, useCallback, useEffect } from "react";
+import { SidePanelCloseFilled } from "@carbon/icons-react";
+import { Plus, Trash2, Clock, Film } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { StoredProject } from "@/lib/projectStorage";
+
+function resolveProjectTitle(project: StoredProject): string {
+	if (project.originalLabel) return project.originalLabel;
+	const events = project.promptEvents || [];
+	for (let i = events.length - 1; i >= 0; i--) {
+		const e = events[i];
+		if (String(e?.source || "") === "user_rewrite" && typeof e?.text === "string" && e.text.trim()) {
+			return e.text.trim();
+		}
+	}
+	return "Untitled project";
+}
+
+function formatRelativeTime(timestamp: number): string {
+	const diff = Date.now() - timestamp;
+	const seconds = Math.floor(diff / 1000);
+	if (seconds < 60) return "just now";
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m ago`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	if (days < 7) return `${days}d ago`;
+	return new Date(timestamp).toLocaleDateString();
+}
+
+interface SidebarProps {
+	open?: boolean;
+	currentProjectId?: string;
+	currentProjectLabel?: string;
+	sessionActive?: boolean;
+	sessionExpired?: boolean;
+	projectResetPending?: boolean;
+	savedProjects?: StoredProject[];
+	viewingProjectId?: string | null;
+	isViewingPastProject?: boolean;
+	onClose?: () => void;
+	onSelectProject?: (projectId: string) => void;
+	onSelectCurrentProject?: () => void;
+	onDeleteProject?: (projectId: string) => void;
+	onNewProject?: () => void;
+}
+
+export default function Sidebar({
+	open = false,
+	currentProjectId = "",
+	currentProjectLabel = "",
+	sessionActive = false,
+	sessionExpired = false,
+	projectResetPending = false,
+	savedProjects = [],
+	viewingProjectId = null,
+	isViewingPastProject = false,
+	onClose = () => {},
+	onSelectProject = () => {},
+	onSelectCurrentProject = () => {},
+	onDeleteProject = () => {},
+	onNewProject = () => {},
+}: SidebarProps) {
+	const hasCurrentProject = sessionActive || sessionExpired;
+	const previousProjects = currentProjectId ? savedProjects.filter((p) => p.id !== currentProjectId) : savedProjects;
+
+	const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+	const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const clearPendingDelete = useCallback(() => {
+		setPendingDeleteId(null);
+		if (deleteTimerRef.current) {
+			clearTimeout(deleteTimerRef.current);
+			deleteTimerRef.current = null;
+		}
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+		};
+	}, []);
+
+	useEffect(() => {
+		if (!open) clearPendingDelete();
+	}, [open, clearPendingDelete]);
+
+	function handleDeleteClick(e: React.MouseEvent, projectId: string) {
+		e.stopPropagation();
+		if (pendingDeleteId === projectId) {
+			clearPendingDelete();
+			onDeleteProject(projectId);
+		} else {
+			setPendingDeleteId(projectId);
+			if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current);
+			deleteTimerRef.current = setTimeout(() => setPendingDeleteId(null), 3000);
+		}
+	}
+
+	return (
+		<>
+			<div
+				className={cn("fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px] transition-opacity duration-200", open ? "opacity-100" : "pointer-events-none opacity-0")}
+				onClick={onClose}
+				aria-hidden="true"
+			/>
+
+			<aside
+				className={cn(
+					"fixed inset-y-0 left-0 z-50 flex w-[280px] max-w-[calc(100vw-3rem)] flex-col border-r border-border/60 bg-card/95 backdrop-blur-xl transition-transform duration-200 ease-out",
+					open ? "translate-x-0" : "-translate-x-full",
+				)}
+				aria-label="Project history"
+			>
+				<div className="flex items-center justify-between px-5 pt-4 pb-2">
+					<span className="text-lg font-semibold text-foreground">Projects</span>
+					<Button variant="ghost" size="icon" onClick={onClose} aria-label="Close sidebar">
+						<SidePanelCloseFilled size={18} />
+					</Button>
+				</div>
+
+				<div className="px-4 pb-3">
+					<Button
+						variant="outline"
+						size="sm"
+						className="w-full gap-2 rounded-lg font-medium"
+						onClick={onNewProject}
+						disabled={projectResetPending}
+					>
+						<Plus className="size-4" />
+						{projectResetPending ? "Starting new project..." : "New project"}
+					</Button>
+				</div>
+
+				<nav className="flex-1 overflow-y-auto px-3 pb-4">
+					{hasCurrentProject && (
+						<div className="mb-3">
+							<p className="mb-1.5 px-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Current</p>
+							<div
+								className={cn("rounded-xl px-3 py-2.5", isViewingPastProject ? "cursor-pointer bg-accent/40 hover:bg-accent/60 transition-colors" : "bg-accent/80")}
+								onClick={isViewingPastProject ? onSelectCurrentProject : undefined}
+								role={isViewingPastProject ? "button" : undefined}
+								tabIndex={isViewingPastProject ? 0 : undefined}
+								onKeyDown={isViewingPastProject ? (e) => e.key === "Enter" && onSelectCurrentProject() : undefined}
+							>
+								<div className="flex items-center gap-2">
+									<Film className="size-3.5 shrink-0 text-muted-foreground" />
+									<span className="min-w-0 flex-1 truncate text-[13px] font-medium text-foreground">{currentProjectLabel || "Untitled project"}</span>
+								</div>
+								<div className="mt-1.5 flex items-center gap-1.5">
+									{sessionExpired ? (
+										<Badge variant="secondary" className="rounded-md px-1.5 py-0 text-[10px]">
+											Expired
+										</Badge>
+									) : (
+										<Badge variant="default" className="rounded-md px-1.5 py-0 text-[10px]">
+											Active
+										</Badge>
+									)}
+								</div>
+							</div>
+						</div>
+					)}
+
+					{previousProjects.length > 0 && (
+						<div>
+							<p className="mb-1.5 px-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Previous</p>
+							<div className="flex flex-col gap-1">
+								{previousProjects.map((project) => {
+									const isViewing = viewingProjectId === project.id;
+									return (
+										<div
+											key={project.id}
+											className={cn("group flex items-start gap-2 rounded-xl px-3 py-2.5 transition-colors cursor-pointer", isViewing ? "bg-accent/60" : "hover:bg-accent/40")}
+											onClick={() => onSelectProject(project.id)}
+											role="button"
+											tabIndex={0}
+											onKeyDown={(e) => e.key === "Enter" && onSelectProject(project.id)}
+										>
+											{project.lastThumbnail ? (
+												<img src={project.lastThumbnail} alt="" className="mt-0.5 h-8 w-auto shrink-0 rounded border border-border object-cover" />
+											) : (
+												<Film className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+											)}
+											<div className="min-w-0 flex-1">
+												<p className="truncate text-[13px] font-medium text-foreground">{resolveProjectTitle(project)}</p>
+												<div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+													<Clock className="size-3" />
+													<span>{formatRelativeTime(project.createdAt)}</span>
+												</div>
+											</div>
+											{pendingDeleteId === project.id ? (
+												<button
+													type="button"
+													className="mt-0.5 shrink-0 rounded bg-destructive/15 px-1.5 py-0.5 !text-xs !font-medium text-destructive transition-colors hover:bg-destructive/25"
+													onClick={(e) => handleDeleteClick(e, project.id)}
+													aria-label="Confirm delete project"
+												>
+													Delete?
+												</button>
+											) : (
+												<button
+													type="button"
+													className="mt-0.5 shrink-0 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover:opacity-100"
+													onClick={(e) => handleDeleteClick(e, project.id)}
+													aria-label="Delete project"
+												>
+													<Trash2 className="size-3.5" />
+												</button>
+											)}
+										</div>
+									);
+								})}
+							</div>
+						</div>
+					)}
+
+					{!hasCurrentProject && previousProjects.length === 0 && <p className="px-2 py-4 text-center text-[13px] text-muted-foreground">No projects yet</p>}
+				</nav>
+			</aside>
+		</>
+	);
+}

--- a/apps/dreamverse/web/src/components/SpeechToTextButton.test.tsx
+++ b/apps/dreamverse/web/src/components/SpeechToTextButton.test.tsx
@@ -1,0 +1,113 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+
+import SpeechToTextButton from './SpeechToTextButton';
+import {
+  getWhisperApiKey,
+  startWhisperStt,
+} from '@/lib/whisperStt';
+
+vi.mock('@/lib/whisperStt', () => ({
+  getWhisperApiKey: vi.fn(),
+  startWhisperStt: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+describe('SpeechToTextButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows a toast error when speech input is not configured', async () => {
+    const user = userEvent.setup();
+    vi.mocked(getWhisperApiKey).mockReturnValue('');
+
+    render(<SpeechToTextButton onTranscript={vi.fn()} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Start speech input' }),
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Speech input is not configured.',
+        { id: 'speech-to-text-error' },
+      );
+    });
+    expect(startWhisperStt).not.toHaveBeenCalled();
+  });
+
+  it('transcribes speech when stop is clicked', async () => {
+    const user = userEvent.setup();
+    const onTranscript = vi.fn();
+    const stop = vi.fn().mockResolvedValue('hello world');
+
+    vi.mocked(getWhisperApiKey).mockReturnValue('sk-key');
+    vi.mocked(startWhisperStt).mockResolvedValue({
+      active: true,
+      stop,
+    });
+
+    render(<SpeechToTextButton onTranscript={onTranscript} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Start speech input' }),
+    );
+
+    await waitFor(() => {
+      expect(startWhisperStt).toHaveBeenCalledTimes(1);
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: 'Stop speech input' }),
+    );
+
+    await waitFor(() => {
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(onTranscript).toHaveBeenCalledWith('hello world');
+    });
+  });
+
+  it('does not call onTranscript when stop returns no text', async () => {
+    const user = userEvent.setup();
+    const onTranscript = vi.fn();
+    const stop = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(getWhisperApiKey).mockReturnValue('sk-key');
+    vi.mocked(startWhisperStt).mockResolvedValue({
+      active: true,
+      stop,
+    });
+
+    render(<SpeechToTextButton onTranscript={onTranscript} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Start speech input' }),
+    );
+
+    await waitFor(() => {
+      expect(startWhisperStt).toHaveBeenCalledTimes(1);
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: 'Stop speech input' }),
+    );
+
+    await waitFor(() => {
+      expect(stop).toHaveBeenCalledTimes(1);
+    });
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+});

--- a/apps/dreamverse/web/src/components/SpeechToTextButton.tsx
+++ b/apps/dreamverse/web/src/components/SpeechToTextButton.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import { Mic, Square, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { startWhisperStt, getWhisperApiKey, type WhisperSttSession } from "@/lib/whisperStt";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface SpeechToTextButtonProps {
+	disabled?: boolean;
+	onTranscript: (text: string) => void;
+	onInterimChange?: (text: string) => void;
+	onBusyChange?: (busy: boolean) => void;
+}
+
+export default function SpeechToTextButton({ disabled = false, onTranscript, onInterimChange, onBusyChange }: SpeechToTextButtonProps) {
+	const [state, setState] = useState<"idle" | "connecting" | "recording" | "transcribing">("idle");
+	const sessionRef = useRef<WhisperSttSession | null>(null);
+	const errorToastId = "speech-to-text-error";
+
+	const showErrorToast = useCallback((message: string) => {
+		toast.error(message, { id: errorToastId });
+	}, []);
+
+	useEffect(() => {
+		onBusyChange?.(state !== "idle");
+	}, [state, onBusyChange]);
+
+	useEffect(() => {
+		return () => {
+			if (sessionRef.current) {
+				sessionRef.current.stop();
+				sessionRef.current = null;
+			}
+		};
+	}, []);
+
+	async function startRecording() {
+		onInterimChange?.("");
+
+		const apiKey = getWhisperApiKey();
+		if (!apiKey) {
+			showErrorToast("Speech input is not configured.");
+			return;
+		}
+
+		setState("connecting");
+
+		try {
+			toast.dismiss(errorToastId);
+			const session = await startWhisperStt({
+				apiKey,
+				onError: (err) => {
+					showErrorToast(err.message || "Speech recognition error");
+					setState("idle");
+					sessionRef.current = null;
+				},
+				onClose: () => {
+					sessionRef.current = null;
+				},
+			});
+			sessionRef.current = session;
+			setState("recording");
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : "Failed to start recording";
+			showErrorToast(msg);
+			setState("idle");
+			sessionRef.current = null;
+		}
+	}
+
+	async function handleStop() {
+		const session = sessionRef.current;
+		if (!session) return;
+		sessionRef.current = null;
+
+		setState("transcribing");
+		onInterimChange?.("");
+
+		const text = await session.stop();
+		if (text) {
+			onTranscript(text);
+		}
+		setState("idle");
+	}
+
+	function toggleRecording() {
+		if (state === "recording") {
+			handleStop();
+		} else if (state === "idle") {
+			startRecording();
+		}
+	}
+
+	const recording = state === "recording";
+	const busy = state === "connecting" || state === "transcribing";
+
+	return (
+		<Button
+			type="button"
+			variant="ghost"
+			size="icon-sm"
+			aria-label={recording ? "Stop speech input" : "Start speech input"}
+			title={recording ? "Stop speech input" : "Start speech input"}
+			onClick={toggleRecording}
+			disabled={(disabled && !recording) || busy}
+			className={cn(
+				"shrink-0 rounded-full transition-all duration-200",
+				recording && "animate-stt-pulse border border-rose-500 bg-rose-600/75 text-white shadow-[0_0_0_3px_rgba(239,68,68,0.2)] hover:border-rose-400 hover:bg-rose-600/90 hover:text-white",
+				!recording && !busy && "text-muted-foreground hover:text-foreground",
+				busy && "text-muted-foreground",
+			)}
+		>
+			{busy ? <Loader2 className="size-5 animate-spin" aria-hidden="true" /> : recording ? <Square className="size-4" aria-hidden="true" /> : <Mic className="size-5" aria-hidden="true" />}
+		</Button>
+	);
+}

--- a/apps/dreamverse/web/src/components/VideoPlayer.tsx
+++ b/apps/dreamverse/web/src/components/VideoPlayer.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { PlayFilledAlt } from "@carbon/icons-react";
+import { Download, Loader2, Share } from "lucide-react";
+import { Button } from "@/components/ui/button";
+interface VideoPlayerProps {
+	videoRef?: React.RefCallback<HTMLVideoElement>;
+	archivedPlaybackRef?: React.RefCallback<HTMLVideoElement>;
+	activeClip?: Record<string, any> | null;
+	canDownload?: boolean;
+	sessionStarted?: boolean;
+	avPlaybackStarted?: boolean;
+	mediaAppendError?: string | null;
+	timeLeft?: number | null;
+	gpuAssigned?: boolean;
+	connected?: boolean;
+	queuePosition?: number;
+	loadingAnimation?: boolean;
+	showLivePlayback?: boolean;
+	defaultMuted?: boolean;
+	rewritePending?: boolean;
+	onPlaying?: () => void;
+	onDownload?: () => void;
+}
+
+function LoadingSpinner({ className }: { className?: string }) {
+	return (
+		<div className={cn("relative size-10", className)}>
+			<div className="absolute -inset-3 animate-pulse rounded-full bg-white/10 blur-lg" />
+			<div className="absolute inset-0 rounded-full border-[2.5px] border-white/8" />
+			<div className="absolute inset-0 animate-spin rounded-full border-[2.5px] border-transparent border-t-white/80" />
+		</div>
+	);
+}
+
+function generatingLabel(connected: boolean, gpuAssigned: boolean) {
+	if (!connected) return "Connecting\u2026";
+	if (!gpuAssigned) return "Waiting for GPU\u2026";
+	return "Generating video\u2026";
+}
+
+export default function VideoPlayer({
+	videoRef,
+	archivedPlaybackRef,
+	activeClip = null,
+	canDownload = false,
+	sessionStarted = false,
+	avPlaybackStarted = false,
+	mediaAppendError = null,
+	timeLeft = null,
+	gpuAssigned = false,
+	connected = false,
+	queuePosition = 0,
+	loadingAnimation = false,
+	showLivePlayback = true,
+	defaultMuted = true,
+	rewritePending = false,
+	onPlaying = () => {},
+	onDownload,
+}: VideoPlayerProps) {
+	const inQueue = sessionStarted && connected && queuePosition > 0 && !gpuAssigned;
+	const showArchived = !showLivePlayback && !!activeClip;
+
+	const liveVideoEl = useRef<HTMLVideoElement | null>(null);
+	const liveWasUnmuted = useRef(false);
+
+	const combinedLiveRef = useCallback((el: HTMLVideoElement | null) => {
+		liveVideoEl.current = el;
+		videoRef?.(el);
+	}, [videoRef]);
+
+	useEffect(() => {
+		const el = liveVideoEl.current;
+		if (!el) return;
+		if (showArchived) {
+			liveWasUnmuted.current = !el.muted;
+			el.muted = true;
+		} else if (liveWasUnmuted.current) {
+			el.muted = false;
+			liveWasUnmuted.current = false;
+		}
+	}, [showArchived]);
+
+	const [canShare, setCanShare] = useState(false);
+	useEffect(() => {
+		setCanShare(typeof navigator.canShare === "function" && window.matchMedia("(pointer: coarse)").matches);
+	}, []);
+
+	return (
+		<div className="mx-auto w-full max-w-3xl mb-2 sm:mb-6">
+			<div className="rounded-2xl border border-border bg-card/50 p-2 shadow-lg backdrop-blur-md">
+				<div className="relative aspect-video w-full overflow-hidden rounded-xl border border-border bg-black shadow-lg">
+					{/* Archived playback video — hidden when not viewing a clip */}
+					<video ref={archivedPlaybackRef} className={cn("h-full w-full bg-slate-900/80 object-cover", !showArchived && "hidden")} onPlaying={onPlaying} playsInline muted={defaultMuted} preload="auto" controls />
+
+					{/* Live video + overlays — always mounted to preserve MSE MediaSource attachment */}
+					<div className={cn(showArchived ? "hidden" : "contents")}>
+						<video ref={combinedLiveRef} className="h-full w-full bg-slate-900/80 object-cover" onPlaying={onPlaying} playsInline muted={defaultMuted} controls />
+
+						{!sessionStarted && !avPlaybackStarted ? (
+							<div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-slate-900/50 p-4 text-center">
+								<PlayFilledAlt className="size-10 text-white/25" />
+								<p className="text-sm text-white/50">Your video will appear here</p>
+							</div>
+						) : !avPlaybackStarted && !mediaAppendError && !inQueue && loadingAnimation ? (
+							<div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-slate-900/60 p-4 backdrop-blur-[2px]">
+								<div className="pointer-events-none absolute inset-0 overflow-hidden">
+									<div className="absolute inset-0 -translate-x-full animate-[shimmer_3s_ease-in-out_infinite] bg-gradient-to-r from-transparent via-white/[0.04] to-transparent" />
+								</div>
+								<LoadingSpinner />
+								<p className="relative text-sm font-medium text-white/90">{generatingLabel(connected, gpuAssigned)}</p>
+							</div>
+						) : null}
+
+						{rewritePending && avPlaybackStarted && (
+							<div className="absolute inset-x-0 bottom-0 z-10 flex items-center justify-center gap-2 bg-gradient-to-t from-black/60 to-transparent px-4 pb-12 pt-8 pointer-events-none">
+								<Loader2 className="size-4 animate-spin text-white/90" />
+								<p className="text-sm font-medium text-white/90">Applying edit&hellip;</p>
+							</div>
+						)}
+
+						{mediaAppendError && (
+							<div className="absolute inset-0 flex items-center justify-center bg-black/80 p-4">
+								<div className="max-w-sm rounded-xl border border-rose-500/30 bg-rose-950/50 p-4 text-center text-rose-100 shadow-xl">
+									<h2 className="text-base font-semibold">Playback Error</h2>
+									<p className="mt-1 text-xs leading-5 text-rose-100/90">{mediaAppendError}</p>
+								</div>
+							</div>
+						)}
+
+						{timeLeft === 0 && gpuAssigned && (
+							<div className="absolute inset-0 flex items-center justify-center bg-black/80 p-4">
+								<div className="max-w-sm rounded-xl border border-amber-500/25 bg-amber-950/45 p-4 text-center text-amber-50 shadow-xl">
+									<h2 className="text-base font-semibold">Session Expired</h2>
+									<p className="mt-1 text-xs leading-5 text-amber-50/90">Your session has ended.</p>
+								</div>
+							</div>
+						)}
+
+						{inQueue && (
+							<div className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-black/80 p-4">
+								<LoadingSpinner />
+								<div className="max-w-sm rounded-xl border border-border bg-card/90 p-4 text-center text-card-foreground shadow-xl backdrop-blur-sm">
+									<h2 className="text-base font-semibold">In Queue</h2>
+									<p className="mt-1 text-xs leading-5 text-muted-foreground">All GPUs are currently busy.</p>
+									<p className="mt-2 text-xs text-foreground">
+										Position: <strong>{queuePosition}</strong>
+									</p>
+								</div>
+							</div>
+						)}
+					</div>
+
+					{onDownload && canDownload && !mediaAppendError && !(timeLeft === 0 && gpuAssigned) && !inQueue && (
+						<Button
+							onClick={(e) => {
+								e.stopPropagation();
+								onDownload();
+							}}
+							size="icon"
+							variant="outline"
+							className="absolute top-3 left-3 z-10 cursor-pointer bg-slate-800/50 text-white/90 shadow-md backdrop-blur-sm transition-all border-white/30 hover:bg-slate-800/85 hover:border-white/50 hover:text-white hover:scale-105"
+						>
+							{canShare ? <Share className="size-5" /> : <Download className="size-5" />}
+						</Button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/dreamverse/web/src/components/Workspace.tsx
+++ b/apps/dreamverse/web/src/components/Workspace.tsx
@@ -1,0 +1,350 @@
+"use client";
+import React, { useRef, useMemo, useEffect, useCallback, useState } from "react";
+import { motion, useAnimationControls } from "framer-motion";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { Check, Lightbulb, Pencil } from "lucide-react";
+
+export const WORKSPACE_ORIGINAL_SELECTION_KEY = "original";
+export const WORKSPACE_CURRENT_SELECTION_KEY = "current";
+
+interface WorkspaceProps {
+	promptEvents?: Record<string, any>[];
+	currentThumbnail?: string | null;
+	originalLabel?: string;
+	sessionStarted?: boolean;
+	onSelectOriginal?: () => void;
+	onSelectEvent?: (event: Record<string, any>) => void;
+	onSelectCurrent?: () => void;
+	selectedClipId?: string;
+	selectedEntryKey?: string;
+	originalClipId?: string;
+}
+
+function normalizeText(value: any): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function isEditEvent(event: Record<string, any>): boolean {
+	if (!normalizeText(event?.text)) {
+		return false;
+	}
+	return String(event?.source || "").trim() === "user_rewrite";
+}
+
+export function getWorkspaceEventSelectionKey(
+	event: Record<string, any>,
+	fallbackIndex = 0,
+): string {
+	return `edit:${String(event?.promptId || event?.clipId || fallbackIndex)}`;
+}
+
+const CHROMA_PATHS = (prefix: string) => (
+	<>
+		<path d="M0 584H174V295H0V584Z" fill={`url(#${prefix}0)`} />
+		<path d="M174 584H348V184H174V584Z" fill={`url(#${prefix}1)`} />
+		<path d="M348 584H522V104H348V584Z" fill={`url(#${prefix}2)`} />
+		<path d="M522 584H697V54H522V584Z" fill={`url(#${prefix}3)`} />
+		<path d="M697 584H870V0H697V584Z" fill={`url(#${prefix}4)`} />
+		<path d="M870 584H1045V54H870V584Z" fill={`url(#${prefix}5)`} />
+		<path d="M1045 584H1219V104H1045V584Z" fill={`url(#${prefix}6)`} />
+		<path d="M1219 584H1393V184H1219V584Z" fill={`url(#${prefix}7)`} />
+		<path d="M1393 584H1567V294H1393V584Z" fill={`url(#${prefix}8)`} />
+	</>
+);
+
+const CHROMA_CHILD_GRADIENTS = (prefix: string) => (
+	<>
+		<linearGradient id={`${prefix}0`} href={`#${prefix}b`} x1="87" y1="584" x2="87" y2="295" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}1`} href={`#${prefix}b`} x1="261" y1="584" x2="261" y2="184" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}2`} href={`#${prefix}b`} x1="435" y1="584" x2="435" y2="104" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}3`} href={`#${prefix}b`} x1="609.5" y1="584" x2="609.5" y2="54" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}4`} href={`#${prefix}b`} x1="783.5" y1="584" x2="783.5" y2="0" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}5`} href={`#${prefix}b`} x1="957.5" y1="584" x2="957.5" y2="54" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}6`} href={`#${prefix}b`} x1="1132" y1="584" x2="1132" y2="104" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}7`} href={`#${prefix}b`} x1="1306" y1="584" x2="1306" y2="184" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}8`} href={`#${prefix}b`} x1="1480" y1="584" x2="1480" y2="294" gradientUnits="userSpaceOnUse" />
+	</>
+);
+
+const CHROMA_PATHS_SM = (prefix: string) => (
+	<>
+		<path d="M0 584H224V295H0V584Z" fill={`url(#${prefix}0)`} />
+		<path d="M224 584H448V184H224V584Z" fill={`url(#${prefix}1)`} />
+		<path d="M448 584H672V54H448V584Z" fill={`url(#${prefix}2)`} />
+		<path d="M672 584H896V0H672V584Z" fill={`url(#${prefix}3)`} />
+		<path d="M896 584H1120V54H896V584Z" fill={`url(#${prefix}4)`} />
+		<path d="M1120 584H1344V184H1120V584Z" fill={`url(#${prefix}5)`} />
+		<path d="M1344 584H1567V295H1344V584Z" fill={`url(#${prefix}6)`} />
+	</>
+);
+
+const CHROMA_CHILD_GRADIENTS_SM = (prefix: string) => (
+	<>
+		<linearGradient id={`${prefix}0`} href={`#${prefix}b`} x1="112" y1="584" x2="112" y2="295" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}1`} href={`#${prefix}b`} x1="336" y1="584" x2="336" y2="184" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}2`} href={`#${prefix}b`} x1="560" y1="584" x2="560" y2="54" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}3`} href={`#${prefix}b`} x1="784" y1="584" x2="784" y2="0" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}4`} href={`#${prefix}b`} x1="1008" y1="584" x2="1008" y2="54" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}5`} href={`#${prefix}b`} x1="1232" y1="584" x2="1232" y2="184" gradientUnits="userSpaceOnUse" />
+		<linearGradient id={`${prefix}6`} href={`#${prefix}b`} x1="1455.5" y1="584" x2="1455.5" y2="295" gradientUnits="userSpaceOnUse" />
+	</>
+);
+
+const LIGHT_GRADIENT_STOPS = (
+	<>
+		<stop stopColor="#162E6E" />
+		<stop offset="0.10" stopColor="#356CFF" />
+		<stop offset="0.18" stopColor="#60A5FA" />
+		<stop offset="0.28" stopColor="#FFFFFF" />
+		<stop offset="0.40" stopColor="#FEF3C7" />
+		<stop offset="0.48" stopColor="#FCD34D" />
+		<stop offset="0.58" stopColor="#F59E0B" />
+		<stop offset="0.70" stopColor="#D97706" stopOpacity="0.35" />
+		<stop offset="1" stopColor="#D97706" stopOpacity="0" />
+	</>
+);
+
+const DARK_GRADIENT_STOPS = (
+	<>
+		<stop stopColor="#071530" />
+		<stop offset="0.10" stopColor="#0E3280" />
+		<stop offset="0.18" stopColor="#2260D4" />
+		<stop offset="0.28" stopColor="#3596F8" />
+		<stop offset="0.40" stopColor="#93BDFF" />
+		<stop offset="0.48" stopColor="#DCEAFC" />
+		<stop offset="0.58" stopColor="#FDECAA" />
+		<stop offset="0.70" stopColor="#FBDD70" stopOpacity="0.35" />
+		<stop offset="1" stopColor="#FBDD70" stopOpacity="0" />
+	</>
+);
+
+function chromaSvg(prefix: string, pathsFn: (p: string) => React.ReactNode, gradientsFn: (p: string) => React.ReactNode, stops: React.ReactNode) {
+	return (
+		<svg className="h-full w-full" viewBox="0 0 1567 584" preserveAspectRatio="none" fill="none">
+			<g clipPath={`url(#${prefix}-clip)`} filter={`url(#${prefix}-blur)`}>
+				{pathsFn(prefix)}
+			</g>
+			<defs>
+				<filter id={`${prefix}-blur`} x="-30" y="-80" width="1627" height="744" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+					<feFlood floodOpacity="0" result="BackgroundImageFix" />
+					<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+					<feGaussianBlur stdDeviation="15" result="blur" />
+				</filter>
+				<linearGradient id={`${prefix}b`} gradientUnits="userSpaceOnUse">
+					{stops}
+				</linearGradient>
+				{gradientsFn(prefix)}
+				<clipPath id={`${prefix}-clip`}>
+					<rect width="1567" height="584" fill="white" />
+				</clipPath>
+			</defs>
+		</svg>
+	);
+}
+
+function ChromaGradient({ sessionStarted = false }: { sessionStarted?: boolean }) {
+	const controls = useAnimationControls();
+	const prevStarted = useRef(sessionStarted);
+
+	useEffect(() => {
+		const wasStarted = prevStarted.current;
+		prevStarted.current = sessionStarted;
+
+		if (sessionStarted && !wasStarted) {
+			controls.start({
+				scaleY: [1, 1.3, 0.14],
+				transition: { duration: 1.0, times: [0, 0.25, 1], ease: "easeInOut" },
+			});
+		} else if (sessionStarted) {
+			controls.start({
+				scaleY: 0.14,
+				transition: { duration: 0.4, ease: "easeOut" },
+			});
+		} else {
+			controls.start({
+				scaleY: 1,
+				transition: { duration: 0.6, ease: "easeOut" },
+			});
+		}
+	}, [sessionStarted, controls]);
+
+	return (
+		<>
+			{/* Mobile (<md): 7 wider bars */}
+			<div className="contents md:hidden">
+				<motion.div
+					initial={{ scaleY: 1 }}
+					animate={controls}
+					style={{ transformOrigin: "bottom" }}
+					className="pointer-events-none fixed inset-x-0 bottom-0 z-0 h-[42vh] opacity-80 dark:hidden"
+					aria-hidden="true"
+				>
+					{chromaSvg("ml", CHROMA_PATHS_SM, CHROMA_CHILD_GRADIENTS_SM, LIGHT_GRADIENT_STOPS)}
+				</motion.div>
+				<motion.div
+					initial={{ scaleY: 1 }}
+					animate={controls}
+					style={{ transformOrigin: "bottom" }}
+					className="pointer-events-none fixed inset-x-0 bottom-0 z-0 hidden h-[42vh] opacity-55 dark:block"
+					aria-hidden="true"
+				>
+					{chromaSvg("mk", CHROMA_PATHS_SM, CHROMA_CHILD_GRADIENTS_SM, DARK_GRADIENT_STOPS)}
+				</motion.div>
+			</div>
+
+			{/* Desktop (md+): 9 bars */}
+			<div className="hidden md:contents">
+				<motion.div
+					initial={{ scaleY: 1 }}
+					animate={controls}
+					style={{ transformOrigin: "bottom" }}
+					className="pointer-events-none fixed inset-x-0 bottom-0 z-0 h-[50vh] opacity-80 dark:hidden"
+					aria-hidden="true"
+				>
+					{chromaSvg("cl", CHROMA_PATHS, CHROMA_CHILD_GRADIENTS, LIGHT_GRADIENT_STOPS)}
+				</motion.div>
+				<motion.div
+					initial={{ scaleY: 1 }}
+					animate={controls}
+					style={{ transformOrigin: "bottom" }}
+					className="pointer-events-none fixed inset-x-0 bottom-0 z-0 hidden h-[50vh] opacity-55 dark:block"
+					aria-hidden="true"
+				>
+					{chromaSvg("cd", CHROMA_PATHS, CHROMA_CHILD_GRADIENTS, DARK_GRADIENT_STOPS)}
+				</motion.div>
+			</div>
+		</>
+	);
+}
+
+export default function Workspace({ promptEvents = [], currentThumbnail = null, originalLabel = "", sessionStarted = false, onSelectOriginal, onSelectEvent, onSelectCurrent, selectedClipId, selectedEntryKey: selectedEntryKeyProp, originalClipId = "" }: WorkspaceProps) {
+	const bottomSentinelRef = useRef<HTMLDivElement>(null);
+	const topSentinelRef = useRef<HTMLDivElement>(null);
+	const [showTopFade, setShowTopFade] = useState(false);
+
+	const conversationEvents = useMemo(() => {
+		const all = promptEvents.filter(isEditEvent).slice().reverse();
+		if (all.length > 0 && originalLabel && normalizeText(all[0].text) === originalLabel.trim()) {
+			return all.slice(1);
+		}
+		return all;
+	}, [promptEvents, originalLabel]);
+
+	const selectedEntryKey = useMemo(() => {
+		if (selectedEntryKeyProp !== undefined) return selectedEntryKeyProp;
+		if (!selectedClipId) return WORKSPACE_CURRENT_SELECTION_KEY;
+		if (selectedClipId === originalClipId) return WORKSPACE_ORIGINAL_SELECTION_KEY;
+		const matchIndex = conversationEvents.findIndex((e) => e.clipId === selectedClipId);
+		if (matchIndex >= 0 && matchIndex === conversationEvents.length - 1) return WORKSPACE_CURRENT_SELECTION_KEY;
+		if (matchIndex >= 0) return getWorkspaceEventSelectionKey(conversationEvents[matchIndex], matchIndex);
+		return WORKSPACE_CURRENT_SELECTION_KEY;
+	}, [selectedEntryKeyProp, selectedClipId, originalClipId, conversationEvents]);
+
+	const scrollToBottom = useCallback(() => {
+		setTimeout(() => {
+			bottomSentinelRef.current?.scrollIntoView({ block: "end", behavior: "smooth" });
+		}, 60);
+	}, []);
+
+	useEffect(() => {
+		if (conversationEvents.length > 0) scrollToBottom();
+	}, [conversationEvents, scrollToBottom]);
+
+	useEffect(() => {
+		const el = topSentinelRef.current;
+		if (!el) return;
+		const observer = new IntersectionObserver(([entry]) => setShowTopFade(!entry.isIntersecting), { threshold: 0.1 });
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [conversationEvents.length]);
+
+	return (
+		<div className="mt-auto flex flex-col">
+			<ChromaGradient sessionStarted={sessionStarted} />
+			{conversationEvents.length >= 1 && (
+				<section className="relative z-10 flex flex-col h-full items-bottom">
+					<div
+						className={cn(
+							"pointer-events-none sticky top-0 z-20 -mb-12 h-12 bg-linear-to-b from-background to-transparent transition-opacity duration-200",
+							showTopFade ? "opacity-100" : "opacity-0",
+						)}
+						aria-hidden="true"
+					/>
+					<div ref={topSentinelRef} className="h-0 w-0" aria-hidden="true" />
+					<div className="flex flex-col gap-4 pt-4 pb-4">
+						<div className="vertical gap-2">
+							<div
+								className={cn(
+									"flex items-start gap-3 rounded-xl p-3 transition-colors duration-200",
+									originalClipId && onSelectOriginal ? "cursor-pointer hover:dark:bg-slate-800/30 hover:bg-slate-200/50" : "hover:dark:bg-slate-800/30 hover:bg-slate-200/50",
+									selectedEntryKey === WORKSPACE_ORIGINAL_SELECTION_KEY && "ring-2 ring-blue-500/40 bg-slate-200/70 dark:bg-slate-800/50",
+								)}
+								data-selected={selectedEntryKey === WORKSPACE_ORIGINAL_SELECTION_KEY ? "true" : "false"}
+								onClick={() => { if (originalClipId && onSelectOriginal) onSelectOriginal(); }}
+							>
+								<div className="flex min-w-0 flex-1 flex-col gap-2">
+									<Badge variant="secondary" className="horizontal gap-2 items-center w-fit">
+										<Lightbulb className="size-3 opacity-70" />
+										Original
+									</Badge>
+									{originalLabel && <p className="line-clamp-2 text-sm leading-5 text-muted-foreground">{originalLabel}</p>}
+								</div>
+								{conversationEvents[0].thumbnail && (
+									<img src={conversationEvents[0].thumbnail} alt="" className="mt-0.5 h-12 w-auto shrink-0 rounded-md border border-border object-cover" />
+								)}
+							</div>
+
+							{conversationEvents.map((event, index) => {
+								const isLast = index === conversationEvents.length - 1;
+								const eventSelectionKey = isLast
+									? WORKSPACE_CURRENT_SELECTION_KEY
+									: getWorkspaceEventSelectionKey(event, index);
+								const isClickable = isLast
+									? Boolean(onSelectCurrent)
+									: Boolean(event.clipId && onSelectEvent);
+								const isSelected = selectedEntryKey === eventSelectionKey;
+								return (
+									<div
+										key={event.promptId || index}
+											className={cn(
+												"flex items-start gap-3 rounded-xl p-3 transition-colors duration-200",
+												isClickable && "cursor-pointer",
+												isSelected && "ring-2 ring-blue-500/40 bg-slate-200/70 dark:bg-slate-800/50",
+												!isSelected && "hover:bg-slate-200/50 hover:dark:bg-slate-800/30",
+											)}
+										data-selected={isSelected ? "true" : "false"}
+										onClick={() => {
+											if (isLast && onSelectCurrent) onSelectCurrent();
+											else if (!isLast && event.clipId && onSelectEvent) onSelectEvent(event);
+										}}
+									>
+										<div className="flex min-w-0 flex-1 flex-col gap-2">
+											<Badge variant="secondary" className="horizontal gap-2 items-center w-fit">
+												{isLast ? <Check className="size-3 opacity-70" /> : <Pencil className="size-3 opacity-70" />}
+												{isLast ? "Current" : "Edit"}
+											</Badge>
+											<p className="line-clamp-2 text-sm leading-5 text-muted-foreground">{event.text}</p>
+										</div>
+									{isLast ? (
+										currentThumbnail ? (
+											<img src={currentThumbnail} alt="" className="mt-0.5 h-12 w-auto shrink-0 rounded-md border border-border object-cover" />
+										) : (
+											<div className="mt-0.5 h-12 w-[5.3rem] shrink-0 animate-pulse rounded-md border border-border bg-muted" />
+										)
+									) : (
+										(event.resultThumbnail || event.thumbnail) && (
+											<img src={event.resultThumbnail || event.thumbnail} alt="" className="mt-0.5 h-12 w-auto shrink-0 rounded-md border border-border object-cover" />
+										)
+									)}
+									</div>
+								);
+							})}
+						</div>
+					</div>
+					<div ref={bottomSentinelRef} className="h-0 w-0" aria-hidden="true" />
+				</section>
+			)}
+		</div>
+	);
+}

--- a/apps/dreamverse/web/src/components/devtools/DevtoolsComposer.tsx
+++ b/apps/dreamverse/web/src/components/devtools/DevtoolsComposer.tsx
@@ -1,0 +1,380 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+
+import SpeechToTextButton from '@/components/SpeechToTextButton';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+
+interface DevtoolsComposerProps {
+  connected?: boolean;
+  gpuAssigned?: boolean;
+  sessionStarted?: boolean;
+  queuePosition?: number;
+  connecting?: boolean;
+  storyPresets?: Array<Record<string, any>>;
+  selectedPresetId?: string;
+  livePromptDraft?: string;
+  canJoinSession?: boolean;
+  canSubmitContinuation?: boolean;
+  editableMode?: boolean;
+  editableCanJoin?: boolean;
+  demoMode?: boolean;
+  enhancementEnabled?: boolean;
+  autoExtensionEnabled?: boolean;
+  loopGenerationEnabled?: boolean;
+  curatedPromptLimit?: number;
+  maxCuratedPromptCount?: number;
+  rewriteWindowMode?: boolean;
+  rewritingSeedPrompts?: boolean;
+  autoExtensionTimeoutHint?: string;
+  onPresetChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onLivePromptInput?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onLivePromptKeydown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onJoin?: () => void;
+  onSubmitLivePrompt?: () => void;
+  onLeave?: () => void;
+  onEnhancementToggle?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onCuratedPromptLimitChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAutoExtensionToggle?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onLoopToggle?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onLivePromptModeToggle?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSpeechTranscript?: (text: string) => void;
+  onSpeechInterimChange?: (text: string) => void;
+}
+
+export default function DevtoolsComposer({
+  connected = false,
+  gpuAssigned = false,
+  sessionStarted = false,
+  queuePosition = 0,
+  connecting = false,
+  storyPresets = [],
+  selectedPresetId = '',
+  livePromptDraft = '',
+  canJoinSession = false,
+  canSubmitContinuation = false,
+  editableMode = false,
+  editableCanJoin = false,
+  demoMode = false,
+  enhancementEnabled = true,
+  autoExtensionEnabled = false,
+  loopGenerationEnabled = false,
+  curatedPromptLimit = 0,
+  maxCuratedPromptCount = 0,
+  rewriteWindowMode = false,
+  rewritingSeedPrompts = false,
+  autoExtensionTimeoutHint = '',
+  onPresetChange = () => {},
+  onLivePromptInput = () => {},
+  onLivePromptKeydown = () => {},
+  onJoin = () => {},
+  onSubmitLivePrompt = () => {},
+  onLeave = () => {},
+  onEnhancementToggle = () => {},
+  onCuratedPromptLimitChange = () => {},
+  onAutoExtensionToggle = () => {},
+  onLoopToggle = () => {},
+  onLivePromptModeToggle = () => {},
+  onSpeechTranscript,
+  onSpeechInterimChange,
+}: DevtoolsComposerProps) {
+  const [sttBusy, setSttBusy] = useState(false);
+  const submitButtonLabel = useMemo(
+    () =>
+      rewriteWindowMode
+        ? rewritingSeedPrompts
+          ? 'Rewriting...'
+          : 'Rewrite Window'
+        : 'Extend',
+    [rewriteWindowMode, rewritingSeedPrompts],
+  );
+
+  const submitDisabled = useMemo(
+    () =>
+      !canSubmitContinuation ||
+      (rewriteWindowMode && rewritingSeedPrompts),
+    [canSubmitContinuation, rewriteWindowMode, rewritingSeedPrompts],
+  );
+
+  return (
+    <section>
+      <Card>
+        <CardContent className="space-y-5 p-5">
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_320px]">
+            <div className="space-y-4">
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,16rem)_minmax(0,1fr)]">
+                <div className="space-y-2">
+                  <Label htmlFor="devtools-story-preset">Preset</Label>
+                  <Select
+                    value={selectedPresetId}
+                    onValueChange={(value) =>
+                      onPresetChange({
+                        currentTarget: { value },
+                      } as React.ChangeEvent<HTMLSelectElement>)
+                    }
+                    disabled={sessionStarted || storyPresets.length === 0}
+                  >
+                    <SelectTrigger
+                      id="devtools-story-preset"
+                      aria-label="Story preset"
+                    >
+                      <SelectValue placeholder="No presets loaded" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {storyPresets.map((preset) => (
+                        <SelectItem key={preset.id} value={preset.id}>
+                          {preset.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <Label htmlFor="devtools-continuation-prompt">
+                      What should happen next?
+                    </Label>
+                    {!demoMode && (
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          id="devtools-rewrite-window"
+                          checked={rewriteWindowMode}
+                          onCheckedChange={(checked) =>
+                            onLivePromptModeToggle({
+                              target: { checked: Boolean(checked) },
+                              currentTarget: { checked: Boolean(checked) },
+                            } as React.ChangeEvent<HTMLInputElement>)
+                          }
+                        />
+                        <Label htmlFor="devtools-rewrite-window">
+                          Rewrite prompt window
+                        </Label>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex items-start gap-2">
+                    <Textarea
+                      id="devtools-continuation-prompt"
+                      aria-label="Continuation prompt"
+                      rows={3}
+                      maxLength={500}
+                      value={livePromptDraft}
+                      onChange={onLivePromptInput}
+                      onKeyDown={onLivePromptKeydown}
+                      placeholder={
+                        sttBusy
+                          ? 'Listening\u2026'
+                          : sessionStarted
+                            ? rewriteWindowMode
+                              ? 'Describe how to rewrite all prompt-window segments'
+                              : 'Describe the next beat in the story'
+                            : 'Generate from a preset first, then continue the story here'
+                      }
+                      disabled={!sessionStarted || sttBusy}
+                      className="min-h-[132px] min-w-0 flex-1 resize-none"
+                    />
+                    {onSpeechTranscript && (
+                      <SpeechToTextButton
+                        disabled={!sessionStarted}
+                        onTranscript={onSpeechTranscript}
+                        onInterimChange={onSpeechInterimChange}
+                        onBusyChange={setSttBusy}
+                      />
+                    )}
+                  </div>
+
+                  <p className="text-sm text-muted-foreground">
+                    {sessionStarted
+                      ? 'Ctrl/Cmd + Enter submits the current prompt.'
+                      : 'Start a session to submit prompts.'}
+                  </p>
+                </div>
+              </div>
+
+              <div
+                className="flex flex-wrap gap-2"
+                aria-label="Generation settings"
+              >
+                <Badge variant="secondary">LTX-2 Fast</Badge>
+                <Badge variant="outline">
+                  {enhancementEnabled
+                    ? 'Prompt enhance on'
+                    : 'Prompt enhance off'}
+                </Badge>
+                <Badge variant="outline">
+                  {autoExtensionEnabled
+                    ? 'Auto extension on'
+                    : 'Auto extension off'}
+                </Badge>
+                <Badge variant="outline">
+                  {loopGenerationEnabled ? 'Loop on' : 'Loop off'}
+                </Badge>
+                {maxCuratedPromptCount > 0 && (
+                  <Badge variant="outline">
+                    Prompt count {curatedPromptLimit}/{maxCuratedPromptCount}
+                  </Badge>
+                )}
+                {rewriteWindowMode && (
+                  <Badge variant="default">Rewrite window mode</Badge>
+                )}
+                {sessionStarted && queuePosition > 0 ? (
+                  <Badge variant="warning">Queue {queuePosition}</Badge>
+                ) : sessionStarted && connecting ? (
+                  <Badge variant="warning">Connecting</Badge>
+                ) : connected && !gpuAssigned && queuePosition === 0 ? (
+                  <Badge variant="secondary">Loading model</Badge>
+                ) : null}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                {!sessionStarted ? (
+                  <Button onClick={onJoin} disabled={!canJoinSession}>
+                    Generate
+                  </Button>
+                ) : (
+                  <>
+                    <Button onClick={onSubmitLivePrompt} disabled={submitDisabled}>
+                      {submitButtonLabel}
+                    </Button>
+                    <Button variant="outline" onClick={onLeave} disabled={rewritingSeedPrompts}>
+                      Leave
+                    </Button>
+                  </>
+                )}
+              </div>
+
+              {sessionStarted && autoExtensionTimeoutHint && (
+                <div className="rounded-2xl border border-amber-400/25 bg-amber-950/40 px-4 py-3 text-sm text-amber-100">
+                  {autoExtensionTimeoutHint}
+                </div>
+              )}
+
+              {editableMode && !sessionStarted && !editableCanJoin && (
+                <div className="rounded-2xl border border-rose-400/25 bg-rose-950/40 px-4 py-3 text-sm text-rose-100">
+                  Add at least 2 non-empty segments to join.
+                </div>
+              )}
+            </div>
+
+            <div
+              className="space-y-4 rounded-2xl border border-border bg-secondary p-4"
+              aria-label="Session options"
+            >
+              <div className="space-y-1">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-200/70">
+                  Session options
+                </p>
+                <h3 className="text-lg font-semibold text-foreground">
+                  Runtime controls
+                </h3>
+              </div>
+
+              <div className="space-y-4">
+                <div className="flex items-start gap-3">
+                  <Checkbox
+                    id="devtools-enhance-prompts"
+                    checked={enhancementEnabled}
+                    onCheckedChange={(checked) =>
+                      onEnhancementToggle({
+                        target: { checked: Boolean(checked) },
+                        currentTarget: { checked: Boolean(checked) },
+                      } as React.ChangeEvent<HTMLInputElement>)
+                    }
+                    disabled={sessionStarted}
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="devtools-enhance-prompts">
+                      Enhance prompts
+                    </Label>
+                    <p className="text-sm text-muted-foreground">
+                      Uses the planner before the session starts.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-start gap-3">
+                  <Checkbox
+                    id="devtools-auto-extension"
+                    checked={autoExtensionEnabled}
+                    onCheckedChange={(checked) =>
+                      onAutoExtensionToggle({
+                        target: { checked: Boolean(checked) },
+                        currentTarget: { checked: Boolean(checked) },
+                      } as React.ChangeEvent<HTMLInputElement>)
+                    }
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="devtools-auto-extension">
+                      Auto extension
+                    </Label>
+                    <p className="text-sm text-muted-foreground">
+                      Extends the rollout automatically between segments.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-start gap-3">
+                  <Checkbox
+                    id="devtools-loop-generation"
+                    checked={loopGenerationEnabled}
+                    onCheckedChange={(checked) =>
+                      onLoopToggle({
+                        target: { checked: Boolean(checked) },
+                        currentTarget: { checked: Boolean(checked) },
+                      } as React.ChangeEvent<HTMLInputElement>)
+                    }
+                  />
+                  <div className="space-y-1">
+                    <Label htmlFor="devtools-loop-generation">
+                      Loop generation
+                    </Label>
+                    <p className="text-sm text-muted-foreground">
+                      Keeps cycling through the current rollout window.
+                    </p>
+                  </div>
+                </div>
+
+                {maxCuratedPromptCount > 0 && (
+                  <div className="space-y-2">
+                    <Label htmlFor="devtools-prompt-count">Prompt count</Label>
+                    <div className="flex items-center gap-3">
+                      <Input
+                        id="devtools-prompt-count"
+                        aria-label="Prompt count"
+                        type="number"
+                        min={1}
+                        max={maxCuratedPromptCount}
+                        value={curatedPromptLimit}
+                        onChange={onCuratedPromptLimitChange}
+                        disabled={sessionStarted}
+                        className="w-24"
+                      />
+                      <small className="text-sm text-muted-foreground">
+                        of {maxCuratedPromptCount}
+                      </small>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/apps/dreamverse/web/src/components/devtools/DevtoolsDrawer.tsx
+++ b/apps/dreamverse/web/src/components/devtools/DevtoolsDrawer.tsx
@@ -1,0 +1,483 @@
+'use client';
+
+import React, { useMemo } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+interface DevtoolsDrawerProps {
+  editableMode?: boolean;
+  demoMode?: boolean;
+  sessionStarted?: boolean;
+  selectedPreset?: Record<string, any> | null;
+  editableSegments?: string[];
+  editableCanJoin?: boolean;
+  customPresetId?: string;
+  customPresetLabel?: string;
+  currentPromptWindowPrompts?: string[];
+  appendingPromptWindow?: boolean;
+  appendPromptWindowStatus?: string;
+  appendPromptWindowError?: string;
+  onCustomPresetIdInput?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onCustomPresetLabelInput?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAddSegment?: () => void;
+  onResetToPreset?: () => void;
+  onExport?: () => void;
+  onAppendPromptWindowToJson?: () => void;
+  onRemoveSegment?: (index: number) => void;
+  onUpdateSegment?: (index: number, value: string) => void;
+  seedPrompts?: string[];
+  playingSeedPromptIndex?: number | null;
+  generatingSeedPromptIndex?: number | null;
+  promptEvents?: Record<string, any>[];
+  promptConfigEditorOpen?: boolean;
+  promptConfigLoading?: boolean;
+  promptConfigSaving?: boolean;
+  promptConfigStatus?: string;
+  promptConfigError?: string;
+  nextSegmentPromptEditorOpen?: boolean;
+  autoExtensionPromptEditorOpen?: boolean;
+  rewriteWindowPromptEditorOpen?: boolean;
+  nextSegmentSystemPromptDraft?: string;
+  autoExtensionSystemPromptDraft?: string;
+  rewriteWindowSystemPromptDraft?: string;
+  onPromptConfigEditorToggle?: (e: React.SyntheticEvent<HTMLDetailsElement>) => void;
+  onReloadPromptConfig?: () => void;
+  onNextSegmentSystemPromptInput?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onAutoExtensionSystemPromptInput?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onRewriteWindowSystemPromptInput?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onSavePromptConfig?: () => void;
+}
+
+export default function DevtoolsDrawer({
+  editableMode = false,
+  demoMode = false,
+  sessionStarted = false,
+  selectedPreset = null,
+  editableSegments = [],
+  editableCanJoin = false,
+  customPresetId = 'custom_editable',
+  customPresetLabel = 'Custom Editable Preset',
+  currentPromptWindowPrompts = [],
+  appendingPromptWindow = false,
+  appendPromptWindowStatus = '',
+  appendPromptWindowError = '',
+  onCustomPresetIdInput = () => {},
+  onCustomPresetLabelInput = () => {},
+  onAddSegment = () => {},
+  onResetToPreset = () => {},
+  onExport = () => {},
+  onAppendPromptWindowToJson = () => {},
+  onRemoveSegment = () => {},
+  onUpdateSegment = () => {},
+  seedPrompts = [],
+  playingSeedPromptIndex = null,
+  generatingSeedPromptIndex = null,
+  promptEvents = [],
+  promptConfigEditorOpen = false,
+  promptConfigLoading = false,
+  promptConfigSaving = false,
+  promptConfigStatus = '',
+  promptConfigError = '',
+  nextSegmentPromptEditorOpen = false,
+  autoExtensionPromptEditorOpen = false,
+  rewriteWindowPromptEditorOpen = true,
+  nextSegmentSystemPromptDraft = '',
+  autoExtensionSystemPromptDraft = '',
+  rewriteWindowSystemPromptDraft = '',
+  onPromptConfigEditorToggle = () => {},
+  onReloadPromptConfig = () => {},
+  onNextSegmentSystemPromptInput = () => {},
+  onAutoExtensionSystemPromptInput = () => {},
+  onRewriteWindowSystemPromptInput = () => {},
+  onSavePromptConfig = () => {},
+}: DevtoolsDrawerProps) {
+  const displayPrompts = useMemo(() => {
+    if (Array.isArray(seedPrompts) && seedPrompts.length > 0) {
+      return seedPrompts;
+    }
+    return Array.isArray(currentPromptWindowPrompts)
+      ? currentPromptWindowPrompts
+      : [];
+  }, [seedPrompts, currentPromptWindowPrompts]);
+
+  return (
+    <section className="space-y-4" aria-label="Advanced controls">
+      <div className="rounded-2xl border border-border bg-card p-5 shadow-sm backdrop-blur-sm">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-1">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-200/70">
+              Devtools
+            </p>
+            <h2 className="text-2xl font-semibold text-foreground">
+              Advanced controls
+            </h2>
+          </div>
+          <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+            Prompt memory, preset editing, and server-owned system prompts stay
+            separate from the main release workflow.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        {/* Prompt window memory */}
+        <details className="group overflow-hidden rounded-2xl border border-border bg-card shadow-sm" open>
+          <summary className="flex cursor-pointer list-none items-start justify-between gap-4 px-5 py-4">
+            <div className="space-y-1">
+              <span className="block text-lg font-semibold text-foreground">
+                Prompt window memory
+              </span>
+              <span className="block text-sm leading-6 text-muted-foreground">
+                Inspect the prompts currently driving generation.
+              </span>
+            </div>
+            <Badge variant="secondary">{displayPrompts.length} prompts</Badge>
+          </summary>
+          <div className="border-t border-border px-5 py-4">
+            {displayPrompts.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-border bg-secondary px-4 py-6 text-sm text-muted-foreground">
+                No prompts are in the active window yet.
+              </div>
+            ) : (
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {displayPrompts.slice(0, 6).map((prompt, index) => (
+                  <div
+                    key={index}
+                    className={cn(
+                      'rounded-2xl border bg-secondary p-4',
+                      playingSeedPromptIndex === index
+                        ? 'border-sky-400/35 bg-sky-500/10'
+                        : generatingSeedPromptIndex === index &&
+                            playingSeedPromptIndex !== index
+                          ? 'border-amber-400/35 bg-amber-500/10'
+                          : 'border-border',
+                    )}
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                        Prompt {index + 1}
+                      </div>
+                      {playingSeedPromptIndex === index && (
+                        <Badge variant="default">
+                          playing
+                        </Badge>
+                      )}
+                      {generatingSeedPromptIndex === index &&
+                        playingSeedPromptIndex !== index && (
+                          <Badge variant="warning">
+                            generating
+                          </Badge>
+                        )}
+                    </div>
+                    <div className="mt-3 text-sm leading-6 text-foreground">
+                      {prompt}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </details>
+
+        {/* Prompt activity */}
+        <details className="group overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+          <summary className="flex cursor-pointer list-none items-start justify-between gap-4 px-5 py-4">
+            <div className="space-y-1">
+              <span className="block text-lg font-semibold text-foreground">
+                Prompt activity
+              </span>
+              <span className="block text-sm leading-6 text-muted-foreground">
+                Review prompt submissions and rewrite events.
+              </span>
+            </div>
+            <Badge variant="secondary">{promptEvents.length} events</Badge>
+          </summary>
+          <div className="border-t border-border px-5 py-4">
+            {promptEvents.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-border bg-secondary px-4 py-6 text-sm text-muted-foreground">
+                No prompt activity has been recorded yet.
+              </div>
+            ) : (
+              <ScrollArea className="max-h-80 pr-4">
+                <div className="space-y-3">
+                {promptEvents.map((item, idx) => (
+                  <div
+                    key={idx}
+                    className="grid gap-2 rounded-2xl border border-border bg-secondary px-4 py-3"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Badge variant="secondary">{item.status}</Badge>
+                      <Badge variant="outline">
+                      {item.source}
+                      </Badge>
+                      {(item.model ||
+                        Number.isFinite(item.latencyMs)) && (
+                        <span className="text-xs text-muted-foreground">
+                          {item.model && item.model}
+                          {Number.isFinite(item.latencyMs) && (
+                            <>
+                              {item.model && ' · '}
+                              {Math.round(item.latencyMs)}ms
+                            </>
+                          )}
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-sm leading-6 text-foreground">
+                      {item.text}
+                    </span>
+                  </div>
+                ))}
+                </div>
+              </ScrollArea>
+            )}
+          </div>
+        </details>
+
+        {/* Editable preset builder */}
+        {editableMode && (
+          <details
+            className="group overflow-hidden rounded-2xl border border-border bg-card shadow-sm xl:col-span-2"
+            open
+          >
+            <summary className="flex cursor-pointer list-none items-start justify-between gap-4 px-5 py-4">
+              <div className="space-y-1">
+                <span className="block text-lg font-semibold text-foreground">
+                  Editable preset builder
+                </span>
+                <span className="block text-sm leading-6 text-muted-foreground">
+                  Shape curated segments before starting a session or export
+                  them to a local overlay.
+                </span>
+              </div>
+              <Badge variant="secondary">{editableSegments.length} segments</Badge>
+            </summary>
+            <div className="border-t border-border px-5 py-4">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="custom-preset-id">Export Preset ID</Label>
+                  <Input
+                  id="custom-preset-id"
+                  type="text"
+                  value={customPresetId}
+                  onChange={onCustomPresetIdInput}
+                  disabled={sessionStarted}
+                />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="custom-preset-label">Export Label</Label>
+                  <Input
+                  id="custom-preset-label"
+                  type="text"
+                  value={customPresetLabel}
+                  onChange={onCustomPresetLabelInput}
+                  disabled={sessionStarted}
+                />
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-3">
+                <Button
+                  variant="outline"
+                  onClick={onAddSegment}
+                  disabled={sessionStarted}
+                >
+                  Add Segment
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={onResetToPreset}
+                  disabled={sessionStarted || !selectedPreset}
+                >
+                  Reset To Preset
+                </Button>
+                <Button onClick={onExport} disabled={!editableCanJoin}>
+                  Export JSON
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={onAppendPromptWindowToJson}
+                  disabled={
+                    currentPromptWindowPrompts.length < 2 ||
+                    appendingPromptWindow
+                  }
+                >
+                  {appendingPromptWindow
+                    ? 'Appending...'
+                    : 'Append Window To Presets JSON'}
+                </Button>
+              </div>
+
+              {appendPromptWindowStatus && (
+                <div className="mt-4 rounded-2xl border border-emerald-400/25 bg-emerald-950/40 px-4 py-3 text-sm text-emerald-100">
+                  {appendPromptWindowStatus}
+                </div>
+              )}
+              {appendPromptWindowError && (
+                <div className="mt-4 rounded-2xl border border-rose-400/25 bg-rose-950/40 px-4 py-3 text-sm text-rose-100">
+                  {appendPromptWindowError}
+                </div>
+              )}
+
+              <div className="mt-4 grid gap-4">
+                {editableSegments.map((segment, index) => (
+                  <div
+                    key={index}
+                    className="rounded-2xl border border-border bg-secondary p-4"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <span className="text-sm font-semibold text-foreground">
+                        Segment {index + 1}
+                      </span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onRemoveSegment(index)}
+                        disabled={
+                          sessionStarted || editableSegments.length <= 1
+                        }
+                      >
+                        Remove
+                      </Button>
+                    </div>
+
+                    <Textarea
+                      rows={5}
+                      value={segment}
+                      onChange={(e) =>
+                        onUpdateSegment(index, e.currentTarget.value)
+                      }
+                      disabled={sessionStarted}
+                      className="mt-3 min-h-[148px]"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </details>
+        )}
+
+        {/* System prompt editor */}
+        {editableMode && !demoMode && (
+          <details
+            className="group overflow-hidden rounded-2xl border border-border bg-card shadow-sm xl:col-span-2"
+            open={promptConfigEditorOpen}
+            onToggle={onPromptConfigEditorToggle}
+          >
+            <summary className="flex cursor-pointer list-none items-start justify-between gap-4 px-5 py-4">
+              <div className="space-y-1">
+                <span className="block text-lg font-semibold text-foreground">
+                  System prompt editor
+                </span>
+                <span className="block text-sm leading-6 text-muted-foreground">
+                  Edit local overlay files for the server-side system prompts.
+                </span>
+              </div>
+              <Badge variant="secondary">
+                {promptConfigSaving
+                  ? 'Saving'
+                  : promptConfigLoading
+                    ? 'Loading'
+                    : 'Ready'}
+              </Badge>
+            </summary>
+            <div className="border-t border-border px-5 py-4">
+              <div className="space-y-4">
+                <details
+                  className="overflow-hidden rounded-2xl border border-border bg-secondary"
+                  open={nextSegmentPromptEditorOpen}
+                >
+                  <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-foreground">
+                    Next Segment System Prompt (single-segment path)
+                  </summary>
+                  <div className="border-t border-border px-4 py-4">
+                    <Textarea
+                      id="next-segment-system-prompt"
+                      rows={10}
+                      value={nextSegmentSystemPromptDraft}
+                      onChange={onNextSegmentSystemPromptInput}
+                      disabled={promptConfigLoading || promptConfigSaving}
+                      className="min-h-[220px]"
+                    />
+                  </div>
+                </details>
+
+                <details
+                  className="overflow-hidden rounded-2xl border border-border bg-secondary"
+                  open={autoExtensionPromptEditorOpen}
+                >
+                  <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-foreground">
+                    Auto Extension System Prompt (auto path)
+                  </summary>
+                  <div className="border-t border-border px-4 py-4">
+                    <Textarea
+                      id="auto-extension-system-prompt"
+                      rows={10}
+                      value={autoExtensionSystemPromptDraft}
+                      onChange={onAutoExtensionSystemPromptInput}
+                      disabled={promptConfigLoading || promptConfigSaving}
+                      className="min-h-[220px]"
+                    />
+                  </div>
+                </details>
+
+                <details
+                  className="overflow-hidden rounded-2xl border border-border bg-secondary"
+                  open={rewriteWindowPromptEditorOpen}
+                >
+                  <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-foreground">
+                    Rewrite Window System Prompt (rewrite-all path)
+                  </summary>
+                  <div className="border-t border-border px-4 py-4">
+                    <Textarea
+                      id="rewrite-window-system-prompt"
+                      rows={10}
+                      value={rewriteWindowSystemPromptDraft}
+                      onChange={onRewriteWindowSystemPromptInput}
+                      disabled={promptConfigLoading || promptConfigSaving}
+                      className="min-h-[220px]"
+                    />
+                  </div>
+                </details>
+
+                <div className="flex flex-wrap gap-3">
+                  <Button
+                    variant="outline"
+                    onClick={onReloadPromptConfig}
+                    disabled={promptConfigLoading || promptConfigSaving}
+                  >
+                    Reload From Disk
+                  </Button>
+                  <Button
+                    onClick={onSavePromptConfig}
+                    disabled={promptConfigLoading || promptConfigSaving}
+                  >
+                    {promptConfigSaving ? 'Saving...' : 'Save To Disk'}
+                  </Button>
+                </div>
+
+                {promptConfigStatus && (
+                  <div className="rounded-2xl border border-emerald-400/25 bg-emerald-950/40 px-4 py-3 text-sm text-emerald-100">
+                    {promptConfigStatus}
+                  </div>
+                )}
+                {promptConfigError && (
+                  <div className="rounded-2xl border border-rose-400/25 bg-rose-950/40 px-4 py-3 text-sm text-rose-100">
+                    {promptConfigError}
+                  </div>
+                )}
+              </div>
+            </div>
+          </details>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/dreamverse/web/src/components/devtools/DevtoolsShell.test.tsx
+++ b/apps/dreamverse/web/src/components/devtools/DevtoolsShell.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import DevtoolsShell from './DevtoolsShell';
+
+describe('DevtoolsShell', () => {
+  it('reuses the release shell structure and keeps advanced controls in a drawer', () => {
+    render(
+      <DevtoolsShell
+        storyPresets={[
+          {
+            id: 'preset_alpha',
+            label: 'Preset Alpha',
+            segment_prompts: ['intro', 'middle'],
+          },
+        ]}
+        selectedPresetId="preset_alpha"
+        editableMode={true}
+        editableCanJoin={true}
+        editableSegments={['intro', 'middle']}
+        promptEvents={[
+          {
+            status: 'sent',
+            source: 'manual',
+            text: 'A dramatic reveal',
+            latencyMs: 120,
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Preset-driven video continuation' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Devtools Mode')).toBeInTheDocument();
+    expect(screen.getByText('Your video will appear here')).toBeInTheDocument();
+    expect(screen.getByLabelText('Story preset')).toBeInTheDocument();
+    expect(screen.getByLabelText('Continuation prompt')).toBeDisabled();
+
+    expect(screen.getByText('Advanced controls')).toBeInTheDocument();
+    expect(screen.getByText('Rewrite inspector')).toBeInTheDocument();
+    expect(screen.getByText('Editable preset builder')).toBeInTheDocument();
+    expect(screen.getByText('System prompt editor')).toBeInTheDocument();
+    expect(screen.getByText('Prompt activity')).toBeInTheDocument();
+
+    expect(
+      screen.queryByText('Real-Time 1080p Video Generation with FastLTX2 on a single GPU'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Live Prompt Input')).not.toBeInTheDocument();
+  });
+});

--- a/apps/dreamverse/web/src/components/devtools/DevtoolsShell.tsx
+++ b/apps/dreamverse/web/src/components/devtools/DevtoolsShell.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+import React from 'react';
+import SessionAlerts from '../shell/SessionAlerts';
+import TopStatusBar from '../shell/TopStatusBar';
+import WorkspaceShell from '../shell/WorkspaceShell';
+import Workspace from '../Workspace';
+import VideoPlayer from '../VideoPlayer';
+import RewriteInspector from '../rewrite/RewriteInspector';
+import DevtoolsComposer from './DevtoolsComposer';
+import DevtoolsDrawer from './DevtoolsDrawer';
+
+interface DevtoolsShellProps {
+  connected?: boolean;
+  gpuAssigned?: boolean;
+  sessionStarted?: boolean;
+  queuePosition?: number;
+  connecting?: boolean;
+
+  storyPresets?: Record<string, any>[];
+  selectedPresetId?: string;
+  enhancementEnabled?: boolean;
+  autoExtensionEnabled?: boolean;
+  loopGenerationEnabled?: boolean;
+  canJoinSession?: boolean;
+  canSubmitContinuation?: boolean;
+  editableMode?: boolean;
+  demoMode?: boolean;
+  editableCanJoin?: boolean;
+  curatedPromptLimit?: number;
+  maxCuratedPromptCount?: number;
+
+  onPresetChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  onEnhancementToggle?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onCuratedPromptLimitChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAutoExtensionToggle?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onLoopToggle?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onJoin?: () => void;
+  onLeave?: () => void;
+
+  sessionNotice?: string;
+  generationCapReached?: boolean;
+  generationSegmentCap?: number;
+  onRestartGeneration?: () => void;
+
+  selectedPreset?: Record<string, any> | null;
+  editableSegments?: string[];
+  customPresetId?: string;
+  customPresetLabel?: string;
+  currentPromptWindowPrompts?: string[];
+  appendingPromptWindow?: boolean;
+  appendPromptWindowStatus?: string;
+  appendPromptWindowError?: string;
+  onCustomPresetIdInput?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onCustomPresetLabelInput?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAddSegment?: () => void;
+  onResetToPreset?: () => void;
+  onExport?: () => void;
+  onAppendPromptWindowToJson?: () => void;
+  onRemoveSegment?: (index: number) => void;
+  onUpdateSegment?: (index: number, value: string) => void;
+
+  seedPrompts?: string[];
+  playingSeedPromptIndex?: number | null;
+  generatingSeedPromptIndex?: number | null;
+
+  livePromptDraft?: string;
+  livePromptRewriteMode?: boolean;
+  rewritingSeedPrompts?: boolean;
+  promptEvents?: Record<string, any>[];
+  onLivePromptInput?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onLivePromptModeToggle?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onLivePromptKeydown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onSubmitLivePrompt?: () => void;
+  onSpeechTranscript?: (text: string) => void;
+  onSpeechInterimChange?: (text: string) => void;
+
+  promptConfigEditorOpen?: boolean;
+  promptConfigLoading?: boolean;
+  promptConfigSaving?: boolean;
+  promptConfigStatus?: string;
+  promptConfigError?: string;
+  nextSegmentPromptEditorOpen?: boolean;
+  autoExtensionPromptEditorOpen?: boolean;
+  rewriteWindowPromptEditorOpen?: boolean;
+  nextSegmentSystemPromptDraft?: string;
+  autoExtensionSystemPromptDraft?: string;
+  rewriteWindowSystemPromptDraft?: string;
+  onPromptConfigEditorToggle?: (e: React.SyntheticEvent<HTMLDetailsElement>) => void;
+  onReloadPromptConfig?: () => void;
+  onNextSegmentSystemPromptInput?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onAutoExtensionSystemPromptInput?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onRewriteWindowSystemPromptInput?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onSavePromptConfig?: () => void;
+
+  autoExtensionTimeoutHint?: string;
+
+  activeClip?: Record<string, any> | null;
+  liveClipLabel?: string;
+  liveClipPrompt?: string;
+  galleryClips?: Record<string, any>[];
+  activeClipId?: string;
+  showLivePlayback?: boolean;
+  onSelectClip?: (id: string) => void;
+
+  avPlaybackStarted?: boolean;
+  mediaAppendError?: string | null;
+  timeLeft?: number | null;
+  ttffStartAtMs?: number | null;
+  ttffValueMs?: number | null;
+  timeBetweenVideosMs?: number | null;
+  loadingAnimation?: boolean;
+  formatTime?: (seconds: number) => string;
+  formatDurationMs?: (durationMs: number) => string;
+  onPlaying?: () => void;
+}
+
+export default function DevtoolsShell({
+  connected = false,
+  gpuAssigned = false,
+  sessionStarted = false,
+  queuePosition = 0,
+  connecting = false,
+
+  storyPresets = [],
+  selectedPresetId = '',
+  enhancementEnabled = true,
+  autoExtensionEnabled = false,
+  loopGenerationEnabled = false,
+  canJoinSession = false,
+  canSubmitContinuation = false,
+  editableMode = false,
+  demoMode = false,
+  editableCanJoin = false,
+  curatedPromptLimit = 0,
+  maxCuratedPromptCount = 0,
+
+  onPresetChange = () => {},
+  onEnhancementToggle = () => {},
+  onCuratedPromptLimitChange = () => {},
+  onAutoExtensionToggle = () => {},
+  onLoopToggle = () => {},
+  onJoin = () => {},
+  onLeave = () => {},
+
+  sessionNotice = '',
+  selectedPreset = null,
+  editableSegments = [],
+  customPresetId = 'custom_editable',
+  customPresetLabel = 'Custom Editable Preset',
+  currentPromptWindowPrompts = [],
+  appendingPromptWindow = false,
+  appendPromptWindowStatus = '',
+  appendPromptWindowError = '',
+  onCustomPresetIdInput = () => {},
+  onCustomPresetLabelInput = () => {},
+  onAddSegment = () => {},
+  onResetToPreset = () => {},
+  onExport = () => {},
+  onAppendPromptWindowToJson = () => {},
+  onRemoveSegment = () => {},
+  onUpdateSegment = () => {},
+
+  seedPrompts = [],
+  playingSeedPromptIndex = null,
+  generatingSeedPromptIndex = null,
+
+  livePromptDraft = '',
+  livePromptRewriteMode = false,
+  rewritingSeedPrompts = false,
+  promptEvents = [],
+  onLivePromptInput = () => {},
+  onLivePromptModeToggle = () => {},
+  onLivePromptKeydown = () => {},
+  onSubmitLivePrompt = () => {},
+  onSpeechTranscript,
+  onSpeechInterimChange,
+
+  promptConfigEditorOpen = false,
+  promptConfigLoading = false,
+  promptConfigSaving = false,
+  promptConfigStatus = '',
+  promptConfigError = '',
+  nextSegmentPromptEditorOpen = false,
+  autoExtensionPromptEditorOpen = false,
+  rewriteWindowPromptEditorOpen = true,
+  nextSegmentSystemPromptDraft = '',
+  autoExtensionSystemPromptDraft = '',
+  rewriteWindowSystemPromptDraft = '',
+  onPromptConfigEditorToggle = () => {},
+  onReloadPromptConfig = () => {},
+  onNextSegmentSystemPromptInput = () => {},
+  onAutoExtensionSystemPromptInput = () => {},
+  onRewriteWindowSystemPromptInput = () => {},
+  onSavePromptConfig = () => {},
+
+  autoExtensionTimeoutHint = '',
+
+  activeClip = null,
+  showLivePlayback = true,
+
+  avPlaybackStarted = false,
+  mediaAppendError = null,
+  timeLeft = null,
+  ttffStartAtMs = null,
+  ttffValueMs = null,
+  timeBetweenVideosMs = null,
+  loadingAnimation = false,
+  formatTime = (seconds) => `${seconds}`,
+  formatDurationMs = (durationMs) => `${durationMs}`,
+  onPlaying = () => {},
+}: DevtoolsShellProps) {
+  return (
+    <WorkspaceShell
+      devtools={true}
+      topbar={
+        <TopStatusBar
+          modeLabel="Devtools Mode"
+          title="Preset-driven video continuation"
+          connected={connected}
+          connecting={connecting}
+          sessionStarted={sessionStarted}
+          gpuAssigned={gpuAssigned}
+          queuePosition={queuePosition}
+          livePromptRewriteMode={livePromptRewriteMode}
+          rewritingSeedPrompts={rewritingSeedPrompts}
+          timeLeft={timeLeft}
+          ttffStartAtMs={ttffStartAtMs}
+          ttffValueMs={ttffValueMs}
+          videoGapMs={timeBetweenVideosMs}
+          formatTime={formatTime}
+          formatDurationMs={formatDurationMs}
+        />
+      }
+      workspace={
+        <div className="flex flex-col gap-4">
+          <VideoPlayer
+            activeClip={activeClip}
+            sessionStarted={sessionStarted}
+            avPlaybackStarted={avPlaybackStarted}
+            mediaAppendError={mediaAppendError}
+            timeLeft={timeLeft}
+            gpuAssigned={gpuAssigned}
+            connected={connected}
+            queuePosition={queuePosition}
+            loadingAnimation={loadingAnimation}
+            showLivePlayback={showLivePlayback}
+            onPlaying={onPlaying}
+          />
+          <Workspace
+            promptEvents={promptEvents}
+            sessionStarted={sessionStarted}
+          />
+        </div>
+      }
+      sidebar={
+        <RewriteInspector
+          currentPromptWindowPrompts={currentPromptWindowPrompts}
+          promptEvents={promptEvents}
+          rewritingSeedPrompts={rewritingSeedPrompts}
+          rewriteWindowMode={livePromptRewriteMode}
+        />
+      }
+      composer={
+        <DevtoolsComposer
+          connected={connected}
+          gpuAssigned={gpuAssigned}
+          sessionStarted={sessionStarted}
+          queuePosition={queuePosition}
+          connecting={connecting}
+          storyPresets={storyPresets}
+          selectedPresetId={selectedPresetId}
+          livePromptDraft={livePromptDraft}
+          canJoinSession={canJoinSession}
+          canSubmitContinuation={canSubmitContinuation}
+          editableMode={editableMode}
+          editableCanJoin={editableCanJoin}
+          demoMode={demoMode}
+          enhancementEnabled={enhancementEnabled}
+          autoExtensionEnabled={autoExtensionEnabled}
+          loopGenerationEnabled={loopGenerationEnabled}
+          curatedPromptLimit={curatedPromptLimit}
+          maxCuratedPromptCount={maxCuratedPromptCount}
+          rewriteWindowMode={livePromptRewriteMode}
+          rewritingSeedPrompts={rewritingSeedPrompts}
+          autoExtensionTimeoutHint={autoExtensionTimeoutHint}
+          onPresetChange={onPresetChange}
+          onLivePromptInput={onLivePromptInput}
+          onLivePromptKeydown={onLivePromptKeydown}
+          onJoin={onJoin}
+          onSubmitLivePrompt={onSubmitLivePrompt}
+          onLeave={onLeave}
+          onEnhancementToggle={onEnhancementToggle}
+          onCuratedPromptLimitChange={onCuratedPromptLimitChange}
+          onAutoExtensionToggle={onAutoExtensionToggle}
+          onLoopToggle={onLoopToggle}
+          onLivePromptModeToggle={onLivePromptModeToggle}
+          onSpeechTranscript={onSpeechTranscript}
+          onSpeechInterimChange={onSpeechInterimChange}
+        />
+      }
+      alerts={<SessionAlerts sessionNotice={sessionNotice} />}
+      drawer={
+        <DevtoolsDrawer
+          editableMode={editableMode}
+          demoMode={demoMode}
+          sessionStarted={sessionStarted}
+          selectedPreset={selectedPreset}
+          editableSegments={editableSegments}
+          editableCanJoin={editableCanJoin}
+          customPresetId={customPresetId}
+          customPresetLabel={customPresetLabel}
+          currentPromptWindowPrompts={currentPromptWindowPrompts}
+          appendingPromptWindow={appendingPromptWindow}
+          appendPromptWindowStatus={appendPromptWindowStatus}
+          appendPromptWindowError={appendPromptWindowError}
+          onCustomPresetIdInput={onCustomPresetIdInput}
+          onCustomPresetLabelInput={onCustomPresetLabelInput}
+          onAddSegment={onAddSegment}
+          onResetToPreset={onResetToPreset}
+          onExport={onExport}
+          onAppendPromptWindowToJson={onAppendPromptWindowToJson}
+          onRemoveSegment={onRemoveSegment}
+          onUpdateSegment={onUpdateSegment}
+          seedPrompts={seedPrompts}
+          playingSeedPromptIndex={playingSeedPromptIndex}
+          generatingSeedPromptIndex={generatingSeedPromptIndex}
+          promptEvents={promptEvents}
+          promptConfigEditorOpen={promptConfigEditorOpen}
+          promptConfigLoading={promptConfigLoading}
+          promptConfigSaving={promptConfigSaving}
+          promptConfigStatus={promptConfigStatus}
+          promptConfigError={promptConfigError}
+          nextSegmentPromptEditorOpen={nextSegmentPromptEditorOpen}
+          autoExtensionPromptEditorOpen={autoExtensionPromptEditorOpen}
+          rewriteWindowPromptEditorOpen={rewriteWindowPromptEditorOpen}
+          nextSegmentSystemPromptDraft={nextSegmentSystemPromptDraft}
+          autoExtensionSystemPromptDraft={autoExtensionSystemPromptDraft}
+          rewriteWindowSystemPromptDraft={rewriteWindowSystemPromptDraft}
+          onPromptConfigEditorToggle={onPromptConfigEditorToggle}
+          onReloadPromptConfig={onReloadPromptConfig}
+          onNextSegmentSystemPromptInput={onNextSegmentSystemPromptInput}
+          onAutoExtensionSystemPromptInput={onAutoExtensionSystemPromptInput}
+          onRewriteWindowSystemPromptInput={onRewriteWindowSystemPromptInput}
+          onSavePromptConfig={onSavePromptConfig}
+        />
+      }
+    />
+  );
+}

--- a/apps/dreamverse/web/src/components/devtools/DevtoolsShellStub.tsx
+++ b/apps/dreamverse/web/src/components/devtools/DevtoolsShellStub.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export default function DevtoolsShellStub() {
+  return null;
+}

--- a/apps/dreamverse/web/src/components/rewrite/RewriteInspector.test.tsx
+++ b/apps/dreamverse/web/src/components/rewrite/RewriteInspector.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import RewriteInspector from './RewriteInspector';
+
+describe('RewriteInspector', () => {
+  it('shows the current prompt window and latest rewrite details', () => {
+    render(
+      <RewriteInspector
+        currentPromptWindowPrompts={['intro beat', 'dramatic reveal']}
+        rewritingSeedPrompts={false}
+        rewriteWindowMode={true}
+        promptEvents={[
+          {
+            status: 'rewrite_raw_output',
+            source: 'llm_rewrite',
+            text: '{"segment_prompts":["intro beat","dramatic reveal"]}',
+          },
+          {
+            status: 'rewrite_ready',
+            source: 'llm_rewrite',
+            model: 'gpt-oss-120b',
+            latencyMs: 512,
+            text: '[1] intro beat\n[2] dramatic reveal',
+          },
+          {
+            status: 'rewrite_requested',
+            source: 'user_rewrite',
+            text: 'tighten the pacing',
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole('complementary', { name: 'Rewrite inspector' })).toBeInTheDocument();
+    expect(screen.getByText('Current window snapshot')).toBeInTheDocument();
+    expect(screen.getByText('Prompt 1')).toBeInTheDocument();
+    expect(screen.getByText('intro beat')).toBeInTheDocument();
+    expect(screen.getByText('tighten the pacing')).toBeInTheDocument();
+    expect(screen.getByText('rewrite_ready')).toBeInTheDocument();
+    expect(screen.getByText(/\[1\] intro beat/)).toBeInTheDocument();
+    expect(screen.getByText('Raw model output')).toBeInTheDocument();
+  });
+});

--- a/apps/dreamverse/web/src/components/rewrite/RewriteInspector.tsx
+++ b/apps/dreamverse/web/src/components/rewrite/RewriteInspector.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import React, { useMemo } from 'react';
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Separator } from '@/components/ui/separator';
+
+interface RewriteInspectorProps {
+  currentPromptWindowPrompts?: string[];
+  promptEvents?: Record<string, any>[];
+  rewritingSeedPrompts?: boolean;
+  rewriteWindowMode?: boolean;
+}
+
+function isRewriteEvent(event: Record<string, any>): boolean {
+  const status = String(event?.status || '').trim();
+  const source = String(event?.source || '').trim();
+  return (
+    source === 'llm_rewrite' ||
+    source === 'user_rewrite' ||
+    status.startsWith('rewrite_')
+  );
+}
+
+function trimText(value: any): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function toPreview(text: any): string {
+  const normalized = trimText(text);
+  if (!normalized) {
+    return '';
+  }
+  return normalized.length > 180
+    ? `${normalized.slice(0, 180).trimEnd()}...`
+    : normalized;
+}
+
+export default function RewriteInspector({
+  currentPromptWindowPrompts = [],
+  promptEvents = [],
+  rewritingSeedPrompts = false,
+  rewriteWindowMode = false,
+}: RewriteInspectorProps) {
+  const rewriteEvents = useMemo(
+    () => promptEvents.filter(isRewriteEvent),
+    [promptEvents],
+  );
+
+  const latestRewriteRequest = useMemo(
+    () =>
+      rewriteEvents.find(
+        (event) =>
+          event.status === 'rewrite_requested' &&
+          event.source === 'user_rewrite',
+      ) || null,
+    [rewriteEvents],
+  );
+
+  const latestRewriteResult = useMemo(
+    () =>
+      rewriteEvents.find(
+        (event) =>
+          event.status === 'rewrite_ready' ||
+          event.status === 'rewrite_fallback' ||
+          event.status === 'rewrite_error',
+      ) || null,
+    [rewriteEvents],
+  );
+
+  const latestRewriteRawOutput = useMemo(
+    () =>
+      rewriteEvents.find(
+        (event) => event.status === 'rewrite_raw_output',
+      ) || null,
+    [rewriteEvents],
+  );
+
+  const hasRewriteActivity = rewriteEvents.length > 0;
+
+  const statusLabel = rewritingSeedPrompts
+    ? 'Running'
+    : rewriteWindowMode
+      ? 'Armed'
+      : 'Idle';
+
+  const statusVariant = rewritingSeedPrompts
+    ? 'warning'
+    : rewriteWindowMode
+      ? 'default'
+      : 'secondary';
+
+  return (
+    <aside aria-label="Rewrite inspector" className="h-full">
+      <Card className="h-full overflow-hidden">
+        <CardHeader className="gap-4 pb-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-200/70">
+                Rewrite
+              </p>
+              <CardTitle className="mt-1 text-xl">Rewrite inspector</CardTitle>
+            </div>
+            <Badge variant={statusVariant}>{statusLabel}</Badge>
+          </div>
+          <CardDescription>
+            Inspect the active prompt window and the most recent rewrite
+            activity without leaving the workspace.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="space-y-5">
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-semibold text-foreground">
+                  Current window snapshot
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Prompts currently driving generation.
+                </p>
+              </div>
+              <Badge variant="secondary">
+                {currentPromptWindowPrompts.length}
+              </Badge>
+            </div>
+
+            {currentPromptWindowPrompts.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-border bg-secondary px-4 py-6 text-sm text-muted-foreground">
+                No prompts are in the active window yet.
+              </div>
+            ) : (
+              <ScrollArea className="max-h-80 pr-4">
+                <div className="space-y-3">
+                  {currentPromptWindowPrompts.map((prompt, index) => (
+                    <div
+                      key={index}
+                      className="rounded-2xl border border-border bg-secondary p-4"
+                    >
+                      <div className="mb-2 flex items-center justify-between gap-2">
+                        <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                          Prompt {index + 1}
+                        </span>
+                      </div>
+                      <p className="text-sm leading-6 text-foreground">
+                        {prompt}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            )}
+          </section>
+
+          <Separator />
+
+          <section className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h3 className="text-sm font-semibold text-foreground">
+                  Latest rewrite
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  Recent requests, results, and raw model output.
+                </p>
+              </div>
+              <Badge variant="secondary">
+                {hasRewriteActivity ? rewriteEvents.length : 0} events
+              </Badge>
+            </div>
+
+            {!hasRewriteActivity ? (
+              <div className="rounded-2xl border border-dashed border-border bg-secondary px-4 py-6 text-sm text-muted-foreground">
+                Rewrite activity will appear here once the window is rewritten.
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {latestRewriteRequest && (
+                  <div className="rounded-2xl border border-border bg-secondary p-4">
+                    <div className="mb-2 flex items-center justify-between gap-3">
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                        Instruction
+                      </span>
+                      <Badge variant="outline">Request</Badge>
+                    </div>
+                    <p className="text-sm leading-6 text-foreground">
+                      {toPreview(latestRewriteRequest.text) ||
+                        'Rewrite current prompt window'}
+                    </p>
+                  </div>
+                )}
+
+                {latestRewriteResult && (
+                  <div className="rounded-2xl border border-border bg-secondary p-4">
+                    <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                        Result
+                      </span>
+                      <div className="flex flex-wrap gap-2">
+                        <Badge
+                          variant={
+                            latestRewriteResult.status === 'rewrite_error'
+                              ? 'destructive'
+                              : latestRewriteResult.status ===
+                                  'rewrite_fallback'
+                                ? 'warning'
+                                : 'success'
+                          }
+                        >
+                          {latestRewriteResult.status}
+                        </Badge>
+                        {latestRewriteResult.model && (
+                          <Badge variant="outline">
+                            {latestRewriteResult.model}
+                          </Badge>
+                        )}
+                        {Number.isFinite(latestRewriteResult.latencyMs) && (
+                          <Badge variant="secondary">
+                            {Math.round(latestRewriteResult.latencyMs)}ms
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                    <p className="text-sm leading-6 text-foreground">
+                      {latestRewriteResult.text}
+                    </p>
+                  </div>
+                )}
+
+                {latestRewriteRawOutput && (
+                  <Accordion type="single" collapsible>
+                    <AccordionItem value="raw-output">
+                      <AccordionTrigger>Raw model output</AccordionTrigger>
+                      <AccordionContent>
+                        <div className="rounded-2xl bg-card p-4 font-mono text-xs leading-6 text-muted-foreground">
+                          {latestRewriteRawOutput.text}
+                        </div>
+                      </AccordionContent>
+                    </AccordionItem>
+                  </Accordion>
+                )}
+              </div>
+            )}
+          </section>
+        </CardContent>
+      </Card>
+    </aside>
+  );
+}

--- a/apps/dreamverse/web/src/components/shell/SessionAlerts.tsx
+++ b/apps/dreamverse/web/src/components/shell/SessionAlerts.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import React from "react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+interface Props {
+	sessionNotice?: string;
+}
+
+export default function SessionAlerts({ sessionNotice = "" }: Props) {
+	if (!sessionNotice) return null;
+
+	return (
+		<div className="flex h-full self-center">
+			<Alert className="border-blue-700 bg-accent-blue/15 text-blue-700 dark:text-blue-50 mt-14 mb-4 w-fit h-fit">
+				<AlertDescription className="font-medium">{sessionNotice}</AlertDescription>
+			</Alert>
+		</div>
+	);
+}

--- a/apps/dreamverse/web/src/components/shell/TopStatusBar.tsx
+++ b/apps/dreamverse/web/src/components/shell/TopStatusBar.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import React, { useMemo } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+
+interface Props {
+  modeLabel?: string;
+  title?: string;
+  connected?: boolean;
+  connecting?: boolean;
+  sessionStarted?: boolean;
+  gpuAssigned?: boolean;
+  queuePosition?: number;
+  livePromptRewriteMode?: boolean;
+  rewritingSeedPrompts?: boolean;
+  timeLeft?: number | null;
+  ttffStartAtMs?: number | null;
+  ttffValueMs?: number | null;
+  videoGapMs?: number | null;
+  formatTime?: (seconds: number) => string;
+  formatDurationMs?: (durationMs: number) => string;
+}
+
+export default function TopStatusBar({
+  modeLabel = 'Standard Mode',
+  title = 'Preset-driven video continuation',
+  connected = false,
+  connecting = false,
+  sessionStarted = false,
+  gpuAssigned = false,
+  queuePosition = 0,
+  livePromptRewriteMode = false,
+  rewritingSeedPrompts = false,
+  timeLeft = null,
+  ttffStartAtMs = null,
+  ttffValueMs = null,
+  videoGapMs = null,
+  formatTime = (seconds) => `${seconds}`,
+  formatDurationMs = (durationMs) => `${durationMs}`,
+}: Props) {
+  const connectionLabel = connected
+    ? 'Connected'
+    : connecting
+      ? 'Connecting'
+      : 'Offline';
+
+  const sessionLabel = useMemo(() => {
+    if (!sessionStarted) return 'Idle';
+    if (connecting) return 'Connecting';
+    if (sessionStarted && queuePosition > 0 && !gpuAssigned)
+      return `Queue ${queuePosition}`;
+    if (connected && !gpuAssigned) return 'Loading model';
+    return 'Session active';
+  }, [sessionStarted, connecting, queuePosition, gpuAssigned, connected]);
+
+  const gpuLabel = gpuAssigned
+    ? 'GPU ready'
+    : sessionStarted
+      ? 'Awaiting GPU'
+      : 'GPU idle';
+
+  const rewriteLabel = livePromptRewriteMode
+    ? rewritingSeedPrompts
+      ? 'Rewriting window'
+      : 'Rewrite mode'
+    : null;
+
+  const connectionVariant = connected
+    ? 'success'
+    : connecting
+      ? 'warning'
+      : 'outline';
+
+  const gpuVariant = gpuAssigned
+    ? 'success'
+    : sessionStarted
+      ? 'warning'
+      : 'secondary';
+
+  const timeVariant =
+    timeLeft !== null && timeLeft <= 30 ? 'warning' : 'secondary';
+
+  return (
+    <header className="rounded-2xl border border-border bg-card px-5 py-4 shadow-sm backdrop-blur-sm">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <div
+            className="flex items-center rounded-2xl border border-border bg-secondary px-4 py-3"
+            aria-label="FastVideo"
+          >
+            <img
+              src="/logo.svg"
+              alt="FastVideo"
+              className="h-8 w-auto sm:h-9"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-200/70">
+              {modeLabel}
+            </p>
+            <h1 className="text-lg font-semibold text-foreground sm:text-xl">
+              {title}
+            </h1>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3 xl:items-end">
+          <div className="flex flex-wrap gap-2" aria-label="Session status">
+            <Badge variant={connectionVariant}>{connectionLabel}</Badge>
+            <Badge variant="secondary">{sessionLabel}</Badge>
+            <Badge variant={gpuVariant}>{gpuLabel}</Badge>
+            {rewriteLabel && <Badge variant="default">{rewriteLabel}</Badge>}
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {timeLeft !== null && (
+              <Badge
+                variant={timeVariant}
+                className="rounded-xl px-3 py-1 text-xs font-medium normal-case tracking-normal"
+              >
+                Time left: {formatTime(timeLeft)}
+              </Badge>
+            )}
+
+            {ttffStartAtMs !== null && ttffValueMs !== null && (
+              <Badge
+                variant="secondary"
+                className="rounded-xl px-3 py-1 text-xs font-medium normal-case tracking-normal"
+              >
+                Time to first frame: {formatDurationMs(ttffValueMs)}
+              </Badge>
+            )}
+
+            {videoGapMs !== null && (
+              <Badge
+                variant="outline"
+                className="rounded-xl px-3 py-1 text-xs font-medium normal-case tracking-normal"
+              >
+                Time between videos: {formatDurationMs(videoGapMs)}
+              </Badge>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/dreamverse/web/src/components/shell/WorkspaceShell.tsx
+++ b/apps/dreamverse/web/src/components/shell/WorkspaceShell.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface WorkspaceShellProps {
+  devtools?: boolean;
+  topbar?: React.ReactNode;
+  workspace?: React.ReactNode;
+  sidebar?: React.ReactNode;
+  composer?: React.ReactNode;
+  alerts?: React.ReactNode;
+  drawer?: React.ReactNode;
+}
+
+export default function WorkspaceShell({
+  devtools = false,
+  topbar,
+  workspace,
+  sidebar,
+  composer,
+  alerts,
+  drawer,
+}: WorkspaceShellProps) {
+  return (
+    <main
+      className={cn(
+        'mx-auto flex min-h-screen w-full max-w-[1880px] flex-col gap-4 px-4 py-4 sm:px-6',
+        devtools && 'max-w-[1960px]',
+      )}
+    >
+      {topbar}
+      <div
+        className={cn(
+          'flex min-h-0 flex-1 flex-col gap-4 xl:flex-row',
+          sidebar && 'xl:items-stretch',
+        )}
+      >
+        <div className="min-h-0 flex-1">{workspace}</div>
+        {sidebar && (
+          <div className="min-h-0 w-full xl:max-w-[380px]">{sidebar}</div>
+        )}
+      </div>
+      {composer}
+      {alerts}
+      {drawer}
+    </main>
+  );
+}

--- a/apps/dreamverse/web/src/hooks/useStore.ts
+++ b/apps/dreamverse/web/src/hooks/useStore.ts
@@ -1,0 +1,11 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+import type { ManagedStore } from '@/stores/createManagedStore';
+
+export function useStore<T>(
+  store: ManagedStore<T>,
+): T {
+  return useSyncExternalStore(store.subscribe, store.get, store.get);
+}

--- a/apps/dreamverse/web/src/lib/devtoolsMode.test.ts
+++ b/apps/dreamverse/web/src/lib/devtoolsMode.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseDevtoolsQuery,
+  resolveDevtoolsMode,
+} from './devtoolsMode';
+
+describe('parseDevtoolsQuery', () => {
+  it('parses truthy query values', () => {
+    expect(parseDevtoolsQuery('?devtools')).toBe(true);
+    expect(parseDevtoolsQuery('?devtools=1')).toBe(true);
+    expect(parseDevtoolsQuery('?devtools=true')).toBe(true);
+  });
+
+  it('parses falsy query values', () => {
+    expect(parseDevtoolsQuery('?devtools=0')).toBe(false);
+    expect(parseDevtoolsQuery('?devtools=false')).toBe(false);
+  });
+
+  it('returns null for missing or unsupported values', () => {
+    expect(parseDevtoolsQuery('')).toBeNull();
+    expect(parseDevtoolsQuery('?devtools=maybe')).toBeNull();
+  });
+});
+
+describe('resolveDevtoolsMode', () => {
+  it('requires a devtools-capable build', () => {
+    expect(resolveDevtoolsMode({
+      buildEnabled: false,
+      search: '?devtools=1',
+    })).toBe(false);
+  });
+
+  it('activates only for explicit truthy query values', () => {
+    expect(resolveDevtoolsMode({
+      buildEnabled: true,
+      search: '',
+    })).toBe(false);
+    expect(resolveDevtoolsMode({
+      buildEnabled: true,
+      search: '?devtools=1',
+    })).toBe(true);
+  });
+});

--- a/apps/dreamverse/web/src/lib/devtoolsMode.ts
+++ b/apps/dreamverse/web/src/lib/devtoolsMode.ts
@@ -1,0 +1,44 @@
+export function parseDevtoolsQuery(
+  search: string | null | undefined,
+): boolean | null {
+  const params = new URLSearchParams(search || '');
+  if (!params.has('devtools')) {
+    return null;
+  }
+
+  const rawValue = String(params.get('devtools') || '').trim().toLowerCase();
+  if (
+    rawValue === ''
+    || rawValue === '1'
+    || rawValue === 'true'
+    || rawValue === 'yes'
+    || rawValue === 'on'
+  ) {
+    return true;
+  }
+  if (
+    rawValue === '0'
+    || rawValue === 'false'
+    || rawValue === 'no'
+    || rawValue === 'off'
+  ) {
+    return false;
+  }
+  return null;
+}
+
+interface ResolveDevtoolsModeOptions {
+  buildEnabled?: boolean;
+  search?: string;
+}
+
+export function resolveDevtoolsMode({
+  buildEnabled = false,
+  search = '',
+}: ResolveDevtoolsModeOptions = {}): boolean {
+  if (!buildEnabled) {
+    return false;
+  }
+
+  return parseDevtoolsQuery(search) === true;
+}

--- a/apps/dreamverse/web/src/lib/editableMode.test.ts
+++ b/apps/dreamverse/web/src/lib/editableMode.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseEditableQuery,
+  resolveEditableMode,
+} from './editableMode';
+
+describe('parseEditableQuery', () => {
+  it('parses true/false values', () => {
+    expect(parseEditableQuery('?editable=true')).toBe(true);
+    expect(parseEditableQuery('?editable=false')).toBe(false);
+  });
+
+  it('returns null for missing or unsupported values', () => {
+    expect(parseEditableQuery('')).toBeNull();
+    expect(parseEditableQuery('?editable=1')).toBeNull();
+    expect(parseEditableQuery('?foo=bar')).toBeNull();
+  });
+});
+
+describe('resolveEditableMode', () => {
+  it('defaults to disabled in dev mode', () => {
+    expect(resolveEditableMode({ isDev: true, envValue: '', search: '' })).toBe(false);
+  });
+
+  it('enables mode outside dev only when VITE_ENABLE_EDITABLE_MODE=true', () => {
+    expect(resolveEditableMode({ isDev: false, envValue: 'true', search: '' })).toBe(true);
+    expect(resolveEditableMode({ isDev: false, envValue: 'false', search: '' })).toBe(false);
+    expect(resolveEditableMode({ isDev: false, envValue: '', search: '' })).toBe(false);
+  });
+
+  it('applies query override in dev mode', () => {
+    expect(resolveEditableMode({
+      isDev: true,
+      envValue: '',
+      search: '?editable=false',
+    })).toBe(false);
+
+    expect(resolveEditableMode({
+      isDev: true,
+      envValue: 'false',
+      search: '?editable=true',
+    })).toBe(true);
+  });
+
+  it('ignores query override outside dev mode', () => {
+    expect(resolveEditableMode({
+      isDev: false,
+      envValue: 'false',
+      search: '?editable=true',
+    })).toBe(false);
+
+    expect(resolveEditableMode({
+      isDev: false,
+      envValue: 'true',
+      search: '?editable=false',
+    })).toBe(true);
+  });
+});

--- a/apps/dreamverse/web/src/lib/editableMode.ts
+++ b/apps/dreamverse/web/src/lib/editableMode.ts
@@ -1,0 +1,35 @@
+export function parseEditableQuery(
+  search: string | null | undefined,
+): boolean | null {
+  const params = new URLSearchParams(search || '');
+  const queryValue = params.get('editable');
+  if (queryValue === 'true') return true;
+  if (queryValue === 'false') return false;
+  return null;
+}
+
+interface ResolveEditableModeOptions {
+  isDev?: boolean;
+  envValue?: string;
+  search?: string;
+}
+
+export function resolveEditableMode({
+  isDev = false,
+  envValue = '',
+  search = '',
+}: ResolveEditableModeOptions = {}): boolean {
+  const envEnabled = String(envValue || '').toLowerCase() === 'true';
+  const baseMode = envEnabled;
+
+  if (!isDev) {
+    return baseMode;
+  }
+
+  const urlOverride = parseEditableQuery(search);
+  if (urlOverride !== null) {
+    return urlOverride;
+  }
+
+  return baseMode;
+}

--- a/apps/dreamverse/web/src/lib/presets.test.ts
+++ b/apps/dreamverse/web/src/lib/presets.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseStoryPresets,
+  sanitizePresetId,
+} from './presets';
+
+describe('sanitizePresetId', () => {
+  it('normalizes case, spacing, and symbols', () => {
+    expect(sanitizePresetId('  My Preset #1  ')).toBe('my_preset_1');
+  });
+
+  it('falls back to custom_editable when empty', () => {
+    expect(sanitizePresetId('___')).toBe('custom_editable');
+    expect(sanitizePresetId('')).toBe('custom_editable');
+  });
+});
+
+describe('parseStoryPresets', () => {
+  it('keeps only valid entries and trims text fields', () => {
+    const parsed = parseStoryPresets([
+      {
+        id: ' preset_one ',
+        label: ' Preset One ',
+        segment_prompts: [' first ', ' second '],
+      },
+      {
+        id: '',
+        label: 'Missing id',
+        segment_prompts: ['a', 'b'],
+      },
+      {
+        id: 'only_one_prompt',
+        label: 'Too short',
+        segment_prompts: ['a'],
+      },
+      {
+        id: 'blank_prompt',
+        label: 'Blank prompt',
+        segment_prompts: ['a', '   '],
+      },
+    ]);
+
+    expect(parsed).toEqual([
+      {
+        id: 'preset_one',
+        label: 'Preset One',
+        segment_prompts: ['first', 'second'],
+      },
+    ]);
+  });
+
+  it('returns empty array for invalid raw preset payload', () => {
+    expect(parseStoryPresets(null)).toEqual([]);
+    expect(parseStoryPresets({})).toEqual([]);
+  });
+
+  it('supports wrapped default export payloads', () => {
+    const parsed = parseStoryPresets({
+      default: [
+        {
+          id: 'example',
+          label: 'Example',
+          segment_prompts: ['a', 'b'],
+        },
+      ],
+    });
+
+    expect(parsed).toEqual([
+      {
+        id: 'example',
+        label: 'Example',
+        segment_prompts: ['a', 'b'],
+      },
+    ]);
+  });
+});

--- a/apps/dreamverse/web/src/lib/presets.ts
+++ b/apps/dreamverse/web/src/lib/presets.ts
@@ -1,0 +1,50 @@
+export const DEFAULT_CUSTOM_PRESET_ID = 'custom_editable';
+
+export function sanitizePresetId(value: string | null | undefined): string {
+  const normalized = (value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return normalized || DEFAULT_CUSTOM_PRESET_ID;
+}
+
+export interface StoryPreset {
+  [key: string]: unknown;
+  id: string;
+  label: string;
+  description?: string;
+  segment_prompts: string[];
+}
+
+export function parseStoryPresets(rawPresets: any): StoryPreset[] {
+  const source: any[] = Array.isArray(rawPresets)
+    ? rawPresets
+    : Array.isArray(rawPresets?.default)
+      ? rawPresets.default
+      : [];
+
+  const parsed: StoryPreset[] = [];
+  for (const entry of source) {
+    const id = (entry?.id || '').trim();
+    const label = (entry?.label || '').trim();
+    const prompts = entry?.segment_prompts;
+
+    if (
+      id &&
+      label &&
+      Array.isArray(prompts) &&
+      prompts.length >= 2 &&
+      prompts.every((prompt: any) => typeof prompt === 'string' && prompt.trim())
+    ) {
+      parsed.push({
+        id,
+        label,
+        description: typeof entry?.description === 'string' ? entry.description.trim() : undefined,
+        segment_prompts: prompts.map((prompt: string) => prompt.trim()),
+      });
+    }
+  }
+
+  return parsed;
+}

--- a/apps/dreamverse/web/src/lib/productMode.test.ts
+++ b/apps/dreamverse/web/src/lib/productMode.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PRODUCT_MODE_SINGLE5S,
+  PRODUCT_MODE_STREAMING,
+  normalizeProductMode,
+  resolveProductMode,
+  resolveSimpleMode,
+} from './productMode';
+
+describe('normalizeProductMode', () => {
+  it('keeps supported product modes', () => {
+    expect(normalizeProductMode('streaming')).toBe(PRODUCT_MODE_STREAMING);
+    expect(normalizeProductMode('single5s')).toBe(PRODUCT_MODE_SINGLE5S);
+  });
+
+  it('falls back to streaming for unknown values', () => {
+    expect(normalizeProductMode('')).toBe(PRODUCT_MODE_STREAMING);
+    expect(normalizeProductMode('unknown')).toBe(PRODUCT_MODE_STREAMING);
+  });
+});
+
+describe('resolveProductMode', () => {
+  it('uses the build mode when runtime overrides are disabled', () => {
+    expect(resolveProductMode({
+      buildProductMode: PRODUCT_MODE_SINGLE5S,
+      search: '?simple=0',
+      allowRuntimeOverride: false,
+    })).toBe(PRODUCT_MODE_SINGLE5S);
+  });
+
+  it('allows the simple query to override the build mode in dev/test', () => {
+    expect(resolveProductMode({
+      buildProductMode: PRODUCT_MODE_STREAMING,
+      search: '?simple=1',
+      allowRuntimeOverride: true,
+    })).toBe(PRODUCT_MODE_SINGLE5S);
+    expect(resolveProductMode({
+      buildProductMode: PRODUCT_MODE_SINGLE5S,
+      search: '?simple=0',
+      allowRuntimeOverride: true,
+    })).toBe(PRODUCT_MODE_STREAMING);
+  });
+});
+
+describe('resolveSimpleMode', () => {
+  it('returns whether the effective product mode is single5s', () => {
+    expect(resolveSimpleMode({
+      buildProductMode: PRODUCT_MODE_STREAMING,
+      search: '',
+      allowRuntimeOverride: false,
+    })).toBe(false);
+    expect(resolveSimpleMode({
+      buildProductMode: PRODUCT_MODE_SINGLE5S,
+      search: '',
+      allowRuntimeOverride: false,
+    })).toBe(true);
+  });
+});

--- a/apps/dreamverse/web/src/lib/productMode.ts
+++ b/apps/dreamverse/web/src/lib/productMode.ts
@@ -1,0 +1,56 @@
+import { parseSimpleQuery } from './simpleMode';
+
+export const PRODUCT_MODE_STREAMING = 'streaming';
+export const PRODUCT_MODE_SINGLE5S = 'single5s';
+
+export function normalizeProductMode(value: string | null | undefined): string {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (normalized === PRODUCT_MODE_SINGLE5S) {
+    return PRODUCT_MODE_SINGLE5S;
+  }
+  return PRODUCT_MODE_STREAMING;
+}
+
+interface ResolveProductModeOptions {
+  buildProductMode?: string;
+  search?: string;
+  allowRuntimeOverride?: boolean;
+}
+
+export function resolveProductMode({
+  buildProductMode = PRODUCT_MODE_STREAMING,
+  search = '',
+  allowRuntimeOverride = false,
+}: ResolveProductModeOptions = {}): string {
+  const normalizedBuildMode = normalizeProductMode(buildProductMode);
+  if (!allowRuntimeOverride) {
+    return normalizedBuildMode;
+  }
+
+  const runtimeSimpleMode = parseSimpleQuery(search);
+  if (runtimeSimpleMode === true) {
+    return PRODUCT_MODE_SINGLE5S;
+  }
+  if (runtimeSimpleMode === false) {
+    return PRODUCT_MODE_STREAMING;
+  }
+  return normalizedBuildMode;
+}
+
+interface ResolveSimpleModeOptions {
+  buildProductMode?: string;
+  search?: string;
+  allowRuntimeOverride?: boolean;
+}
+
+export function resolveSimpleMode({
+  buildProductMode = PRODUCT_MODE_STREAMING,
+  search = '',
+  allowRuntimeOverride = false,
+}: ResolveSimpleModeOptions = {}): boolean {
+  return resolveProductMode({
+    buildProductMode,
+    search,
+    allowRuntimeOverride,
+  }) === PRODUCT_MODE_SINGLE5S;
+}

--- a/apps/dreamverse/web/src/lib/projectStorage.ts
+++ b/apps/dreamverse/web/src/lib/projectStorage.ts
@@ -1,0 +1,378 @@
+const DB_NAME = "fastvideo-projects";
+const DB_VERSION = 1;
+const PROJECTS_STORE = "projects";
+const CLIPS_STORE = "clips";
+
+function ensureIdbError(error: unknown, fallbackMessage: string): Error {
+	if (error instanceof Error) {
+		return error;
+	}
+	if (typeof error === "string" && error.trim()) {
+		return new Error(error.trim());
+	}
+	if (error && typeof error === "object") {
+		const maybeName =
+			"name" in error && typeof error.name === "string" ? error.name : "";
+		const maybeMessage =
+			"message" in error && typeof error.message === "string"
+				? error.message
+				: "";
+		const combined = [maybeName, maybeMessage]
+			.filter((part) => part && part.trim())
+			.join(": ");
+		if (combined) {
+			return new Error(combined);
+		}
+	}
+	return new Error(fallbackMessage);
+}
+
+export interface StoredProject {
+	id: string;
+	label: string;
+	presetId: string;
+	originalLabel: string;
+	createdAt: number;
+	lastThumbnail: string | null;
+	promptEvents: Record<string, unknown>[];
+}
+
+export interface StoredClip {
+	id: string;
+	projectId: string;
+	label: string;
+	prompt: string;
+	mime: string;
+	blob: Blob;
+	createdAt: number;
+}
+
+interface PersistedClipRecord {
+	id: string;
+	projectId: string;
+	label: string;
+	prompt: string;
+	mime: string;
+	createdAt: number;
+	blob?: Blob;
+	blobBytes?: ArrayBuffer | ArrayBufferView;
+}
+
+function settleTransaction(
+	tx: IDBTransaction,
+	db: IDBDatabase,
+	resolve: () => void,
+	reject: (error: unknown) => void,
+	{
+		onTransactionError = "IndexedDB transaction failed.",
+		onTransactionAbort = "IndexedDB transaction was aborted.",
+		getTransactionError,
+	}: {
+		onTransactionError?: string;
+		onTransactionAbort?: string;
+		getTransactionError?: () => unknown;
+	} = {},
+) {
+	tx.oncomplete = () => {
+		db.close();
+		resolve();
+	};
+	tx.onerror = () => {
+		db.close();
+		reject(
+			ensureIdbError(
+				getTransactionError ? getTransactionError() : tx.error,
+				onTransactionError,
+			),
+		);
+	};
+	tx.onabort = () => {
+		db.close();
+		reject(
+			ensureIdbError(
+				getTransactionError ? getTransactionError() : tx.error,
+				onTransactionAbort,
+			),
+		);
+	};
+}
+
+function openProjectDB(): Promise<IDBDatabase> {
+	return new Promise((resolve, reject) => {
+		if (typeof indexedDB === "undefined") {
+			reject(new Error("IndexedDB is not available"));
+			return;
+		}
+		const request = indexedDB.open(DB_NAME, DB_VERSION);
+		request.onupgradeneeded = () => {
+			const db = request.result;
+			if (!db.objectStoreNames.contains(PROJECTS_STORE)) {
+				db.createObjectStore(PROJECTS_STORE, { keyPath: "id" });
+			}
+			if (!db.objectStoreNames.contains(CLIPS_STORE)) {
+				const clipStore = db.createObjectStore(CLIPS_STORE, {
+					keyPath: "id",
+				});
+				clipStore.createIndex("projectId", "projectId", {
+					unique: false,
+				});
+			}
+		};
+		request.onsuccess = () => resolve(request.result);
+		request.onerror = () =>
+			reject(
+				ensureIdbError(
+					request.error,
+					"Failed to open projects IndexedDB.",
+				),
+			);
+	});
+}
+
+function cloneArrayBufferFromView(view: ArrayBufferView): ArrayBuffer {
+	return new Uint8Array(
+		view.buffer,
+		view.byteOffset,
+		view.byteLength,
+	).slice().buffer;
+}
+
+function normalizeBlobBytes(value: unknown): ArrayBuffer | null {
+	if (value instanceof ArrayBuffer) {
+		return value.slice(0);
+	}
+	if (ArrayBuffer.isView(value)) {
+		return cloneArrayBufferFromView(value);
+	}
+	return null;
+}
+
+async function serializeClipForStorage(
+	clip: StoredClip,
+): Promise<PersistedClipRecord> {
+	const mime =
+		typeof clip.mime === "string" && clip.mime.trim()
+			? clip.mime.trim()
+			: clip.blob.type || "application/octet-stream";
+	const blobBytes = await clip.blob.arrayBuffer();
+	return {
+		id: clip.id,
+		projectId: clip.projectId,
+		label: clip.label,
+		prompt: clip.prompt,
+		mime,
+		createdAt: clip.createdAt,
+		blobBytes,
+	};
+}
+
+function deserializeStoredClip(record: PersistedClipRecord): StoredClip | null {
+	const mime =
+		typeof record.mime === "string" && record.mime.trim()
+			? record.mime.trim()
+			: "application/octet-stream";
+
+	if (record.blob instanceof Blob) {
+		return {
+			id: record.id,
+			projectId: record.projectId,
+			label: record.label,
+			prompt: record.prompt,
+			mime,
+			blob: record.blob,
+			createdAt: record.createdAt,
+		};
+	}
+
+	const blobBytes = normalizeBlobBytes(record.blobBytes);
+	if (!blobBytes) {
+		return null;
+	}
+
+	return {
+		id: record.id,
+		projectId: record.projectId,
+		label: record.label,
+		prompt: record.prompt,
+		mime,
+		blob: new Blob([blobBytes], { type: mime }),
+		createdAt: record.createdAt,
+	};
+}
+
+export async function saveProject(
+	project: StoredProject,
+	clips: StoredClip[],
+): Promise<void> {
+	const db = await openProjectDB();
+	const persistedClips = await Promise.all(
+		clips.map(async (clip) => {
+			try {
+				return await serializeClipForStorage(clip);
+			} catch (error) {
+				throw ensureIdbError(
+					error,
+					`Failed to serialize clip ${clip.id} for storage.`,
+				);
+			}
+		}),
+	);
+
+	return new Promise((resolve, reject) => {
+		let requestError: unknown = null;
+		const trackRequestError = (event: Event) => {
+			const req = event.target as IDBRequest<unknown> | null;
+			if (!requestError && req?.error) {
+				requestError = req.error;
+			}
+		};
+
+		const tx = db.transaction([PROJECTS_STORE, CLIPS_STORE], "readwrite");
+		const projectStore = tx.objectStore(PROJECTS_STORE);
+		const clipStore = tx.objectStore(CLIPS_STORE);
+		const index = clipStore.index("projectId");
+		const existingClipKeysRequest = index.getAllKeys(project.id);
+
+		existingClipKeysRequest.onerror = (event) => {
+			trackRequestError(event);
+			tx.abort();
+		};
+		existingClipKeysRequest.onsuccess = () => {
+			const existingClipKeys =
+				(existingClipKeysRequest.result as IDBValidKey[]) || [];
+			for (const key of existingClipKeys) {
+				const clipDeleteReq = clipStore.delete(key);
+				clipDeleteReq.onerror = trackRequestError;
+			}
+
+			const projectPutReq = projectStore.put(project);
+			projectPutReq.onerror = trackRequestError;
+
+			for (const clip of persistedClips) {
+				const clipPutReq = clipStore.put(clip);
+				clipPutReq.onerror = trackRequestError;
+			}
+		};
+
+		settleTransaction(tx, db, resolve, reject, {
+			onTransactionError: "Failed to save project in IndexedDB.",
+			onTransactionAbort: "Failed to save project in IndexedDB.",
+			getTransactionError: () => tx.error ?? requestError,
+		});
+	});
+}
+
+export async function saveProjectMetadata(
+	project: StoredProject,
+): Promise<void> {
+	const db = await openProjectDB();
+	return new Promise((resolve, reject) => {
+		const tx = db.transaction(PROJECTS_STORE, "readwrite");
+		tx.objectStore(PROJECTS_STORE).put(project);
+
+		settleTransaction(tx, db, resolve, reject, {
+			onTransactionError:
+				"Failed to save project metadata in IndexedDB.",
+			onTransactionAbort:
+				"Failed to save project metadata in IndexedDB.",
+		});
+	});
+}
+
+export async function listProjects(): Promise<StoredProject[]> {
+	const db = await openProjectDB();
+	return new Promise((resolve, reject) => {
+		const tx = db.transaction(PROJECTS_STORE, "readonly");
+		const request = tx.objectStore(PROJECTS_STORE).getAll();
+		request.onsuccess = () => {
+			db.close();
+			const projects = (request.result as StoredProject[]) || [];
+			projects.sort((a, b) => b.createdAt - a.createdAt);
+			resolve(projects);
+		};
+		request.onerror = () => {
+			db.close();
+			reject(
+				ensureIdbError(
+					request.error,
+					"Failed to list saved projects from IndexedDB.",
+				),
+			);
+		};
+	});
+}
+
+export async function loadProjectClips(
+	projectId: string,
+): Promise<StoredClip[]> {
+	const db = await openProjectDB();
+	return new Promise((resolve, reject) => {
+		const tx = db.transaction(CLIPS_STORE, "readonly");
+		const index = tx.objectStore(CLIPS_STORE).index("projectId");
+		const request = index.getAll(projectId);
+		request.onsuccess = () => {
+			db.close();
+			const clips = ((request.result as PersistedClipRecord[]) || [])
+				.map((item) => deserializeStoredClip(item))
+				.filter((item): item is StoredClip => Boolean(item));
+			clips.sort((a, b) => a.createdAt - b.createdAt);
+			resolve(clips);
+		};
+		request.onerror = () => {
+			db.close();
+			reject(
+				ensureIdbError(
+					request.error,
+					`Failed to load project clips for ${projectId}.`,
+				),
+			);
+		};
+	});
+}
+
+export async function deleteProject(projectId: string): Promise<void> {
+	const db = await openProjectDB();
+	return new Promise((resolve, reject) => {
+		let requestError: unknown = null;
+		const trackRequestError = (event: Event) => {
+			const req = event.target as IDBRequest<unknown> | null;
+			if (!requestError && req?.error) {
+				requestError = req.error;
+			}
+		};
+
+		const tx = db.transaction([PROJECTS_STORE, CLIPS_STORE], "readwrite");
+		const projectDeleteReq = tx.objectStore(PROJECTS_STORE).delete(projectId);
+		projectDeleteReq.onerror = trackRequestError;
+
+		const clipStore = tx.objectStore(CLIPS_STORE);
+		const index = clipStore.index("projectId");
+		const cursorReq = index.openKeyCursor(IDBKeyRange.only(projectId));
+		cursorReq.onerror = trackRequestError;
+		cursorReq.onsuccess = () => {
+			const cursor = cursorReq.result;
+			if (cursor) {
+				const clipDeleteReq = clipStore.delete(cursor.primaryKey);
+				clipDeleteReq.onerror = trackRequestError;
+				cursor.continue();
+			}
+		};
+
+		settleTransaction(tx, db, resolve, reject, {
+			onTransactionError:
+				`Failed to delete project ${projectId} from IndexedDB.`,
+			onTransactionAbort:
+				`Failed to delete project ${projectId} from IndexedDB.`,
+			getTransactionError: () => tx.error ?? requestError,
+		});
+	});
+}
+
+export async function pruneOldProjects(maxCount: number): Promise<void> {
+	const projects = await listProjects();
+	if (projects.length <= maxCount) return;
+	const toDelete = projects.slice(maxCount);
+	for (const project of toDelete) {
+		await deleteProject(project.id);
+	}
+}

--- a/apps/dreamverse/web/src/lib/promptEvents.test.ts
+++ b/apps/dreamverse/web/src/lib/promptEvents.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  prependPromptEvent,
+  updatePromptEvent,
+} from './promptEvents';
+
+interface PromptEvent {
+  promptId: string;
+  status: string;
+  source?: string;
+}
+
+describe('updatePromptEvent', () => {
+  it('updates only the matching prompt event', () => {
+    const events: PromptEvent[] = [
+      { promptId: 'a', status: 'submitted' },
+      { promptId: 'b', status: 'submitted' },
+    ];
+
+    const updated = updatePromptEvent(events, 'b', {
+      status: 'ready',
+      source: 'enhanced',
+    });
+
+    expect(updated).toEqual([
+      { promptId: 'a', status: 'submitted' },
+      { promptId: 'b', status: 'ready', source: 'enhanced' },
+    ]);
+  });
+});
+
+describe('prependPromptEvent', () => {
+  it('prepends new event', () => {
+    const events: PromptEvent[] = [{ promptId: 'a', status: 'submitted' }];
+    const next = prependPromptEvent(events, {
+      promptId: 'b',
+      status: 'submitted',
+    });
+
+    expect(next[0].promptId).toBe('b');
+    expect(next[1].promptId).toBe('a');
+  });
+
+  it('caps list length to 24 entries', () => {
+    const events: PromptEvent[] = Array.from({ length: 24 }, (_, i: number) => ({
+      promptId: `p-${i}`,
+      status: 'submitted',
+    }));
+
+    const next = prependPromptEvent(events, {
+      promptId: 'new',
+      status: 'submitted',
+    });
+
+    expect(next).toHaveLength(24);
+    expect(next[0].promptId).toBe('new');
+    expect(next.some((item: any) => item.promptId === 'p-23')).toBe(false);
+  });
+});

--- a/apps/dreamverse/web/src/lib/promptEvents.ts
+++ b/apps/dreamverse/web/src/lib/promptEvents.ts
@@ -1,0 +1,20 @@
+export const MAX_PROMPT_EVENTS = 24;
+
+export function updatePromptEvent(
+  events: Record<string, any>[],
+  promptId: string,
+  update: Record<string, any>,
+): Record<string, any>[] {
+  return events.map((event) => (
+    event.promptId === promptId
+      ? { ...event, ...update }
+      : event
+  ));
+}
+
+export function prependPromptEvent(
+  events: Record<string, any>[],
+  event: Record<string, any>,
+): Record<string, any>[] {
+  return [event, ...events].slice(0, MAX_PROMPT_EVENTS);
+}

--- a/apps/dreamverse/web/src/lib/sessionState.test.ts
+++ b/apps/dreamverse/web/src/lib/sessionState.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { applySessionUiMessage } from './sessionState';
+
+interface SessionUiState {
+  autoExtensionEnabled: boolean;
+  gpuAssigned: boolean;
+  queuePosition: number;
+  sessionTimeout: number | null;
+  timeLeft: number | null;
+}
+
+const initialState: SessionUiState = {
+  autoExtensionEnabled: false,
+  gpuAssigned: false,
+  queuePosition: 0,
+  sessionTimeout: null,
+  timeLeft: null,
+};
+
+describe('applySessionUiMessage', () => {
+  it('updates queue position from queue_status', () => {
+    const next = applySessionUiMessage(initialState, {
+      type: 'queue_status',
+      position: 3,
+    });
+
+    expect(next.queuePosition).toBe(3);
+    expect(next.gpuAssigned).toBe(false);
+  });
+
+  it('updates state on gpu_assigned', () => {
+    const next = applySessionUiMessage(initialState, {
+      type: 'gpu_assigned',
+      gpu_id: 0,
+      session_timeout: 120,
+    });
+
+    expect(next.gpuAssigned).toBe(true);
+    expect(next.queuePosition).toBe(0);
+    expect(next.sessionTimeout).toBe(120);
+    expect(next.timeLeft).toBe(120);
+  });
+
+  it('updates auto extension toggle', () => {
+    const next = applySessionUiMessage(initialState, {
+      type: 'auto_extension_updated',
+      enabled: 1,
+    });
+
+    expect(next.autoExtensionEnabled).toBe(true);
+  });
+
+  it('handles session timeout state', () => {
+    const state: SessionUiState = {
+      ...initialState,
+      gpuAssigned: true,
+      timeLeft: 15,
+    };
+    const next = applySessionUiMessage(state, {
+      type: 'session_timeout',
+    });
+
+    expect(next.gpuAssigned).toBe(false);
+    expect(next.timeLeft).toBe(0);
+  });
+});

--- a/apps/dreamverse/web/src/lib/sessionState.ts
+++ b/apps/dreamverse/web/src/lib/sessionState.ts
@@ -1,0 +1,42 @@
+export function applySessionUiMessage<T extends object>(
+  state: T,
+  data: any,
+): T {
+  if (!data || typeof data !== 'object') {
+    return state;
+  }
+
+  if (data.type === 'queue_status') {
+    return {
+      ...state,
+      queuePosition: data.position,
+    } as T;
+  }
+
+  if (data.type === 'auto_extension_updated') {
+    return {
+      ...state,
+      autoExtensionEnabled: Boolean(data.enabled),
+    } as T;
+  }
+
+  if (data.type === 'gpu_assigned') {
+    return {
+      ...state,
+      gpuAssigned: true,
+      queuePosition: 0,
+      sessionTimeout: data.session_timeout,
+      timeLeft: data.session_timeout,
+    } as T;
+  }
+
+  if (data.type === 'session_timeout') {
+    return {
+      ...state,
+      gpuAssigned: false,
+      timeLeft: 0,
+    } as T;
+  }
+
+  return state;
+}

--- a/apps/dreamverse/web/src/lib/simpleMode.ts
+++ b/apps/dreamverse/web/src/lib/simpleMode.ts
@@ -1,0 +1,25 @@
+export function parseSimpleQuery(
+  search: string | null | undefined,
+): boolean | null {
+  const params = new URLSearchParams(search || '');
+  if (!params.has('simple')) return null;
+
+  const value = String(params.get('simple') || '').trim().toLowerCase();
+  if (value === '' || value === '1' || value === 'true' || value === 'yes' || value === 'on') {
+    return true;
+  }
+  if (value === '0' || value === 'false' || value === 'no' || value === 'off') {
+    return false;
+  }
+  return null;
+}
+
+interface ResolveSimpleModeOptions {
+  search?: string;
+}
+
+export function resolveSimpleMode({
+  search = '',
+}: ResolveSimpleModeOptions = {}): boolean {
+  return parseSimpleQuery(search) === true;
+}

--- a/apps/dreamverse/web/src/lib/storyPresetsData.ts
+++ b/apps/dreamverse/web/src/lib/storyPresetsData.ts
@@ -1,0 +1,3 @@
+import rawPresets from '../../prompts/selected_ltx2_continuation_story_presets.json';
+
+export default rawPresets;

--- a/apps/dreamverse/web/src/lib/utils.ts
+++ b/apps/dreamverse/web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/dreamverse/web/src/lib/whisperStt.ts
+++ b/apps/dreamverse/web/src/lib/whisperStt.ts
@@ -1,0 +1,134 @@
+const OPENAI_TRANSCRIPTION_URL =
+  'https://api.openai.com/v1/audio/transcriptions';
+
+export interface WhisperSttSession {
+  readonly active: boolean;
+  stop: () => Promise<string | undefined>;
+}
+
+interface StartWhisperSttParams {
+  apiKey: string;
+  onError?: (error: Error) => void;
+  onOpen?: () => void;
+  onClose?: () => void;
+}
+
+export async function startWhisperStt({
+  apiKey,
+  onError = () => {},
+  onOpen = () => {},
+  onClose = () => {},
+}: StartWhisperSttParams): Promise<WhisperSttSession> {
+  if (!apiKey) {
+    throw new Error('OpenAI API key is required');
+  }
+
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+      },
+    });
+  } catch (err: unknown) {
+    const msg =
+      err instanceof Error ? err.message : 'unknown error';
+    throw new Error(`Microphone access denied: ${msg}`);
+  }
+
+  const chunks: Blob[] = [];
+  const mediaRecorder = new MediaRecorder(stream, {
+    mimeType: getSupportedMimeType(),
+  });
+
+  mediaRecorder.ondataavailable = (e) => {
+    if (e.data.size > 0) chunks.push(e.data);
+  };
+
+  mediaRecorder.start(250);
+  onOpen();
+
+  let active = true;
+
+  const session: WhisperSttSession = {
+    get active() {
+      return active;
+    },
+    async stop() {
+      if (!active) return undefined;
+      active = false;
+
+      mediaRecorder.stop();
+      stream.getTracks().forEach((track) => track.stop());
+
+      await new Promise<void>((resolve) => {
+        mediaRecorder.onstop = () => resolve();
+      });
+
+      if (chunks.length === 0) {
+        onClose();
+        return undefined;
+      }
+
+      const blob = new Blob(chunks, {
+        type: mediaRecorder.mimeType,
+      });
+      const ext = mediaRecorder.mimeType.includes('webm')
+        ? 'webm'
+        : 'ogg';
+
+      const formData = new FormData();
+      formData.append('file', blob, `recording.${ext}`);
+      formData.append('model', 'whisper-1');
+
+      try {
+        const response = await fetch(OPENAI_TRANSCRIPTION_URL, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: formData,
+        });
+
+        if (!response.ok) {
+          const body = await response.text();
+          throw new Error(
+            `Whisper STT error (${response.status}): ${body}`,
+          );
+        }
+
+        const data = await response.json();
+        onClose();
+        return (data.text as string) || undefined;
+      } catch (err: unknown) {
+        const error =
+          err instanceof Error
+            ? err
+            : new Error('Whisper STT request failed');
+        onError(error);
+        onClose();
+        return undefined;
+      }
+    },
+  };
+
+  return session;
+}
+
+function getSupportedMimeType(): string {
+  const types = [
+    'audio/webm;codecs=opus',
+    'audio/webm',
+    'audio/ogg;codecs=opus',
+    'audio/ogg',
+  ];
+  for (const type of types) {
+    if (MediaRecorder.isTypeSupported(type)) return type;
+  }
+  return 'audio/webm';
+}
+
+export function getWhisperApiKey(): string {
+  return process.env.NEXT_PUBLIC_OPENAI_API_KEY || '';
+}

--- a/apps/dreamverse/web/src/lib/ws/client.ts
+++ b/apps/dreamverse/web/src/lib/ws/client.ts
@@ -1,0 +1,36 @@
+interface CreateWebSocketConnectionParams {
+  url: string;
+  binaryType?: BinaryType;
+  onOpen?: (event: Event) => void;
+  onMessage?: (event: MessageEvent) => void;
+  onError?: (event: Event) => void;
+  onClose?: (event: CloseEvent) => void;
+}
+
+export function createWebSocketConnection({
+  url,
+  binaryType = 'arraybuffer',
+  onOpen = () => {},
+  onMessage = () => {},
+  onError = () => {},
+  onClose = () => {},
+}: CreateWebSocketConnectionParams): WebSocket {
+  const ws = new WebSocket(url);
+  ws.binaryType = binaryType;
+  ws.onopen = onOpen;
+  ws.onmessage = onMessage;
+  ws.onerror = onError;
+  ws.onclose = onClose;
+  return ws;
+}
+
+export function detachAndCloseWebSocket(
+  ws: WebSocket | null,
+): void {
+  if (!ws) return;
+  ws.onopen = null;
+  ws.onmessage = null;
+  ws.onerror = null;
+  ws.onclose = null;
+  ws.close();
+}

--- a/apps/dreamverse/web/src/lib/ws/handlers.ts
+++ b/apps/dreamverse/web/src/lib/ws/handlers.ts
@@ -1,0 +1,65 @@
+export interface DecodedJsonEvent {
+  kind: 'json';
+  data: any;
+}
+
+export interface DecodedBinaryEvent {
+  kind: 'binary';
+  data: ArrayBuffer;
+}
+
+export interface DecodedIgnoreEvent {
+  kind: 'ignore';
+  data: null;
+}
+
+export type DecodedWebSocketEvent =
+  | DecodedJsonEvent
+  | DecodedBinaryEvent
+  | DecodedIgnoreEvent;
+
+export async function decodeWebSocketEvent(
+  event: MessageEvent,
+): Promise<DecodedWebSocketEvent> {
+  if (typeof event.data === 'string') {
+    return {
+      kind: 'json',
+      data: JSON.parse(event.data),
+    };
+  }
+
+  const chunk =
+    event.data instanceof ArrayBuffer
+      ? event.data
+      : event.data instanceof Blob
+        ? await event.data.arrayBuffer()
+        : null;
+
+  if (!chunk) {
+    return { kind: 'ignore', data: null };
+  }
+
+  return {
+    kind: 'binary',
+    data: chunk,
+  };
+}
+
+export async function routeSocketMessage(
+  data: any,
+  handlers: Record<string, (data: any) => Promise<void> | void>,
+  onUnhandled:
+    | ((data: any) => Promise<void> | void)
+    | null = null,
+): Promise<boolean> {
+  const handler = handlers[data?.type];
+  if (handler) {
+    await handler(data);
+    return true;
+  }
+
+  if (onUnhandled) {
+    await onUnhandled(data);
+  }
+  return false;
+}

--- a/apps/dreamverse/web/src/lib/ws/protocol.ts
+++ b/apps/dreamverse/web/src/lib/ws/protocol.ts
@@ -1,0 +1,51 @@
+const EVENT_TYPE_MAP: Record<string, string> = {
+  queue_status: 'session/queue_status',
+  prompt_received: 'prompt/received',
+  prompt_enhancing: 'prompt/enhancing',
+  prompt_ready: 'prompt/ready',
+  prompt_fallback_used: 'prompt/fallback_used',
+  segment_prompt_source: 'prompt/source_selected',
+  seed_prompts_updated: 'prompt_window/updated',
+  rewrite_seed_prompts_started: 'rewrite/started',
+  rewrite_seed_prompts_complete: 'rewrite/completed',
+  loop_generation_updated: 'session/loop_generation_updated',
+  generation_paused_updated: 'session/generation_paused_updated',
+  loop_restarted: 'session/loop_restarted',
+  seed_prompts_reset_applied: 'prompt_window/reset_applied',
+  auto_prompt_failed: 'prompt/auto_failed',
+  prompt_sources_blocked: 'prompt/sources_blocked',
+  prompt_sources_resumed: 'prompt/sources_resumed',
+  auto_extension_updated: 'session/auto_extension_updated',
+  step_complete: 'segment/step_complete',
+  gpu_assigned: 'session/gpu_assigned',
+  session_timeout: 'session/timeout',
+  project_idle: 'session/project_idle',
+  generation_cap_reached: 'session/generation_cap_reached',
+  generation_restarted: 'session/generation_restarted',
+  ltx2_stream_start: 'stream/started',
+  media_init: 'stream/media_init',
+  media_segment_complete: 'stream/media_segment_complete',
+  ltx2_segment_start: 'segment/started',
+  ltx2_segment_complete: 'segment/completed',
+  ltx2_stream_complete: 'stream/completed',
+  error: 'session/error',
+};
+
+export interface NormalizedSocketMessage {
+  type: string;
+  rawType: string;
+  payload: any;
+}
+
+export function normalizeSocketMessage(
+  data: any,
+): NormalizedSocketMessage {
+  const rawType =
+    typeof data?.type === 'string' ? data.type : 'unknown';
+
+  return {
+    type: EVENT_TYPE_MAP[rawType] || 'server/unhandled',
+    rawType,
+    payload: data,
+  };
+}

--- a/apps/dreamverse/web/src/lib/ws/reducer.test.ts
+++ b/apps/dreamverse/web/src/lib/ws/reducer.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveSessionErrorMessage } from './reducer';
+
+describe('resolveSessionErrorMessage', () => {
+  it('returns a dedicated message for IP session limit errors', () => {
+    expect(resolveSessionErrorMessage({
+      error_code: 'ip_session_limit',
+      message: 'ignored',
+    })).toBe(
+      'Only one active websocket session is allowed per IP. '
+      + 'Close the other session and click Run to retry.',
+    );
+  });
+
+  it('falls back to payload message for other server errors', () => {
+    expect(resolveSessionErrorMessage({
+      message: 'Backend replica unavailable. Rejoin session.',
+    })).toBe('Backend replica unavailable. Rejoin session.');
+  });
+});

--- a/apps/dreamverse/web/src/lib/ws/reducer.ts
+++ b/apps/dreamverse/web/src/lib/ws/reducer.ts
@@ -1,0 +1,499 @@
+function buildPromptExtensionFailureMessage(): string {
+	return "Prompt extension failed for this request. " + "Turn off Prompt extension and try again to use your raw prompt directly.";
+}
+
+function resolveSessionErrorMessage(payload: any): string {
+	if (payload?.error_code === "ip_session_limit") {
+		return "Only one active websocket session is allowed per IP. " + "Close the other session and click Run to retry.";
+	}
+
+	if (typeof payload?.message === "string" && payload.message.trim()) {
+		return payload.message.trim();
+	}
+
+	return "An error occurred. Please start a new project.";
+}
+
+function isInfrastructureError(payload: any): boolean {
+	const msg = typeof payload?.message === "string" ? payload.message.toLowerCase() : "";
+	return msg.includes("replica unavailable");
+}
+
+export async function applyNormalizedSocketEvent(event: any, context: any): Promise<void> {
+	const {
+		sessionStore,
+		promptWindowStore,
+		rewriteStore,
+		streamStore,
+		uiStore,
+		avPipeline,
+		tick,
+		defaultAvMime,
+		fixedRewriteModel,
+		parseLatencyMs,
+		formatPromptWindowEventText,
+		makePromptId,
+		buildClipLabel,
+		startSessionCountdown,
+		clearCountdownInterval,
+		resetTtffTimer,
+		startTtffTimer,
+		preserveArchivedPlaybackSelection,
+		finalizeStreamCompletion,
+	} = context;
+
+	const payload = event?.payload;
+	sessionStore.applyServerUiMessage(payload);
+
+	switch (event?.type) {
+		case "session/queue_status":
+			console.log(`Queue position: ${sessionStore.get().queuePosition}`);
+			return;
+
+		case "prompt/received":
+			rewriteStore.trackPromptEvent(payload.prompt_id, {
+				status: "queued",
+			});
+			return;
+
+		case "prompt/enhancing":
+			rewriteStore.trackPromptEvent(payload.prompt_id, {
+				status: "enhancing",
+			});
+			return;
+
+		case "prompt/ready":
+			if (uiStore.get().simpleMode) {
+				sessionStore.patch({
+					promptExtensionError: "",
+				});
+			}
+			rewriteStore.trackPromptEvent(payload.prompt_id, {
+				status: "ready",
+				source: payload.source || "user_raw",
+				text: payload.prompt,
+			});
+			return;
+
+		case "prompt/fallback_used":
+			if (uiStore.get().simpleMode) {
+				const fallbackClip = streamStore.get().completedSimpleClips[0] || null;
+				const promptExtensionError = buildPromptExtensionFailureMessage();
+				avPipeline.reset();
+				sessionStore.patch({
+					promptExtensionError,
+				});
+				streamStore.patch({
+					loadingAnimation: false,
+					avPlaybackStarted: false,
+					mediaAppendError: null,
+					generatingSeedPromptIndex: null,
+					simpleCompletionFinalized: true,
+					simpleLiveCardVisible: true,
+					activeSimpleArchivedClipId: fallbackClip?.id || "",
+					activeSimplePlaybackObjectUrl: fallbackClip?.objectUrl || "",
+					activeSimplePlaybackStartTime: 0,
+				});
+			}
+			rewriteStore.trackPromptEvent(payload.prompt_id, {
+				status: "ready_fallback",
+				source: payload.source || "user_raw",
+				text: payload.prompt,
+			});
+			console.warn("[PromptEnhanceFallback] Prompt extension failed for this request.");
+			return;
+
+		case "prompt/source_selected":
+			rewriteStore.applySegmentPromptSource(payload);
+			if (payload.prompt_id) {
+				rewriteStore.trackPromptEvent(payload.prompt_id, {
+					status: "consumed",
+					source: payload.source || "user_raw",
+				});
+			}
+			return;
+
+		case "prompt_window/updated": {
+			const nextPrompts = Array.isArray(payload.prompts) ? payload.prompts : [];
+			streamStore.patch((state: any) => ({
+				pendingClip: state.pendingClip
+					? {
+							...state.pendingClip,
+							promptWindowPrompts: [...nextPrompts],
+						}
+					: state.pendingClip,
+				liveClip:
+					!state.pendingClip && state.liveClip
+						? {
+								...state.liveClip,
+								promptWindowPrompts: [...nextPrompts],
+							}
+						: state.liveClip,
+			}));
+			if (payload.reason === "rewrite") {
+				promptWindowStore.replacePromptWindow(nextPrompts, { syncEditable: true });
+				const latencyMs = parseLatencyMs(payload.latency_ms);
+				const rewriteModel = typeof payload.model === "string" && payload.model.trim() ? payload.model.trim() : fixedRewriteModel;
+				const rawLlmOutput = typeof payload.raw_llm_output === "string" ? payload.raw_llm_output.trim() : "";
+				const rewriteOutput = formatPromptWindowEventText(nextPrompts);
+
+				if (rewriteOutput) {
+					rewriteStore.addPromptEvent({
+						promptId: makePromptId(),
+						status: payload.fallback_used ? "rewrite_fallback" : "rewrite_ready",
+						source: "llm_rewrite",
+						model: rewriteModel,
+						latencyMs,
+						text: rewriteOutput,
+					});
+					if (rawLlmOutput) {
+						rewriteStore.addPromptEvent({
+							promptId: makePromptId(),
+							status: "rewrite_raw_output",
+							source: "llm_rewrite",
+							model: rewriteModel,
+							latencyMs,
+							text: rawLlmOutput,
+						});
+					}
+				} else if (payload.error) {
+					rewriteStore.addPromptEvent({
+						promptId: makePromptId(),
+						status: "rewrite_error",
+						source: "llm_rewrite",
+						model: rewriteModel,
+						latencyMs,
+						text: payload.error,
+					});
+					if (rawLlmOutput) {
+						rewriteStore.addPromptEvent({
+							promptId: makePromptId(),
+							status: "rewrite_raw_output",
+							source: "llm_rewrite",
+							model: rewriteModel,
+							latencyMs,
+							text: rawLlmOutput,
+						});
+					}
+				}
+				rewriteStore.patch({
+					rewritingSeedPrompts: false,
+				});
+				return;
+			}
+
+			promptWindowStore.setSeedPrompts(nextPrompts);
+			return;
+		}
+
+		case "rewrite/started":
+			rewriteStore.patch({ rewritingSeedPrompts: true });
+			return;
+
+		case "rewrite/completed":
+			rewriteStore.patch({ rewritingSeedPrompts: false });
+			if (payload?.error) {
+				const latencyMs = parseLatencyMs(payload.latency_ms);
+				rewriteStore.addPromptEvent({
+					promptId: makePromptId(),
+					status: "rewrite_error",
+					source: "llm_rewrite",
+					model: typeof payload.model === "string" && payload.model.trim() ? payload.model.trim() : fixedRewriteModel,
+					latencyMs,
+					text: payload.error,
+				});
+			}
+			return;
+
+		case "session/loop_generation_updated":
+			sessionStore.patch({
+				loopGenerationEnabled: Boolean(payload.enabled),
+			});
+			return;
+
+		case "session/generation_paused_updated":
+			sessionStore.patch({
+				generationPaused: Boolean(payload.paused),
+			});
+			return;
+
+		case "session/loop_restarted":
+		case "prompt_window/reset_applied":
+			streamStore.patch({
+				currentSegmentNumber: 0,
+				playingSeedPromptIndex: null,
+				generatingSeedPromptIndex: null,
+				seedPromptIndexBySegment: {},
+			});
+			return;
+
+		case "prompt/auto_failed": {
+			if (uiStore.get().simpleMode) {
+				sessionStore.patch({ autoExtensionTimeoutHint: "" });
+				return;
+			}
+
+			console.error("[AutoPromptFailed]", payload);
+			const segmentLabel = Number.isInteger(payload?.segment_idx) ? `segment ${payload.segment_idx}` : "next segment";
+			const errorText = typeof payload?.error === "string" && payload.error.trim() ? payload.error.trim() : "Auto prompt timed out.";
+			sessionStore.patch({
+				autoExtensionTimeoutHint: `${errorText} Retry ${segmentLabel} by toggling Auto extension off, then on.`,
+			});
+			return;
+		}
+
+		case "prompt/sources_blocked":
+			sessionStore.patch({
+				autoExtensionTimeoutHint: uiStore.get().simpleMode ? "" : "blocked on user input, increase prompt count for smoother experience",
+			});
+			return;
+
+		case "prompt/sources_resumed":
+		case "session/auto_extension_updated":
+			sessionStore.patch({ autoExtensionTimeoutHint: "" });
+			if (event.type === "session/auto_extension_updated") {
+				console.log("[AutoExtensionUpdated]", {
+					enabled: sessionStore.get().autoExtensionEnabled,
+				});
+			}
+			return;
+
+		case "segment/step_complete":
+			streamStore.patch({
+				lastGenerationLatencyMs: parseLatencyMs(payload?.latency_ms?.worker_e2e),
+				lastE2eLatencyMs: parseLatencyMs(payload?.latency_ms?.total),
+			});
+			return;
+
+		case "session/gpu_assigned":
+			console.log(`GPU ${payload.gpu_id} assigned, session timeout: ${sessionStore.get().sessionTimeout}s`);
+			startSessionCountdown();
+			return;
+
+		case "session/timeout":
+			sessionStore.patch({
+				preservePlaybackOnClose: false,
+				generationCapReached: false,
+				projectResetPending: false,
+				sessionExpired: true,
+				sessionNotice: "",
+			});
+			console.log("Session timed out");
+			clearCountdownInterval();
+			resetTtffTimer();
+			return;
+
+		case "session/project_idle":
+			return;
+
+		case "session/generation_cap_reached": {
+			if (uiStore.get().simpleMode) {
+				return;
+			}
+			sessionStore.patch({
+				preservePlaybackOnClose: false,
+				generationCapReached: false,
+				sessionNotice: "",
+			});
+			await finalizeStreamCompletion();
+			resetTtffTimer();
+			return;
+		}
+
+		case "session/generation_restarted": {
+			const capSegments = Number.parseInt(payload?.segment_cap, 10);
+			sessionStore.patch({
+				generatedSegmentCount: 0,
+				generationSegmentCap: uiStore.get().simpleMode ? 0 : Number.isFinite(capSegments) && capSegments > 0 ? capSegments : sessionStore.get().generationSegmentCap,
+				generationCapReached: false,
+				sessionNotice: "",
+			});
+			return;
+		}
+
+		case "stream/started":
+			sessionStore.patch({
+				generatedSegmentCount: 0,
+				generationSegmentCap: uiStore.get().simpleMode
+					? 0
+					: Number.parseInt(payload?.generation_segment_cap, 10) > 0
+						? Number.parseInt(payload.generation_segment_cap, 10)
+						: sessionStore.get().generationSegmentCap,
+				generationCapReached: false,
+				sessionNotice: "",
+				promptExtensionError: "",
+				autoExtensionTimeoutHint: "",
+			});
+			streamStore.patch({
+				mediaAppendError: null,
+				loadingAnimation: true,
+				currentSegmentNumber: 0,
+				playingSeedPromptIndex: null,
+				generatingSeedPromptIndex: null,
+				lastGenerationLatencyMs: null,
+				lastE2eLatencyMs: null,
+				seedPromptIndexBySegment: {},
+				simpleCompletionFinalized: false,
+				activeSimplePlaybackObjectUrl: uiStore.get().simpleMode ? "" : streamStore.get().activeSimplePlaybackObjectUrl,
+				activeSimplePlaybackStartTime: uiStore.get().simpleMode ? 0 : streamStore.get().activeSimplePlaybackStartTime,
+				liveClip: uiStore.get().simpleMode ? streamStore.get().liveClip : streamStore.get().pendingClip || streamStore.get().liveClip,
+				pendingClip: uiStore.get().simpleMode ? streamStore.get().pendingClip : null,
+				activeClipId: uiStore.get().simpleMode || preserveArchivedPlaybackSelection ? streamStore.get().activeClipId : "",
+				activePlaybackStartTime: uiStore.get().simpleMode || preserveArchivedPlaybackSelection ? streamStore.get().activePlaybackStartTime : 0,
+				simpleLiveCardVisible: uiStore.get().simpleMode ? true : streamStore.get().simpleLiveCardVisible,
+			});
+			avPipeline.reset();
+			avPipeline.setStreamCompleted(false);
+			if (typeof payload.loop_generation_enabled === "boolean") {
+				sessionStore.patch({
+					loopGenerationEnabled: payload.loop_generation_enabled,
+				});
+			}
+			startTtffTimer();
+			console.log(`Stream starting: ${payload.total_segments} segments`);
+			return;
+
+		case "stream/media_init":
+			streamStore.patch({
+				mediaAppendError: null,
+				loadingAnimation: streamStore.get().avPlaybackStarted ? streamStore.get().loadingAnimation : true,
+				activeClipId: uiStore.get().simpleMode || preserveArchivedPlaybackSelection ? streamStore.get().activeClipId : "",
+				activePlaybackStartTime: uiStore.get().simpleMode || preserveArchivedPlaybackSelection ? streamStore.get().activePlaybackStartTime : 0,
+			});
+			avPipeline.noteSegmentInit({
+				segmentIdx: Number.isInteger(payload?.segment_idx) ? payload.segment_idx : null,
+				streamId: typeof payload?.stream_id === "string" ? payload.stream_id : "",
+				mime: typeof payload?.mime === "string" ? payload.mime : "",
+			});
+
+			try {
+				await tick();
+				await avPipeline.ensurePipeline(payload.mime || defaultAvMime);
+			} catch (error) {
+				streamStore.patch({
+					mediaAppendError: "Unable to initialize AV streaming.",
+					avPlaybackStarted: false,
+				});
+				console.error("media_init failed:", error);
+				avPipeline.reset();
+			}
+			return;
+
+		case "stream/media_segment_complete": {
+			avPipeline.noteSegmentComplete({
+				segmentIdx: Number.isInteger(payload?.segment_idx) ? payload.segment_idx : null,
+				streamId: typeof payload?.stream_id === "string" ? payload.stream_id : "",
+			});
+			avPipeline.maybeStartPlayback();
+
+			const currentSession = sessionStore.get();
+			if (!currentSession.generationCapReached) {
+				const nextGeneratedSegmentCount = currentSession.generatedSegmentCount + 1;
+				const reachedCap = !uiStore.get().simpleMode && currentSession.generationSegmentCap > 0 && nextGeneratedSegmentCount >= currentSession.generationSegmentCap;
+				sessionStore.patch({
+					generatedSegmentCount: nextGeneratedSegmentCount,
+					generationCapReached: reachedCap || currentSession.generationCapReached,
+				});
+				if (reachedCap) {
+					resetTtffTimer();
+				}
+			}
+
+			const completedSegment = Number.isInteger(payload?.segment_idx) ? payload.segment_idx : null;
+			if (completedSegment !== null) {
+				const completedSeedIndex = streamStore.get().seedPromptIndexBySegment[completedSegment];
+				if (Number.isInteger(completedSeedIndex)) {
+					streamStore.patch({
+						playingSeedPromptIndex: completedSeedIndex,
+						generatingSeedPromptIndex: streamStore.get().generatingSeedPromptIndex === completedSeedIndex ? null : streamStore.get().generatingSeedPromptIndex,
+					});
+				}
+			}
+			return;
+		}
+
+		case "segment/started": {
+			sessionStore.patch({ autoExtensionTimeoutHint: "" });
+			const pendingSegmentSource = rewriteStore.get().pendingSegmentSource;
+			const seedIndex = Number.isInteger(payload.seed_prompt_index) ? payload.seed_prompt_index : (pendingSegmentSource?.seedPromptIndex ?? null);
+
+			const nextSeedPromptIndexBySegment = Number.isInteger(seedIndex)
+				? {
+						...streamStore.get().seedPromptIndexBySegment,
+						[payload.segment_idx]: seedIndex,
+					}
+				: streamStore.get().seedPromptIndexBySegment;
+
+			streamStore.patch({
+				currentSegmentNumber: payload.segment_idx,
+				generatingSeedPromptIndex: Number.isInteger(seedIndex) ? seedIndex : null,
+				playingSeedPromptIndex: streamStore.get().playingSeedPromptIndex === null && Number.isInteger(seedIndex) ? seedIndex : streamStore.get().playingSeedPromptIndex,
+				seedPromptIndexBySegment: nextSeedPromptIndexBySegment,
+			});
+
+			if (!uiStore.get().simpleMode) {
+				const fallbackClip = {
+					label: buildClipLabel({
+						segmentIdx: Number.isInteger(payload.segment_idx) ? payload.segment_idx : null,
+						source: payload.source || pendingSegmentSource?.source || rewriteStore.get().lastPromptSource || "",
+					}),
+					prompt: typeof payload.prompt === "string" ? payload.prompt.trim() : streamStore.get().liveClip?.prompt || "",
+					source: payload.source || pendingSegmentSource?.source || rewriteStore.get().lastPromptSource || "",
+					segmentIdx: Number.isInteger(payload.segment_idx) ? payload.segment_idx : null,
+				};
+				streamStore.patch({
+					liveClip: streamStore.get().liveClip || fallbackClip,
+				});
+			}
+
+			streamStore.pushPromptHistory({
+				segmentIdx: payload.segment_idx,
+				source: payload.source || pendingSegmentSource?.source || rewriteStore.get().lastPromptSource || "unknown",
+				prompt: payload.prompt || "",
+				seedPromptIndex: seedIndex,
+				loopIteration: Number.isInteger(payload.loop_iteration) ? payload.loop_iteration : (pendingSegmentSource?.loopIteration ?? null),
+			});
+			rewriteStore.patch({
+				pendingSegmentSource: null,
+			});
+			console.log(`Segment ${payload.segment_idx}/${payload.total_segments}: ${payload.prompt?.substring(0, 60)}...`);
+			return;
+		}
+
+		case "segment/completed":
+			console.log(`Segment ${payload.segment_idx}/${payload.total_segments} complete`);
+			if (uiStore.get().simpleMode && Number.isInteger(payload?.segment_idx) && Number.isInteger(payload?.total_segments) && payload.segment_idx >= payload.total_segments) {
+				await finalizeStreamCompletion({ isFallback: true });
+			}
+			return;
+
+		case "stream/completed":
+			sessionStore.patch({
+				generationCapReached: false,
+				sessionNotice: "",
+			});
+			await finalizeStreamCompletion();
+			return;
+
+		case "session/error": {
+			const errorMessage = resolveSessionErrorMessage(payload);
+			sessionStore.patch({
+				generationCapReached: false,
+				preservePlaybackOnClose: false,
+				promptExtensionError: "",
+				sessionNotice: errorMessage,
+			});
+			rewriteStore.patch({
+				rewritingSeedPrompts: false,
+			});
+			console.error("[StreamingError]", payload.message || payload);
+			return;
+		}
+
+		case "server/unhandled":
+		default:
+			return;
+	}
+}
+
+export { resolveSessionErrorMessage, isInfrastructureError };

--- a/apps/dreamverse/web/src/stores/createManagedStore.ts
+++ b/apps/dreamverse/web/src/stores/createManagedStore.ts
@@ -1,0 +1,51 @@
+type Subscriber<T> = (state: T) => void;
+
+export interface ManagedStore<T> {
+  subscribe: (callback: Subscriber<T>) => () => void;
+  get: () => T;
+  set: (nextState: T) => T;
+  update: (updater: (state: T) => T) => T;
+  patch: (partial: Partial<T> | ((state: T) => Partial<T>)) => T;
+}
+
+export function createManagedStore<T extends object>(
+  initialState: T,
+  deriveState: (state: T) => T = (state) => state,
+): ManagedStore<T> {
+  let currentState = deriveState(initialState);
+  const subscribers = new Set<Subscriber<T>>();
+
+  function notify() {
+    subscribers.forEach((cb) => cb(currentState));
+  }
+
+  function set(nextState: T): T {
+    currentState = deriveState(nextState);
+    notify();
+    return currentState;
+  }
+
+  function update(updater: (state: T) => T): T {
+    return set(updater(currentState));
+  }
+
+  function patch(partial: Partial<T> | ((state: T) => Partial<T>)): T {
+    return update((state) => ({
+      ...state,
+      ...(typeof partial === 'function' ? partial(state) : partial),
+    }));
+  }
+
+  return {
+    subscribe(callback: Subscriber<T>) {
+      subscribers.add(callback);
+      return () => {
+        subscribers.delete(callback);
+      };
+    },
+    get: () => currentState,
+    set,
+    update,
+    patch,
+  };
+}

--- a/apps/dreamverse/web/src/stores/promptWindow.ts
+++ b/apps/dreamverse/web/src/stores/promptWindow.ts
@@ -1,0 +1,491 @@
+import { createManagedStore, type ManagedStore } from './createManagedStore';
+
+function normalizePromptList(
+  nextPrompts: unknown,
+): string[] {
+  if (!Array.isArray(nextPrompts)) {
+    return [];
+  }
+
+  return nextPrompts
+    .map((prompt) =>
+      typeof prompt === 'string' ? prompt.trim() : '',
+    )
+    .filter((prompt) => prompt.length > 0);
+}
+
+export interface PromptWindowState {
+  simpleMode: boolean;
+  editableMode: boolean;
+  storyPresets: Record<string, unknown>[];
+  selectedPresetId: string;
+  selectedPreset: Record<string, unknown> | null;
+  previewSegments: string[];
+  maxCuratedPromptCount: number;
+  curatedPromptLimit: number;
+  outboundCuratedPrompts: string[];
+  seedPrompts: string[];
+  currentPromptWindowPrompts: string[];
+  outboundSessionPrompts: string[];
+  canJoinSession: boolean;
+  editableSegments: string[];
+  sanitizedEditableSegments: string[];
+  editableCanJoin: boolean;
+  editableDirty: boolean;
+  customPresetId: string;
+  customPresetLabel: string;
+  simplePromptOptions: Record<string, unknown>[];
+  selectedSimplePrompt: Record<string, unknown> | null;
+  selectedSimplePromptId: string;
+  simplePromptDraft: string;
+  simplePromptsLoading: boolean;
+  simplePromptsError: string;
+  simpleInputImageName: string;
+  simpleInputImageMimeType: string;
+  simpleInputImageDataUrl: string;
+  simpleInputImageLoading: boolean;
+  simpleInputImageError: string;
+}
+
+function derivePromptWindowState(
+  state: PromptWindowState,
+): PromptWindowState {
+  const storyPresets = Array.isArray(state.storyPresets)
+    ? state.storyPresets
+    : [];
+  const simplePromptOptions = Array.isArray(state.simplePromptOptions)
+    ? state.simplePromptOptions
+    : [];
+
+  let selectedPresetId =
+    typeof state.selectedPresetId === 'string'
+      ? state.selectedPresetId
+      : '';
+  if (
+    selectedPresetId &&
+    storyPresets.length > 0 &&
+    !storyPresets.some((preset) => preset.id === selectedPresetId)
+  ) {
+    selectedPresetId = storyPresets[0].id as string;
+  }
+  const selectedPreset =
+    storyPresets.find((preset) => preset.id === selectedPresetId) ||
+    null;
+
+  let selectedSimplePromptId =
+    typeof state.selectedSimplePromptId === 'string'
+      ? state.selectedSimplePromptId
+      : '';
+  if (
+    selectedSimplePromptId &&
+    !simplePromptOptions.some(
+      (prompt) => prompt.id === selectedSimplePromptId,
+    )
+  ) {
+    selectedSimplePromptId = '';
+  }
+  const selectedSimplePrompt =
+    simplePromptOptions.find(
+      (prompt) => prompt.id === selectedSimplePromptId,
+    ) || null;
+
+  const editableSegments = Array.isArray(state.editableSegments)
+    ? state.editableSegments
+    : [];
+  const sanitizedEditableSegments =
+    normalizePromptList(editableSegments);
+  const editableCanJoin = sanitizedEditableSegments.length >= 2;
+
+  const previewSegments = state.editableMode
+    ? sanitizedEditableSegments
+    : normalizePromptList(
+        (selectedPreset as Record<string, unknown> | null)
+          ?.segment_prompts,
+      );
+
+  const maxCuratedPromptCount = previewSegments.length;
+  let curatedPromptLimit = Number.parseInt(
+    state.curatedPromptLimit as unknown as string,
+    10,
+  );
+  if (!Number.isFinite(curatedPromptLimit)) {
+    curatedPromptLimit = 0;
+  }
+  if (maxCuratedPromptCount === 0) {
+    curatedPromptLimit = 0;
+  } else if (
+    curatedPromptLimit < 1 ||
+    curatedPromptLimit > maxCuratedPromptCount
+  ) {
+    curatedPromptLimit = maxCuratedPromptCount;
+  }
+
+  const outboundCuratedPrompts =
+    curatedPromptLimit > 0
+      ? previewSegments.slice(0, curatedPromptLimit)
+      : [];
+  const seedPrompts = normalizePromptList(state.seedPrompts);
+  const outboundSessionPrompts = state.simpleMode
+    ? normalizePromptList([state.simplePromptDraft])
+    : outboundCuratedPrompts;
+  const currentPromptWindowPrompts =
+    seedPrompts.length > 0 ? seedPrompts : outboundSessionPrompts;
+  const canJoinSession = state.simpleMode
+    ? outboundSessionPrompts.length > 0
+    : state.editableMode
+      ? editableCanJoin
+      : Boolean(selectedPreset);
+
+  return {
+    ...state,
+    storyPresets,
+    selectedPresetId,
+    selectedPreset,
+    simplePromptOptions,
+    selectedSimplePromptId,
+    selectedSimplePrompt,
+    editableSegments,
+    sanitizedEditableSegments,
+    editableCanJoin,
+    previewSegments,
+    maxCuratedPromptCount,
+    curatedPromptLimit,
+    seedPrompts,
+    outboundCuratedPrompts,
+    outboundSessionPrompts,
+    currentPromptWindowPrompts,
+    canJoinSession,
+  } as unknown as PromptWindowState;
+}
+
+const DEFAULT_PROMPT_WINDOW_STATE: PromptWindowState = {
+  simpleMode: false,
+  editableMode: false,
+  storyPresets: [],
+  selectedPresetId: '',
+  selectedPreset: null,
+  previewSegments: [],
+  maxCuratedPromptCount: 0,
+  curatedPromptLimit: 0,
+  outboundCuratedPrompts: [],
+  seedPrompts: [],
+  currentPromptWindowPrompts: [],
+  outboundSessionPrompts: [],
+  canJoinSession: false,
+  editableSegments: [],
+  sanitizedEditableSegments: [],
+  editableCanJoin: false,
+  editableDirty: false,
+  customPresetId: '',
+  customPresetLabel: '',
+  simplePromptOptions: [],
+  selectedSimplePrompt: null,
+  selectedSimplePromptId: '',
+  simplePromptDraft: '',
+  simplePromptsLoading: false,
+  simplePromptsError: '',
+  simpleInputImageName: '',
+  simpleInputImageMimeType: '',
+  simpleInputImageDataUrl: '',
+  simpleInputImageLoading: false,
+  simpleInputImageError: '',
+};
+
+export interface SimpleInputImageArgs {
+  name?: string;
+  mimeType?: string;
+  dataUrl?: string;
+}
+
+export interface SeedEditableOptions {
+  defaultCustomPresetId?: string;
+  defaultCustomPresetLabel?: string;
+}
+
+export interface ReplacePromptWindowOptions {
+  syncEditable?: boolean;
+}
+
+export type PromptWindowStore = ManagedStore<PromptWindowState> & {
+  reset: (overrides?: Partial<PromptWindowState>) => PromptWindowState;
+  resetSessionState: () => PromptWindowState;
+  setModeContext: (
+    modeContext: Partial<PromptWindowState>,
+  ) => PromptWindowState;
+  setStoryPresets: (
+    nextStoryPresets: Record<string, unknown>[],
+  ) => PromptWindowState;
+  appendStoryPreset: (
+    preset: Record<string, unknown>,
+  ) => PromptWindowState;
+  seedEditableFromPreset: (
+    preset: Record<string, unknown> | null,
+    options?: SeedEditableOptions,
+  ) => PromptWindowState;
+  setSelectedPresetId: (
+    selectedPresetId: string,
+  ) => PromptWindowState;
+  setCuratedPromptLimit: (
+    curatedPromptLimit: number,
+  ) => PromptWindowState;
+  setSeedPrompts: (nextPrompts: unknown) => PromptWindowState;
+  replacePromptWindow: (
+    nextPrompts: unknown,
+    options?: ReplacePromptWindowOptions,
+  ) => PromptWindowState;
+  addEditableSegment: () => PromptWindowState;
+  removeEditableSegment: (index: number) => PromptWindowState;
+  updateEditableSegment: (
+    index: number,
+    value: string,
+  ) => PromptWindowState;
+  setCustomPresetId: (
+    customPresetId: string,
+  ) => PromptWindowState;
+  setCustomPresetLabel: (
+    customPresetLabel: string,
+  ) => PromptWindowState;
+  setSimplePromptOptions: (
+    simplePromptOptions: Record<string, unknown>[],
+  ) => PromptWindowState;
+  applySelectedSimplePrompt: (
+    promptId: string,
+    options?: { overwriteDraft?: boolean },
+  ) => PromptWindowState;
+  setSimplePromptDraft: (
+    simplePromptDraft: string,
+  ) => PromptWindowState;
+  setSimplePromptsLoading: (
+    simplePromptsLoading: boolean,
+  ) => PromptWindowState;
+  setSimplePromptsError: (
+    simplePromptsError: string,
+  ) => PromptWindowState;
+  setSimpleInputImage: (
+    args?: SimpleInputImageArgs,
+  ) => PromptWindowState;
+  clearSimpleInputImage: () => PromptWindowState;
+  setSimpleInputImageLoading: (
+    simpleInputImageLoading: boolean,
+  ) => PromptWindowState;
+  setSimpleInputImageError: (
+    simpleInputImageError: string,
+  ) => PromptWindowState;
+};
+
+export function createPromptWindowStore(
+  initialState: Partial<PromptWindowState> = {},
+): PromptWindowStore {
+  const store = createManagedStore<PromptWindowState>(
+    {
+      ...DEFAULT_PROMPT_WINDOW_STATE,
+      ...initialState,
+    } as PromptWindowState,
+    derivePromptWindowState,
+  );
+
+  return {
+    ...store,
+    reset(overrides: Partial<PromptWindowState> = {}) {
+      return store.set({
+        ...DEFAULT_PROMPT_WINDOW_STATE,
+        ...initialState,
+        ...overrides,
+      } as PromptWindowState);
+    },
+    resetSessionState() {
+      return store.patch({
+        seedPrompts: [],
+        simpleInputImageLoading: false,
+        simpleInputImageError: '',
+      });
+    },
+    setModeContext(modeContext: Partial<PromptWindowState>) {
+      return store.patch(modeContext);
+    },
+    setStoryPresets(nextStoryPresets: Record<string, unknown>[]) {
+      return store.patch({
+        storyPresets: Array.isArray(nextStoryPresets)
+          ? nextStoryPresets
+          : [],
+      });
+    },
+    appendStoryPreset(preset: Record<string, unknown>) {
+      return store.update((state) => ({
+        ...state,
+        storyPresets: [...state.storyPresets, preset],
+      }));
+    },
+    seedEditableFromPreset(
+      preset: Record<string, unknown> | null,
+      {
+        defaultCustomPresetId = '',
+        defaultCustomPresetLabel = '',
+      }: SeedEditableOptions = {},
+    ) {
+      return store.update((state) => {
+        if (
+          preset &&
+          Array.isArray(preset.segment_prompts) &&
+          preset.segment_prompts.length > 0
+        ) {
+          return {
+            ...state,
+            editableSegments: [
+              ...(preset.segment_prompts as string[]),
+            ],
+            customPresetId: `${preset.id}_custom`,
+            customPresetLabel: `${preset.label} (Custom)`,
+            editableDirty: false,
+          };
+        }
+
+        return {
+          ...state,
+          editableSegments: ['', ''],
+          customPresetId:
+            state.customPresetId.trim() || defaultCustomPresetId,
+          customPresetLabel:
+            state.customPresetLabel.trim() || defaultCustomPresetLabel,
+          editableDirty: false,
+        };
+      });
+    },
+    setSelectedPresetId(selectedPresetId: string) {
+      return store.patch({ selectedPresetId });
+    },
+    setCuratedPromptLimit(curatedPromptLimit: number) {
+      return store.patch({ curatedPromptLimit });
+    },
+    setSeedPrompts(nextPrompts: unknown) {
+      return store.patch({
+        seedPrompts: normalizePromptList(nextPrompts),
+      });
+    },
+    replacePromptWindow(
+      nextPrompts: unknown,
+      { syncEditable = false }: ReplacePromptWindowOptions = {},
+    ) {
+      const normalized = normalizePromptList(nextPrompts);
+      return store.update((state) => ({
+        ...state,
+        seedPrompts: normalized,
+        editableSegments:
+          syncEditable &&
+          state.editableMode &&
+          normalized.length > 0
+            ? [...normalized]
+            : state.editableSegments,
+        editableDirty:
+          syncEditable &&
+          state.editableMode &&
+          normalized.length > 0
+            ? false
+            : state.editableDirty,
+      }));
+    },
+    addEditableSegment() {
+      return store.update((state) => ({
+        ...state,
+        editableSegments: [...state.editableSegments, ''],
+        editableDirty: true,
+      }));
+    },
+    removeEditableSegment(index: number) {
+      return store.update((state) => {
+        const nextSegments = state.editableSegments.filter(
+          (_, i) => i !== index,
+        );
+        return {
+          ...state,
+          editableSegments:
+            nextSegments.length > 0 ? nextSegments : [''],
+          editableDirty: true,
+        };
+      });
+    },
+    updateEditableSegment(index: number, value: string) {
+      return store.update((state) => ({
+        ...state,
+        editableSegments: state.editableSegments.map((segment, i) =>
+          i === index ? value : segment,
+        ),
+        editableDirty: true,
+      }));
+    },
+    setCustomPresetId(customPresetId: string) {
+      return store.patch({
+        customPresetId,
+        editableDirty: true,
+      });
+    },
+    setCustomPresetLabel(customPresetLabel: string) {
+      return store.patch({
+        customPresetLabel,
+        editableDirty: true,
+      });
+    },
+    setSimplePromptOptions(
+      simplePromptOptions: Record<string, unknown>[],
+    ) {
+      return store.patch({ simplePromptOptions });
+    },
+    applySelectedSimplePrompt(
+      promptId: string,
+      { overwriteDraft = true }: { overwriteDraft?: boolean } = {},
+    ) {
+      return store.update((state) => {
+        const selectedPrompt =
+          state.simplePromptOptions.find(
+            (item) => item.id === promptId,
+          ) || null;
+        return {
+          ...state,
+          selectedSimplePromptId:
+            (selectedPrompt?.id as string) || '',
+          simplePromptDraft:
+            selectedPrompt && overwriteDraft
+              ? (selectedPrompt.prompt as string)
+              : state.simplePromptDraft,
+        };
+      });
+    },
+    setSimplePromptDraft(simplePromptDraft: string) {
+      return store.patch({ simplePromptDraft });
+    },
+    setSimplePromptsLoading(simplePromptsLoading: boolean) {
+      return store.patch({ simplePromptsLoading });
+    },
+    setSimplePromptsError(simplePromptsError: string) {
+      return store.patch({ simplePromptsError });
+    },
+    setSimpleInputImage({
+      name = '',
+      mimeType = '',
+      dataUrl = '',
+    }: SimpleInputImageArgs = {}) {
+      return store.patch({
+        simpleInputImageName: name,
+        simpleInputImageMimeType: mimeType,
+        simpleInputImageDataUrl: dataUrl,
+        simpleInputImageError: '',
+      });
+    },
+    clearSimpleInputImage() {
+      return store.patch({
+        simpleInputImageName: '',
+        simpleInputImageMimeType: '',
+        simpleInputImageDataUrl: '',
+        simpleInputImageError: '',
+      });
+    },
+    setSimpleInputImageLoading(simpleInputImageLoading: boolean) {
+      return store.patch({ simpleInputImageLoading });
+    },
+    setSimpleInputImageError(simpleInputImageError: string) {
+      return store.patch({ simpleInputImageError });
+    },
+  };
+}
+
+export { DEFAULT_PROMPT_WINDOW_STATE, normalizePromptList };

--- a/apps/dreamverse/web/src/stores/rewrite.ts
+++ b/apps/dreamverse/web/src/stores/rewrite.ts
@@ -1,0 +1,112 @@
+import {
+  prependPromptEvent,
+  updatePromptEvent,
+} from '../lib/promptEvents';
+import { createManagedStore, type ManagedStore } from './createManagedStore';
+
+export interface RewriteState {
+  rewritingSeedPrompts: boolean;
+  promptEvents: Record<string, unknown>[];
+  lastPromptSource: string;
+  pendingSegmentSource: Record<string, unknown> | null;
+}
+
+const DEFAULT_REWRITE_STATE: RewriteState = {
+  rewritingSeedPrompts: false,
+  promptEvents: [],
+  lastPromptSource: '',
+  pendingSegmentSource: null,
+};
+
+export interface SegmentPromptSourcePayload {
+  source?: string;
+  seed_prompt_index?: number;
+  loop_iteration?: number;
+  prompt_id?: string;
+}
+
+export type RewriteStore = ManagedStore<RewriteState> & {
+  reset: (overrides?: Partial<RewriteState>) => RewriteState;
+  resetSessionState: () => RewriteState;
+  trackPromptEvent: (
+    promptId: string,
+    update: Record<string, unknown>,
+  ) => RewriteState;
+  addPromptEvent: (
+    event: Record<string, unknown>,
+  ) => RewriteState;
+  applySegmentPromptSource: (
+    payload: SegmentPromptSourcePayload | null,
+  ) => RewriteState;
+};
+
+export function createRewriteStore(
+  initialState: Partial<RewriteState> = {},
+): RewriteStore {
+  const store = createManagedStore<RewriteState>({
+    ...DEFAULT_REWRITE_STATE,
+    ...initialState,
+  } as RewriteState);
+
+  return {
+    ...store,
+    reset(overrides: Partial<RewriteState> = {}) {
+      return store.set({
+        ...DEFAULT_REWRITE_STATE,
+        ...initialState,
+        ...overrides,
+      } as RewriteState);
+    },
+    resetSessionState() {
+      return store.patch({
+        rewritingSeedPrompts: false,
+        promptEvents: [],
+        lastPromptSource: '',
+        pendingSegmentSource: null,
+      });
+    },
+    trackPromptEvent(
+      promptId: string,
+      update: Record<string, unknown>,
+    ) {
+      return store.update((state) => ({
+        ...state,
+        promptEvents: updatePromptEvent(
+          state.promptEvents,
+          promptId,
+          update,
+        ),
+      }));
+    },
+    addPromptEvent(event: Record<string, unknown>) {
+      return store.update((state) => ({
+        ...state,
+        promptEvents: prependPromptEvent(
+          state.promptEvents,
+          event,
+        ),
+      }));
+    },
+    applySegmentPromptSource(
+      payload: SegmentPromptSourcePayload | null,
+    ) {
+      return store.patch({
+        lastPromptSource: payload?.source || '',
+        pendingSegmentSource: {
+          source: payload?.source || 'unknown',
+          seedPromptIndex: Number.isInteger(
+            payload?.seed_prompt_index,
+          )
+            ? (payload!.seed_prompt_index as number)
+            : null,
+          loopIteration: Number.isInteger(payload?.loop_iteration)
+            ? (payload!.loop_iteration as number)
+            : null,
+          promptId: payload?.prompt_id || null,
+        },
+      });
+    },
+  };
+}
+
+export { DEFAULT_REWRITE_STATE };

--- a/apps/dreamverse/web/src/stores/session.ts
+++ b/apps/dreamverse/web/src/stores/session.ts
@@ -1,0 +1,82 @@
+import { applySessionUiMessage } from '../lib/sessionState';
+import { createManagedStore, type ManagedStore } from './createManagedStore';
+
+export interface SessionState {
+  connected: boolean;
+  connecting: boolean;
+  sessionStarted: boolean;
+  sessionTimeout: number | null;
+  timeLeft: number | null;
+  queuePosition: number;
+  gpuAssigned: boolean;
+  enhancementEnabled: boolean;
+  promptExtensionError: string;
+  autoExtensionEnabled: boolean;
+  autoExtensionTimeoutHint: string;
+  loopGenerationEnabled: boolean;
+  generationPaused: boolean;
+  livePromptDraft: string;
+  sessionNotice: string;
+  generationCapReached: boolean;
+  generationSegmentCap: number;
+  generatedSegmentCount: number;
+  preservePlaybackOnClose: boolean;
+  livePromptRewriteMode: boolean;
+  sessionExpired: boolean;
+  projectResetPending: boolean;
+}
+
+const DEFAULT_SESSION_STATE: SessionState = {
+  connected: false,
+  connecting: false,
+  sessionStarted: false,
+  sessionTimeout: null,
+  timeLeft: null,
+  queuePosition: 0,
+  gpuAssigned: false,
+  enhancementEnabled: true,
+  promptExtensionError: '',
+  autoExtensionEnabled: false,
+  autoExtensionTimeoutHint: '',
+  loopGenerationEnabled: false,
+  generationPaused: false,
+  livePromptDraft: '',
+  sessionNotice: '',
+  generationCapReached: false,
+  generationSegmentCap: 0,
+  generatedSegmentCount: 0,
+  preservePlaybackOnClose: false,
+  livePromptRewriteMode: false,
+  sessionExpired: false,
+  projectResetPending: false,
+};
+
+export type SessionStore = ManagedStore<SessionState> & {
+  reset: (overrides?: Partial<SessionState>) => SessionState;
+  applyServerUiMessage: (data: unknown) => SessionState;
+};
+
+export function createSessionStore(
+  initialState: Partial<SessionState> = {},
+): SessionStore {
+  const store = createManagedStore<SessionState>({
+    ...DEFAULT_SESSION_STATE,
+    ...initialState,
+  } as SessionState);
+
+  return {
+    ...store,
+    reset(overrides: Partial<SessionState> = {}) {
+      return store.set({
+        ...DEFAULT_SESSION_STATE,
+        ...(initialState as SessionState),
+        ...overrides,
+      } as SessionState);
+    },
+    applyServerUiMessage(data: unknown) {
+      return store.update((state) => applySessionUiMessage(state, data));
+    },
+  };
+}
+
+export { DEFAULT_SESSION_STATE };

--- a/apps/dreamverse/web/src/stores/stream.ts
+++ b/apps/dreamverse/web/src/stores/stream.ts
@@ -1,0 +1,194 @@
+import { createManagedStore, type ManagedStore } from "./createManagedStore";
+
+export interface StreamState {
+	playingSeedPromptIndex: number | null;
+	generatingSeedPromptIndex: number | null;
+	seedPromptIndexBySegment: Record<string, unknown>;
+	currentSegmentNumber: number;
+	promptHistory: Record<string, unknown>[];
+	promptHistoryCounter: number;
+	selectedHistoryId: string;
+	selectedHistoryEntry: Record<string, unknown> | null;
+	completedSimpleClips: Record<string, unknown>[];
+	activeSimpleClip: Record<string, unknown> | null;
+	simpleLiveCardVisible: boolean;
+	simpleCompletionFinalized: boolean;
+	activeSimpleArchivedClipId: string;
+	activeSimplePlaybackObjectUrl: string;
+	activeSimplePlaybackStartTime: number;
+	completedClips: Record<string, unknown>[];
+	activeClipId: string;
+	activeClip: Record<string, unknown> | null;
+	activePlaybackStartTime: number;
+	pendingClip: Record<string, unknown> | null;
+	liveClip: Record<string, unknown> | null;
+	loadingAnimation: boolean;
+	avPlaybackStarted: boolean;
+	mediaAppendError: string | null;
+	lastVideoCompletedAtMs: number | null;
+	timeBetweenVideosMs: number | null;
+	lastGenerationLatencyMs: number | null;
+	lastE2eLatencyMs: number | null;
+}
+
+function deriveStreamState(state: StreamState): StreamState {
+	const promptHistory = Array.isArray(state.promptHistory) ? state.promptHistory : [];
+	const completedSimpleClips = Array.isArray(state.completedSimpleClips) ? state.completedSimpleClips : [];
+	const completedClips = Array.isArray(state.completedClips) ? state.completedClips : [];
+
+	return {
+		...state,
+		promptHistory,
+		completedSimpleClips,
+		completedClips,
+		selectedHistoryEntry: promptHistory.find((item) => item.id === state.selectedHistoryId) || null,
+		activeClip: completedClips.find((clip) => clip.id === state.activeClipId) || null,
+	} as unknown as StreamState;
+}
+
+const DEFAULT_STREAM_STATE: StreamState = {
+	playingSeedPromptIndex: null,
+	generatingSeedPromptIndex: null,
+	seedPromptIndexBySegment: {},
+	currentSegmentNumber: 0,
+	promptHistory: [],
+	promptHistoryCounter: 0,
+	selectedHistoryId: "",
+	selectedHistoryEntry: null,
+	completedSimpleClips: [],
+	activeSimpleClip: null,
+	simpleLiveCardVisible: false,
+	simpleCompletionFinalized: false,
+	activeSimpleArchivedClipId: "",
+	activeSimplePlaybackObjectUrl: "",
+	activeSimplePlaybackStartTime: 0,
+	completedClips: [],
+	activeClipId: "",
+	activeClip: null,
+	activePlaybackStartTime: 0,
+	pendingClip: null,
+	liveClip: null,
+	loadingAnimation: false,
+	avPlaybackStarted: false,
+	mediaAppendError: null,
+	lastVideoCompletedAtMs: null,
+	timeBetweenVideosMs: null,
+	lastGenerationLatencyMs: null,
+	lastE2eLatencyMs: null,
+};
+
+export interface PushPromptHistoryArgs {
+	segmentIdx?: number;
+	source?: string;
+	prompt?: string;
+	seedPromptIndex?: number | null;
+	loopIteration?: number | null;
+}
+
+export type StreamStore = ManagedStore<StreamState> & {
+	reset: (overrides?: Partial<StreamState>) => StreamState;
+	resetSessionState: () => StreamState;
+	pushPromptHistory: (args: PushPromptHistoryArgs) => StreamState;
+	selectPromptHistory: (selectedHistoryId: string) => StreamState;
+	addCompletedSimpleClip: (clip: Record<string, unknown>) => StreamState;
+	addCompletedClip: (clip: Record<string, unknown>) => StreamState;
+	selectClip: (clipId: string, playbackStartTime?: number) => StreamState;
+};
+
+export function createStreamStore(initialState: Partial<StreamState> = {}): StreamStore {
+	const store = createManagedStore<StreamState>(
+		{
+			...DEFAULT_STREAM_STATE,
+			...initialState,
+		} as StreamState,
+		deriveStreamState,
+	);
+
+	return {
+		...store,
+		reset(overrides: Partial<StreamState> = {}) {
+			return store.set({
+				...DEFAULT_STREAM_STATE,
+				...initialState,
+				...overrides,
+			} as StreamState);
+		},
+		resetSessionState() {
+			return store.patch({
+				playingSeedPromptIndex: null,
+				generatingSeedPromptIndex: null,
+				seedPromptIndexBySegment: {},
+				currentSegmentNumber: 0,
+				promptHistory: [],
+				promptHistoryCounter: 0,
+				selectedHistoryId: "",
+				activeSimpleClip: null,
+				simpleLiveCardVisible: false,
+				simpleCompletionFinalized: false,
+				activeSimpleArchivedClipId: "",
+				activeSimplePlaybackObjectUrl: "",
+				activeSimplePlaybackStartTime: 0,
+				activeClipId: "",
+				activePlaybackStartTime: 0,
+				pendingClip: null,
+				liveClip: null,
+				loadingAnimation: false,
+				avPlaybackStarted: false,
+				mediaAppendError: null,
+				lastVideoCompletedAtMs: null,
+				timeBetweenVideosMs: null,
+				lastGenerationLatencyMs: null,
+				lastE2eLatencyMs: null,
+			});
+		},
+		pushPromptHistory({ segmentIdx, source, prompt, seedPromptIndex = null, loopIteration = null }: PushPromptHistoryArgs) {
+			const text = typeof prompt === "string" ? prompt.trim() : "";
+			if (!text) {
+				return store.get();
+			}
+
+			return store.update((state) => {
+				const nextCounter = state.promptHistoryCounter + 1;
+				const entry: Record<string, unknown> = {
+					id: `h_${nextCounter}`,
+					order: nextCounter,
+					segmentIdx: typeof segmentIdx === "number" ? segmentIdx : null,
+					source: source || "unknown",
+					prompt: text,
+					seedPromptIndex: typeof seedPromptIndex === "number" ? seedPromptIndex : null,
+					loopIteration: typeof loopIteration === "number" ? loopIteration : null,
+				};
+
+				return {
+					...state,
+					promptHistoryCounter: nextCounter,
+					promptHistory: [entry, ...state.promptHistory].slice(0, 120),
+					selectedHistoryId: state.selectedHistoryId || (entry.id as string),
+				};
+			});
+		},
+		selectPromptHistory(selectedHistoryId: string) {
+			return store.patch({ selectedHistoryId });
+		},
+		addCompletedSimpleClip(clip: Record<string, unknown>) {
+			return store.update((state) => ({
+				...state,
+				completedSimpleClips: [clip, ...state.completedSimpleClips],
+			}));
+		},
+		addCompletedClip(clip: Record<string, unknown>) {
+			return store.update((state) => ({
+				...state,
+				completedClips: [...state.completedClips, clip],
+			}));
+		},
+		selectClip(clipId: string, playbackStartTime: number = 0) {
+			return store.patch({
+				activeClipId: clipId,
+				activePlaybackStartTime: Number.isFinite(playbackStartTime) ? Math.max(playbackStartTime, 0) : 0,
+			});
+		},
+	};
+}
+
+export { DEFAULT_STREAM_STATE };

--- a/apps/dreamverse/web/src/stores/ui.ts
+++ b/apps/dreamverse/web/src/stores/ui.ts
@@ -1,0 +1,93 @@
+import { createManagedStore, type ManagedStore } from './createManagedStore';
+
+export interface UiState {
+  isMonitorRoute: boolean;
+  demoMode: boolean;
+  simpleMode: boolean;
+  devtoolsMode: boolean;
+  editableMode: boolean;
+  appendingPromptWindow: boolean;
+  appendPromptWindowStatus: string;
+  appendPromptWindowError: string;
+  promptConfigEditorOpen: boolean;
+  promptConfigLoading: boolean;
+  promptConfigSaving: boolean;
+  promptConfigLoaded: boolean;
+  promptConfigError: string;
+  promptConfigStatus: string;
+  nextSegmentPromptEditorOpen: boolean;
+  autoExtensionPromptEditorOpen: boolean;
+  rewriteWindowPromptEditorOpen: boolean;
+  nextSegmentSystemPromptDraft: string;
+  autoExtensionSystemPromptDraft: string;
+  rewriteWindowSystemPromptDraft: string;
+}
+
+const DEFAULT_UI_STATE: UiState = {
+  isMonitorRoute: false,
+  demoMode: false,
+  simpleMode: false,
+  devtoolsMode: false,
+  editableMode: false,
+  appendingPromptWindow: false,
+  appendPromptWindowStatus: '',
+  appendPromptWindowError: '',
+  promptConfigEditorOpen: false,
+  promptConfigLoading: false,
+  promptConfigSaving: false,
+  promptConfigLoaded: false,
+  promptConfigError: '',
+  promptConfigStatus: '',
+  nextSegmentPromptEditorOpen: false,
+  autoExtensionPromptEditorOpen: false,
+  rewriteWindowPromptEditorOpen: true,
+  nextSegmentSystemPromptDraft: '',
+  autoExtensionSystemPromptDraft: '',
+  rewriteWindowSystemPromptDraft: '',
+};
+
+export type UiStore = ManagedStore<UiState> & {
+  reset: (overrides?: Partial<UiState>) => UiState;
+  resetSessionState: () => UiState;
+};
+
+export function createUiStore(
+  initialState: Partial<UiState> = {},
+): UiStore {
+  const store = createManagedStore<UiState>({
+    ...DEFAULT_UI_STATE,
+    ...initialState,
+  } as UiState);
+
+  return {
+    ...store,
+    reset(overrides: Partial<UiState> = {}) {
+      return store.set({
+        ...DEFAULT_UI_STATE,
+        ...initialState,
+        ...overrides,
+      } as UiState);
+    },
+    resetSessionState() {
+      return store.patch({
+        appendingPromptWindow: false,
+        appendPromptWindowStatus: '',
+        appendPromptWindowError: '',
+        promptConfigEditorOpen: false,
+        promptConfigLoading: false,
+        promptConfigSaving: false,
+        promptConfigLoaded: false,
+        promptConfigError: '',
+        promptConfigStatus: '',
+        nextSegmentPromptEditorOpen: false,
+        autoExtensionPromptEditorOpen: false,
+        rewriteWindowPromptEditorOpen: true,
+        nextSegmentSystemPromptDraft: '',
+        autoExtensionSystemPromptDraft: '',
+        rewriteWindowSystemPromptDraft: '',
+      });
+    },
+  };
+}
+
+export { DEFAULT_UI_STATE };


### PR DESCRIPTION
## Summary

Adds the main Dreamverse frontend session experience.

This PR includes the workspace/chat/session UI, devtools/monitoring components, websocket protocol/reducer/client logic, prompt/session stores, local persistence helpers, and associated unit/integration tests.

## Review focus

Please review this PR as stack slice 7/14. The base branch is the previous stack slice, so the Files Changed view should show only this slice rather than the full Dreamverse integration.

## Stack / merge notes

This is part of the Dreamverse stacked PR series. Review this PR against its current base branch to see only this slice. After the previous stack PR lands into `main`, retarget this PR's base to `main` before merging it.

## Verification

- Commit hooks passed when the local stack commits were created.
- Stack equivalence was verified locally:
  - `feat/dreamverse-monorepo-main-sync` equals `feat/dreamverse-stack-13-activation`.
  - `feat/dreamverse-monorepo-main-sync-plus-profile` equals `feat/dreamverse-stack-14-ltx2-profile-speedups`.

## Attribution

This PR is a path-scoped reconstruction from `will/dreamverse-monorepo` at `03d3e61df69fe99a81eb62d86a3926a5f769f857`. The synthetic commit keeps coauthor trailers for the source collaborators, omitting Junda Su because he is already the commit author.
