### PR TITLE
[feat] Dreamverse 12/14: Add LTX2 refine and upsampler support

### DIFF
--- a/.agents/memory/dreamverse-integration/open-threads.md
+++ b/.agents/memory/dreamverse-integration/open-threads.md
@@ -6,7 +6,8 @@ recommended next action.
 For why each item is open see [decisions-log.md](decisions-log.md). For
 PR-level context see [pr-roadmap.md](pr-roadmap.md).
 
-**Last updated:** 2026-05-13 (added DR-5 follow-up for PR #1333's LTX2
+**Last updated:** 2026-05-14 (added DR-6 follow-up for PR #1335's Gemma
+lazy-load/device-placement behavior outside compiled `forward`. Earlier: 2026-05-13 added DR-5 follow-up for PR #1333's LTX2
 distilled SSIM reference refresh. Earlier: 2026-05-12 added DR-4 follow-up for PR #1330's skipped
 `App websocket integration` suite. Earlier: 2026-05-05 D-20 broken-pipe root cause + fix landed on
 `will/dreamverse-monorepo` @ `5eaf0a13`; added new thread D-20-CP for
@@ -36,6 +37,7 @@ different vehicle.).
 | **DR-3** | Low | Replace Dreamverse `PromptEnhancer._run_blocking_request` manual thread/queue polling with `asyncio.to_thread` after the PR #1327 prompt-enhancer compatibility surface is retired or isolated | S | Review comment #1327 (`prompt_enhancer.py`) is valid, but deferred to avoid patching the local fork in this PR. |
 | **DR-4** | Low | Investigate unskipping PR #1330's skipped public `App websocket integration` suite | S-M | Public PR #1330 has `describe.skip(...)` around 27 websocket tests while the internal equivalent suite is active with 25 tests. The 2 public-only tests cover backend unreachable / GPU workers not ready. Not blocking while skipped, but stale assertions may need safe refresh before unskip. |
 | **DR-5** | Low | Regenerate LTX2-Distilled latent SSIM references under the intended neutral/distilled defaults, then remove the PR #1333 historical full-guidance pins | S-M | PR #1333 changed public LTX2 distilled defaults to neutral/distilled values, but existing LTX2 latent SSIM references appear to have been generated with historical full-guidance defaults. The current PR pins the SSIM test to old values to keep CI compatible until references are refreshed. |
+| **DR-6** | Low | Decide whether `LTX2GemmaTextEncoderModel` needs a non-forward device-placement hook after lazy Gemma load | S | PR #1335 should remove the `model.device` / `model.to(...)` guard from `forward` for Dynamo/fullgraph compatibility. Non-compiled runs probably do not need it because `gemma_model` moves Gemma at first load, but a later wrapper `.to(...)` after lazy load could leave Gemma on the old device unless lifecycle placement handles it. |
 | **3** | Med | Add `cerebras_ifm` to `PromptEnhancerConfig.provider` Literal + provider | S-M | Public-side resolution if DR-2 picks (a) |
 | **4** | Med | Expose `layer_profile` on typed `engine.quantization` | M | Removes Dreamverse's `experimental["pipeline_config"]` dodge for stage profiles |
 | **5** | Med | Design typed `dit_config.quant_config` carrier | L design + L impl | Removes broader `experimental["pipeline_config"]` escape hatch |
@@ -422,6 +424,38 @@ current PR #1330 review.
 **Dependencies:** Best handled when someone can run the frontend integration
 stack end-to-end and compare the public assertions against the internal active
 suite.
+
+### Item DR-6: Gemma lazy-load device placement outside `forward`
+
+**Why:** PR #1335 review flagged this pattern in
+`fastvideo/models/encoders/gemma.py::LTX2GemmaTextEncoderModel.forward`:
+
+```py
+if model.device != target_device:
+    model.to(device=target_device)
+```
+
+The immediate concern is the compiled/Dynamo path: `model.device` and
+`model.to(...)` inside `forward` can introduce non-tensor/device parsing work
+that fullgraph tracing should not see. Removing the guard from `forward` is the
+right PR #1335 review fix.
+
+For non-compiled execution, the guard is mostly defensive rather than required:
+`gemma_model` already moves the lazily loaded HF Gemma model to the wrapper's
+current parameter device on first load. The remaining edge case is a lifecycle
+sequence where Gemma is loaded, then the parent wrapper is later moved to a
+different device; in that case Gemma could stay behind unless placement is
+handled outside `forward`.
+
+**Action:** After PR #1335 review is unblocked, decide whether FastVideo needs a
+small lifecycle hook/helper for this class so lazy Gemma is moved whenever the
+wrapper/device placement changes. If yes, implement it outside `forward`; if no,
+document that Gemma must be loaded after final device placement.
+
+**Effort:** Small.
+
+**Dependencies:** Not blocking PR #1335 if the forward-path guard is removed and
+the normal load path keeps placing Gemma on the wrapper's current device.
 
 ### Item D-12-C: Avoid locking `PoolAssignment.gpu_id: int` as public
 

--- a/.agents/memory/dreamverse-integration/open-threads.md
+++ b/.agents/memory/dreamverse-integration/open-threads.md
@@ -6,7 +6,8 @@ recommended next action.
 For why each item is open see [decisions-log.md](decisions-log.md). For
 PR-level context see [pr-roadmap.md](pr-roadmap.md).
 
-**Last updated:** 2026-05-14 (added DR-6 follow-up for PR #1335's Gemma
+**Last updated:** 2026-05-14 (added DR-7 follow-up to remove LTX2 debug
+logging env vars and replace them with per-pipeline/model state. Earlier: 2026-05-14 added DR-6 follow-up for PR #1335's Gemma
 lazy-load/device-placement behavior outside compiled `forward`. Earlier: 2026-05-13 added DR-5 follow-up for PR #1333's LTX2
 distilled SSIM reference refresh. Earlier: 2026-05-12 added DR-4 follow-up for PR #1330's skipped
 `App websocket integration` suite. Earlier: 2026-05-05 D-20 broken-pipe root cause + fix landed on
@@ -38,6 +39,7 @@ different vehicle.).
 | **DR-4** | Low | Investigate unskipping PR #1330's skipped public `App websocket integration` suite | S-M | Public PR #1330 has `describe.skip(...)` around 27 websocket tests while the internal equivalent suite is active with 25 tests. The 2 public-only tests cover backend unreachable / GPU workers not ready. Not blocking while skipped, but stale assertions may need safe refresh before unskip. |
 | **DR-5** | Low | Regenerate LTX2-Distilled latent SSIM references under the intended neutral/distilled defaults, then remove the PR #1333 historical full-guidance pins | S-M | PR #1333 changed public LTX2 distilled defaults to neutral/distilled values, but existing LTX2 latent SSIM references appear to have been generated with historical full-guidance defaults. The current PR pins the SSIM test to old values to keep CI compatible until references are refreshed. |
 | **DR-6** | Low | Decide whether `LTX2GemmaTextEncoderModel` needs a non-forward device-placement hook after lazy Gemma load | S | PR #1335 should remove the `model.device` / `model.to(...)` guard from `forward` for Dynamo/fullgraph compatibility. Non-compiled runs probably do not need it because `gemma_model` moves Gemma at first load, but a later wrapper `.to(...)` after lazy load could leave Gemma on the old device unless lifecycle placement handles it. |
+| **DR-7** | Low | Remove LTX2 debug logging env-var plumbing and replace it with per-pipeline/model debug state | S-M | PR #1335 review flagged that `initialize_pipeline()` mutates process-global LTX2 debug env vars, which can leak/race across pipeline instances. Deleting only the mutation is low-risk but loses config-driven debug logging; deleting all reads without replacement would remove useful SSIM/latent drift diagnostics. |
 | **3** | Med | Add `cerebras_ifm` to `PromptEnhancerConfig.provider` Literal + provider | S-M | Public-side resolution if DR-2 picks (a) |
 | **4** | Med | Expose `layer_profile` on typed `engine.quantization` | M | Removes Dreamverse's `experimental["pipeline_config"]` dodge for stage profiles |
 | **5** | Med | Design typed `dit_config.quant_config` carrier | L design + L impl | Removes broader `experimental["pipeline_config"]` escape hatch |
@@ -456,6 +458,33 @@ document that Gemma must be loaded after final device placement.
 
 **Dependencies:** Not blocking PR #1335 if the forward-path guard is removed and
 the normal load path keeps placing Gemma on the wrapper's current device.
+
+### Item DR-7: Remove LTX2 debug logging env-var plumbing
+
+**Why:** PR #1335 review flagged that
+`fastvideo/pipelines/basic/ltx2/ltx2_pipeline.py::initialize_pipeline()` sets
+and pops LTX2 debug env vars such as `LTX2_PIPELINE_DEBUG_LOG`,
+`LTX2_PIPELINE_DEBUG_PATH`, `LTX2_DEBUG_DETAIL`, and
+`LTX2_PIPELINE_DEBUG_DETAIL_PATH`. Those env vars are process-global, so one
+pipeline instance can enable, overwrite, or clear debug behavior for another
+pipeline instance running in the same process.
+
+Deleting only the `initialize_pipeline()` env mutation is low risk for normal
+generation, but it would stop config-driven debug logging unless replaced.
+Deleting all env-var reads without replacement is riskier because these logs are
+useful for SSIM/latent drift diagnosis and may be used by local debug scripts.
+
+**Action:** Replace LTX2 debug env-var plumbing with per-pipeline/model debug
+state. Use pipeline/model config for construction-time hooks and a
+`ForwardContext`/`ForwardBatch`-style carrier for forward-time logging. Keep
+external env-var compatibility only if there is a documented operator workflow
+that still needs it.
+
+**Effort:** Small-Medium.
+
+**Dependencies:** Not blocking PR #1335 if the immediate fix is limited to
+removing process-global mutation from pipeline initialization while preserving
+existing externally supplied env-var reads.
 
 ### Item D-12-C: Avoid locking `PoolAssignment.gpu_id: int` as public
 

--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -84,6 +84,8 @@ surfaces:
       ltx2_refine_transformer_path: "LTX-2 refine transformer carrier; no typed equivalent yet."
       ltx2_refine_noise_path: "LTX-2 refine noise carrier; no typed equivalent yet."
       ltx2_refine_audio_noise_path: "LTX-2 refine audio noise carrier; no typed equivalent yet."
+      ltx2_legacy_native_noise_order: "LTX-2 SSIM compatibility knob preserving legacy native latent noise ordering."
+      ltx2_use_distilled_sigmas: "LTX-2 compatibility knob gating use of distilled sigma schedule."
     private_only:
       ray_placement_group: "Ray deployment-only field."
       ray_runtime_env: "Ray deployment-only field."

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -206,6 +206,8 @@ class FastVideoArgs:
     ltx2_refine_add_noise: bool = True
     ltx2_refine_noise_path: str | None = None
     ltx2_refine_audio_noise_path: str | None = None
+    ltx2_legacy_native_noise_order: bool = False
+    ltx2_use_distilled_sigmas: bool = True
 
     # model paths for correct deallocation
     model_paths: dict[str, str] = field(default_factory=dict)

--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -28,11 +28,57 @@ from fastvideo.distributed.communication_op import (
 )
 from fastvideo.distributed.parallel_state import get_sp_parallel_rank, get_sp_world_size
 from fastvideo.forward_context import ForwardContext, get_forward_context, set_forward_context
+from fastvideo.layers.linear import ReplicatedLinear
+from fastvideo.layers.quantization.base_config import QuantizationConfig
 from fastvideo.logger import init_logger
 from fastvideo.models.dits.base import BaseDiT
 from fastvideo.platforms import AttentionBackendEnum
 
 logger = init_logger(__name__)
+
+
+def _supports_prequantized_input(linear: ReplicatedLinear) -> bool:
+    """Whether ``linear``'s quant method is willing to accept a
+    pre-quantized ``(x_fp4, x_scale, x_global_sf)`` input tuple.
+
+    Used by the LTX-2 attention forward path so that a single input
+    tensor can be quantized once and reused across q/k/v projections
+    when they share the same source (self-attention).
+    """
+    quant_method = getattr(linear, "quant_method", None)
+    if not callable(getattr(quant_method, "quantize_input", None)):
+        return False
+    wants_prequant = getattr(quant_method, "wants_prequantized_input", None)
+    if callable(wants_prequant):
+        try:
+            return bool(wants_prequant())
+        except Exception:
+            return False
+    return True
+
+
+def _linear_project_with_optional_prequant(
+    linear: ReplicatedLinear,
+    x: torch.Tensor,
+    pre_quantized: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None,
+) -> torch.Tensor:
+    """Project ``x`` through ``linear``, optionally bypassing the
+    in-method quantize step when ``pre_quantized`` is supplied.
+
+    When the linear's quant method does not support pre-quantized
+    inputs (e.g. ``UnquantizedLinearMethod``), falls back to the
+    standard ``linear(x)`` call and discards the bias-pass-through
+    tuple element.
+    """
+    if pre_quantized is None or not _supports_prequantized_input(linear):
+        return linear(x)[0]
+    bias = linear.bias if not linear.skip_bias_add else None
+    return linear.quant_method.apply(  # type: ignore[union-attr]
+        linear,
+        x,
+        bias=bias,
+        pre_quantized=pre_quantized,
+    )
 
 
 def get_timestep_embedding(
@@ -172,25 +218,57 @@ class PixArtAlphaTextProjection(torch.nn.Module):
 
 class GELUApprox(nn.Module):
     """Linear + tanh-approximate GELU used by LTX-2 FFN."""
-    def __init__(self, in_features: int, out_features: int):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
         super().__init__()
-        self.proj = nn.Linear(in_features, out_features)
+        self.proj = ReplicatedLinear(
+            in_features,
+            out_features,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc_in",
+        )
         self.act = nn.GELU(approximate="tanh")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.act(self.proj(x))
+        return self.act(self.proj(x)[0])
 
 
 class FeedForward(nn.Module):
     """LTX-2 FFN: GELUApprox -> Identity -> Linear."""
-    def __init__(self, dim: int, dim_out: int, mult: int = 4) -> None:
+    def __init__(
+        self,
+        dim: int,
+        dim_out: int,
+        mult: int = 4,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
         super().__init__()
         inner_dim = int(dim * mult)
-        project_in = GELUApprox(dim, inner_dim)
-        self.net = nn.Sequential(project_in, nn.Identity(), nn.Linear(inner_dim, dim_out))
+        project_in = GELUApprox(
+            dim,
+            inner_dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.ffn",
+        )
+        project_out = ReplicatedLinear(
+            inner_dim,
+            dim_out,
+            quant_config=quant_config,
+            prefix=f"{prefix}.ffn.fc_out",
+        )
+        self.net = nn.ModuleList([project_in, nn.Identity(), project_out])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.net(x)
+        x = self.net[0](x)
+        x = self.net[1](x)
+        x = self.net[2](x)[0]
+        return x
 
 
 class VideoLatentShape(tuple):
@@ -1246,6 +1324,8 @@ class LTXSelfAttention(nn.Module):
         norm_eps: float,
         rope_type: LTXRopeType,
         supported_attention_backends: tuple[AttentionBackendEnum, ...],
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
     ) -> None:
         super().__init__()
         inner_dim = dim_head * heads
@@ -1257,10 +1337,37 @@ class LTXSelfAttention(nn.Module):
 
         self.q_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
         self.k_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
-        self.to_q = nn.Linear(query_dim, inner_dim, bias=True)
-        self.to_k = nn.Linear(context_dim, inner_dim, bias=True)
-        self.to_v = nn.Linear(context_dim, inner_dim, bias=True)
-        self.to_out = nn.Sequential(nn.Linear(inner_dim, query_dim, bias=True), nn.Identity())
+        self.to_q = ReplicatedLinear(
+            query_dim,
+            inner_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_q",
+        )
+        self.to_k = ReplicatedLinear(
+            context_dim,
+            inner_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_k",
+        )
+        self.to_v = ReplicatedLinear(
+            context_dim,
+            inner_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_v",
+        )
+        self.to_out = nn.ModuleList([
+            ReplicatedLinear(
+                inner_dim,
+                query_dim,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.to_out",
+            ),
+            nn.Identity(),
+        ])
 
         self.attn = LTXLocalAttention(
             num_heads=heads,
@@ -1271,9 +1378,15 @@ class LTXSelfAttention(nn.Module):
             causal=False,
             supported_attention_backends=supported_attention_backends,
         )
-        self.to_gate_compress: nn.Linear | None = None
+        self.to_gate_compress: ReplicatedLinear | None = None
         if self.attn.backend == AttentionBackendEnum.VIDEO_SPARSE_ATTN:
-            self.to_gate_compress = nn.Linear(context_dim, inner_dim, bias=True)
+            self.to_gate_compress = ReplicatedLinear(
+                context_dim,
+                inner_dim,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.to_gate_compress",
+            )
         self.attn_masked = LTXLocalAttention(
             num_heads=heads,
             head_size=dim_head,
@@ -1292,11 +1405,24 @@ class LTXSelfAttention(nn.Module):
         pe: tuple[torch.Tensor, torch.Tensor] | None = None,
         k_pe: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> torch.Tensor:
-        q = self.to_q(x)
         context = x if context is None else context
-        k = self.to_k(context)
-        v = self.to_v(context)
-        gate_compress = (self.to_gate_compress(context)
+
+        q_pre_quantized = (
+            self.to_q.quant_method.quantize_input(x)  # type: ignore[union-attr]
+            if _supports_prequantized_input(self.to_q) else None)
+        kv_pre_quantized = None
+        if (_supports_prequantized_input(self.to_k)
+                and _supports_prequantized_input(self.to_v)):
+            if context is x and q_pre_quantized is not None:
+                kv_pre_quantized = q_pre_quantized
+            else:
+                kv_pre_quantized = self.to_k.quant_method.quantize_input(  # type: ignore[union-attr]
+                    context)
+
+        q = _linear_project_with_optional_prequant(self.to_q, x, q_pre_quantized)
+        k = _linear_project_with_optional_prequant(self.to_k, context, kv_pre_quantized)
+        v = _linear_project_with_optional_prequant(self.to_v, context, kv_pre_quantized)
+        gate_compress = (self.to_gate_compress(context)[0]
                          if self.to_gate_compress is not None else None)
 
         q = self.q_norm(q)
@@ -1346,7 +1472,8 @@ class LTXSelfAttention(nn.Module):
                             ltx_freqs_cis=pe,
                             ltx_k_freqs_cis=k_pe)
         out = out.reshape(b, q_len, -1)
-        return self.to_out(out)
+        out = self.to_out[0](out)[0]
+        return self.to_out[1](out)
 
 
 class LTXDistributedSelfAttention(nn.Module):
@@ -1361,6 +1488,7 @@ class LTXDistributedSelfAttention(nn.Module):
         norm_eps: float,
         rope_type: LTXRopeType,
         supported_attention_backends: tuple[AttentionBackendEnum, ...],
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -1373,10 +1501,37 @@ class LTXDistributedSelfAttention(nn.Module):
 
         self.q_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
         self.k_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
-        self.to_q = nn.Linear(query_dim, inner_dim, bias=True)
-        self.to_k = nn.Linear(context_dim, inner_dim, bias=True)
-        self.to_v = nn.Linear(context_dim, inner_dim, bias=True)
-        self.to_out = nn.Sequential(nn.Linear(inner_dim, query_dim, bias=True), nn.Identity())
+        self.to_q = ReplicatedLinear(
+            query_dim,
+            inner_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_q",
+        )
+        self.to_k = ReplicatedLinear(
+            context_dim,
+            inner_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_k",
+        )
+        self.to_v = ReplicatedLinear(
+            context_dim,
+            inner_dim,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.to_v",
+        )
+        self.to_out = nn.ModuleList([
+            ReplicatedLinear(
+                inner_dim,
+                query_dim,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.to_out",
+            ),
+            nn.Identity(),
+        ])
 
         self.attn = LTXDistributedAttention(
             num_heads=heads,
@@ -1386,9 +1541,15 @@ class LTXDistributedSelfAttention(nn.Module):
             supported_attention_backends=supported_attention_backends,
             prefix=f"{prefix}.attn",
         )
-        self.to_gate_compress: nn.Linear | None = None
+        self.to_gate_compress: ReplicatedLinear | None = None
         if self.attn.backend == AttentionBackendEnum.VIDEO_SPARSE_ATTN:
-            self.to_gate_compress = nn.Linear(context_dim, inner_dim, bias=True)
+            self.to_gate_compress = ReplicatedLinear(
+                context_dim,
+                inner_dim,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.to_gate_compress",
+            )
 
     def forward(
         self,
@@ -1408,11 +1569,24 @@ class LTXDistributedSelfAttention(nn.Module):
             k_pe: Rotary position embeddings for K (cos, sin), or None to use pe
             original_seq_len: Original (unpadded) full sequence length
         """
-        q = self.to_q(x)
         context = x if context is None else context
-        k = self.to_k(context)
-        v = self.to_v(context)
-        gate_compress = (self.to_gate_compress(context)
+
+        q_pre_quantized = (
+            self.to_q.quant_method.quantize_input(x)  # type: ignore[union-attr]
+            if _supports_prequantized_input(self.to_q) else None)
+        kv_pre_quantized = None
+        if (_supports_prequantized_input(self.to_k)
+                and _supports_prequantized_input(self.to_v)):
+            if context is x and q_pre_quantized is not None:
+                kv_pre_quantized = q_pre_quantized
+            else:
+                kv_pre_quantized = self.to_k.quant_method.quantize_input(  # type: ignore[union-attr]
+                    context)
+
+        q = _linear_project_with_optional_prequant(self.to_q, x, q_pre_quantized)
+        k = _linear_project_with_optional_prequant(self.to_k, context, kv_pre_quantized)
+        v = _linear_project_with_optional_prequant(self.to_v, context, kv_pre_quantized)
+        gate_compress = (self.to_gate_compress(context)[0]
                          if self.to_gate_compress is not None else None)
 
         q = self.q_norm(q)
@@ -1443,7 +1617,8 @@ class LTXDistributedSelfAttention(nn.Module):
         )
 
         out = out.reshape(b, q_len, -1)
-        return self.to_out(out)
+        out = self.to_out[0](out)[0]
+        return self.to_out[1](out)
 
 
 class BasicAVTransformerBlock(torch.nn.Module):
@@ -1457,6 +1632,7 @@ class BasicAVTransformerBlock(torch.nn.Module):
         rope_type: LTXRopeType = LTXRopeType.INTERLEAVED,
         norm_eps: float = 1e-6,
         use_distributed_attention: bool = False,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -1488,15 +1664,8 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=video_self_attn_backends,
-                prefix=f"{prefix}.blocks.{idx}.attn1" if use_distributed_attention else "",
-            ) if use_distributed_attention else LTXSelfAttention(
-                query_dim=video.dim,
-                context_dim=None,
-                heads=video.heads,
-                dim_head=video.d_head,
-                norm_eps=norm_eps,
-                rope_type=rope_type,
-                supported_attention_backends=video_self_attn_backends,
+                quant_config=quant_config,
+                prefix=f"{prefix}.blocks.{idx}.attn1",
             )
             # Text cross-attention - always local (text is replicated)
             self.attn2 = CrossAttnCls(
@@ -1507,8 +1676,15 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
+                quant_config=quant_config,
+                prefix=f"{prefix}.blocks.{idx}.attn2",
             )
-            self.ff = FeedForward(video.dim, dim_out=video.dim)
+            self.ff = FeedForward(
+                video.dim,
+                dim_out=video.dim,
+                quant_config=quant_config,
+                prefix=f"{prefix}.blocks.{idx}",
+            )
             self.scale_shift_table = torch.nn.Parameter(torch.empty(6, video.dim))
 
         if audio is not None:
@@ -1521,15 +1697,8 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
-                prefix=f"{prefix}.blocks.{idx}.audio_attn1" if use_distributed_attention else "",
-            ) if use_distributed_attention else LTXSelfAttention(
-                query_dim=audio.dim,
-                context_dim=None,
-                heads=audio.heads,
-                dim_head=audio.d_head,
-                norm_eps=norm_eps,
-                rope_type=rope_type,
-                supported_attention_backends=dense_attn_backends,
+                quant_config=quant_config,
+                prefix=f"{prefix}.blocks.{idx}.audio_attn1",
             )
             # Text cross-attention - always local (text is replicated)
             self.audio_attn2 = CrossAttnCls(
@@ -1540,8 +1709,15 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
+                quant_config=quant_config,
+                prefix=f"{prefix}.blocks.{idx}.audio_attn2",
             )
-            self.audio_ff = FeedForward(audio.dim, dim_out=audio.dim)
+            self.audio_ff = FeedForward(
+                audio.dim,
+                dim_out=audio.dim,
+                quant_config=quant_config,
+                prefix=f"{prefix}.blocks.{idx}.audio",
+            )
             self.audio_scale_shift_table = torch.nn.Parameter(torch.empty(6, audio.dim))
 
         if audio is not None and video is not None:
@@ -1555,6 +1731,8 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
+                quant_config=quant_config,
+                prefix=f"{prefix}.blocks.{idx}.audio_to_video_attn",
             )
             # Video-to-audio cross-attention
             # Uses local attention - context is gathered from all SP ranks in forward()
@@ -1566,6 +1744,8 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
+                quant_config=quant_config,
+                prefix=f"{prefix}.blocks.{idx}.video_to_audio_attn",
             )
             self.scale_shift_table_a2v_ca_audio = torch.nn.Parameter(torch.empty(5, audio.dim))
             self.scale_shift_table_a2v_ca_video = torch.nn.Parameter(torch.empty(5, video.dim))
@@ -1889,6 +2069,7 @@ class LTXModel(torch.nn.Module):
         rope_type: LTXRopeType = LTXRopeType.INTERLEAVED,
         double_precision_rope: bool = False,
         use_distributed_attention: bool = False,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ):
         super().__init__()
@@ -1942,6 +2123,7 @@ class LTXModel(torch.nn.Module):
             audio_cross_attention_dim=audio_cross_attention_dim,
             norm_eps=norm_eps,
             use_distributed_attention=use_distributed_attention,
+            quant_config=quant_config,
             prefix=prefix,
         )
 
@@ -2073,6 +2255,7 @@ class LTXModel(torch.nn.Module):
         audio_cross_attention_dim: int,
         norm_eps: float,
         use_distributed_attention: bool = False,
+        quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
         video_config = (
@@ -2105,6 +2288,7 @@ class LTXModel(torch.nn.Module):
                     rope_type=self.rope_type,
                     norm_eps=norm_eps,
                     use_distributed_attention=use_distributed_attention,
+                    quant_config=quant_config,
                     prefix=prefix,
                 )
                 for idx in range(num_layers)
@@ -2293,6 +2477,7 @@ class LTX2Transformer3DModel(BaseDiT):
             audio_positional_embedding_max_pos=arch.audio_positional_embedding_max_pos,
             av_ca_timestep_scale_multiplier=arch.av_ca_timestep_scale_multiplier,
             use_distributed_attention=use_distributed_attention,
+            quant_config=config.quant_config,
             prefix=config.prefix,
         )
 

--- a/fastvideo/models/encoders/gemma.py
+++ b/fastvideo/models/encoders/gemma.py
@@ -361,6 +361,10 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
                 continue
             yield name, param
 
+    def prepare_for_compile(self) -> None:
+        # Load Gemma outside Dynamo so torch.compile does not trace HF file-system checks.
+        _ = self.gemma_model
+
     @property
     def gemma_model(self) -> Gemma3ForConditionalGeneration:
         if self._gemma_model is None:
@@ -517,18 +521,21 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
             attention_mask = torch.ones_like(input_ids)
 
         model = self.gemma_model
-        orig_device = model.device
-        model.to(device=get_local_torch_device())
-        # input_ids = input_ids.to(device=model.device)
-        # attention_mask = attention_mask.to(device=model.device)
+        target_device = get_local_torch_device()
+        # Do not invoke model.to() inside the compiled forward path.
+        # _parse_to returns a non-Tensor torch.device, which Dynamo cannot
+        # trace under fullgraph=True. The model is already moved to device
+        # when first loaded (see gemma_model property + prepare_for_compile),
+        # so this guard is a runtime no-op and Dynamo can DCE it.
+        if model.device != target_device:
+            model.to(device=target_device)
         outputs = model(
             input_ids=input_ids,
             attention_mask=attention_mask,
             output_hidden_states=True,
             return_dict=True,
         )
-        model.to(device=orig_device)
-        
+
         encoded_inputs = self._run_feature_extractor(
             outputs.hidden_states,
             attention_mask,

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -100,6 +100,12 @@ class ComponentLoader(ABC):
             # NumberConditioners; not a pure text encoder, so it gets
             # its own loader.
             "conditioner": (ConditionerLoader, "fastvideo"),
+            # LTX-2 spatial / temporal upsamplers — share the
+            # UpsamplerLoader path with the upsampler/upsampler_2 keys
+            # so the SR pipeline picks up real weights instead of the
+            # generic config-only loader.
+            "spatial_upsampler": (UpsamplerLoader, "diffusers"),
+            "temporal_upsampler": (UpsamplerLoader, "diffusers"),
         }
 
         if module_type in module_loaders:
@@ -1059,7 +1065,7 @@ class ConditionerLoader(ComponentLoader):
 
 
 class UpsamplerLoader(ComponentLoader):
-    """Loader for upsamplers."""
+    """Loader for upsamplers (incl. LTX-2 spatial/temporal upsamplers)."""
 
     def load(self, model_path: str, fastvideo_args: FastVideoArgs):
         """Load the upsampler based on the model path, and inference args."""
@@ -1069,36 +1075,65 @@ class UpsamplerLoader(ComponentLoader):
         if class_name is None:
             raise ValueError(
                 "Model config does not contain a _class_name attribute. "
-                "Only diffusers format is supported."
-            )
+                "Only diffusers format is supported.")
 
-        try:
-            upsampler_cfg = deepcopy(fastvideo_args.pipeline_config.upsampler_config[0])
-            upsampler_cfg.update_model_config(config_dict)
-        except Exception as e:
-            upsampler_cfg = deepcopy(fastvideo_args.pipeline_config.upsampler_config[1])
-            upsampler_cfg.update_model_config(config_dict)
+        # The base PipelineConfig declares ``upsampler_config`` as a
+        # single ``UpsamplerConfig`` instance, but Hunyuan15 narrows it
+        # to a tuple of two configs (one per SR target). We only treat
+        # the attribute as a multi-config when it actually is one;
+        # otherwise the LTX-2 branch below handles the single-class
+        # path that takes the diffusers config dict directly.
+        upsampler_config_attr = getattr(fastvideo_args.pipeline_config,
+                                        "upsampler_config", None)
+        if isinstance(upsampler_config_attr, list | tuple):
+            try:
+                upsampler_cfg = deepcopy(upsampler_config_attr[0])
+                upsampler_cfg.update_model_config(config_dict)
+            except Exception:
+                upsampler_cfg = deepcopy(upsampler_config_attr[1])
+                upsampler_cfg.update_model_config(config_dict)
+        elif class_name == "LTX2LatentUpsampler":
+            # LTX-2 pipeline_config does not declare upsampler_config; the
+            # `LTX2LatentUpsampler` wrapper takes the raw diffusers config
+            # dict directly via LatentUpsamplerConfigurator.
+            upsampler_cfg = deepcopy(config_dict)
+        else:
+            raise AttributeError(
+                "pipeline_config.upsampler_config is missing; cannot build "
+                f"upsampler config for class {class_name}")
 
         model_cls, _ = ModelRegistry.resolve_model_cls(class_name)
         model = model_cls(upsampler_cfg)
 
         target_device = get_local_torch_device()
-        model = model.to(target_device, dtype=PRECISION_TO_TYPE[fastvideo_args.pipeline_config.upsampler_precision])
+        upsampler_precision = getattr(fastvideo_args.pipeline_config,
+                                      "upsampler_precision", "bf16")
+        model = model.to(target_device,
+                         dtype=PRECISION_TO_TYPE[upsampler_precision])
 
-        # Find all safetensors files
         safetensors_list = glob.glob(
             os.path.join(str(model_path), "*.safetensors"))
         if not safetensors_list:
             raise ValueError(f"No safetensors files found in {model_path}")
-        
+
         if len(safetensors_list) == 1:
             loaded = safetensors_load_file(safetensors_list[0])
         else:
             loaded = {}
             for sf_file in safetensors_list:
                 loaded.update(safetensors_load_file(sf_file))
-        
-        model.load_state_dict(loaded, strict=True)
+
+        # The LTX-2 latent upsampler wrapper exposes the actual conv
+        # stack at ``self.model``; checkpoint state_dicts may be saved
+        # without the ``model.`` prefix when the inner module was
+        # serialised directly. Strip / forward as needed so both layouts
+        # load cleanly.
+        target_module = getattr(model, "model", model)
+        if loaded and all(k.startswith("model.") for k in loaded):
+            stripped = {k[len("model."):]: v for k, v in loaded.items()}
+            target_module.load_state_dict(stripped, strict=True)
+        else:
+            target_module.load_state_dict(loaded, strict=True)
 
         return model.eval()
 

--- a/fastvideo/models/loader/fsdp_load.py
+++ b/fastvideo/models/loader/fsdp_load.py
@@ -28,6 +28,37 @@ from fastvideo.utils import set_mixed_precision_policy, is_pin_memory_available
 logger = init_logger(__name__)
 
 
+def _maybe_convert_model_to_nvfp4(model: nn.Module) -> None:
+    """Quantize NVFP4-tagged linear layers in-place after weights are loaded.
+
+    Walks the module tree once, looking for layers whose ``quant_method``
+    is an :class:`NVFP4QuantizeMethod` (attached at construction time by
+    :meth:`NVFP4Config.get_quant_method`). When at least one such layer
+    exists, calls :func:`convert_model_to_nvfp4` to register the
+    ``_nvfp4_weight*`` / ``_nvfp4_alpha`` / ``_weight_global_sf`` buffers
+    on each targeted layer.
+
+    The walk returns on the first NVFP4 layer found so non-NVFP4 callers
+    pay only an ``isinstance`` check per module. flashinfer is imported
+    lazily inside :func:`convert_model_to_nvfp4` so this helper is a
+    no-op on hosts without the NVFP4 backend.
+    """
+    # Defer the import: nvfp4_config imports heavy diffusers /
+    # torch.distributed symbols at module-load time, and unconditional
+    # import would penalize every loader call regardless of whether
+    # NVFP4 is wired.
+    from fastvideo.layers.quantization.nvfp4_config import (
+        NVFP4QuantizeMethod, convert_model_to_nvfp4,
+    )
+
+    for mod in model.modules():
+        if isinstance(getattr(mod, "quant_method", None),
+                      NVFP4QuantizeMethod):
+            logger.info("Converting loaded model weights for NVFP4 linear layers")
+            convert_model_to_nvfp4(model)
+            return
+
+
 # TODO(PY): move this to utils elsewhere
 @contextlib.contextmanager
 def set_default_dtype(dtype: torch.dtype) -> Generator[None, None, None]:
@@ -157,6 +188,15 @@ def maybe_load_fsdp_model(
         # Avoid unintended computation graph accumulation during inference
         if isinstance(p, torch.nn.Parameter):
             p.requires_grad = False
+
+    # NVFP4 weight prequantization. We detect by the registered
+    # ``quant_method`` on linear layers rather than by a separate flag —
+    # construction-time ``NVFP4Config.get_quant_method`` already attached
+    # ``NVFP4QuantizeMethod`` to every targeted layer, so the loader's
+    # responsibility is just to materialize the per-layer nvfp4 weight /
+    # scale buffers from the freshly-loaded bf16 weights. No-op when
+    # ``flashinfer`` is not installed (lazy import inside the helper).
+    _maybe_convert_model_to_nvfp4(model)
 
     compile_in_loader = enable_torch_compile and training_mode
     if compile_in_loader:

--- a/fastvideo/models/upsamplers/__init__.py
+++ b/fastvideo/models/upsamplers/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from fastvideo.models.upsamplers.ltx2_upsampler import (
+    BlurDownsample,
+    LTX2LatentUpsampler,
+    LatentUpsampler,
+    LatentUpsamplerConfigurator,
+    PixelShuffleND,
+    ResBlock,
+    SpatialRationalResampler,
+    upsample_video,
+)
+
+__all__ = [
+    "BlurDownsample",
+    "LTX2LatentUpsampler",
+    "LatentUpsampler",
+    "LatentUpsamplerConfigurator",
+    "PixelShuffleND",
+    "ResBlock",
+    "SpatialRationalResampler",
+    "upsample_video",
+]

--- a/fastvideo/models/upsamplers/ltx2_upsampler.py
+++ b/fastvideo/models/upsamplers/ltx2_upsampler.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+LTX-2 latent upsampler (spatial/temporal) implementation.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Optional, Tuple
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+
+
+class PixelShuffleND(nn.Module):
+    """N-dimensional pixel shuffle for upsampling."""
+
+    def __init__(self, dims: int, upscale_factors: Tuple[int, int, int] = (2, 2, 2)) -> None:
+        super().__init__()
+        if dims not in (1, 2, 3):
+            raise ValueError("dims must be 1, 2, or 3")
+        self.dims = dims
+        self.upscale_factors = upscale_factors
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.dims == 3:
+            return rearrange(
+                x,
+                "b (c p1 p2 p3) d h w -> b c (d p1) (h p2) (w p3)",
+                p1=self.upscale_factors[0],
+                p2=self.upscale_factors[1],
+                p3=self.upscale_factors[2],
+            )
+        if self.dims == 2:
+            return rearrange(
+                x,
+                "b (c p1 p2) h w -> b c (h p1) (w p2)",
+                p1=self.upscale_factors[0],
+                p2=self.upscale_factors[1],
+            )
+        if self.dims == 1:
+            return rearrange(
+                x,
+                "b (c p1) f h w -> b c (f p1) h w",
+                p1=self.upscale_factors[0],
+            )
+        raise ValueError(f"Unsupported dims: {self.dims}")
+
+
+class BlurDownsample(nn.Module):
+    """
+    Anti-aliased spatial downsampling by integer stride using a fixed separable binomial kernel.
+    Applies only on H,W. Works for dims=2 or dims=3 (per-frame).
+    """
+
+    def __init__(self, dims: int, stride: int, kernel_size: int = 5) -> None:
+        super().__init__()
+        if dims not in (2, 3):
+            raise ValueError("dims must be 2 or 3")
+        if stride < 1:
+            raise ValueError("stride must be >= 1")
+        if kernel_size < 3 or kernel_size % 2 != 1:
+            raise ValueError("kernel_size must be an odd integer >= 3")
+
+        self.dims = dims
+        self.stride = stride
+        self.kernel_size = kernel_size
+
+        k = torch.tensor([math.comb(kernel_size - 1, idx) for idx in range(kernel_size)])
+        k2d = k[:, None] @ k[None, :]
+        k2d = (k2d / k2d.sum()).float()
+        self.register_buffer("kernel", k2d[None, None, :, :])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.stride == 1:
+            return x
+        if self.dims == 2:
+            return self._apply_2d(x)
+        b, _, f, _, _ = x.shape
+        x = rearrange(x, "b c f h w -> (b f) c h w")
+        x = self._apply_2d(x)
+        h2, w2 = x.shape[-2:]
+        return rearrange(x, "(b f) c h w -> b c f h w", b=b, f=f, h=h2, w=w2)
+
+    def _apply_2d(self, x2d: torch.Tensor) -> torch.Tensor:
+        c = x2d.shape[1]
+        weight = self.kernel.expand(c, 1, self.kernel_size, self.kernel_size)
+        return nn.functional.conv2d(
+            x2d,
+            weight=weight,
+            bias=None,
+            stride=self.stride,
+            padding=self.kernel_size // 2,
+            groups=c,
+        )
+
+
+def _rational_for_scale(scale: float) -> Tuple[int, int]:
+    mapping = {0.75: (3, 4), 1.5: (3, 2), 2.0: (2, 1), 4.0: (4, 1)}
+    if float(scale) not in mapping:
+        raise ValueError(f"Unsupported scale {scale}. Choose from {list(mapping.keys())}")
+    return mapping[float(scale)]
+
+
+class SpatialRationalResampler(nn.Module):
+    """
+    Fully-learned rational spatial scaling: up by 'num' via PixelShuffle, then
+    anti-aliased downsample by 'den' using fixed blur + stride. Operates on H,W only.
+    For dims==3, work per-frame for spatial scaling (temporal axis untouched).
+    """
+
+    def __init__(self, mid_channels: int, scale: float) -> None:
+        super().__init__()
+        self.scale = float(scale)
+        self.num, self.den = _rational_for_scale(self.scale)
+        self.conv = nn.Conv2d(mid_channels, (self.num**2) * mid_channels, kernel_size=3, padding=1)
+        self.pixel_shuffle = PixelShuffleND(2, upscale_factors=(self.num, self.num))
+        self.blur_down = BlurDownsample(dims=2, stride=self.den)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, _, f, _, _ = x.shape
+        x = rearrange(x, "b c f h w -> (b f) c h w")
+        x = self.conv(x)
+        x = self.pixel_shuffle(x)
+        x = self.blur_down(x)
+        return rearrange(x, "(b f) c h w -> b c f h w", b=b, f=f)
+
+
+class ResBlock(nn.Module):
+    """Residual block with two convolutional layers, group norm, and SiLU."""
+
+    def __init__(self, channels: int, mid_channels: Optional[int] = None, dims: int = 3) -> None:
+        super().__init__()
+        if mid_channels is None:
+            mid_channels = channels
+
+        conv = nn.Conv2d if dims == 2 else nn.Conv3d
+
+        self.conv1 = conv(channels, mid_channels, kernel_size=3, padding=1)
+        self.norm1 = nn.GroupNorm(32, mid_channels)
+        self.conv2 = conv(mid_channels, channels, kernel_size=3, padding=1)
+        self.norm2 = nn.GroupNorm(32, channels)
+        self.activation = nn.SiLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = x
+        x = self.conv1(x)
+        x = self.norm1(x)
+        x = self.activation(x)
+        x = self.conv2(x)
+        x = self.norm2(x)
+        x = self.activation(x + residual)
+        return x
+
+
+class LatentUpsampler(nn.Module):
+    """
+    Model to upsample VAE latents spatially and/or temporally.
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 128,
+        mid_channels: int = 512,
+        num_blocks_per_stage: int = 4,
+        dims: int = 3,
+        spatial_upsample: bool = True,
+        temporal_upsample: bool = False,
+        spatial_scale: float = 2.0,
+        rational_resampler: bool = False,
+    ) -> None:
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.mid_channels = mid_channels
+        self.num_blocks_per_stage = num_blocks_per_stage
+        self.dims = dims
+        self.spatial_upsample = spatial_upsample
+        self.temporal_upsample = temporal_upsample
+        self.spatial_scale = float(spatial_scale)
+        self.rational_resampler = rational_resampler
+
+        conv = nn.Conv2d if dims == 2 else nn.Conv3d
+
+        self.initial_conv = conv(in_channels, mid_channels, kernel_size=3, padding=1)
+        self.initial_norm = nn.GroupNorm(32, mid_channels)
+        self.initial_activation = nn.SiLU()
+
+        self.res_blocks = nn.ModuleList([ResBlock(mid_channels, dims=dims) for _ in range(num_blocks_per_stage)])
+
+        if spatial_upsample and temporal_upsample:
+            self.upsampler = nn.Sequential(
+                nn.Conv3d(mid_channels, 8 * mid_channels, kernel_size=3, padding=1),
+                PixelShuffleND(3),
+            )
+        elif spatial_upsample:
+            if rational_resampler:
+                self.upsampler = SpatialRationalResampler(mid_channels=mid_channels, scale=self.spatial_scale)
+            else:
+                self.upsampler = nn.Sequential(
+                    nn.Conv2d(mid_channels, 4 * mid_channels, kernel_size=3, padding=1),
+                    PixelShuffleND(2),
+                )
+        elif temporal_upsample:
+            self.upsampler = nn.Sequential(
+                nn.Conv3d(mid_channels, 2 * mid_channels, kernel_size=3, padding=1),
+                PixelShuffleND(1),
+            )
+        else:
+            raise ValueError("Either spatial_upsample or temporal_upsample must be True")
+
+        self.post_upsample_res_blocks = nn.ModuleList(
+            [ResBlock(mid_channels, dims=dims) for _ in range(num_blocks_per_stage)]
+        )
+
+        self.final_conv = conv(mid_channels, in_channels, kernel_size=3, padding=1)
+
+    def forward(self, latent: torch.Tensor) -> torch.Tensor:
+        b, _, f, _, _ = latent.shape
+
+        if self.dims == 2:
+            x = rearrange(latent, "b c f h w -> (b f) c h w")
+            x = self.initial_conv(x)
+            x = self.initial_norm(x)
+            x = self.initial_activation(x)
+
+            for block in self.res_blocks:
+                x = block(x)
+
+            x = self.upsampler(x)
+
+            for block in self.post_upsample_res_blocks:
+                x = block(x)
+
+            x = self.final_conv(x)
+            x = rearrange(x, "(b f) c h w -> b c f h w", b=b, f=f)
+        else:
+            x = self.initial_conv(latent)
+            x = self.initial_norm(x)
+            x = self.initial_activation(x)
+
+            for block in self.res_blocks:
+                x = block(x)
+
+            if self.temporal_upsample:
+                x = self.upsampler(x)
+                x = x[:, :, 1:, :, :]
+            elif isinstance(self.upsampler, SpatialRationalResampler):
+                x = self.upsampler(x)
+            else:
+                x = rearrange(x, "b c f h w -> (b f) c h w")
+                x = self.upsampler(x)
+                x = rearrange(x, "(b f) c h w -> b c f h w", b=b, f=f)
+
+            for block in self.post_upsample_res_blocks:
+                x = block(x)
+
+            x = self.final_conv(x)
+
+        return x
+
+
+class LatentUpsamplerConfigurator:
+    """Configurator for LatentUpsampler from a config dict."""
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> LatentUpsampler:
+        cfg = dict(config)
+        cfg.pop("_class_name", None)
+        if "upsampler" in cfg and isinstance(cfg["upsampler"], dict):
+            cfg = cfg["upsampler"]
+
+        return LatentUpsampler(
+            in_channels=cfg.get("in_channels", 128),
+            mid_channels=cfg.get("mid_channels", 512),
+            num_blocks_per_stage=cfg.get("num_blocks_per_stage", 4),
+            dims=cfg.get("dims", 3),
+            spatial_upsample=cfg.get("spatial_upsample", True),
+            temporal_upsample=cfg.get("temporal_upsample", False),
+            spatial_scale=cfg.get("spatial_scale", 2.0),
+            rational_resampler=cfg.get("rational_resampler", False),
+        )
+
+
+class LTX2LatentUpsampler(nn.Module):
+    """Public wrapper for the LTX-2 latent upsampler."""
+
+    def __init__(self, config: dict[str, Any]):
+        super().__init__()
+        self.model: LatentUpsampler = LatentUpsamplerConfigurator.from_config(config)
+
+    def forward(self, latent: torch.Tensor) -> torch.Tensor:
+        return self.model(latent)
+
+
+def upsample_video(latent: torch.Tensor, video_encoder: Any, upsampler: LatentUpsampler) -> torch.Tensor:
+    """
+    Upsample a latent tensor with normalization based on the video encoder's per-channel statistics.
+    """
+    if not hasattr(video_encoder, "per_channel_statistics"):
+        raise ValueError("video_encoder must expose per_channel_statistics for normalization")
+    stats = video_encoder.per_channel_statistics
+    latent = stats.un_normalize(latent)
+    latent = upsampler(latent)
+    latent = stats.normalize(latent)
+    return latent
+
+
+__all__ = [
+    "PixelShuffleND",
+    "BlurDownsample",
+    "SpatialRationalResampler",
+    "ResBlock",
+    "LatentUpsampler",
+    "LatentUpsamplerConfigurator",
+    "LTX2LatentUpsampler",
+    "upsample_video",
+]

--- a/fastvideo/pipelines/basic/ltx2/ltx2_pipeline.py
+++ b/fastvideo/pipelines/basic/ltx2/ltx2_pipeline.py
@@ -11,14 +11,15 @@ from transformers import AutoTokenizer
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
 from fastvideo.models.loader.component_loader import PipelineComponentLoader
-from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.pipelines.lora_pipeline import LoRAPipeline
 from fastvideo.pipelines.stages import (DecodingStage, InputValidationStage, LTX2AudioDecodingStage, LTX2DenoisingStage,
-                                        LTX2LatentPreparationStage, LTX2TextEncodingStage)
+                                        LTX2LatentPreparationStage, LTX2RefineInitStage, LTX2RefineLoRAStage,
+                                        LTX2TextEncodingStage, LTX2UpsampleStage, STAGE_2_DISTILLED_SIGMA_VALUES)
 
 logger = init_logger(__name__)
 
 
-class LTX2Pipeline(ComposedPipelineBase):
+class LTX2Pipeline(LoRAPipeline):
 
     _required_config_modules = [
         "text_encoder",
@@ -30,6 +31,8 @@ class LTX2Pipeline(ComposedPipelineBase):
     ]
 
     def create_pipeline_stages(self, fastvideo_args: FastVideoArgs):
+        refine_enabled = fastvideo_args.ltx2_refine_enabled
+
         self.add_stage(
             stage_name="input_validation_stage",
             stage=InputValidationStage(),
@@ -43,15 +46,87 @@ class LTX2Pipeline(ComposedPipelineBase):
             ),
         )
 
+        if refine_enabled:
+            self.add_stage(
+                stage_name="ltx2_refine_init_stage",
+                stage=LTX2RefineInitStage(),
+            )
+
         self.add_stage(
             stage_name="latent_preparation_stage",
-            stage=LTX2LatentPreparationStage(transformer=self.get_module("transformer"), ),
+            stage=LTX2LatentPreparationStage(
+                transformer=self.get_module("transformer"),
+                vae=self.get_module("vae"),
+            ),
         )
 
         self.add_stage(
             stage_name="denoising_stage",
             stage=LTX2DenoisingStage(transformer=self.get_module("transformer"), ),
         )
+
+        if refine_enabled:
+            stage2_steps = fastvideo_args.ltx2_refine_num_inference_steps
+            # LTX-2 refine currently supports two explicitly tested step
+            # counts:
+            # - 3 steps: official distilled schedule
+            # - 2 steps: custom reduced schedule used for faster
+            #   experimentation
+            # Other values are intentionally rejected to avoid silent
+            # quality regressions.
+            if stage2_steps == 3:
+                # Official distilled stage-2 refine schedule.
+                stage2_sigmas = STAGE_2_DISTILLED_SIGMA_VALUES
+            elif stage2_steps == 2:
+                # Reduced 2-step refine schedule (explicitly omits 0.725).
+                stage2_sigmas = [
+                    STAGE_2_DISTILLED_SIGMA_VALUES[0],
+                    STAGE_2_DISTILLED_SIGMA_VALUES[2],
+                    STAGE_2_DISTILLED_SIGMA_VALUES[3],
+                ]
+            else:
+                logger.warning(
+                    "For LTX-2 refinement, "
+                    "ltx2_refine_num_inference_steps=%s is not a tested "
+                    "setting. Using denoising steps other than 2 or 3 "
+                    "may cause quality degradation.",
+                    stage2_steps,
+                )
+                raise ValueError("LTX-2 refinement supports only 2 or 3 denoising "
+                                 "steps.")
+
+            transformer_refine = self.get_module("transformer_refine", self.get_module("transformer"))
+
+            self.add_stage(
+                stage_name="ltx2_upsample_stage",
+                stage=LTX2UpsampleStage(
+                    upsampler=self.get_module("spatial_upsampler"),
+                    vae=self.get_module("vae"),
+                    transformer=transformer_refine,
+                    sigmas=stage2_sigmas,
+                    add_noise=fastvideo_args.ltx2_refine_add_noise,
+                ),
+            )
+
+            if fastvideo_args.ltx2_refine_lora_path:
+                self.add_stage(
+                    stage_name="ltx2_refine_lora_stage",
+                    stage=LTX2RefineLoRAStage(
+                        pipeline=self,
+                        lora_path=fastvideo_args.ltx2_refine_lora_path,
+                    ),
+                )
+
+            self.add_stage(
+                stage_name="ltx2_refine_denoising_stage",
+                stage=LTX2DenoisingStage(
+                    transformer=transformer_refine,
+                    sigmas_override=stage2_sigmas,
+                    num_inference_steps_override=len(stage2_sigmas) - 1,
+                    force_guidance_scale=(fastvideo_args.ltx2_refine_guidance_scale),
+                    initial_audio_latents_key="ltx2_audio_latents",
+                ),
+            )
 
         self.add_stage(
             stage_name="audio_decoding_stage",
@@ -67,6 +142,36 @@ class LTX2Pipeline(ComposedPipelineBase):
         )
 
     def initialize_pipeline(self, fastvideo_args: FastVideoArgs):
+        # Optional debug-instrumentation env vars. The internal FastVideoArgs
+        # carries debug_model_sums / debug_model_detail toggles; the public
+        # args don't define them yet, so getattr-with-default keeps the
+        # pipeline runnable on both shapes without forcing the public args
+        # to add fields a public consumer wouldn't otherwise touch.
+        if getattr(fastvideo_args, "debug_model_sums", False):
+            os.environ["LTX2_PIPELINE_DEBUG_LOG"] = "1"
+            sums_path = getattr(fastvideo_args, "debug_model_sums_path", None)
+            if sums_path:
+                os.environ["LTX2_PIPELINE_DEBUG_PATH"] = sums_path
+            else:
+                logger.warning("debug_model_sums is enabled but "
+                               "debug_model_sums_path is not set; no model sums "
+                               "will be logged.")
+        else:
+            os.environ.pop("LTX2_PIPELINE_DEBUG_LOG", None)
+            os.environ.pop("LTX2_PIPELINE_DEBUG_PATH", None)
+        if getattr(fastvideo_args, "debug_model_detail", False):
+            os.environ["LTX2_DEBUG_DETAIL"] = "1"
+            detail_path = getattr(fastvideo_args, "debug_model_detail_path", None)
+            if detail_path:
+                os.environ["LTX2_PIPELINE_DEBUG_DETAIL_PATH"] = detail_path
+            else:
+                logger.warning("debug_model_detail is enabled but "
+                               "debug_model_detail_path is not set; no detailed "
+                               "hooks will be logged.")
+        else:
+            os.environ.pop("LTX2_DEBUG_DETAIL", None)
+            os.environ.pop("LTX2_PIPELINE_DEBUG_DETAIL_PATH", None)
+
         tokenizer = self.get_module("tokenizer")
         if tokenizer is not None:
             tokenizer.padding_side = "left"
@@ -80,6 +185,51 @@ class LTX2Pipeline(ComposedPipelineBase):
     ) -> dict[str, Any]:
         model_index = self._load_config(self.model_path)
         logger.info("Loading pipeline modules from config: %s", model_index)
+
+        # Apply optional FastVideo-specific refine defaults embedded in
+        # model_index.json. These are bundled with distilled checkpoints
+        # so the pipeline can self-configure without explicit user kwargs.
+        def _resolve_refine_path(value: str | None) -> str | None:
+            if value is None:
+                return None
+            if os.path.isabs(value):
+                return value
+            candidate = os.path.join(self.model_path, value)
+            if os.path.exists(candidate):
+                return candidate
+            return value
+
+        if (model_index.get("fastvideo_refine_enabled") is True and fastvideo_args.refine_enabled is None):
+            fastvideo_args.ltx2_refine_enabled = True
+        if (fastvideo_args.refine_upsampler_path is None and fastvideo_args.ltx2_refine_upsampler_path is None):
+            fastvideo_args.ltx2_refine_upsampler_path = _resolve_refine_path(
+                model_index.get("fastvideo_refine_upsampler_path"))
+            if (fastvideo_args.ltx2_refine_upsampler_path is None and "spatial_upsampler" in model_index):
+                fastvideo_args.ltx2_refine_upsampler_path = (_resolve_refine_path("spatial_upsampler"))
+        if (fastvideo_args.refine_transformer_path is None and fastvideo_args.ltx2_refine_transformer_path is None):
+            fastvideo_args.ltx2_refine_transformer_path = (_resolve_refine_path(
+                model_index.get("fastvideo_refine_transformer_path")))
+        if (fastvideo_args.refine_lora_path is None and fastvideo_args.ltx2_refine_lora_path is None):
+            fastvideo_args.ltx2_refine_lora_path = _resolve_refine_path(model_index.get("fastvideo_refine_lora_path"))
+        if (fastvideo_args.refine_num_inference_steps is None
+                and fastvideo_args.ltx2_refine_num_inference_steps == FastVideoArgs.ltx2_refine_num_inference_steps
+                and model_index.get("fastvideo_refine_num_inference_steps") is not None):
+            # Only apply the model-index default when the caller didn't
+            # explicitly set either refine_num_inference_steps (generic)
+            # or ltx2_refine_num_inference_steps (LTX-2-specific). This
+            # prevents bundled defaults from overwriting explicit caller
+            # intent (e.g. requesting 2-step refinement).
+            fastvideo_args.ltx2_refine_num_inference_steps = int(model_index["fastvideo_refine_num_inference_steps"])
+        if (fastvideo_args.refine_guidance_scale is None
+                and model_index.get("fastvideo_refine_guidance_scale") is not None):
+            fastvideo_args.ltx2_refine_guidance_scale = float(model_index["fastvideo_refine_guidance_scale"])
+        if (fastvideo_args.refine_add_noise is None and model_index.get("fastvideo_refine_add_noise") is not None):
+            fastvideo_args.ltx2_refine_add_noise = bool(model_index["fastvideo_refine_add_noise"])
+        if (fastvideo_args.refine_noise_path is None and fastvideo_args.ltx2_refine_noise_path is None):
+            fastvideo_args.ltx2_refine_noise_path = _resolve_refine_path(model_index.get("fastvideo_refine_noise_path"))
+        if (fastvideo_args.refine_audio_noise_path is None and fastvideo_args.ltx2_refine_audio_noise_path is None):
+            fastvideo_args.ltx2_refine_audio_noise_path = (_resolve_refine_path(
+                model_index.get("fastvideo_refine_audio_noise_path")))
 
         model_index.pop("_class_name")
         model_index.pop("_diffusers_version")
@@ -111,7 +261,8 @@ class LTX2Pipeline(ComposedPipelineBase):
                 if os.path.isdir(gemma_path):
                     component_model_path = gemma_path
                 else:
-                    raise ValueError("Tokenizer directory missing and Gemma weights were not found.")
+                    raise ValueError("Tokenizer directory missing and Gemma weights "
+                                     "were not found.")
 
             module = PipelineComponentLoader.load_module(
                 module_name=module_name,
@@ -130,6 +281,44 @@ class LTX2Pipeline(ComposedPipelineBase):
         for module_name in required_modules:
             if module_name not in modules or modules[module_name] is None:
                 raise ValueError(f"Required module {module_name} was not loaded properly")
+
+        if fastvideo_args.ltx2_refine_enabled:
+            upsampler_path = fastvideo_args.ltx2_refine_upsampler_path
+            if upsampler_path is None:
+                raise ValueError("ltx2_refine_enabled is True but "
+                                 "ltx2_refine_upsampler_path was not provided.")
+            if not os.path.isdir(upsampler_path):
+                raise ValueError("ltx2_refine_upsampler_path must be a directory "
+                                 "containing Diffusers-style upsampler weights; "
+                                 f"got {upsampler_path}")
+            config_path = os.path.join(upsampler_path, "config.json")
+            if not os.path.exists(config_path):
+                raise ValueError("ltx2_refine_upsampler_path must contain a Diffusers "
+                                 f"config.json; missing {config_path}")
+            if (loaded_modules is not None and "spatial_upsampler" in loaded_modules):
+                modules["spatial_upsampler"] = loaded_modules["spatial_upsampler"]
+            else:
+                modules["spatial_upsampler"] = (PipelineComponentLoader.load_module(
+                    module_name="spatial_upsampler",
+                    component_model_path=upsampler_path,
+                    transformers_or_diffusers="diffusers",
+                    fastvideo_args=fastvideo_args,
+                ))
+            logger.info("Loaded module spatial_upsampler from %s", upsampler_path)
+
+            if (loaded_modules is not None and "transformer_refine" in loaded_modules):
+                modules["transformer_refine"] = loaded_modules["transformer_refine"]
+            elif fastvideo_args.ltx2_refine_transformer_path:
+                modules["transformer_refine"] = (PipelineComponentLoader.load_module(
+                    module_name="transformer_refine",
+                    component_model_path=(fastvideo_args.ltx2_refine_transformer_path),
+                    transformers_or_diffusers="diffusers",
+                    fastvideo_args=fastvideo_args,
+                ))
+                logger.info(
+                    "Loaded module transformer_refine from %s",
+                    fastvideo_args.ltx2_refine_transformer_path,
+                )
 
         return modules
 

--- a/fastvideo/pipelines/basic/ltx2/stages/__init__.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/__init__.py
@@ -6,6 +6,12 @@ from fastvideo.pipelines.basic.ltx2.stages.ltx2_denoising import (
     LTX2DenoisingStage, )
 from fastvideo.pipelines.basic.ltx2.stages.ltx2_latent_preparation import (
     LTX2LatentPreparationStage, )
+from fastvideo.pipelines.basic.ltx2.stages.ltx2_refine import (
+    STAGE_2_DISTILLED_SIGMA_VALUES,
+    LTX2RefineInitStage,
+    LTX2RefineLoRAStage,
+    LTX2UpsampleStage,
+)
 from fastvideo.pipelines.basic.ltx2.stages.ltx2_text_encoding import (
     LTX2TextEncodingStage, )
 
@@ -13,5 +19,9 @@ __all__ = [
     "LTX2AudioDecodingStage",
     "LTX2DenoisingStage",
     "LTX2LatentPreparationStage",
+    "LTX2RefineInitStage",
+    "LTX2RefineLoRAStage",
     "LTX2TextEncodingStage",
+    "LTX2UpsampleStage",
+    "STAGE_2_DISTILLED_SIGMA_VALUES",
 ]

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_denoising.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_denoising.py
@@ -5,8 +5,11 @@ LTX-2 denoising stage using the native sigma schedule.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from itertools import combinations
 import math
 import os
+from pathlib import Path
 
 import torch
 from tqdm.auto import tqdm
@@ -17,6 +20,11 @@ from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.forward_context import set_forward_context
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.basic.ltx2.stages.ltx2_image_conditioning import (LTX2_CONTINUATION_STAGE2_LAST_LATENT_KEY,
+                                                                           LTX2_VIDEO_CLEAN_LATENT_KEY,
+                                                                           LTX2_VIDEO_DENOISE_MASK_KEY,
+                                                                           apply_ltx2_gaussian_noiser,
+                                                                           post_process_ltx2_denoised)
 from fastvideo.pipelines.stages.validators import StageValidators as V
 from fastvideo.pipelines.stages.validators import VerificationResult
 from fastvideo.logger import init_logger
@@ -24,6 +32,9 @@ from fastvideo.models.dits.ltx2 import (AudioLatentShape, DEFAULT_LTX2_AUDIO_CHA
                                         DEFAULT_LTX2_AUDIO_HOP_LENGTH, DEFAULT_LTX2_AUDIO_MEL_BINS,
                                         DEFAULT_LTX2_AUDIO_SAMPLE_RATE, VideoLatentShape)
 from fastvideo.utils import is_vsa_available
+
+LTX2_AUDIO_CLEAN_LATENT_KEY = "ltx2_audio_clean_latent"
+LTX2_AUDIO_DENOISE_MASK_KEY = "ltx2_audio_denoise_mask"
 
 BASE_SHIFT_ANCHOR = 1024
 MAX_SHIFT_ANCHOR = 4096
@@ -38,6 +49,18 @@ try:
     vsa_available = is_vsa_available()
 except ImportError:
     vsa_available = False
+
+
+@contextmanager
+def _nvtx_range(name: str):
+    if os.getenv("FASTVIDEO_NVTX_PROFILE", "0") == "1" and torch.cuda.is_available():
+        torch.cuda.nvtx.range_push(name)
+        try:
+            yield
+        finally:
+            torch.cuda.nvtx.range_pop()
+    else:
+        yield
 
 
 def _ltx2_sigmas(
@@ -76,12 +99,75 @@ def _ltx2_sigmas(
     return sigmas
 
 
+def _distilled_subset_sigmas(
+    steps: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, list[int]]:
+    """Select distilled sigma values for a requested denoising step count.
+
+    For steps < 8, choose indices that minimize the largest adjacent sigma
+    drop while always preserving both endpoints.
+    """
+    max_steps = len(DISTILLED_SIGMA_VALUES) - 1
+    if steps < 1 or steps > max_steps:
+        raise ValueError(f"Distilled subset supports steps in [1, {max_steps}], got {steps}.")
+
+    max_index = len(DISTILLED_SIGMA_VALUES) - 1
+    if steps == max_steps:
+        full_indices = list(range(max_index + 1))
+        full_sigmas = torch.tensor(
+            DISTILLED_SIGMA_VALUES,
+            dtype=torch.float32,
+            device=device,
+        )
+        return full_sigmas, full_indices
+
+    interior_count = steps - 1
+    best_key: tuple[float, float, float] | None = None
+    best_indices: tuple[int, ...] | None = None
+
+    for interior in combinations(range(1, max_index), interior_count):
+        candidate = (0, *interior, max_index)
+        gaps = [
+            DISTILLED_SIGMA_VALUES[lo] - DISTILLED_SIGMA_VALUES[hi]
+            for lo, hi in zip(candidate, candidate[1:], strict=False)
+        ]
+        key = (max(gaps), gaps[-1], sum(gap * gap for gap in gaps))
+        if best_key is None or key < best_key:
+            best_key = key
+            best_indices = candidate
+
+    if best_indices is None:
+        raise RuntimeError("Failed to construct distilled subset schedule.")
+
+    base_sigmas = torch.tensor(
+        DISTILLED_SIGMA_VALUES,
+        dtype=torch.float32,
+        device=device,
+    )
+    subset_indices = torch.tensor(best_indices, dtype=torch.long, device=device)
+    subset_sigmas = base_sigmas.index_select(0, subset_indices)
+    return subset_sigmas, list(best_indices)
+
+
 class LTX2DenoisingStage(PipelineStage):
     """Run the LTX-2 denoising loop over the sigma schedule."""
 
-    def __init__(self, transformer) -> None:
+    def __init__(
+        self,
+        transformer,
+        *,
+        sigmas_override: list[float] | None = None,
+        num_inference_steps_override: int | None = None,
+        force_guidance_scale: float | None = None,
+        initial_audio_latents_key: str | None = "ltx2_audio_latents",
+    ) -> None:
         super().__init__()
         self.transformer = transformer
+        self.sigmas_override = sigmas_override
+        self.num_inference_steps_override = num_inference_steps_override
+        self.force_guidance_scale = force_guidance_scale
+        self.initial_audio_latents_key = initial_audio_latents_key
 
     def forward(
         self,
@@ -92,16 +178,48 @@ class LTX2DenoisingStage(PipelineStage):
             raise ValueError("Latents must be provided before denoising.")
 
         latents = batch.latents
+        video_clean_latent = batch.extra.get(LTX2_VIDEO_CLEAN_LATENT_KEY)
+        video_denoise_mask = batch.extra.get(LTX2_VIDEO_DENOISE_MASK_KEY)
+        if (video_clean_latent is None) != (video_denoise_mask is None):
+            raise ValueError("LTX-2 i2v conditioning state is inconsistent: clean_latent/mask "
+                             "must both be set or both be unset.")
+        if video_clean_latent is not None and video_denoise_mask is not None:
+            if not torch.is_tensor(video_clean_latent) or not torch.is_tensor(video_denoise_mask):
+                raise TypeError("LTX-2 i2v conditioning tensors must be Tensors.")
+            video_clean_latent = video_clean_latent.to(
+                device=latents.device,
+                dtype=latents.dtype,
+            )
+            video_denoise_mask = video_denoise_mask.to(
+                device=latents.device,
+                dtype=torch.float32,
+            )
+
         prompt_embeds = batch.prompt_embeds[0]
         prompt_mask = None
 
+        num_inference_steps = (self.num_inference_steps_override
+                               if self.num_inference_steps_override is not None else batch.num_inference_steps)
+
+        cfg_scale_video = batch.ltx2_cfg_scale_video
+        cfg_scale_audio = batch.ltx2_cfg_scale_audio
+        effective_guidance_scale = batch.guidance_scale
+        use_cfg = batch.do_classifier_free_guidance
+        if self.force_guidance_scale is not None:
+            effective_guidance_scale = float(self.force_guidance_scale)
+            cfg_scale_video = effective_guidance_scale
+            cfg_scale_audio = effective_guidance_scale
+            use_cfg = effective_guidance_scale > 1.0
+
         neg_prompt_embeds = None
         neg_prompt_mask = None
-        # Only load negative prompts if CFG is actually enabled
-        if batch.do_classifier_free_guidance:
-            if not batch.negative_prompt_embeds:
-                raise ValueError("CFG is enabled but negative_prompt_embeds is empty")
-            neg_prompt_embeds = batch.negative_prompt_embeds[0]
+        if use_cfg:
+            if batch.negative_prompt_embeds is not None and batch.negative_prompt_embeds:
+                neg_prompt_embeds = batch.negative_prompt_embeds[0]
+            else:
+                logger.warning("[LTX2] CFG requested but negative_prompt_embeds missing; "
+                               "falling back to no-CFG for this stage.")
+                use_cfg = False
 
         # Ensure text conditioning is on the same device as latents.
         if prompt_embeds.device != latents.device:
@@ -116,22 +234,42 @@ class LTX2DenoisingStage(PipelineStage):
         target_dtype = torch.bfloat16
         autocast_enabled = (target_dtype != torch.float32) and not fastvideo_args.disable_autocast
 
-        # Use official distilled sigma schedule for 8 steps (distilled models)
-        use_distilled_sigmas = os.getenv("LTX2_USE_DISTILLED_SIGMAS", "1") == "1"
-        if use_distilled_sigmas and batch.num_inference_steps == 8:
+        if self.sigmas_override is not None:
             sigmas = torch.tensor(
-                DISTILLED_SIGMA_VALUES,
+                self.sigmas_override,
                 device=latents.device,
                 dtype=torch.float32,
             )
-            logger.info("[LTX2] Using official distilled sigma schedule")
+            logger.info("[LTX2] Using override sigma schedule, %s", self.sigmas_override)
         else:
-            sigmas = _ltx2_sigmas(
-                steps=batch.num_inference_steps,
-                latent=None,
-                device=latents.device,
-            )
-            logger.info("[LTX2] Using computed sigma schedule")
+            # Use distilled hardcoded schedule (or subsets) when enabled.
+            use_distilled_sigmas = os.getenv("LTX2_USE_DISTILLED_SIGMAS", "1") == "1"
+            max_distilled_steps = len(DISTILLED_SIGMA_VALUES) - 1
+            if use_distilled_sigmas and num_inference_steps <= max_distilled_steps:
+                sigmas, distilled_indices = _distilled_subset_sigmas(
+                    steps=num_inference_steps,
+                    device=latents.device,
+                )
+                if num_inference_steps == max_distilled_steps:
+                    logger.info("[LTX2] Using official distilled sigma schedule")
+                else:
+                    gaps = sigmas[:-1] - sigmas[1:]
+                    logger.info(
+                        "[LTX2] Using distilled sigma subset for %d steps "
+                        "(indices=%s max_gap=%.6f tail_gap=%.6f)",
+                        num_inference_steps,
+                        distilled_indices,
+                        float(gaps.max().item()),
+                        float(gaps[-1].item()),
+                    )
+            else:
+                sigmas = _ltx2_sigmas(
+                    steps=num_inference_steps,
+                    latent=None,
+                    device=latents.device,
+                )
+                logger.info("[LTX2] Using computed sigma schedule, "
+                            "num_inference_steps=%s", num_inference_steps)
         if hasattr(self.transformer, "patchifier"):
             video_shape = VideoLatentShape.from_torch_shape(latents.shape)
             token_count = self.transformer.patchifier.get_token_count(video_shape)
@@ -139,23 +277,53 @@ class LTX2DenoisingStage(PipelineStage):
             token_count = 1
 
         timestep_template = torch.ones(
-            (latents.shape[0], token_count),
+            (latents.shape[0], token_count, 1),
             device=latents.device,
             dtype=torch.float32,
         )
+        if video_denoise_mask is not None:
+            patchifier = getattr(self.transformer, "patchifier", None)
+            if patchifier is not None:
+                mask_patch = patchifier.patchify(video_denoise_mask.to(dtype=latents.dtype))
+                timestep_template = mask_patch.mean(dim=-1).to(torch.float32)
+            else:
+                flat_mask = video_denoise_mask.reshape(video_denoise_mask.shape[0], -1).to(torch.float32)
+                if flat_mask.shape[1] != token_count:
+                    raise ValueError("LTX-2 i2v timestep mask token count mismatch: "
+                                     f"expected {token_count}, got {flat_mask.shape[1]}")
+                timestep_template = flat_mask
         audio_prompt_embeds = batch.extra.get("ltx2_audio_prompt_embeds")
         audio_neg_embeds = batch.extra.get("ltx2_audio_negative_embeds")
         audio_context_p = audio_prompt_embeds[0] if audio_prompt_embeds else None
         audio_context_n = audio_neg_embeds[0] if audio_neg_embeds else None
-        audio_latents = None
+        audio_latents = batch.extra.get(self.initial_audio_latents_key)
+        if isinstance(audio_latents, torch.Tensor):
+            audio_latents = audio_latents.to(device=latents.device, dtype=latents.dtype)
+        # Audio conditioning: mirror video i2v mask approach.
+        audio_clean_latent = batch.extra.get(LTX2_AUDIO_CLEAN_LATENT_KEY)
+        audio_denoise_mask = batch.extra.get(LTX2_AUDIO_DENOISE_MASK_KEY)
+        if isinstance(audio_clean_latent, torch.Tensor):
+            audio_clean_latent = audio_clean_latent.to(device=latents.device, dtype=latents.dtype)
+        if isinstance(audio_denoise_mask, torch.Tensor):
+            audio_denoise_mask = audio_denoise_mask.to(device=latents.device, dtype=torch.float32)
         audio_timestep_template = None
-        if audio_context_p is not None:
+        if audio_latents is not None:
+            audio_timestep_template = torch.ones(
+                (latents.shape[0], audio_latents.shape[2], 1),
+                device=latents.device,
+                dtype=torch.float32,
+            )
+        if audio_context_p is not None and audio_latents is None:
             fps_value = batch.fps
             if isinstance(fps_value, list):
                 fps_value = fps_value[0] if fps_value else None
             if fps_value is None:
                 fps_value = 1.0
-            duration = float(batch.num_frames) / float(fps_value)
+            # Allow audio to span a longer duration than video so
+            # audio conditioning can overlap more without shrinking
+            # the newly-generated audio region.
+            audio_num_frames = batch.extra.get("audio_num_frames", batch.num_frames)
+            duration = float(audio_num_frames) / float(fps_value)
             audio_shape = AudioLatentShape.from_duration(
                 batch=latents.shape[0],
                 duration=duration,
@@ -165,44 +333,86 @@ class LTX2DenoisingStage(PipelineStage):
                 hop_length=DEFAULT_LTX2_AUDIO_HOP_LENGTH,
                 audio_latent_downsample_factor=DEFAULT_LTX2_AUDIO_DOWNSAMPLE,
             )
-            audio_generator = None
-            if fastvideo_args.ltx2_initial_latent_path and batch.seed is not None:
-                audio_generator = torch.Generator(device=latents.device).manual_seed(batch.seed)
-            elif batch.generator is not None:
-                audio_generator = batch.generator[0] if isinstance(batch.generator, list) else batch.generator
-            if audio_generator is not None and audio_generator.device.type != latents.device.type:
-                if batch.seed is None:
-                    audio_generator = torch.Generator(device=latents.device)
-                else:
-                    audio_generator = torch.Generator(device=latents.device).manual_seed(batch.seed)
-            audio_patch_shape = (
+            expected_shape = (
                 audio_shape.batch,
+                audio_shape.channels,
                 audio_shape.frames,
-                audio_shape.channels * audio_shape.mel_bins,
+                audio_shape.mel_bins,
             )
-            audio_latents_patch = torch.randn(
-                audio_patch_shape,
-                generator=audio_generator,
+            audio_latent_path = fastvideo_args.ltx2_audio_latent_path
+            audio_latents = self._load_audio_latents(
+                audio_latent_path,
                 device=latents.device,
                 dtype=latents.dtype,
-            )
-            if hasattr(self.transformer, "audio_patchifier"):
-                audio_latents = self.transformer.audio_patchifier.unpatchify(audio_latents_patch, audio_shape)
-            else:
-                audio_latents = audio_latents_patch.view(
+                expected_shape=expected_shape,
+            ) if audio_latent_path else None
+            if audio_latents is None:
+                audio_generator = None
+                if fastvideo_args.ltx2_initial_latent_path and batch.seed is not None:
+                    audio_generator = torch.Generator(device=latents.device).manual_seed(batch.seed)
+                elif batch.generator is not None:
+                    audio_generator = (batch.generator[0] if isinstance(batch.generator, list) else batch.generator)
+                if audio_generator is not None and audio_generator.device.type != latents.device.type:
+                    if batch.seed is None:
+                        audio_generator = torch.Generator(device=latents.device)
+                    else:
+                        audio_generator = torch.Generator(device=latents.device).manual_seed(batch.seed)
+                audio_patch_shape = (
                     audio_shape.batch,
                     audio_shape.frames,
-                    audio_shape.channels,
-                    audio_shape.mel_bins,
-                ).permute(0, 2, 1, 3).contiguous()
+                    audio_shape.channels * audio_shape.mel_bins,
+                )
+                audio_latents_patch = torch.randn(
+                    audio_patch_shape,
+                    generator=audio_generator,
+                    device=latents.device,
+                    dtype=latents.dtype,
+                )
+                if hasattr(self.transformer, "audio_patchifier"):
+                    audio_latents = self.transformer.audio_patchifier.unpatchify(audio_latents_patch, audio_shape)
+                else:
+                    audio_latents = audio_latents_patch.view(
+                        audio_shape.batch,
+                        audio_shape.frames,
+                        audio_shape.channels,
+                        audio_shape.mel_bins,
+                    ).permute(0, 2, 1, 3).contiguous()
+                if audio_latent_path:
+                    self._save_audio_latents(audio_latent_path, audio_latents)
             audio_timestep_template = torch.ones(
-                (latents.shape[0], audio_shape.frames),
+                (latents.shape[0], audio_shape.frames, 1),
                 device=latents.device,
                 dtype=torch.float32,
             )
+        # Apply audio conditioning mask (mirrors video i2v approach).
+        if (audio_latents is not None and audio_clean_latent is not None and audio_denoise_mask is not None):
+            audio_T = audio_latents.shape[2]
+            cond_T = audio_clean_latent.shape[2]
+            if audio_T != cond_T:
+                logger.warning(
+                    "[LTX2] Audio conditioning T mismatch: "
+                    "latents=%d, clean=%d; skipping audio "
+                    "conditioning.", audio_T, cond_T)
+                audio_clean_latent = None
+                audio_denoise_mask = None
+            else:
+                # audio_denoise_mask: [B, 1, T, 1] → [B, T]
+                # for timestep template.
+                audio_timestep_template = (audio_denoise_mask[:, 0, :, 0])
+                audio_latents = apply_ltx2_gaussian_noiser(
+                    noise=audio_latents,
+                    clean_latent=audio_clean_latent,
+                    denoise_mask=audio_denoise_mask,
+                    noise_scale=1.0,
+                )
+
+        # Video position offset: when audio is longer than video for
+        # conditioning, shift video RoPE positions forward so the
+        # audio prefix sits at t>=0 and video aligns with the later
+        # portion of audio.
+        video_position_offset_sec = float(batch.extra.get("video_position_offset_sec", 0.0))
+
         # Multi-modal CFG parameters (per-stream scales).
-        cfg_scale_video = batch.ltx2_cfg_scale_video
-        cfg_scale_audio = batch.ltx2_cfg_scale_audio
         modality_scale_video = batch.ltx2_modality_scale_video
         modality_scale_audio = batch.ltx2_modality_scale_audio
         rescale_scale = batch.ltx2_rescale_scale
@@ -211,11 +421,13 @@ class LTX2DenoisingStage(PipelineStage):
         stg_scale_audio = batch.ltx2_stg_scale_audio
         stg_blocks_video = batch.ltx2_stg_blocks_video
         stg_blocks_audio = batch.ltx2_stg_blocks_audio
-        do_stg_video = stg_scale_video != 0.0
-        do_stg_audio = stg_scale_audio != 0.0
+        do_stg_video = not math.isclose(float(stg_scale_video), 0.0)
+        do_stg_audio = not math.isclose(float(stg_scale_audio), 0.0)
         do_stg = do_stg_video or do_stg_audio
-        do_cfg_text = (cfg_scale_video != 1.0 or cfg_scale_audio != 1.0)
-        do_mod = (modality_scale_video != 1.0 or modality_scale_audio != 1.0)
+        do_cfg_text = use_cfg and (cfg_scale_video != 1.0 or cfg_scale_audio != 1.0)
+        do_modality_video = not math.isclose(float(modality_scale_video), 1.0)
+        do_modality_audio = not math.isclose(float(modality_scale_audio), 1.0)
+        do_mod = do_modality_video or do_modality_audio
         do_guidance = do_cfg_text or do_mod or do_stg
 
         if do_cfg_text and neg_prompt_embeds is None:
@@ -225,12 +437,14 @@ class LTX2DenoisingStage(PipelineStage):
 
         logger.info(
             "[LTX2] Denoising start: steps=%d dtype=%s "
+            "cfg=%.1f "
             "cfg_video=%.1f cfg_audio=%.1f mod_video=%.1f "
             "mod_audio=%.1f rescale=%.2f "
             "stg_video=%.1f stg_audio=%.1f "
             "sigmas_shape=%s latents_shape=%s",
-            batch.num_inference_steps,
+            num_inference_steps,
             target_dtype,
+            effective_guidance_scale,
             cfg_scale_video,
             cfg_scale_audio,
             modality_scale_video,
@@ -241,7 +455,20 @@ class LTX2DenoisingStage(PipelineStage):
             tuple(sigmas.shape),
             tuple(latents.shape),
         )
-        use_vsa = (vsa_available and envs.FASTVIDEO_ATTENTION_BACKEND == "VIDEO_SPARSE_ATTN")
+        # Hint runtime FP4 layer gating (single shared transformer path):
+        # stage-1 denoising uses "base", stage-2 refine uses "refine".
+        batch.extra["ltx2_fp4_stage_profile"] = ("refine" if self.sigmas_override is not None else "base")
+        attention_backend = os.getenv("FASTVIDEO_ATTENTION_BACKEND", envs.FASTVIDEO_ATTENTION_BACKEND)
+        wants_vsa_metadata = attention_backend in (
+            "VIDEO_SPARSE_ATTN",
+            "SAGE_ATTN_THREE",
+        )
+        # VIDEO_SPARSE_ATTN requires the fastvideo-kernel VSA op.
+        # SAGE_ATTN_THREE VSA+QAT only needs VSA metadata and its own kernel path.
+        use_vsa = wants_vsa_metadata and (attention_backend != "VIDEO_SPARSE_ATTN" or vsa_available)
+        if attention_backend == "VIDEO_SPARSE_ATTN" and not vsa_available:
+            logger.warning("FASTVIDEO_ATTENTION_BACKEND=VIDEO_SPARSE_ATTN but VSA kernel "
+                           "is unavailable; disabling VSA metadata for this run.")
         vsa_metadata_builder = (VideoSparseAttentionMetadataBuilder() if use_vsa else None)
 
         for step_index in tqdm(range(len(sigmas) - 1)):
@@ -249,6 +476,7 @@ class LTX2DenoisingStage(PipelineStage):
             sigma_next = sigmas[step_index + 1]
             timestep = timestep_template * sigma
             audio_timestep = (audio_timestep_template * sigma if audio_timestep_template is not None else None)
+            latent_model_input = latents.to(target_dtype)
             attn_metadata = None
             if vsa_metadata_builder is not None:
                 attn_metadata = vsa_metadata_builder.build(
@@ -264,26 +492,27 @@ class LTX2DenoisingStage(PipelineStage):
                     dtype=target_dtype,
                     enabled=autocast_enabled,
             ), set_forward_context(
-                    current_timestep=sigma.item(),
+                    current_timestep=sigma,
                     attn_metadata=attn_metadata,
                     forward_batch=batch,
             ):
                 # Pass 1: Full conditioning (text + cross-modal)
-                pos_outputs = self.transformer(
-                    hidden_states=latents.to(target_dtype),
-                    encoder_hidden_states=prompt_embeds,
-                    encoder_attention_mask=prompt_mask,
-                    timestep=timestep,
-                    audio_hidden_states=audio_latents,
-                    audio_encoder_hidden_states=audio_context_p,
-                    audio_timestep=audio_timestep,
-                )
+                with _nvtx_range("ltx2.denoise.pass.pos"):
+                    pos_outputs = self.transformer(
+                        hidden_states=latent_model_input,
+                        encoder_hidden_states=prompt_embeds,
+                        encoder_attention_mask=prompt_mask,
+                        timestep=timestep,
+                        audio_hidden_states=audio_latents,
+                        audio_encoder_hidden_states=audio_context_p,
+                        audio_timestep=audio_timestep,
+                        video_position_offset_sec=video_position_offset_sec,
+                    )
                 if isinstance(pos_outputs, tuple):
                     pos_denoised, pos_audio = pos_outputs
                 else:
                     pos_denoised = pos_outputs
                     pos_audio = None
-
                 if do_guidance:
                     # Defaults: (pos - pos) = 0 under each scale.
                     neg_denoised = pos_denoised
@@ -295,56 +524,63 @@ class LTX2DenoisingStage(PipelineStage):
 
                     # Pass 2: text CFG (negative prompt)
                     if do_cfg_text:
-                        neg_outputs = self.transformer(
-                            hidden_states=latents.to(target_dtype),
-                            encoder_hidden_states=neg_prompt_embeds,
-                            encoder_attention_mask=neg_prompt_mask,
-                            timestep=timestep,
-                            audio_hidden_states=audio_latents,
-                            audio_encoder_hidden_states=audio_context_n,
-                            audio_timestep=audio_timestep,
-                        )
+                        with _nvtx_range("ltx2.denoise.pass.neg"):
+                            neg_outputs = self.transformer(
+                                hidden_states=latent_model_input,
+                                encoder_hidden_states=neg_prompt_embeds,
+                                encoder_attention_mask=neg_prompt_mask,
+                                timestep=timestep,
+                                audio_hidden_states=audio_latents,
+                                audio_encoder_hidden_states=audio_context_n,
+                                audio_timestep=audio_timestep,
+                                video_position_offset_sec=video_position_offset_sec,
+                            )
                         if isinstance(neg_outputs, tuple):
                             neg_denoised, neg_audio = neg_outputs
                         else:
                             neg_denoised = neg_outputs
+                            neg_audio = None
 
-                    # Pass 3: Modality-isolated (skip cross-modal
-                    # attn)
+                    # Pass 3: Modality-isolated (skip cross-modal attn)
                     if do_mod:
-                        mod_outputs = self.transformer(
-                            hidden_states=latents.to(target_dtype),
-                            encoder_hidden_states=prompt_embeds,
-                            encoder_attention_mask=prompt_mask,
-                            timestep=timestep,
-                            audio_hidden_states=audio_latents,
-                            audio_encoder_hidden_states=audio_context_p,
-                            audio_timestep=audio_timestep,
-                            skip_cross_modal_attn=True,
-                        )
+                        with _nvtx_range("ltx2.denoise.pass.modality"):
+                            mod_outputs = self.transformer(
+                                hidden_states=latent_model_input,
+                                encoder_hidden_states=prompt_embeds,
+                                encoder_attention_mask=prompt_mask,
+                                timestep=timestep,
+                                audio_hidden_states=audio_latents,
+                                audio_encoder_hidden_states=audio_context_p,
+                                audio_timestep=audio_timestep,
+                                skip_cross_modal_attn=True,
+                                video_position_offset_sec=video_position_offset_sec,
+                            )
                         if isinstance(mod_outputs, tuple):
                             mod_denoised, mod_audio = mod_outputs
                         else:
                             mod_denoised = mod_outputs
+                            mod_audio = None
 
-                    # Pass 4: STG perturbed (skip self-attn in
-                    # specified blocks)
+                    # Pass 4: STG perturbed (skip self-attn in specified blocks)
                     if do_stg:
-                        ptb_outputs = self.transformer(
-                            hidden_states=latents.to(target_dtype),
-                            encoder_hidden_states=prompt_embeds,
-                            encoder_attention_mask=prompt_mask,
-                            timestep=timestep,
-                            audio_hidden_states=audio_latents,
-                            audio_encoder_hidden_states=(audio_context_p),
-                            audio_timestep=audio_timestep,
-                            skip_video_self_attn_blocks=(stg_blocks_video if do_stg_video else None),
-                            skip_audio_self_attn_blocks=(stg_blocks_audio if do_stg_audio else None),
-                        )
+                        with _nvtx_range("ltx2.denoise.pass.stg"):
+                            ptb_outputs = self.transformer(
+                                hidden_states=latent_model_input,
+                                encoder_hidden_states=prompt_embeds,
+                                encoder_attention_mask=prompt_mask,
+                                timestep=timestep,
+                                audio_hidden_states=audio_latents,
+                                audio_encoder_hidden_states=audio_context_p,
+                                audio_timestep=audio_timestep,
+                                skip_video_self_attn_blocks=(stg_blocks_video if do_stg_video else None),
+                                skip_audio_self_attn_blocks=(stg_blocks_audio if do_stg_audio else None),
+                                video_position_offset_sec=video_position_offset_sec,
+                            )
                         if isinstance(ptb_outputs, tuple):
                             ptb_denoised, ptb_audio = ptb_outputs
                         else:
                             ptb_denoised = ptb_outputs
+                            ptb_audio = None
 
                     # Multi-modal guidance formula per stream.
                     vid = (pos_denoised + (cfg_scale_video - 1) * (pos_denoised - neg_denoised) +
@@ -369,23 +605,74 @@ class LTX2DenoisingStage(PipelineStage):
                     pos_denoised = vid
                     pos_audio = aud
 
+            if video_clean_latent is not None and video_denoise_mask is not None:
+                pos_denoised = post_process_ltx2_denoised(
+                    denoised=pos_denoised,
+                    denoise_mask=video_denoise_mask,
+                    clean_latent=video_clean_latent,
+                )
+            if (audio_clean_latent is not None and audio_denoise_mask is not None and pos_audio is not None):
+                pos_audio = post_process_ltx2_denoised(
+                    denoised=pos_audio,
+                    denoise_mask=audio_denoise_mask,
+                    clean_latent=audio_clean_latent,
+                )
+
             sigma_value = sigma.to(torch.float32) if isinstance(sigma, torch.Tensor) else torch.tensor(
                 float(sigma),
                 device=latents.device,
                 dtype=torch.float32,
             )
             dt = sigma_next - sigma
-            velocity = ((latents.float() - pos_denoised.float()) / sigma_value).to(latents.dtype)
-
-            latents = (latents.float() + velocity.float() * dt).to(latents.dtype)
-            if pos_audio is not None and audio_latents is not None:
-                audio_velocity = ((audio_latents.float() - pos_audio.float()) / sigma_value).to(audio_latents.dtype)
-                audio_latents = (audio_latents.float() + audio_velocity.float() * dt).to(audio_latents.dtype)
+            with _nvtx_range("ltx2.denoise.scheduler_update"):
+                velocity = ((latents.float() - pos_denoised.float()) / sigma_value).to(latents.dtype)
+                latents = (latents.float() + velocity.float() * dt).to(latents.dtype)
+                if pos_audio is not None and audio_latents is not None:
+                    audio_velocity = ((audio_latents.float() - pos_audio.float()) / sigma_value).to(audio_latents.dtype)
+                    audio_latents = (audio_latents.float() + audio_velocity.float() * dt).to(audio_latents.dtype)
 
         batch.latents = latents
-        batch.extra["ltx2_audio_latents"] = audio_latents
+        if (batch.return_continuation_state and self.sigmas_override is not None):
+            batch.extra[LTX2_CONTINUATION_STAGE2_LAST_LATENT_KEY] = (latents[:, :, -1:, :, :].detach().clone())
+        batch.extra[self.initial_audio_latents_key] = audio_latents
+        if self.initial_audio_latents_key != "ltx2_audio_latents":
+            batch.extra["ltx2_audio_latents"] = audio_latents
         logger.info("[LTX2] Denoising done.")
         return batch
+
+    def _load_audio_latents(
+        self,
+        latent_path: str | None,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+        expected_shape: tuple[int, ...],
+    ) -> torch.Tensor | None:
+        if not latent_path:
+            return None
+        path = Path(latent_path)
+        if not path.exists():
+            return None
+        payload = torch.load(path, map_location=device)
+        if isinstance(payload, dict):
+            latent = (payload.get("audio_latent") or payload.get("latent") or payload.get("audio"))
+        else:
+            latent = payload
+        if not torch.is_tensor(latent):
+            raise TypeError(f"Expected tensor audio latent in {path}")
+        if tuple(latent.shape) != tuple(expected_shape):
+            raise ValueError(
+                f"Audio latent shape mismatch for {path}: expected {expected_shape}, got {tuple(latent.shape)}")
+        logger.info("[LTX2] Loaded audio latent from %s", path)
+        return latent.to(device=device, dtype=dtype)
+
+    def _save_audio_latents(self, latent_path: str, latents: torch.Tensor) -> None:
+        path = Path(latent_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            return
+        torch.save({"audio_latent": latents.detach().cpu()}, path)
+        logger.info("[LTX2] Saved audio latent to %s", path)
 
     def verify_input(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> VerificationResult:
         result = VerificationResult()

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_denoising.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_denoising.py
@@ -243,7 +243,8 @@ class LTX2DenoisingStage(PipelineStage):
             logger.info("[LTX2] Using override sigma schedule, %s", self.sigmas_override)
         else:
             # Use distilled hardcoded schedule (or subsets) when enabled.
-            use_distilled_sigmas = os.getenv("LTX2_USE_DISTILLED_SIGMAS", "1") == "1"
+            use_distilled_sigmas = (fastvideo_args.ltx2_use_distilled_sigmas
+                                    and os.getenv("LTX2_USE_DISTILLED_SIGMAS", "1") == "1")
             max_distilled_steps = len(DISTILLED_SIGMA_VALUES) - 1
             if use_distilled_sigmas and num_inference_steps <= max_distilled_steps:
                 sigmas, distilled_indices = _distilled_subset_sigmas(

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_image_conditioning.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_image_conditioning.py
@@ -1,0 +1,499 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FastVideo-native LTX-2 image-to-video conditioning helpers.
+
+Public-side port of ``FastVideo-internal/.../ltx2_i2v_conditioning.py``.
+The module composes a ``clean_latent`` + ``denoise_mask`` pair that the
+LTX-2 latent-prep + denoising stages mix into the noise tensor, so a
+generated segment can be anchored to:
+
+* one or more conditioning images at specific latent frame indices
+  (``ltx2_images``),
+* a multi-frame conditioning video clip jointly VAE-encoded
+  (``ltx2_video_conditions``),
+* a continuation latent carried over from the previous segment
+  (``ltx2_conditioning_latent_stage1`` / ``_stage2``).
+
+The streaming server's session controller populates the continuation
+latents between segments; the legacy from_pretrained path passes
+``ltx2_images`` / ``ltx2_image_crf`` through compat translation.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from io import BytesIO
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from fastvideo.logger import init_logger
+from fastvideo.models.vision_utils import load_image
+
+if TYPE_CHECKING:
+    from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+
+try:
+    import av
+except ImportError:  # pragma: no cover - optional dependency
+    av = None
+
+logger = init_logger(__name__)
+
+LTX2_VIDEO_CLEAN_LATENT_KEY = "ltx2_video_clean_latent"
+LTX2_VIDEO_DENOISE_MASK_KEY = "ltx2_video_denoise_mask"
+LTX2_CONTINUATION_STAGE1_LAST_LATENT_KEY = ("ltx2_continuation_stage1_last_latent")
+LTX2_CONTINUATION_STAGE2_LAST_LATENT_KEY = ("ltx2_continuation_stage2_last_latent")
+# NOTE: hard-coded for continuation quality experiments. The first
+# latent frame of the next clip is anchored to the previous clip's
+# last latent at full strength.
+LTX2_CONTINUATION_TARGET_FRAME_IDX = 0
+LTX2_CONTINUATION_STRENGTH = 1.0
+DEFAULT_LTX2_IMAGE_CRF = 33.0
+
+
+@dataclass
+class LTX2ImageConditioningState:
+    """Result of building image / continuation conditioning."""
+    clean_latent: torch.Tensor
+    denoise_mask: torch.Tensor
+    images: list[tuple[str, int, float]]
+    latent_conditioned: bool = False
+
+
+def resolve_ltx2_images(batch: ForwardBatch) -> list[tuple[str, int, float]]:
+    """Collect any LTX-2 image conditioning inputs from the batch.
+
+    Falls back to ``batch.image_path`` for the simple single-image i2v
+    case (anchors the first latent frame at full strength).
+    """
+    images = batch.ltx2_images
+    if images is None and batch.image_path:
+        images = [(batch.image_path, 0, 1.0)]
+    if not images:
+        return []
+
+    resolved: list[tuple[str, int, float]] = []
+    for item in images:
+        if not isinstance(item, tuple | list) or len(item) != 3:
+            raise ValueError("Each ltx2_images item must be a tuple/list of "
+                             "(path, frame_idx, strength).")
+        image_path, frame_idx, strength = item
+        frame_idx_int = int(frame_idx)
+        strength_float = float(strength)
+        if frame_idx_int < 0:
+            raise ValueError(f"LTX-2 frame_idx must be >= 0, got {frame_idx_int}")
+        if strength_float < 0.0 or strength_float > 1.0:
+            raise ValueError(f"LTX-2 image conditioning strength must be in [0, 1], "
+                             f"got {strength_float}")
+        resolved.append((str(image_path), frame_idx_int, strength_float))
+    return resolved
+
+
+def _resize_and_center_crop(
+    tensor: torch.Tensor,
+    height: int,
+    width: int,
+) -> torch.Tensor:
+    if tensor.ndim != 3:
+        raise ValueError(f"Expected image tensor [H, W, C], got shape {tuple(tensor.shape)}")
+
+    tensor = tensor.permute(2, 0, 1).unsqueeze(0)
+    _, _, src_h, src_w = tensor.shape
+    scale = max(height / src_h, width / src_w)
+    new_h = math.ceil(src_h * scale)
+    new_w = math.ceil(src_w * scale)
+    tensor = F.interpolate(
+        tensor,
+        size=(new_h, new_w),
+        mode="bilinear",
+        align_corners=False,
+    )
+
+    crop_top = (new_h - height) // 2
+    crop_left = (new_w - width) // 2
+    tensor = tensor[:, :, crop_top:crop_top + height, crop_left:crop_left + width]
+    return tensor.unsqueeze(2)
+
+
+def _encode_single_frame(output_file: BytesIO, image_array: np.ndarray, crf: float) -> None:
+    container = av.open(output_file, "w", format="mp4")
+    try:
+        stream = container.add_stream(
+            "libx264",
+            rate=1,
+            options={
+                "crf": str(crf),
+                "preset": "veryfast",
+            },
+        )
+        height = image_array.shape[0] // 2 * 2
+        width = image_array.shape[1] // 2 * 2
+        image_array = image_array[:height, :width]
+        stream.height = height
+        stream.width = width
+        frame = av.VideoFrame.from_ndarray(image_array, format="rgb24").reformat(format="yuv420p")
+        container.mux(stream.encode(frame))
+        container.mux(stream.encode())
+    finally:
+        container.close()
+
+
+def _decode_single_frame(video_file: BytesIO) -> np.ndarray:
+    container = av.open(video_file)
+    try:
+        stream = next(s for s in container.streams if s.type == "video")
+        frame = next(container.decode(stream))
+    finally:
+        container.close()
+    return frame.to_ndarray(format="rgb24")
+
+
+def _preprocess_conditioning_image(
+    image: np.ndarray,
+    image_crf: float,
+) -> np.ndarray:
+    """H.264 CRF re-encode the conditioning image to match the
+    quantization the model was trained on. ``image_crf <= 0.0`` skips
+    the re-encode (used by the streaming server which conditions on
+    already-decoded VAE-quality frames)."""
+    if image_crf <= 0.0:
+        return image
+    if av is None:
+        logger.warning("[LTX2] PyAV is unavailable; skipping CRF "
+                       "conditioning preprocessing.")
+        return image
+
+    with BytesIO() as output_file:
+        _encode_single_frame(output_file, image, image_crf)
+        encoded = output_file.getvalue()
+    with BytesIO(encoded) as video_file:
+        return _decode_single_frame(video_file)
+
+
+def load_ltx2_conditioning_image(
+    image_path: str,
+    *,
+    height: int,
+    width: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    image_crf: float,
+) -> torch.Tensor:
+    image = load_image(image_path)
+    image_np = np.array(image)[..., :3]
+    image_np = _preprocess_conditioning_image(image_np, image_crf=image_crf)
+    image_tensor = torch.tensor(image_np, dtype=torch.float32, device=device)
+    image_tensor = _resize_and_center_crop(image_tensor, height, width)
+    image_tensor = (image_tensor / 127.5 - 1.0).to(device=device, dtype=dtype)
+    return image_tensor
+
+
+def load_ltx2_conditioning_video_clip(
+    frame_paths: list[str],
+    *,
+    height: int,
+    width: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    image_crf: float,
+) -> torch.Tensor:
+    """Load multiple frames and stack as ``[1, C, T, H, W]`` for joint
+    VAE encoding so the resulting latent captures temporal/motion info.
+    """
+    frame_tensors: list[torch.Tensor] = []
+    for path in frame_paths:
+        image = load_image(path)
+        image_np = np.array(image)[..., :3]
+        image_np = _preprocess_conditioning_image(image_np, image_crf=image_crf)
+        t = torch.tensor(image_np, dtype=torch.float32, device=device)
+        # _resize_and_center_crop returns [1, C, 1, H, W]
+        t = _resize_and_center_crop(t, height, width)
+        frame_tensors.append(t)
+    # Concat along T dimension -> [1, C, T, H, W]
+    video = torch.cat(frame_tensors, dim=2)
+    return (video / 127.5 - 1.0).to(device=device, dtype=dtype)
+
+
+def _extract_video_latent(vae: torch.nn.Module, image: torch.Tensor) -> torch.Tensor:
+    with torch.no_grad():
+        encoded = vae.encode(image)
+
+    latent_dist = getattr(encoded, "latent_dist", None)
+    if latent_dist is not None:
+        encoded = latent_dist
+
+    latent: torch.Tensor
+    if torch.is_tensor(encoded):
+        latent = encoded
+    elif hasattr(encoded, "mode"):
+        latent = encoded.mode()
+    elif hasattr(encoded, "sample"):
+        latent = encoded.sample()
+    elif (isinstance(encoded, tuple | list) and encoded and torch.is_tensor(encoded[0])):
+        latent = encoded[0]
+    else:
+        raise TypeError(f"Unsupported VAE encode output type: {type(encoded)}")
+
+    if latent.ndim == 4:
+        latent = latent.unsqueeze(2)
+    if latent.ndim != 5:
+        raise ValueError(f"Expected video latent with 5 dims [B,C,T,H,W], got "
+                         f"{tuple(latent.shape)}")
+    return latent
+
+
+def _insert_conditioning_latent(
+    *,
+    conditioning_latent: torch.Tensor,
+    clean_latent: torch.Tensor,
+    denoise_mask: torch.Tensor,
+    frame_idx: int,
+    strength: float,
+    source_name: str,
+) -> None:
+    if conditioning_latent.ndim == 4:
+        conditioning_latent = conditioning_latent.unsqueeze(2)
+    if conditioning_latent.ndim != 5:
+        raise ValueError(f"LTX-2 {source_name} latent must have 5 dims [B,C,T,H,W], "
+                         f"got {tuple(conditioning_latent.shape)}")
+
+    if conditioning_latent.shape[0] == 1 and clean_latent.shape[0] > 1:
+        conditioned_latent = conditioning_latent.expand(
+            clean_latent.shape[0],
+            -1,
+            -1,
+            -1,
+            -1,
+        )
+    elif conditioning_latent.shape[0] == clean_latent.shape[0]:
+        conditioned_latent = conditioning_latent
+    else:
+        raise ValueError(f"LTX-2 {source_name} latent batch mismatch: "
+                         f"{conditioning_latent.shape[0]} vs {clean_latent.shape[0]}")
+
+    if conditioned_latent.shape[1] != clean_latent.shape[1]:
+        raise ValueError(f"LTX-2 {source_name} latent channels mismatch: "
+                         f"{conditioned_latent.shape[1]} vs {clean_latent.shape[1]}")
+    if conditioned_latent.shape[-2:] != clean_latent.shape[-2:]:
+        raise ValueError(f"LTX-2 {source_name} latent spatial shape "
+                         f"mismatch: {tuple(conditioned_latent.shape[-2:])} "
+                         f"vs {tuple(clean_latent.shape[-2:])}")
+
+    frame_count = conditioned_latent.shape[2]
+    end_idx = frame_idx + frame_count
+    if frame_idx < 0 or end_idx > clean_latent.shape[2]:
+        raise ValueError(f"LTX-2 {source_name} latent frame range out of bounds: "
+                         f"frame_idx={frame_idx}, frame_count={frame_count}, "
+                         f"latent_frames={clean_latent.shape[2]}")
+
+    clean_latent[:, :, frame_idx:end_idx] = conditioned_latent.to(
+        device=clean_latent.device,
+        dtype=clean_latent.dtype,
+    )
+    denoise_mask[:, :, frame_idx:end_idx] = 1.0 - float(strength)
+
+
+def build_ltx2_image_conditioning(
+    *,
+    batch: ForwardBatch,
+    latents: torch.Tensor,
+    vae: torch.nn.Module,
+    height: int,
+    width: int,
+    image_crf: float | None = None,
+    base_clean_latent: torch.Tensor | None = None,
+) -> LTX2ImageConditioningState | None:
+    """Build the (clean_latent, denoise_mask) state for the next segment.
+
+    Returns ``None`` for plain T2V (no images, no continuation, no
+    video conditions). The denoise mask is 1 where the model should
+    sample fresh, 0 where it should preserve the conditioning latent
+    exactly. ``base_clean_latent is None`` corresponds to stage 1
+    (fresh half-res latent); ``base_clean_latent`` set means stage 2
+    (already-upsampled latent from the upsampler stage).
+    """
+    images = resolve_ltx2_images(batch)
+    conditioning_latent_stage1 = getattr(batch, "ltx2_conditioning_latent_stage1", None)
+    conditioning_latent_stage2 = getattr(batch, "ltx2_conditioning_latent_stage2", None)
+    is_stage1_conditioning = base_clean_latent is None
+    is_stage2_conditioning = not is_stage1_conditioning
+    has_latent_conditioning = False
+    continuation_latent_to_insert: torch.Tensor | None = None
+    if (conditioning_latent_stage1 is not None and not torch.is_tensor(conditioning_latent_stage1)):
+        raise TypeError("LTX-2 stage1 continuation latent conditioning "
+                        "expects a torch.Tensor.")
+    if (conditioning_latent_stage2 is not None and not torch.is_tensor(conditioning_latent_stage2)):
+        raise TypeError("LTX-2 stage2 continuation latent conditioning "
+                        "expects a torch.Tensor.")
+
+    if (conditioning_latent_stage1 is None) != (conditioning_latent_stage2 is None):
+        raise ValueError("LTX-2 continuation expects both stage1 and stage2 "
+                         "conditioning latents (or neither for first round).")
+    if is_stage1_conditioning and conditioning_latent_stage1 is not None:
+        has_latent_conditioning = True
+        continuation_latent_to_insert = conditioning_latent_stage1.to(
+            device=latents.device,
+            dtype=latents.dtype,
+        )
+    elif is_stage2_conditioning and conditioning_latent_stage2 is not None:
+        has_latent_conditioning = True
+        continuation_latent_to_insert = conditioning_latent_stage2.to(
+            device=latents.device,
+            dtype=latents.dtype,
+        )
+
+    video_conditions = getattr(batch, "ltx2_video_conditions", None) or []
+
+    if not images and not has_latent_conditioning and not video_conditions:
+        return None
+
+    clean_latent = (torch.zeros_like(latents) if base_clean_latent is None else base_clean_latent.clone())
+
+    denoise_mask = torch.ones(
+        (
+            latents.shape[0],
+            1,
+            latents.shape[2],
+            latents.shape[3],
+            latents.shape[4],
+        ),
+        dtype=torch.float32,
+        device=latents.device,
+    )
+
+    if image_crf is None:
+        image_crf = getattr(batch, "ltx2_image_crf", DEFAULT_LTX2_IMAGE_CRF)
+
+    vae_param = next(vae.parameters(), None)
+    encoder_dtype = (vae_param.dtype if vae_param is not None else latents.dtype)
+    encoder_device = (vae_param.device if vae_param is not None else latents.device)
+    cache: dict[tuple[str, int, int, float], torch.Tensor] = {}
+    latent_conditioned = False
+
+    if has_latent_conditioning:
+        if continuation_latent_to_insert is None:
+            raise RuntimeError("LTX-2 continuation latent conditioning state is invalid.")
+        # NOTE: frame index and strength are intentionally hard-coded.
+        # We always anchor the first frame of the next clip at full
+        # strength to the previous clip's last latent.
+        _insert_conditioning_latent(
+            conditioning_latent=continuation_latent_to_insert,
+            clean_latent=clean_latent,
+            denoise_mask=denoise_mask,
+            frame_idx=LTX2_CONTINUATION_TARGET_FRAME_IDX,
+            strength=LTX2_CONTINUATION_STRENGTH,
+            source_name="continuation",
+        )
+        latent_conditioned = True
+
+    for image_path, frame_idx, strength in images:
+        cache_key = (image_path, height, width, float(image_crf))
+        image_latent = cache.get(cache_key)
+        if image_latent is None:
+            image_tensor = load_ltx2_conditioning_image(
+                image_path=image_path,
+                height=height,
+                width=width,
+                dtype=encoder_dtype,
+                device=encoder_device,
+                image_crf=float(image_crf),
+            )
+            image_latent = _extract_video_latent(vae, image_tensor).to(
+                device=latents.device,
+                dtype=latents.dtype,
+            )
+            cache[cache_key] = image_latent
+
+        _insert_conditioning_latent(
+            conditioning_latent=image_latent,
+            clean_latent=clean_latent,
+            denoise_mask=denoise_mask,
+            frame_idx=frame_idx,
+            strength=strength,
+            source_name="image",
+        )
+
+    for frame_paths, frame_idx, strength in video_conditions:
+        video_tensor = load_ltx2_conditioning_video_clip(
+            frame_paths,
+            height=height,
+            width=width,
+            dtype=encoder_dtype,
+            device=encoder_device,
+            image_crf=float(image_crf),
+        )
+        video_latent = _extract_video_latent(vae, video_tensor).to(
+            device=latents.device,
+            dtype=latents.dtype,
+        )
+        logger.info(
+            "[LTX2] Video-clip condition: %d frames -> "
+            "latent T=%d at frame_idx=%d strength=%.2f",
+            len(frame_paths),
+            video_latent.shape[2],
+            frame_idx,
+            strength,
+        )
+        _insert_conditioning_latent(
+            conditioning_latent=video_latent,
+            clean_latent=clean_latent,
+            denoise_mask=denoise_mask,
+            frame_idx=frame_idx,
+            strength=strength,
+            source_name="video_clip",
+        )
+
+    return LTX2ImageConditioningState(
+        clean_latent=clean_latent,
+        denoise_mask=denoise_mask,
+        images=images,
+        latent_conditioned=latent_conditioned,
+    )
+
+
+def apply_ltx2_gaussian_noiser(
+    *,
+    noise: torch.Tensor,
+    clean_latent: torch.Tensor,
+    denoise_mask: torch.Tensor,
+    noise_scale: float = 1.0,
+) -> torch.Tensor:
+    """Mix ``noise`` into ``clean_latent`` along ``denoise_mask`` * scale.
+
+    Values close to 1 in the mask produce near-pure noise (used in a
+    fresh stage-2 latent), values near 0 leave the clean latent
+    untouched (used in conditioning regions).
+    """
+    scaled_mask = denoise_mask * float(noise_scale)
+    return (noise * scaled_mask + clean_latent * (1.0 - scaled_mask)).to(noise.dtype)
+
+
+def post_process_ltx2_denoised(
+    *,
+    denoised: torch.Tensor,
+    denoise_mask: torch.Tensor,
+    clean_latent: torch.Tensor,
+) -> torch.Tensor:
+    """Restore the conditioning regions of ``clean_latent`` outside the
+    denoise mask after the model has filled in the masked area."""
+    return (denoised * denoise_mask + clean_latent.float() * (1.0 - denoise_mask)).to(denoised.dtype)
+
+
+__all__ = [
+    "DEFAULT_LTX2_IMAGE_CRF",
+    "LTX2_CONTINUATION_STAGE1_LAST_LATENT_KEY",
+    "LTX2_CONTINUATION_STAGE2_LAST_LATENT_KEY",
+    "LTX2_CONTINUATION_STRENGTH",
+    "LTX2_CONTINUATION_TARGET_FRAME_IDX",
+    "LTX2_VIDEO_CLEAN_LATENT_KEY",
+    "LTX2_VIDEO_DENOISE_MASK_KEY",
+    "LTX2ImageConditioningState",
+    "apply_ltx2_gaussian_noiser",
+    "build_ltx2_image_conditioning",
+    "load_ltx2_conditioning_image",
+    "load_ltx2_conditioning_video_clip",
+    "post_process_ltx2_denoised",
+    "resolve_ltx2_images",
+]

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_latent_preparation.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_latent_preparation.py
@@ -3,6 +3,7 @@
 Latent preparation stage for LTX-2 pipelines.
 """
 
+import math
 from pathlib import Path
 
 import torch
@@ -11,28 +12,80 @@ from diffusers.utils.torch_utils import randn_tensor
 from fastvideo.distributed import get_local_torch_device
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
+from fastvideo.models.dits.ltx2 import VideoLatentShape
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.basic.ltx2.stages.ltx2_image_conditioning import (LTX2_VIDEO_CLEAN_LATENT_KEY,
+                                                                           LTX2_VIDEO_DENOISE_MASK_KEY,
+                                                                           apply_ltx2_gaussian_noiser,
+                                                                           build_ltx2_image_conditioning)
 from fastvideo.pipelines.stages.validators import StageValidators as V
 from fastvideo.pipelines.stages.validators import VerificationResult
 
 logger = init_logger(__name__)
 
 
+def _randn_ltx2_video_latents(
+    *,
+    shape: tuple[int, int, int, int, int],
+    transformer,
+    generator,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Match official LTX-2 video noise sampling order.
+
+    Official code builds a patchified latent state first, then samples noise in
+    token order. FastVideo stores latents in [B, C, T, H, W], so we sample in
+    token order here and unpatchify back to native layout.
+    """
+    patchifier = getattr(transformer, "patchifier", None)
+    if patchifier is None or not callable(getattr(patchifier, "unpatchify", None)):
+        return randn_tensor(
+            shape,
+            generator=generator,
+            device=device,
+            dtype=dtype,
+        )
+
+    video_shape = VideoLatentShape.from_torch_shape(torch.Size(shape))
+
+    patch_volume = math.prod(getattr(patchifier, "patch_size", (1, 1, 1)))
+    patch_shape = (
+        shape[0],
+        patchifier.get_token_count(video_shape),
+        shape[1] * patch_volume,
+    )
+    # `torch.randn` accepts only a single torch.Generator. Some callers
+    # (e.g. InputValidationStage) hand us a one-element list when
+    # num_videos_per_prompt == 1; unwrap it here. For batched sampling
+    # (>1 sample) this collapses to the first generator — match this
+    # against expected reproducibility semantics if that path is ever used.
+    if isinstance(generator, list):
+        generator = generator[0] if generator else None
+    patch_noise = torch.randn(
+        patch_shape,
+        generator=generator,
+        device=device,
+        dtype=dtype,
+    )
+    return patchifier.unpatchify(patch_noise, video_shape)
+
+
 class LTX2LatentPreparationStage(PipelineStage):
     """Prepare initial LTX-2 latents without relying on a diffusers scheduler."""
 
-    def __init__(self, transformer) -> None:
+    def __init__(self, transformer, vae) -> None:
         super().__init__()
         self.transformer = transformer
+        self.vae = vae
 
     def forward(
         self,
         batch: ForwardBatch,
         fastvideo_args: FastVideoArgs,
     ) -> ForwardBatch:
-        latent_num_frames = (batch.num_frames -
-                             1) // fastvideo_args.pipeline_config.vae_config.arch_config.temporal_compression_ratio + 1
+        latent_num_frames = self._adjust_video_length(batch, fastvideo_args)
         if not batch.prompt_embeds:
             batch_size = 1
         elif isinstance(batch.prompt, list):
@@ -61,6 +114,22 @@ class LTX2LatentPreparationStage(PipelineStage):
         dtype = batch.prompt_embeds[0].dtype
         device = get_local_torch_device()
         generator = batch.generator
+        if generator is not None:
+            if isinstance(generator, list):
+                if generator and generator[0].device.type != device.type:
+                    seeds = batch.seeds
+                    if seeds is None and batch.seed is not None:
+                        seeds = [batch.seed + i for i in range(len(generator))]
+                    if seeds is not None:
+                        generator = [torch.Generator(device=device).manual_seed(seed) for seed in seeds]
+                        batch.generator = generator
+            else:
+                if generator.device.type != device.type:
+                    if batch.seed is not None:
+                        generator = torch.Generator(device=device).manual_seed(batch.seed)
+                    else:
+                        generator = torch.Generator(device=device)
+                    batch.generator = generator
         latents = batch.latents
         num_frames = latent_num_frames if latent_num_frames is not None else batch.num_frames
         height = batch.height
@@ -92,16 +161,18 @@ class LTX2LatentPreparationStage(PipelineStage):
                 if loaded_latents is not None:
                     latents = loaded_latents
                 else:
-                    latents = randn_tensor(
-                        shape,
+                    latents = _randn_ltx2_video_latents(
+                        shape=shape,
+                        transformer=self.transformer,
                         generator=generator,
                         device=device,
                         dtype=dtype,
                     )
                     self._save_initial_latent(latent_path, latents)
             else:
-                latents = randn_tensor(
-                    shape,
+                latents = _randn_ltx2_video_latents(
+                    shape=shape,
+                    transformer=self.transformer,
                     generator=generator,
                     device=device,
                     dtype=dtype,
@@ -109,9 +180,41 @@ class LTX2LatentPreparationStage(PipelineStage):
         else:
             latents = latents.to(device)
 
+        image_conditioning = build_ltx2_image_conditioning(
+            batch=batch,
+            latents=latents,
+            vae=self.vae,
+            height=height,
+            width=width,
+        )
+        if image_conditioning is None:
+            batch.extra.pop(LTX2_VIDEO_CLEAN_LATENT_KEY, None)
+            batch.extra.pop(LTX2_VIDEO_DENOISE_MASK_KEY, None)
+        else:
+            latents = apply_ltx2_gaussian_noiser(
+                noise=latents,
+                clean_latent=image_conditioning.clean_latent,
+                denoise_mask=image_conditioning.denoise_mask,
+                noise_scale=1.0,
+            )
+            batch.extra[LTX2_VIDEO_CLEAN_LATENT_KEY] = (image_conditioning.clean_latent)
+            batch.extra[LTX2_VIDEO_DENOISE_MASK_KEY] = (image_conditioning.denoise_mask)
+            logger.info(
+                "[LTX2] Applied conditioning for stage-1: images=%d latent=%s.",
+                len(image_conditioning.images),
+                image_conditioning.latent_conditioned,
+            )
+
         batch.latents = latents
         batch.raw_latent_shape = shape
         return batch
+
+    def _adjust_video_length(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> int | None:
+        if not fastvideo_args.pipeline_config.vae_config.use_temporal_scaling_frames:
+            return None
+        temporal_scale_factor = (fastvideo_args.pipeline_config.vae_config.arch_config.temporal_compression_ratio)
+        video_length = batch.num_frames
+        return int((video_length - 1) // temporal_scale_factor + 1)
 
     def _load_initial_latent(
         self,

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_latent_preparation.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_latent_preparation.py
@@ -114,7 +114,7 @@ class LTX2LatentPreparationStage(PipelineStage):
         dtype = batch.prompt_embeds[0].dtype
         device = get_local_torch_device()
         generator = batch.generator
-        if generator is not None:
+        if generator is not None and not fastvideo_args.ltx2_legacy_native_noise_order:
             if isinstance(generator, list):
                 if generator and generator[0].device.type != device.type:
                     seeds = batch.seeds
@@ -160,6 +160,14 @@ class LTX2LatentPreparationStage(PipelineStage):
                 loaded_latents = self._load_initial_latent(latent_path, device, dtype)
                 if loaded_latents is not None:
                     latents = loaded_latents
+                elif fastvideo_args.ltx2_legacy_native_noise_order:
+                    latents = randn_tensor(
+                        shape,
+                        generator=generator,
+                        device=device,
+                        dtype=dtype,
+                    )
+                    self._save_initial_latent(latent_path, latents)
                 else:
                     latents = _randn_ltx2_video_latents(
                         shape=shape,
@@ -170,13 +178,21 @@ class LTX2LatentPreparationStage(PipelineStage):
                     )
                     self._save_initial_latent(latent_path, latents)
             else:
-                latents = _randn_ltx2_video_latents(
-                    shape=shape,
-                    transformer=self.transformer,
-                    generator=generator,
-                    device=device,
-                    dtype=dtype,
-                )
+                if fastvideo_args.ltx2_legacy_native_noise_order:
+                    latents = randn_tensor(
+                        shape,
+                        generator=generator,
+                        device=device,
+                        dtype=dtype,
+                    )
+                else:
+                    latents = _randn_ltx2_video_latents(
+                        shape=shape,
+                        transformer=self.transformer,
+                        generator=generator,
+                        device=device,
+                        dtype=dtype,
+                    )
         else:
             latents = latents.to(device)
 

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_refine.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_refine.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LTX-2 refinement stages for 2x spatial upscaling + distilled denoising.
+
+Public-side port of ``FastVideo-internal/.../stages/ltx2_refine.py``.
+The three stages run between the stage-1 denoising pass and the stage-2
+denoising pass:
+
+* :class:`LTX2RefineInitStage` — halves the requested resolution so the
+  first denoise runs at ½× and stashes the original target resolution
+  on ``batch.extra`` so the upsample stage can recover it.
+* :class:`LTX2UpsampleStage` — upsamples the stage-1 latents through
+  the LTX-2 latent upsampler, optionally re-applies image conditioning,
+  and mixes in fresh noise scaled by the stage-2 sigma so the next
+  denoise has something to refine.
+* :class:`LTX2RefineLoRAStage` — swaps in a refinement LoRA before the
+  stage-2 denoise (no-op when the path is unset).
+
+Behaviour matches the internal version 1:1 for the text-to-video path;
+the i2v / continuation branches inside ``build_ltx2_image_conditioning``
+defer to a NotImplementedError until the rest of the i2v conditioning
+module is ported.
+"""
+
+from __future__ import annotations
+
+import weakref
+from pathlib import Path
+from typing import Any
+
+import torch
+from diffusers.utils.torch_utils import randn_tensor
+
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.logger import init_logger
+from fastvideo.models.dits.ltx2 import AudioLatentShape, VideoLatentShape
+from fastvideo.models.upsamplers import upsample_video
+from fastvideo.pipelines.basic.ltx2.stages.ltx2_image_conditioning import (
+    LTX2_CONTINUATION_STAGE1_LAST_LATENT_KEY,
+    LTX2_VIDEO_CLEAN_LATENT_KEY,
+    LTX2_VIDEO_DENOISE_MASK_KEY,
+    apply_ltx2_gaussian_noiser,
+    build_ltx2_image_conditioning,
+)
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.base import PipelineStage
+from fastvideo.pipelines.stages.validators import StageValidators as V
+from fastvideo.pipelines.stages.validators import VerificationResult
+
+logger = init_logger(__name__)
+
+# Reduced schedule for super-resolution stage 2 (subset of distilled values).
+# Lifted verbatim from LTX-2 upstream
+# (packages/ltx-pipelines/src/ltx_pipelines/utils/constants.py).
+STAGE_2_DISTILLED_SIGMA_VALUES = [0.909375, 0.725, 0.421875, 0.0]
+
+
+class LTX2RefineInitStage(PipelineStage):
+    """Switch the request to half resolution before the stage-1 denoise.
+
+    Stashes the original target resolution on ``batch.extra`` so
+    :class:`LTX2UpsampleStage` can recover it after stage 1 runs. When
+    the refine path is disabled the stage is a no-op.
+    """
+
+    def forward(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> ForwardBatch:
+        if not fastvideo_args.ltx2_refine_enabled:
+            return batch
+
+        height = batch.height
+        width = batch.width
+        if height is None or width is None:
+            raise ValueError("Height and width must be provided for LTX-2 refinement.")
+        if isinstance(height, list) or isinstance(width, list):
+            raise ValueError("LTX-2 refinement expects scalar height/width.")
+
+        if height % 2 != 0 or width % 2 != 0:
+            raise ValueError("LTX-2 refinement requires even height/width so stage1 can be "
+                             "half resolution.")
+
+        spatial_ratio = (fastvideo_args.pipeline_config.vae_config.arch_config.spatial_compression_ratio)
+        stage1_height = height // 2
+        stage1_width = width // 2
+        if stage1_height % spatial_ratio != 0 or stage1_width % spatial_ratio != 0:
+            raise ValueError(f"LTX-2 refinement requires height/width divisible by "
+                             f"{2 * spatial_ratio} (got {height}x{width}).")
+
+        batch.extra["ltx2_refine_target_height"] = height
+        batch.extra["ltx2_refine_target_width"] = width
+        batch.height = stage1_height
+        batch.width = stage1_width
+
+        logger.info(
+            "[LTX2] Refinement enabled: stage1=%dx%d stage2=%dx%d",
+            stage1_width,
+            stage1_height,
+            width,
+            height,
+        )
+        return batch
+
+    def verify_output(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> VerificationResult:
+        # Only meaningful checks live downstream of the upsample stage;
+        # the init stage just rewrites height/width which the existing
+        # latent-prep stage already validates.
+        return VerificationResult()
+
+
+class LTX2UpsampleStage(PipelineStage):
+    """Upsample stage-1 latents to stage-2 resolution and add refine noise."""
+
+    def __init__(
+        self,
+        *,
+        upsampler: Any,
+        vae: Any,
+        transformer: Any | None = None,
+        sigmas: list[float] | None = None,
+        add_noise: bool = True,
+    ) -> None:
+        super().__init__()
+        self.upsampler = upsampler
+        self.vae = vae
+        self.transformer = transformer
+        self.sigmas = sigmas or STAGE_2_DISTILLED_SIGMA_VALUES
+        self.add_noise = add_noise
+
+    def forward(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> ForwardBatch:
+        if not fastvideo_args.ltx2_refine_enabled:
+            return batch
+
+        if batch.latents is None:
+            raise ValueError("Latents must be available before LTX-2 upsample stage.")
+
+        latents = batch.latents
+        if batch.return_continuation_state:
+            batch.extra[LTX2_CONTINUATION_STAGE1_LAST_LATENT_KEY] = (latents[:, :, -1:, :, :].detach().clone())
+
+        orig_dtype = latents.dtype
+        orig_device = latents.device
+        if isinstance(self.upsampler, torch.nn.Module):
+            first_param = next(self.upsampler.parameters(), None)
+            if first_param is not None:
+                if first_param.device != orig_device:
+                    latents = latents.to(device=first_param.device)
+                if first_param.dtype != latents.dtype:
+                    latents = latents.to(dtype=first_param.dtype)
+                if (latents.dtype != orig_dtype or latents.device != orig_device):
+                    logger.info(
+                        "[LTX2] Cast latents to %s on %s for upsampler.",
+                        latents.dtype,
+                        latents.device,
+                    )
+        target_height = batch.extra.get("ltx2_refine_target_height")
+        target_width = batch.extra.get("ltx2_refine_target_width")
+        if target_height is None or target_width is None:
+            raise ValueError("Missing target resolution for LTX-2 refinement.")
+
+        video_encoder = getattr(self.vae, "encoder", None)
+        if video_encoder is None:
+            raise ValueError("LTX-2 VAE encoder is required for latent upsampling.")
+
+        upsampler_module = getattr(self.upsampler, "model", self.upsampler)
+        latents = upsample_video(latents, video_encoder, upsampler_module)
+        if latents.dtype != orig_dtype or latents.device != orig_device:
+            latents = latents.to(device=orig_device, dtype=orig_dtype)
+
+        image_conditioning = build_ltx2_image_conditioning(
+            batch=batch,
+            latents=latents,
+            vae=self.vae,
+            height=target_height,
+            width=target_width,
+            base_clean_latent=latents,
+        )
+        if image_conditioning is None:
+            batch.extra.pop(LTX2_VIDEO_CLEAN_LATENT_KEY, None)
+            batch.extra.pop(LTX2_VIDEO_DENOISE_MASK_KEY, None)
+            clean_latents = latents
+            denoise_mask = torch.ones(
+                (latents.shape[0], 1, latents.shape[2], latents.shape[3], latents.shape[4]),
+                dtype=torch.float32,
+                device=latents.device,
+            )
+        else:
+            clean_latents = image_conditioning.clean_latent
+            denoise_mask = image_conditioning.denoise_mask
+            batch.extra[LTX2_VIDEO_CLEAN_LATENT_KEY] = clean_latents
+            batch.extra[LTX2_VIDEO_DENOISE_MASK_KEY] = denoise_mask
+            logger.info(
+                "[LTX2] Applied conditioning for stage-2: images=%d latent=%s.",
+                len(image_conditioning.images),
+                image_conditioning.latent_conditioned,
+            )
+
+        sigma0 = float(self.sigmas[0]) if self.sigmas else 1.0
+        if self.add_noise:
+            patchifier = getattr(self.transformer, "patchifier", None)
+            patch_noise_shape: torch.Size | None = None
+            video_shape: VideoLatentShape | None = None
+            if patchifier is not None:
+                video_shape = VideoLatentShape.from_torch_shape(latents.shape)
+                patch_noise_shape = patchifier.patchify(latents).shape
+            noise_path = fastvideo_args.ltx2_refine_noise_path
+            noise = self._load_noise(
+                noise_path,
+                device=latents.device,
+                dtype=latents.dtype,
+                expected_shape=latents.shape,
+                alternate_shape=patch_noise_shape,
+            ) if noise_path else None
+            if noise is None:
+                noise = randn_tensor(
+                    latents.shape,
+                    generator=batch.generator,
+                    device=latents.device,
+                    dtype=latents.dtype,
+                )
+                if noise_path:
+                    self._save_noise(noise_path, noise)
+            elif (patchifier is not None and patch_noise_shape is not None and video_shape is not None
+                  and noise.shape == patch_noise_shape):
+                noise = patchifier.unpatchify(noise, video_shape)
+
+            latents = apply_ltx2_gaussian_noiser(
+                noise=noise,
+                clean_latent=clean_latents,
+                denoise_mask=denoise_mask,
+                noise_scale=sigma0,
+            )
+        else:
+            latents = clean_latents
+
+        audio_latents = batch.extra.get("ltx2_audio_latents")
+        if audio_latents is not None:
+            audio_latents = audio_latents.to(device=latents.device)
+            if self.add_noise:
+                audio_patchifier = getattr(self.transformer, "audio_patchifier", None)
+                if audio_patchifier is not None:
+                    audio_shape = AudioLatentShape.from_torch_shape(audio_latents.shape)
+                    audio_patch = audio_patchifier.patchify(audio_latents)
+                    audio_noise_shape = audio_patch.shape
+                    audio_noise_path = (fastvideo_args.ltx2_refine_audio_noise_path)
+                    audio_noise = self._load_noise(
+                        audio_noise_path,
+                        device=audio_latents.device,
+                        dtype=audio_latents.dtype,
+                        expected_shape=audio_noise_shape,
+                        alternate_shape=audio_latents.shape,
+                    ) if audio_noise_path else None
+                    if audio_noise is None:
+                        audio_noise = randn_tensor(
+                            audio_noise_shape,
+                            generator=batch.generator,
+                            device=audio_latents.device,
+                            dtype=audio_latents.dtype,
+                        )
+                        if audio_noise_path:
+                            self._save_noise(audio_noise_path, audio_noise)
+                    elif audio_noise.shape == audio_latents.shape:
+                        audio_noise = audio_patchifier.patchify(audio_noise)
+                    audio_noised_patch = audio_noise * sigma0 + audio_patch * (1.0 - sigma0)
+                    audio_latents = audio_patchifier.unpatchify(audio_noised_patch, audio_shape)
+                else:
+                    audio_noise_path = (fastvideo_args.ltx2_refine_audio_noise_path)
+                    audio_noise = self._load_noise(
+                        audio_noise_path,
+                        device=audio_latents.device,
+                        dtype=audio_latents.dtype,
+                        expected_shape=audio_latents.shape,
+                    ) if audio_noise_path else None
+                    if audio_noise is None:
+                        audio_noise = randn_tensor(
+                            audio_latents.shape,
+                            generator=batch.generator,
+                            device=audio_latents.device,
+                            dtype=audio_latents.dtype,
+                        )
+                        if audio_noise_path:
+                            self._save_noise(audio_noise_path, audio_noise)
+                    # Same noise mixing as video latents for the
+                    # distilled refinement schedule.
+                    audio_latents = audio_noise * sigma0 + audio_latents * (1.0 - sigma0)
+            batch.extra["ltx2_audio_latents"] = audio_latents
+
+        batch.latents = latents
+        batch.raw_latent_shape = latents.shape
+        batch.height = target_height
+        batch.width = target_width
+        return batch
+
+    def verify_input(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> VerificationResult:
+        result = VerificationResult()
+        if fastvideo_args.ltx2_refine_enabled:
+            result.add_check("latents", batch.latents, [V.is_tensor, V.with_dims(5)])
+        return result
+
+    def _load_noise(
+        self,
+        noise_path: str | None,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+        expected_shape: torch.Size | tuple[int, ...],
+        alternate_shape: torch.Size | tuple[int, ...] | None = None,
+    ) -> torch.Tensor | None:
+        if not noise_path:
+            return None
+        path = Path(noise_path)
+        if not path.exists():
+            return None
+        payload = torch.load(path, map_location=device)
+        if isinstance(payload, dict):
+            noise = (payload.get("noise") or payload.get("latent_noise") or payload.get("latent")
+                     or payload.get("video_noise"))
+        else:
+            noise = payload
+        if not torch.is_tensor(noise):
+            raise TypeError(f"Expected tensor noise in {path}")
+        noise_shape = tuple(noise.shape)
+        if (noise_shape != tuple(expected_shape)
+                and (alternate_shape is None or noise_shape != tuple(alternate_shape))):
+            raise ValueError(f"Noise shape mismatch for {path}: expected "
+                             f"{tuple(expected_shape)}, got {noise_shape}")
+        logger.info("[LTX2] Loaded refine noise from %s", path)
+        return noise.to(device=device, dtype=dtype)
+
+    def _save_noise(self, noise_path: str, noise: torch.Tensor) -> None:
+        path = Path(noise_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            return
+        torch.save({"noise": noise.detach().cpu()}, path)
+        logger.info("[LTX2] Saved refine noise to %s", path)
+
+
+class LTX2RefineLoRAStage(PipelineStage):
+    """Apply a refinement-specific LoRA before stage-2 denoising."""
+
+    def __init__(
+        self,
+        *,
+        pipeline: Any,
+        lora_path: str | None,
+        lora_nickname: str = "ltx2_refine",
+    ) -> None:
+        super().__init__()
+        self._pipeline_ref = (weakref.ref(pipeline) if pipeline is not None else None)
+        self._lora_path = lora_path
+        self._lora_nickname = lora_nickname
+        self._applied = False
+
+    def forward(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+    ) -> ForwardBatch:
+        if not fastvideo_args.ltx2_refine_enabled:
+            return batch
+        lora_path = fastvideo_args.ltx2_refine_lora_path or self._lora_path
+        if not lora_path or self._applied:
+            return batch
+
+        pipeline = (self._pipeline_ref() if self._pipeline_ref is not None else None)
+        if pipeline is None or not hasattr(pipeline, "set_lora_adapter"):
+            raise ValueError("LTX2 refinement LoRA requested but pipeline does not "
+                             "support LoRA adapters.")
+
+        pipeline.set_lora_adapter(self._lora_nickname, lora_path)
+        self._applied = True
+        logger.info("[LTX2] Applied refinement LoRA from %s", lora_path)
+        return batch
+
+
+__all__ = [
+    "LTX2RefineInitStage",
+    "LTX2RefineLoRAStage",
+    "LTX2UpsampleStage",
+    "STAGE_2_DISTILLED_SIGMA_VALUES",
+]

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -133,6 +133,11 @@ class ComposedPipelineBase(ABC):
             )
             return
 
+        prepare_for_compile = getattr(module, "prepare_for_compile", None)
+        if callable(prepare_for_compile):
+            logger.info("Running prepare_for_compile for %s", module_name)
+            prepare_for_compile()
+
         compiled_count = self._compile_with_conditions(module, compile_kwargs)
         if compiled_count > 0:
             logger.info(
@@ -161,7 +166,11 @@ class ComposedPipelineBase(ABC):
                 self.initialize_validation_pipeline(self.training_args)
 
         self.initialize_pipeline(self.fastvideo_args)
-        if self.fastvideo_args.enable_torch_compile:
+        compile_transformer = self.fastvideo_args.enable_torch_compile
+        compile_text_encoder = (self.fastvideo_args.enable_torch_compile_text_encoder)
+        compile_vae = self.fastvideo_args.enable_torch_compile_vae
+        compile_audio_vae = self.fastvideo_args.enable_torch_compile_audio_vae
+        if (compile_transformer or compile_text_encoder or compile_vae or compile_audio_vae):
             if self.fastvideo_args.training_mode:
                 logger.info("Torch Compile enabled via FSDP loader for training; skipping additional pipeline compile")
             else:
@@ -172,18 +181,58 @@ class ComposedPipelineBase(ABC):
                 except Exception:  # pragma: no cover - FSDP not always available
                     fsdp_module_cls = None
 
-                compile_kwargs = self.fastvideo_args.torch_compile_kwargs or {}
-                self._maybe_compile_pipeline_module(
-                    module_name="transformer",
-                    fsdp_module_cls=fsdp_module_cls,
-                    compile_kwargs=compile_kwargs,
-                )
-                self._maybe_compile_pipeline_module(
-                    module_name="transformer_2",
-                    fsdp_module_cls=fsdp_module_cls,
-                    compile_kwargs=compile_kwargs,
-                )
-                logger.info("Torch Compile enabled for DiT")
+                global_compile_kwargs = (self.fastvideo_args.torch_compile_kwargs or {})
+                dit_compile_kwargs = (self.fastvideo_args.torch_compile_kwargs_dit or global_compile_kwargs)
+                text_compile_kwargs = (self.fastvideo_args.torch_compile_kwargs_text_encoder or global_compile_kwargs)
+                vae_compile_kwargs = (self.fastvideo_args.torch_compile_kwargs_vae or global_compile_kwargs)
+                audio_vae_compile_kwargs = (self.fastvideo_args.torch_compile_kwargs_audio_vae or global_compile_kwargs)
+
+                if compile_transformer:
+                    self._maybe_compile_pipeline_module(
+                        module_name="transformer",
+                        fsdp_module_cls=fsdp_module_cls,
+                        compile_kwargs=dit_compile_kwargs,
+                    )
+                    self._maybe_compile_pipeline_module(
+                        module_name="transformer_refine",
+                        fsdp_module_cls=fsdp_module_cls,
+                        compile_kwargs=dit_compile_kwargs,
+                    )
+                    self._maybe_compile_pipeline_module(
+                        module_name="transformer_2",
+                        fsdp_module_cls=fsdp_module_cls,
+                        compile_kwargs=dit_compile_kwargs,
+                    )
+                    logger.info("Torch Compile enabled for DiT")
+
+                if compile_text_encoder:
+                    self._maybe_compile_pipeline_module(
+                        module_name="text_encoder",
+                        fsdp_module_cls=fsdp_module_cls,
+                        compile_kwargs=text_compile_kwargs,
+                    )
+                    self._maybe_compile_pipeline_module(
+                        module_name="text_encoder_2",
+                        fsdp_module_cls=fsdp_module_cls,
+                        compile_kwargs=text_compile_kwargs,
+                    )
+                    logger.info("Torch Compile enabled for text encoder")
+
+                if compile_vae:
+                    self._maybe_compile_pipeline_module(
+                        module_name="vae",
+                        fsdp_module_cls=fsdp_module_cls,
+                        compile_kwargs=vae_compile_kwargs,
+                    )
+                    logger.info("Torch Compile enabled for VAE")
+
+                if compile_audio_vae:
+                    self._maybe_compile_pipeline_module(
+                        module_name="audio_vae",
+                        fsdp_module_cls=fsdp_module_cls,
+                        compile_kwargs=audio_vae_compile_kwargs,
+                    )
+                    logger.info("Torch Compile enabled for audio VAE")
 
         self._trace_mgr = attach_activation_trace(self.modules.get("transformer"))
 

--- a/fastvideo/pipelines/pipeline_batch_info.py
+++ b/fastvideo/pipelines/pipeline_batch_info.py
@@ -79,6 +79,27 @@ class ForwardBatch:
     image_embeds: list[torch.Tensor] = field(default_factory=list)
     pil_image: torch.Tensor | PIL.Image.Image | None = None
     preprocessed_image: torch.Tensor | None = None
+    # LTX-2 image conditioning. Each entry is (path, frame_idx, strength)
+    # — strength 1.0 anchors the latent at frame_idx exactly to the
+    # encoded image; <1.0 mixes denoised content with the conditioning
+    # image. ``ltx2_image_crf`` controls the H.264 CRF re-encode applied
+    # to the image before VAE encoding (matches official LTX-2 quality
+    # adaptation; 0.0 disables the re-encode).
+    ltx2_images: list[tuple[str, int, float]] | None = None
+    ltx2_image_crf: float = 33.0
+    # Stage-specific continuation latents — populated by the streaming
+    # session controller between segments. ``stage1`` is the last latent
+    # from the previous segment's stage-1 denoise (half-res); ``stage2``
+    # is the last latent from the previous segment's stage-2 refine
+    # (full-res). The image-conditioning builder reads whichever the
+    # current pass needs (``base_clean_latent is None`` -> stage1).
+    ltx2_conditioning_latent_stage1: torch.Tensor | None = None
+    ltx2_conditioning_latent_stage2: torch.Tensor | None = None
+    # Video-clip conditioning: list of (frame_paths, frame_idx, strength)
+    # — multi-frame VAE-encoded conditioning so the resulting latent
+    # captures temporal/motion info (used by the streaming server's
+    # mid-roll continuation flow).
+    ltx2_video_conditions: list[tuple[list[str], int, float]] | None = None
 
     # Text inputs
     prompt: str | list[str] | None = None

--- a/fastvideo/pipelines/pipeline_batch_info.py
+++ b/fastvideo/pipelines/pipeline_batch_info.py
@@ -79,28 +79,6 @@ class ForwardBatch:
     image_embeds: list[torch.Tensor] = field(default_factory=list)
     pil_image: torch.Tensor | PIL.Image.Image | None = None
     preprocessed_image: torch.Tensor | None = None
-    # LTX-2 image conditioning. Each entry is (path, frame_idx, strength)
-    # — strength 1.0 anchors the latent at frame_idx exactly to the
-    # encoded image; <1.0 mixes denoised content with the conditioning
-    # image. ``ltx2_image_crf`` controls the H.264 CRF re-encode applied
-    # to the image before VAE encoding (matches official LTX-2 quality
-    # adaptation; 0.0 disables the re-encode).
-    ltx2_images: list[tuple[str, int, float]] | None = None
-    ltx2_image_crf: float = 33.0
-    # Stage-specific continuation latents — populated by the streaming
-    # session controller between segments. ``stage1`` is the last latent
-    # from the previous segment's stage-1 denoise (half-res); ``stage2``
-    # is the last latent from the previous segment's stage-2 refine
-    # (full-res). The image-conditioning builder reads whichever the
-    # current pass needs (``base_clean_latent is None`` -> stage1).
-    ltx2_conditioning_latent_stage1: torch.Tensor | None = None
-    ltx2_conditioning_latent_stage2: torch.Tensor | None = None
-    # Video-clip conditioning: list of (frame_paths, frame_idx, strength)
-    # — multi-frame VAE-encoded conditioning so the resulting latent
-    # captures temporal/motion info (used by the streaming server's
-    # mid-roll continuation flow).
-    ltx2_video_conditions: list[tuple[list[str], int, float]] | None = None
-
     # Text inputs
     prompt: str | list[str] | None = None
     negative_prompt: str | list[str] | None = None

--- a/fastvideo/pipelines/stages/__init__.py
+++ b/fastvideo/pipelines/stages/__init__.py
@@ -25,11 +25,9 @@ from fastvideo.pipelines.stages.latent_preparation import (Cosmos25LatentPrepara
                                                            Cosmos25AutoLatentPreparationStage,
                                                            Cosmos25T2WLatentPreparationStage,
                                                            Cosmos25V2WLatentPreparationStage, LatentPreparationStage)
-from fastvideo.pipelines.basic.ltx2.stages import (
-    LTX2AudioDecodingStage,
-    LTX2DenoisingStage,
-    LTX2LatentPreparationStage,
-    LTX2TextEncodingStage,
+from fastvideo.pipelines.basic.ltx2.stages import (  # noqa: F401
+    LTX2AudioDecodingStage, LTX2DenoisingStage, LTX2LatentPreparationStage, LTX2RefineInitStage, LTX2RefineLoRAStage,
+    LTX2TextEncodingStage, LTX2UpsampleStage, STAGE_2_DISTILLED_SIGMA_VALUES,
 )
 from fastvideo.pipelines.stages.matrixgame_denoising import (MatrixGameCausalDenoisingStage)
 from fastvideo.pipelines.stages.hyworld_denoising import HYWorldDenoisingStage

--- a/fastvideo/tests/api/test_ltx2_gpu_pool_translation.py
+++ b/fastvideo/tests/api/test_ltx2_gpu_pool_translation.py
@@ -31,7 +31,7 @@ from fastvideo.api.compat import (
 # One item from gpu_pool.py's load_kwargs is deliberately excluded:
 #   - ``pipeline_config=<PipelineConfig instance>`` — an opaque Python
 #     object; internal mutates it in place (``dit_config.quant_config =
-#     FP4Config()``). The typed path for quantization is tracked in
+#     NVFP4Config()``). The typed path for quantization is tracked in
 #     "Known Technical Debt" in PR plan.md; ``pipeline_config`` as an
 #     instance legitimately belongs in ``pipeline.experimental``.
 #

--- a/fastvideo/tests/ssim/test_ltx2_similarity.py
+++ b/fastvideo/tests/ssim/test_ltx2_similarity.py
@@ -123,5 +123,10 @@ def test_ltx2_distilled_inference_similarity(
         full_quality_params_map=FULL_QUALITY_LTX2_DISTILLED_MODEL_TO_PARAMS,
         slice_cosine_threshold=SLICE_COSINE_DISTANCE_THRESHOLD,
         full_cosine_threshold=FULL_COSINE_DISTANCE_THRESHOLD,
+        init_kwargs_override={
+            "dit_cpu_offload": True,
+            "ltx2_legacy_native_noise_order": True,
+            "ltx2_use_distilled_sigmas": False,
+        },
         generation_kwargs_override=LTX2_DISTILLED_REFERENCE_GUIDANCE_OVERRIDES,
     )

--- a/scripts/ltx2_sr_alignment.py
+++ b/scripts/ltx2_sr_alignment.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LTX-2 SR (refine) numerical alignment harness — public vs internal.
+
+Runs the LTX-2 stage-2 spatial-refine pipeline with a fixed prompt and
+seed and writes the decoded video frames + intermediate latents to a
+torch save file. Intended to be invoked twice with different
+``PYTHONPATH`` prefixes — once against ``FastVideo-internal`` and once
+against the public ``FastVideo`` package — so a third pass can diff the
+two outputs tensor-by-tensor.
+
+Usage::
+
+    # 1) Internal reference run.
+    PYTHONPATH=/home/william5lin/FastVideo-internal \
+        python scripts/ltx2_sr_alignment.py --label internal \
+            --output /tmp/ltx2_sr_internal.pt
+
+    # 2) Public run against the new typed API.
+    PYTHONPATH=/home/william5lin/FastVideo \
+        python scripts/ltx2_sr_alignment.py --label public --use-typed-api \
+            --output /tmp/ltx2_sr_public.pt
+
+    # 3) Diff.
+    python scripts/ltx2_sr_alignment.py --diff \
+        --reference /tmp/ltx2_sr_internal.pt \
+        --candidate /tmp/ltx2_sr_public.pt
+
+The harness deliberately matches `examples/inference/basic/basic_ltx2_upscale.py`
+defaults (LTX2-Distilled, 8 base steps, 3 refine steps, 1088x1920, seed=10)
+but skips FP4 and Dreamverse-specific knobs to keep the bf16 path clean.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+def _bootstrap_fastvideo_source() -> None:
+    """If FASTVIDEO_FROM is set in the environment, prepend that path to
+    sys.path **and** strip any editable-install finders from
+    ``sys.meta_path`` so the named source wins over a .pth-installed
+    sibling. This lets us point the same harness at either
+    ``../FastVideo`` or ``../FastVideo-internal`` without juggling
+    venvs."""
+    src = os.environ.get("FASTVIDEO_FROM")
+    if not src:
+        return
+    src = os.path.abspath(src)
+    if not os.path.isdir(src):
+        raise SystemExit(f"FASTVIDEO_FROM={src!r} is not a directory")
+
+    # Remove editable-install finders that would otherwise win over
+    # PYTHONPATH. uv-installed editables register a custom finder
+    # named like ``__editable___fastvideo_0_1_7_finder``.
+    sys.meta_path = [
+        finder for finder in sys.meta_path
+        if "__editable___fastvideo" not in type(finder).__module__
+    ]
+    # Drop pre-resolved fastvideo modules from any earlier import.
+    for name in [k for k in sys.modules if k == "fastvideo" or k.startswith("fastvideo.")]:
+        sys.modules.pop(name, None)
+    # Drop the corresponding .pth-pointed paths from sys.path so the
+    # editable repo doesn't shadow the explicit source.
+    sys.path = [p for p in sys.path if not p.endswith(".egg-info")]
+    sys.path.insert(0, src)
+
+
+_bootstrap_fastvideo_source()
+
+
+import numpy as np  # noqa: E402  (after bootstrap so torch picks up the right env)
+import torch  # noqa: E402
+
+# Pinned alignment fixture — matches basic_ltx2_upscale.py upstream.
+PROMPT = (
+    "A warm sunny backyard. The camera starts in a tight cinematic close-up "
+    "of a woman and a man in their 30s, facing each other with serious "
+    "expressions. The woman, emotional and dramatic, says softly, \"That's "
+    "it... Dad's lost it. And we've lost Dad.\" The man exhales, slightly "
+    "annoyed: \"Stop being so dramatic, Jess.\" A beat. He glances aside, "
+    "then mutters defensively, \"He's just having fun.\" The camera slowly "
+    "pans right, revealing the grandfather in the garden wearing enormous "
+    "butterfly wings, waving his arms in the air like he's trying to take "
+    "off. He shouts, \"Wheeeew!\" as he flaps his wings with full commitment. "
+    "The woman covers her face, on the verge of tears. The tone is deadpan, "
+    "absurd, and quietly tragic.")
+
+DEFAULT_MODEL = "FastVideo/LTX2-Distilled-Diffusers"
+DEFAULT_SEED = 10
+DEFAULT_HEIGHT = 1088
+DEFAULT_WIDTH = 1920
+DEFAULT_FRAMES = 121
+DEFAULT_FPS = 24
+DEFAULT_BASE_STEPS = 8
+DEFAULT_REFINE_STEPS = 3
+
+
+@dataclass
+class RunResult:
+    label: str
+    fastvideo_repo: str
+    output_frames: torch.Tensor
+    metadata: dict[str, Any]
+
+
+def _detect_fastvideo_repo() -> str:
+    import fastvideo  # noqa: PLC0415
+    return os.path.realpath(os.path.dirname(fastvideo.__file__))
+
+
+def _run_legacy(args: argparse.Namespace) -> RunResult:
+    """Legacy ``VideoGenerator.from_pretrained(**flat_kwargs)`` path —
+    used by the internal reference run because the internal API is
+    still flat-kwarg-shaped."""
+    from fastvideo import VideoGenerator  # noqa: PLC0415
+
+    generator = VideoGenerator.from_pretrained(
+        args.model,
+        num_gpus=1,
+        ltx2_refine_enabled=True,
+        ltx2_refine_lora_path="",  # disable refine LoRA — distilled needs none
+        ltx2_refine_num_inference_steps=args.refine_steps,
+        ltx2_refine_guidance_scale=1.0,
+        ltx2_refine_add_noise=True,
+        dit_cpu_offload=False,
+        vae_cpu_offload=False,
+        text_encoder_cpu_offload=False,
+        pin_cpu_memory=True,
+        dit_layerwise_offload=False,
+        enable_torch_compile=False,
+        ltx2_vae_tiling=False,
+    )
+
+    # Pin the LTX-2-specific sampling knobs explicitly so both
+    # internal and public runs use identical denoising mechanics —
+    # otherwise the public LTX2_BASE preset's modality/rescale/stg
+    # defaults (3.0 / 0.7 / 1.0) would diverge from internal's
+    # ForwardBatch defaults (1.0 / 0.0 / 0.0).
+    result = generator.generate_video(
+        prompt=PROMPT,
+        output_path=str(args.output) + ".legacy.mp4",
+        fps=args.fps,
+        seed=args.seed,
+        num_inference_steps=args.base_steps,
+        guidance_scale=1.0,
+        save_video=False,
+        return_frames=True,
+        height=args.height,
+        width=args.width,
+        num_frames=args.frames,
+        ltx2_cfg_scale_video=1.0,
+        ltx2_cfg_scale_audio=1.0,
+        ltx2_modality_scale_video=1.0,
+        ltx2_modality_scale_audio=1.0,
+        ltx2_rescale_scale=0.0,
+        ltx2_stg_scale_video=0.0,
+        ltx2_stg_scale_audio=0.0,
+    )
+    generator.shutdown()
+    frames = _result_frames(result)
+    return RunResult(
+        label=args.label,
+        fastvideo_repo=_detect_fastvideo_repo(),
+        output_frames=frames,
+        metadata={
+            "api": "legacy_from_pretrained",
+            "prompt": PROMPT,
+            "seed": args.seed,
+            "height": args.height,
+            "width": args.width,
+            "num_frames": args.frames,
+            "fps": args.fps,
+            "base_steps": args.base_steps,
+            "refine_steps": args.refine_steps,
+        },
+    )
+
+
+def _run_typed(args: argparse.Namespace) -> RunResult:
+    """New typed public API: GeneratorConfig + GenerationRequest with
+    pipeline.preset_overrides["refine"] driving the SR path."""
+    from fastvideo import VideoGenerator  # noqa: PLC0415
+    from fastvideo.api import (  # noqa: PLC0415
+        ComponentConfig, EngineConfig, GenerationRequest, GeneratorConfig,
+        InputConfig, OutputConfig, PipelineSelection, SamplingConfig)
+
+    config = GeneratorConfig(
+        model_path=args.model,
+        engine=EngineConfig(num_gpus=1, ),
+        pipeline=PipelineSelection(
+            components=ComponentConfig(),
+            preset_overrides={
+                "refine": {
+                    "enabled": True,
+                    "add_noise": True,
+                    "num_inference_steps": args.refine_steps,
+                    "guidance_scale": 1.0,
+                },
+            },
+        ),
+    )
+
+    generator = VideoGenerator.from_pretrained(config=config)
+
+    # The typed SamplingConfig doesn't expose the LTX-2-specific
+    # modality/rescale/stg knobs, so route them through experimental
+    # so the legacy pipeline batch builder picks them up. This keeps
+    # the typed run's denoising mechanics identical to the legacy
+    # run's (and therefore to the internal reference).
+    request = GenerationRequest(
+        prompt=PROMPT,
+        sampling=SamplingConfig(
+            num_frames=args.frames,
+            height=args.height,
+            width=args.width,
+            fps=args.fps,
+            num_inference_steps=args.base_steps,
+            guidance_scale=1.0,
+            seed=args.seed,
+        ),
+        inputs=InputConfig(),
+        output=OutputConfig(
+            save_video=False,
+            return_frames=True,
+        ),
+    )
+    # Set the LTX-2 sampling overrides on the request via attribute so
+    # the legacy SamplingParam translation picks them up alongside the
+    # typed fields. (Until the typed SamplingConfig grows these
+    # fields, this is the canonical override path on the public side.)
+    for attr, value in {
+            "ltx2_cfg_scale_video": 1.0,
+            "ltx2_cfg_scale_audio": 1.0,
+            "ltx2_modality_scale_video": 1.0,
+            "ltx2_modality_scale_audio": 1.0,
+            "ltx2_rescale_scale": 0.0,
+            "ltx2_stg_scale_video": 0.0,
+            "ltx2_stg_scale_audio": 0.0,
+    }.items():
+        setattr(request, attr, value)
+
+    result = generator.generate(request)
+    generator.shutdown()
+    frames = _result_frames(result)
+    return RunResult(
+        label=args.label,
+        fastvideo_repo=_detect_fastvideo_repo(),
+        output_frames=frames,
+        metadata={
+            "api": "typed",
+            "prompt": PROMPT,
+            "seed": args.seed,
+            "height": args.height,
+            "width": args.width,
+            "num_frames": args.frames,
+            "fps": args.fps,
+            "base_steps": args.base_steps,
+            "refine_steps": args.refine_steps,
+        },
+    )
+
+
+def _result_frames(result: Any) -> torch.Tensor:
+    """Coerce whatever generate() returned into ``[F, H, W, C]`` uint8."""
+    frames = getattr(result, "frames", None)
+    if frames is None and isinstance(result, dict):
+        frames = result.get("frames")
+    if frames is None:
+        raise RuntimeError(
+            "Generation returned no frames; ensure return_frames=True.")
+    if isinstance(frames, list):
+        frames = np.stack(frames, axis=0)
+    if isinstance(frames, np.ndarray):
+        return torch.from_numpy(frames)
+    if torch.is_tensor(frames):
+        return frames.detach().cpu()
+    raise TypeError(f"Unsupported frames container: {type(frames)!r}")
+
+
+def _run(args: argparse.Namespace) -> None:
+    if args.use_typed_api:
+        result = _run_typed(args)
+    else:
+        result = _run_legacy(args)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(
+        {
+            "frames": result.output_frames,
+            "metadata": result.metadata,
+            "label": result.label,
+            "fastvideo_repo": result.fastvideo_repo,
+        },
+        output_path,
+    )
+    print(
+        f"[align] saved {result.output_frames.shape} frames "
+        f"({result.fastvideo_repo}) -> {output_path}",
+        flush=True,
+    )
+
+
+def _diff(args: argparse.Namespace) -> None:
+    ref_path = Path(args.reference)
+    cand_path = Path(args.candidate)
+    if not ref_path.is_file() or not cand_path.is_file():
+        raise FileNotFoundError(
+            f"Need both --reference and --candidate to exist: {ref_path}, "
+            f"{cand_path}")
+    ref = torch.load(ref_path, map_location="cpu")
+    cand = torch.load(cand_path, map_location="cpu")
+
+    ref_frames = ref["frames"]
+    cand_frames = cand["frames"]
+    print(f"[align] reference: {ref['label']} {ref_frames.shape} from "
+          f"{ref['fastvideo_repo']}")
+    print(f"[align] candidate: {cand['label']} {cand_frames.shape} from "
+          f"{cand['fastvideo_repo']}")
+
+    if ref_frames.shape != cand_frames.shape:
+        print(f"[align] shape MISMATCH: ref={tuple(ref_frames.shape)} "
+              f"vs cand={tuple(cand_frames.shape)}")
+        return
+
+    diff = (ref_frames.float() - cand_frames.float()).abs()
+    max_abs = float(diff.max().item())
+    mean_abs = float(diff.mean().item())
+    rms = float(torch.sqrt((diff**2).mean()).item())
+
+    # PSNR over uint8 [0,255] data range.
+    if rms == 0.0:
+        psnr = float("inf")
+    else:
+        psnr = 20.0 * float(torch.log10(torch.tensor(255.0 / rms)).item())
+
+    print("[align] frame-level uint8 metrics (per-pixel):")
+    print(f"        max_abs_diff = {max_abs:.4f}")
+    print(f"        mean_abs_diff = {mean_abs:.6f}")
+    print(f"        rms_diff = {rms:.4f}")
+    print(f"        psnr_db = {psnr:.2f}")
+
+    # Bucket pixels by exactness so we have a sense of how close we are.
+    eq = (diff == 0).float().mean().item()
+    within_1 = (diff <= 1).float().mean().item()
+    within_2 = (diff <= 2).float().mean().item()
+    within_4 = (diff <= 4).float().mean().item()
+    print("[align] pixel buckets:")
+    print(f"        exact = {eq * 100:.2f}%")
+    print(f"        within 1 = {within_1 * 100:.2f}%")
+    print(f"        within 2 = {within_2 * 100:.2f}%")
+    print(f"        within 4 = {within_4 * 100:.2f}%")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="mode", required=False)
+
+    run = parser
+    run.add_argument("--label",
+                     default="run",
+                     help="Identifier saved alongside the output (e.g. internal/public).")
+    run.add_argument("--output",
+                     default="/tmp/ltx2_sr_alignment.pt",
+                     help="Destination .pt file.")
+    run.add_argument("--use-typed-api",
+                     action="store_true",
+                     help="Use the new typed GeneratorConfig API "
+                          "(public side); otherwise use legacy from_pretrained.")
+    run.add_argument("--model", default=DEFAULT_MODEL)
+    run.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    run.add_argument("--height", type=int, default=DEFAULT_HEIGHT)
+    run.add_argument("--width", type=int, default=DEFAULT_WIDTH)
+    run.add_argument("--frames", type=int, default=DEFAULT_FRAMES)
+    run.add_argument("--fps", type=int, default=DEFAULT_FPS)
+    run.add_argument("--base-steps", type=int, default=DEFAULT_BASE_STEPS)
+    run.add_argument("--refine-steps", type=int, default=DEFAULT_REFINE_STEPS)
+
+    run.add_argument("--diff",
+                     action="store_true",
+                     help="Diff two .pt outputs instead of running.")
+    run.add_argument("--reference")
+    run.add_argument("--candidate")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.diff:
+        if not (args.reference and args.candidate):
+            parser.error("--diff requires --reference and --candidate")
+        _diff(args)
+        return 0
+    _run(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the LTX2 model/pipeline support needed for Dreamverse continuation and refinement.

This PR introduces the LTX2 latent upsampler, refine/image-conditioning stages, LTX2 pipeline/model updates, loader/FSDP adjustments, pipeline batch metadata, parser tests, GPU-pool translation tests, and an SR alignment script.

## Review focus

Please review this PR as stack slice 12/14. The base branch is the previous stack slice, so the Files Changed view should show only this slice rather than the full Dreamverse integration.

## Stack / merge notes

This is part of the Dreamverse stacked PR series. Review this PR against its current base branch to see only this slice. After the previous stack PR lands into `main`, retarget this PR's base to `main` before merging it.

## Likely LTX2 SSIM/reference-breaking changes

This PR appears to include two intentional LTX2 behavior changes that can break existing latent/SSIM references even when the statistical distributions remain valid:

1. **Initial noise sampling order changed**

   `origin/main` samples initial video noise directly in native latent layout:

   ```py
   randn_tensor([B, C, T, H, W], ...)
   ```

   This PR samples noise in transformer token/patch layout, then unpatchifies it:

   ```py
   torch.randn([B, N_tokens, C * patch_volume], ...)
   patchifier.unpatchify(...)
   ```

   The noise distribution is equivalent, but the deterministic seed-to-coordinate mapping changes. For the same seed, individual latent coordinates receive different random values, so existing SSIM references can fail. This matches the Dreamverse/internal rationale that official LTX2 sampling is `patchify -> noise in token order -> unpatchify`.

2. **Sigma schedule behavior changed for distilled runs under 8 steps**

   On `origin/main`, LTX2 used the official distilled sigma schedule only when:

   ```py
   batch.num_inference_steps == 8
   ```

   Otherwise it used the computed `_ltx2_sigmas(...)` schedule.

   This PR now uses hardcoded distilled sigma subsets whenever:

   ```py
   num_inference_steps <= max_distilled_steps
   ```

   The CI LTX2 SSIM test uses `num_inference_steps=4`, and CI 3013 confirms the new path is active:

   ```text
   [LTX2] Using distilled sigma subset for 4 steps (indices=[0, 5, 6, 7, 8] max_gap=0.421875 tail_gap=0.421875)
   ```

   Therefore, the existing 4-step SSIM reference was likely generated with the old computed sigma schedule, while this PR now runs with the distilled sigma subset. That is a major denoising trajectory change and can independently cause large latent/SSIM mismatches.

### Reviewer expectation / action

If these LTX2 changes are intended, the existing LTX2 latent/SSIM references should likely be regenerated against the new behavior. If compatibility with public `origin/main` reproducibility is required, consider adding explicit compatibility gates/flags for the old noise ordering and/or old computed sigma schedule behavior.

## Verification

- Commit hooks passed when the local stack commits were created.
- Stack equivalence was verified locally:
  - `feat/dreamverse-monorepo-main-sync` equals `feat/dreamverse-stack-13-activation`.
  - `feat/dreamverse-monorepo-main-sync-plus-profile` equals `feat/dreamverse-stack-14-ltx2-profile-speedups`.

## Attribution

This PR is a path-scoped reconstruction from `will/dreamverse-monorepo` at `03d3e61df69fe99a81eb62d86a3926a5f769f857`. The synthetic commit keeps coauthor trailers for the source collaborators, omitting Junda Su because he is already the commit author.

