### PR TITLE
[feat]: Add NVFP4QAT quantization config (Attn-QAT 2/12)

### DIFF
--- a/fastvideo/layers/quantization/__init__.py
+++ b/fastvideo/layers/quantization/__init__.py
@@ -2,7 +2,7 @@ from typing import Literal, get_args
 
 from fastvideo.layers.quantization.base_config import QuantizationConfig
 
-QuantizationMethods = Literal[None, "AbsMaxFP8", "NVFP4"]
+QuantizationMethods = Literal[None, "AbsMaxFP8", "NVFP4", "nvfp4_qat"]
 
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))
 
@@ -52,10 +52,12 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
     # lazy import to avoid triggering `torch.compile` too early
     from .absmax_fp8 import AbsMaxFP8Config
     from .nvfp4_config import NVFP4Config
+    from .nvfp4_qat_config import NVFP4QATConfig
 
     method_to_config: dict[str, type[QuantizationConfig]] = {
         "AbsMaxFP8": AbsMaxFP8Config,
         "NVFP4": NVFP4Config,
+        "nvfp4_qat": NVFP4QATConfig,
     }
     # Update the `method_to_config` with customized quantization methods.
     method_to_config.update(_CUSTOMIZED_METHOD_TO_QUANT_CONFIG)

--- a/fastvideo/layers/quantization/base_config.py
+++ b/fastvideo/layers/quantization/base_config.py
@@ -61,7 +61,7 @@ def method_has_implemented_embedding(method_class: type[QuantizeMethodBase]) -> 
 class QuantizationConfig(ABC):
     """Base class for quantization configs."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # mapping is updated by models as they initialize
         self.packed_modules_mapping: dict[str, list[str]] = dict()

--- a/fastvideo/layers/quantization/nvfp4_qat_config.py
+++ b/fastvideo/layers/quantization/nvfp4_qat_config.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from typing import Any
+
+import torch
+from torch.nn.parameter import Parameter
+
+from fastvideo.layers.quantization.base_config import QuantizationConfig, QuantizeMethodBase
+from fastvideo.models.utils import set_weight_attrs
+
+try:
+    import flashinfer
+except ImportError:
+    flashinfer = None
+
+logger = logging.getLogger(__name__)
+
+
+def _require_flashinfer() -> Any:
+    if flashinfer is None:
+        raise ImportError("flashinfer is required for NVFP4 QAT quantization. "
+                          "Please install flashinfer to use the nvfp4_qat quantization backend.")
+    return flashinfer
+
+
+class NVFP4QATQuantizeMethod(QuantizeMethodBase):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight_fp4 = None
+        self.weight_scale = None
+
+    def create_weights(self, layer: torch.nn.Module, input_size_per_partition: int, output_partition_sizes: list[int],
+                       input_size: int, output_size: int, params_dtype: torch.dtype, **extra_weight_attrs):
+        """Create weights for a linear layer. Note the corrected signature to match LinearMethodBase."""
+        weight = Parameter(torch.empty(
+            sum(output_partition_sizes),
+            input_size_per_partition,
+            dtype=params_dtype,
+        ),
+                           requires_grad=False)
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    @torch.compile
+    def apply(self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
+        """Apply NVFP4 QAT quantized computation."""
+        flashinfer_mod = _require_flashinfer()
+        out_dim = layer.weight.shape[0]
+        original_shape = x.shape
+        assert x.dtype == torch.bfloat16 or x.dtype == torch.float16, f"only allow bf16/fp16 inputs to fp4 linear, got {x.dtype}"
+
+        x = x.view(-1, x.shape[-1])
+
+        x_global_sf = (448 * 6) / x.float().abs().nan_to_num().max()
+        x_fp4, x_scale = flashinfer_mod.nvfp4_quantize(
+            x,
+            x_global_sf,
+            sfLayout=flashinfer_mod.SfLayout.layout_128x4,
+            do_shuffle=False,
+        )
+        weight_fp4 = layer._fp4_weight
+        weight_scale = layer._fp4_weight_scale
+        weight_global_sf = layer._weight_global_sf
+
+        out = flashinfer_mod.mm_fp4(
+            x_fp4,
+            weight_fp4.T,
+            x_scale,
+            weight_scale.T,
+            1.0 / (x_global_sf * weight_global_sf),
+            torch.bfloat16,
+            None,
+            backend="cutlass",
+        )
+
+        if bias is not None:
+            if bias.device != out.device or bias.dtype != out.dtype:
+                bias = bias.to(device=out.device, dtype=out.dtype)
+            out = out + bias
+
+        if len(original_shape) == 3:
+            out = out.view(original_shape[0], original_shape[1], out_dim)
+
+        return out
+
+
+class NVFP4QATConfig(QuantizationConfig):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def get_name(self):
+        return "nvfp4_qat"
+
+    def get_supported_act_dtypes(self):
+        return [torch.bfloat16, torch.float16]
+
+    @classmethod
+    def get_min_capability(cls):
+        return 100
+
+    @staticmethod
+    def get_config_filenames():
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "NVFP4QATConfig":
+        return cls()
+
+    def get_quant_method(self, layer: torch.nn.Module, prefix: str):
+        from fastvideo.layers.linear import LinearBase
+        fp4_layers = ["ffn.fc_in", "ffn.fc_out", "to_q", "to_k", "to_v", "to_out"]
+        if isinstance(layer, LinearBase) and any(layer_name in prefix for layer_name in fp4_layers):
+            return NVFP4QATQuantizeMethod()
+        return None
+
+
+@torch.compile
+def convert_model_to_fp4(model: torch.nn.Module):
+    flashinfer_mod = _require_flashinfer()
+    from torch.distributed.tensor import DTensor  # type: ignore
+    for mod in model.modules():
+        qm = getattr(mod, "quant_method", None)
+        if isinstance(qm, NVFP4QATQuantizeMethod):
+            weight = getattr(mod, "weight", None)
+            if weight is None:
+                continue
+            weight_local = weight.to_local() if isinstance(weight, DTensor) else weight  # type: ignore[arg-type]
+            weight_global_sf = (448 * 6) / weight_local.float().abs().nan_to_num().max()
+            fp4_w, fp4_s = flashinfer_mod.nvfp4_quantize(
+                weight_local,
+                weight_global_sf,
+                sfLayout=flashinfer_mod.SfLayout.layout_128x4,
+                do_shuffle=False,
+            )
+            mod.register_buffer("_fp4_weight", fp4_w, persistent=False)
+            mod.register_buffer("_fp4_weight_scale", fp4_s, persistent=False)
+            mod.register_buffer("_weight_global_sf",
+                                torch.tensor(weight_global_sf, dtype=torch.bfloat16),
+                                persistent=False)


### PR DESCRIPTION
## Summary

Slice **2 of 12** in the decomposition of #1225 (`[feat] Upstream Attn-QAT Video Diffusion Code`). This PR adds the FastVideo-native **FP4 quantization config dataclass** that subsequent slices (FP4 linear layer in 3/12, QAT backends in 4/12) consume.

**Pure deadcode**: no existing code path imports the new `Fp4Config` class yet. The export in `__init__.py` makes it reachable as `from fastvideo.layers.quantization import ...`, but the actual call sites land in slice 3+. Reviewers can rubber-stamp.

## Files
- `fastvideo/layers/quantization/fp4_config.py` (NEW, ~142 LOC) — the dataclass and helpers.
- `fastvideo/layers/quantization/base_config.py` — small additive tweak to support the new config.
- `fastvideo/layers/quantization/__init__.py` — export the new class.

## Stacking
- Base: `main` (slice 1 [#1347](https://github.com/hao-ai-lab/FastVideo/pull/1347) merged).
- Next slice: `[feat]: Add FP4 linear layer (Attn-QAT 3/12)` will base on this branch.
- Final activation: 12/12 wires everything up. Cumulative diff @ 12/12 ≡ full PR #1225 feature.

## Provenance
Extracted from PR #1225 by @RandNMR73 (source SHA: `3f818d0f`). Co-authored via commit trailers with @jzhang38 and @RandNMR73; git author is @SolitaryThinker.

## Test plan
- No behavior change (deadcode). `pre-commit run --files <changed>` passes.
- The new dataclass is unit-test-coverable as a standalone but slice 2 does not ship the test — lands in a later slice once a caller exists.

## Sequence
Tracking the full 12-slice plan offline; will surface the activation PR (12/12) with the cumulative diff against `main`.