### PR TITLE
[feat]: Add NVFP4QAT linear layer (Attn-QAT 3/12)

### DIFF
--- a/fastvideo/layers/fp4linear.py
+++ b/fastvideo/layers/fp4linear.py
@@ -1,0 +1,116 @@
+from typing import Any
+
+import torch
+
+try:
+    import flashinfer
+except ImportError:
+    flashinfer = None
+
+
+def _require_flashinfer() -> Any:
+    if flashinfer is None:
+        raise ImportError("flashinfer is required for FP4 linear layers. "
+                          "Please install flashinfer to use this path.")
+    return flashinfer
+
+
+@torch.compile
+def _global_sf(t: torch.Tensor) -> torch.Tensor:
+    maxabs = t.float().abs().nan_to_num().max()
+    maxabs = maxabs.clamp(min=1e-12)
+    return (448.0 * 6.0) / maxabs
+
+
+class _LinearFWD4BWD16Fn(torch.autograd.Function):
+
+    @staticmethod
+    def forward(ctx, x, weight, bias, backend="cutlass", block_size=16, use_128x4_sf_layout=True):
+        flashinfer_mod = _require_flashinfer()
+
+        # assert activation dtype
+        if x.dtype not in (torch.float16, torch.bfloat16):
+            x = x.to(dtype=torch.bfloat16)
+
+        # cast params (can be fp32) to activation dtype for quantization
+        weight_cast = weight.to(dtype=x.dtype)
+        bias_cast = bias.to(dtype=x.dtype) if bias is not None else None
+
+        # shapes
+        orig_shape = x.shape
+        k = weight_cast.shape[1]
+        n = weight_cast.shape[0]
+        x2d = x.reshape(-1, k).contiguous()
+        M = x2d.shape[0]
+
+        out2d = torch.empty((M, n), device=x.device, dtype=x.dtype)
+
+        a_sf_layout = (flashinfer_mod.SfLayout.layout_128x4
+                       if use_128x4_sf_layout else flashinfer_mod.SfLayout.layout_8x4)
+        global_sf_a = _global_sf(x2d)
+        global_sf_b = _global_sf(weight_cast)
+
+        a_fp4, a_inv_s = flashinfer_mod.nvfp4_quantize(
+            x2d,
+            global_sf_a,
+            sfLayout=a_sf_layout,
+            do_shuffle=False,
+        )
+        b_fp4, b_inv_s = flashinfer_mod.nvfp4_quantize(
+            weight_cast,
+            global_sf_b,
+            sfLayout=flashinfer_mod.SfLayout.layout_128x4,
+            do_shuffle=False,
+        )
+
+        alpha = 1.0 / (global_sf_a * global_sf_b)
+
+        flashinfer_mod.mm_fp4(
+            a_fp4,
+            b_fp4.T,
+            a_inv_s,
+            b_inv_s.T,
+            alpha,
+            x.dtype,
+            out2d,
+            block_size=block_size,
+            use_8x4_sf_layout=(not use_128x4_sf_layout),
+            backend=backend,
+        )
+
+        if bias_cast is not None:
+            out2d.add_(bias_cast)
+
+        # save tensors for backward (keep original dtypes)
+        ctx.save_for_backward(x2d, weight, bias)
+        ctx.k = k
+        ctx.n = n
+        ctx.orig_shape = orig_shape
+        return out2d.reshape(*orig_shape[:-1], n)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        x2d, weight, bias = ctx.saved_tensors
+        M = x2d.shape[0]
+        n = ctx.n
+
+        grad_out_2d = grad_out.reshape(M, n).contiguous()
+
+        # cast to grad dtype for matmuls
+        weight_cast = weight.to(dtype=grad_out.dtype)
+        x_cast = x2d.to(dtype=grad_out.dtype)
+
+        grad_x = grad_out_2d.matmul(weight_cast).reshape(*ctx.orig_shape)
+        grad_w = grad_out_2d.t().matmul(x_cast)
+        grad_b = grad_out_2d.sum(dim=0) if bias is not None else None
+
+        # None for the three extra forward args
+        return grad_x, grad_w, grad_b, None, None, None
+
+
+def fp4_linear_forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor | None]:
+    # pass config **positionally**; autograd.Function.apply ignores kwargs
+    bias = self.bias if not self.skip_bias_add else None
+    output = _LinearFWD4BWD16Fn.apply(x, self.weight, bias, "cutlass", 16, True)
+    output_bias = self.bias if self.skip_bias_add else None
+    return output, output_bias

--- a/fastvideo/layers/quantization/__init__.py
+++ b/fastvideo/layers/quantization/__init__.py
@@ -2,7 +2,7 @@ from typing import Literal, get_args
 
 from fastvideo.layers.quantization.base_config import QuantizationConfig
 
-QuantizationMethods = Literal[None, "AbsMaxFP8", "NVFP4"]
+QuantizationMethods = Literal[None, "AbsMaxFP8", "NVFP4", "nvfp4_qat"]
 
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))
 
@@ -52,10 +52,12 @@ def get_quantization_config(quantization: str) -> type[QuantizationConfig]:
     # lazy import to avoid triggering `torch.compile` too early
     from .absmax_fp8 import AbsMaxFP8Config
     from .nvfp4_config import NVFP4Config
+    from .nvfp4_qat_config import NVFP4QATConfig
 
     method_to_config: dict[str, type[QuantizationConfig]] = {
         "AbsMaxFP8": AbsMaxFP8Config,
         "NVFP4": NVFP4Config,
+        "nvfp4_qat": NVFP4QATConfig,
     }
     # Update the `method_to_config` with customized quantization methods.
     method_to_config.update(_CUSTOMIZED_METHOD_TO_QUANT_CONFIG)

--- a/fastvideo/layers/quantization/base_config.py
+++ b/fastvideo/layers/quantization/base_config.py
@@ -61,7 +61,7 @@ def method_has_implemented_embedding(method_class: type[QuantizeMethodBase]) -> 
 class QuantizationConfig(ABC):
     """Base class for quantization configs."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # mapping is updated by models as they initialize
         self.packed_modules_mapping: dict[str, list[str]] = dict()

--- a/fastvideo/layers/quantization/nvfp4_qat_config.py
+++ b/fastvideo/layers/quantization/nvfp4_qat_config.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+import logging
+from typing import Any
+
+import torch
+from torch.nn.parameter import Parameter
+
+from fastvideo.layers.quantization.base_config import QuantizationConfig, QuantizeMethodBase
+from fastvideo.models.utils import set_weight_attrs
+
+try:
+    import flashinfer
+except ImportError:
+    flashinfer = None
+
+logger = logging.getLogger(__name__)
+
+
+def _require_flashinfer() -> Any:
+    if flashinfer is None:
+        raise ImportError("flashinfer is required for NVFP4 QAT quantization. "
+                          "Please install flashinfer to use the nvfp4_qat quantization backend.")
+    return flashinfer
+
+
+class NVFP4QATQuantizeMethod(QuantizeMethodBase):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weight_fp4 = None
+        self.weight_scale = None
+
+    def create_weights(self, layer: torch.nn.Module, input_size_per_partition: int, output_partition_sizes: list[int],
+                       input_size: int, output_size: int, params_dtype: torch.dtype, **extra_weight_attrs):
+        """Create weights for a linear layer. Note the corrected signature to match LinearMethodBase."""
+        weight = Parameter(torch.empty(
+            sum(output_partition_sizes),
+            input_size_per_partition,
+            dtype=params_dtype,
+        ),
+                           requires_grad=False)
+        set_weight_attrs(weight, {"input_dim": 1, "output_dim": 0})
+        layer.register_parameter("weight", weight)
+        set_weight_attrs(weight, extra_weight_attrs)
+
+    @torch.compile
+    def apply(self, layer: torch.nn.Module, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
+        """Apply NVFP4 QAT quantized computation."""
+        flashinfer_mod = _require_flashinfer()
+        out_dim = layer.weight.shape[0]
+        original_shape = x.shape
+        assert x.dtype == torch.bfloat16 or x.dtype == torch.float16, f"only allow bf16/fp16 inputs to fp4 linear, got {x.dtype}"
+
+        x = x.view(-1, x.shape[-1])
+
+        x_global_sf = (448 * 6) / x.float().abs().nan_to_num().max()
+        x_fp4, x_scale = flashinfer_mod.nvfp4_quantize(
+            x,
+            x_global_sf,
+            sfLayout=flashinfer_mod.SfLayout.layout_128x4,
+            do_shuffle=False,
+        )
+        weight_fp4 = layer._fp4_weight
+        weight_scale = layer._fp4_weight_scale
+        weight_global_sf = layer._weight_global_sf
+
+        out = flashinfer_mod.mm_fp4(
+            x_fp4,
+            weight_fp4.T,
+            x_scale,
+            weight_scale.T,
+            1.0 / (x_global_sf * weight_global_sf),
+            torch.bfloat16,
+            None,
+            backend="cutlass",
+        )
+
+        if bias is not None:
+            if bias.device != out.device or bias.dtype != out.dtype:
+                bias = bias.to(device=out.device, dtype=out.dtype)
+            out = out + bias
+
+        if len(original_shape) == 3:
+            out = out.view(original_shape[0], original_shape[1], out_dim)
+
+        return out
+
+
+class NVFP4QATConfig(QuantizationConfig):
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def get_name(self):
+        return "nvfp4_qat"
+
+    def get_supported_act_dtypes(self):
+        return [torch.bfloat16, torch.float16]
+
+    @classmethod
+    def get_min_capability(cls):
+        return 100
+
+    @staticmethod
+    def get_config_filenames():
+        return []
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> "NVFP4QATConfig":
+        return cls()
+
+    def get_quant_method(self, layer: torch.nn.Module, prefix: str):
+        from fastvideo.layers.linear import LinearBase
+        fp4_layers = ["ffn.fc_in", "ffn.fc_out", "to_q", "to_k", "to_v", "to_out"]
+        if isinstance(layer, LinearBase) and any(layer_name in prefix for layer_name in fp4_layers):
+            return NVFP4QATQuantizeMethod()
+        return None
+
+
+@torch.compile
+def convert_model_to_fp4(model: torch.nn.Module):
+    flashinfer_mod = _require_flashinfer()
+    from torch.distributed.tensor import DTensor  # type: ignore
+    for mod in model.modules():
+        qm = getattr(mod, "quant_method", None)
+        if isinstance(qm, NVFP4QATQuantizeMethod):
+            weight = getattr(mod, "weight", None)
+            if weight is None:
+                continue
+            weight_local = weight.to_local() if isinstance(weight, DTensor) else weight  # type: ignore[arg-type]
+            weight_global_sf = (448 * 6) / weight_local.float().abs().nan_to_num().max()
+            fp4_w, fp4_s = flashinfer_mod.nvfp4_quantize(
+                weight_local,
+                weight_global_sf,
+                sfLayout=flashinfer_mod.SfLayout.layout_128x4,
+                do_shuffle=False,
+            )
+            mod.register_buffer("_fp4_weight", fp4_w, persistent=False)
+            mod.register_buffer("_fp4_weight_scale", fp4_s, persistent=False)
+            mod.register_buffer("_weight_global_sf",
+                                torch.tensor(weight_global_sf, dtype=torch.bfloat16),
+                                persistent=False)


### PR DESCRIPTION
## Summary

Slice **3 of 12** in the decomposition of #1225 (`[feat] Upstream Attn-QAT Video Diffusion Code`). Adds the FastVideo-native **FP4 linear forward helper module** extracted from PR-1225.

**Pure deadcode**: no existing code path imports `fp4_linear_forward` yet. The QAT attention backends (Slice 4) and beyond will wire it up; activation lands in Slice 12.

## Stacking

- Base: `pr1225_s2` (Slice 2, #1348, still open).
- When #1348 merges, GitHub auto-retargets this PR's base to `main`.
- Cumulative diff @ Slice 12/12 ≡ full PR #1225 feature.

## Naming family

- `NVFP4QATConfig` (Slice 2, #1348)
- FP4 linear forward helper module (this slice)
- Distinct from main's `NVFP4Config` / `NVFP4` quant method (Blackwell hardware FP4 inference — added by PR #1334).

## Files

- `fastvideo/layers/fp4linear.py` (NEW, 115 LOC) — source PR-1225 module. The extracted file does not define a public `Fp4Linear*` class or import `Fp4Config`, so no class/file rename or config-import substitution was applied.

## Provenance

Extracted from PR #1225 by @RandNMR73 (source SHA: `3f818d0f`). Git author is @SolitaryThinker; @jzhang38 and @RandNMR73 are co-authored via commit trailers.

## Test plan

- No behavior change (deadcode). `pre-commit run --files fastvideo/layers/fp4linear.py` passes.
- Unit-test coverage for the FP4 linear helper lands in a later slice once a caller exists.