### PR TITLE
[docs] Add copy page action

### DIFF
--- a/docs/assets/copy-page.js
+++ b/docs/assets/copy-page.js
@@ -33,13 +33,13 @@
       }
 
       const label = text(Array.from(node.childNodes).map(serializeInline).join(""));
-      const href = node.getAttribute("href");
+      const href = node.href;
       return href && label ? `${label} (${href})` : label;
     }
 
     if (tagName === "img") {
       const alt = node.getAttribute("alt") || "image";
-      const src = node.getAttribute("src") || "";
+      const src = node.src || "";
       return src ? `[${alt}](${src})` : `[${alt}]`;
     }
 
@@ -51,11 +51,17 @@
   }
 
   function serializeTable(table) {
-    const rows = Array.from(table.querySelectorAll("tr"));
-    return rows
-      .map((row) => Array.from(row.children).map((cell) => text(serializeInline(cell))).join(" | "))
-      .filter(Boolean)
-      .join("\n");
+    const rows = Array.from(table.rows);
+    if (rows.length === 0) return "";
+
+    const mdRows = rows.map(
+      (row) => "| " + Array.from(row.children).map((cell) => text(serializeInline(cell))).join(" | ") + " |"
+    );
+    const separator = "| " + Array.from(rows[0].children)
+      .map(() => "---")
+      .join(" | ") + " |";
+    mdRows.splice(1, 0, separator);
+    return mdRows.join("\n");
   }
 
   function serializeBlock(node, listDepth = 0) {
@@ -122,14 +128,13 @@
     Array.from(item.childNodes).forEach((child) => {
       if (child.nodeType === Node.ELEMENT_NODE && ["ul", "ol"].includes(child.tagName.toLowerCase())) {
         childBlocks.push(serializeBlock(child, listDepth + 1));
-      } else if (child.nodeType === Node.ELEMENT_NODE && ["p", "div"].includes(child.tagName.toLowerCase())) {
-        inlineParts.push(serializeInline(child));
       } else {
-        inlineParts.push(serializeInline(child));
+        const content = serializeInline(child);
+        if (content) inlineParts.push(content);
       }
     });
 
-    const firstLine = `${indent}${marker}${text(inlineParts.join(""))}`.trimEnd();
+    const firstLine = `${indent}${marker}${text(inlineParts.join(" "))}`.trimEnd();
     return [firstLine, ...childBlocks.filter(Boolean)].join("\n");
   }
 

--- a/docs/assets/copy-page.js
+++ b/docs/assets/copy-page.js
@@ -1,0 +1,200 @@
+// Add a one-click copy button for the rendered MkDocs article.
+(function () {
+  const BUTTON_ID = "copy-page-button";
+
+  function text(value) {
+    return (value || "").replace(/\s+/g, " ").trim();
+  }
+
+  function codeLanguage(code) {
+    const classes = Array.from(code.classList || []);
+    const language = classes.find((name) => name.startsWith("language-"));
+    return language ? language.replace("language-", "") : "";
+  }
+
+  function serializeInline(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return node.textContent || "";
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return "";
+    }
+
+    const tagName = node.tagName.toLowerCase();
+
+    if (tagName === "code" && node.parentElement && node.parentElement.tagName.toLowerCase() !== "pre") {
+      return "`" + (node.textContent || "").trim() + "`";
+    }
+
+    if (tagName === "a") {
+      if (node.classList.contains("headerlink")) {
+        return "";
+      }
+
+      const label = text(Array.from(node.childNodes).map(serializeInline).join(""));
+      const href = node.getAttribute("href");
+      return href && label ? `${label} (${href})` : label;
+    }
+
+    if (tagName === "img") {
+      const alt = node.getAttribute("alt") || "image";
+      const src = node.getAttribute("src") || "";
+      return src ? `[${alt}](${src})` : `[${alt}]`;
+    }
+
+    if (tagName === "br") {
+      return "\n";
+    }
+
+    return Array.from(node.childNodes).map(serializeInline).join("");
+  }
+
+  function serializeTable(table) {
+    const rows = Array.from(table.querySelectorAll("tr"));
+    return rows
+      .map((row) => Array.from(row.children).map((cell) => text(serializeInline(cell))).join(" | "))
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  function serializeBlock(node, listDepth = 0) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      return text(node.textContent);
+    }
+
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return "";
+    }
+
+    const tagName = node.tagName.toLowerCase();
+
+    if (["script", "style", "nav", "button"].includes(tagName) || node.id === BUTTON_ID) {
+      return "";
+    }
+
+    if (/^h[1-6]$/.test(tagName)) {
+      const level = Number(tagName.slice(1));
+      return `${"#".repeat(level)} ${text(serializeInline(node))}`;
+    }
+
+    if (tagName === "pre") {
+      const code = node.querySelector("code");
+      const content = code ? code.textContent || "" : node.textContent || "";
+      return `\`\`\`${code ? codeLanguage(code) : ""}\n${content.replace(/\n$/, "")}\n\`\`\``;
+    }
+
+    if (["p", "figcaption"].includes(tagName)) {
+      return text(serializeInline(node));
+    }
+
+    if (tagName === "blockquote") {
+      return serializeChildren(node, listDepth)
+        .split("\n")
+        .map((line) => (line ? `> ${line}` : ">"))
+        .join("\n");
+    }
+
+    if (tagName === "ul" || tagName === "ol") {
+      return Array.from(node.children)
+        .filter((child) => child.tagName && child.tagName.toLowerCase() === "li")
+        .map((item, index) => serializeListItem(item, tagName === "ol", index, listDepth))
+        .join("\n");
+    }
+
+    if (tagName === "table") {
+      return serializeTable(node);
+    }
+
+    if (["hr"].includes(tagName)) {
+      return "---";
+    }
+
+    return serializeChildren(node, listDepth);
+  }
+
+  function serializeListItem(item, ordered, index, listDepth) {
+    const marker = ordered ? `${index + 1}. ` : "- ";
+    const indent = "  ".repeat(listDepth);
+    const childBlocks = [];
+    const inlineParts = [];
+
+    Array.from(item.childNodes).forEach((child) => {
+      if (child.nodeType === Node.ELEMENT_NODE && ["ul", "ol"].includes(child.tagName.toLowerCase())) {
+        childBlocks.push(serializeBlock(child, listDepth + 1));
+      } else if (child.nodeType === Node.ELEMENT_NODE && ["p", "div"].includes(child.tagName.toLowerCase())) {
+        inlineParts.push(serializeInline(child));
+      } else {
+        inlineParts.push(serializeInline(child));
+      }
+    });
+
+    const firstLine = `${indent}${marker}${text(inlineParts.join(""))}`.trimEnd();
+    return [firstLine, ...childBlocks.filter(Boolean)].join("\n");
+  }
+
+  function serializeChildren(node, listDepth = 0) {
+    return Array.from(node.childNodes)
+      .map((child) => serializeBlock(child, listDepth))
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .join("\n\n");
+  }
+
+  function articleText(article) {
+    const clone = article.cloneNode(true);
+    clone.querySelectorAll("script, style, .headerlink, .md-clipboard, #copy-page-button").forEach((node) => node.remove());
+
+    const content = serializeChildren(clone).trim();
+    const title = document.querySelector("h1") || document.querySelector("title");
+    const pageTitle = title ? text(title.textContent) : "";
+
+    if (pageTitle && !content.startsWith("# ")) {
+      return `# ${pageTitle}\n\n${content}`.trim();
+    }
+
+    return content;
+  }
+
+  async function copyArticle(button, article) {
+    const originalLabel = button.textContent;
+    try {
+      await navigator.clipboard.writeText(articleText(article));
+      button.textContent = "Copied!";
+      button.classList.add("copy-page-button--copied");
+    } catch (error) {
+      button.textContent = "Copy failed";
+      button.classList.add("copy-page-button--error");
+      console.error("Failed to copy page", error);
+    }
+
+    window.setTimeout(() => {
+      button.textContent = originalLabel;
+      button.classList.remove("copy-page-button--copied", "copy-page-button--error");
+    }, 2000);
+  }
+
+  function addCopyButton() {
+    const article = document.querySelector("article.md-content__inner");
+    if (!article || document.getElementById(BUTTON_ID)) {
+      return;
+    }
+
+    const button = document.createElement("button");
+    button.id = BUTTON_ID;
+    button.type = "button";
+    button.className = "copy-page-button md-button md-button--primary";
+    button.textContent = "Copy page";
+    button.setAttribute("aria-label", "Copy this page as plain text");
+    button.addEventListener("click", () => copyArticle(button, article));
+
+    article.insertBefore(button, article.firstChild);
+  }
+
+  if (typeof document$ !== "undefined") {
+    document$.subscribe(addCopyButton);
+  }
+
+  document.addEventListener("DOMContentLoaded", addCopyButton);
+  window.addEventListener("load", addCopyButton);
+})();

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -41,3 +41,20 @@ img {
     display: block;
     margin: 0 auto;
 }
+
+.md-typeset .copy-page-button.md-button {
+    float: right;
+    margin: 0 0 1rem 1rem;
+    padding: 0.2em 0.6em;
+    font-size: 1em;
+    font-weight: 400;
+    line-height: 1.2;
+}
+
+.md-typeset .copy-page-button.md-button.copy-page-button--copied {
+    background-color: var(--md-accent-fg-color);
+}
+
+.md-typeset .copy-page-button.md-button.copy-page-button--error {
+    background-color: var(--md-code-hl-number-color);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,3 +189,7 @@ extra:
 # Custom CSS
 extra_css:
   - assets/custom.css
+
+# Custom JavaScript
+extra_javascript:
+  - assets/copy-page.js


### PR DESCRIPTION
## Summary
- Add a MkDocs Material "Copy page" button that copies the rendered article content for agent-friendly sharing.
- Register the page-copy script in `mkdocs.yml` and add compact button styling to the docs CSS.
- Reinitialize on Material instant navigation so the action remains available across docs pages.

## Testing
- `node --check docs/assets/copy-page.js`
- `uv run --with-requirements requirements-mkdocs.txt mkdocs build --site-dir /home/d1su/codes/dreamverse-release/FastVideo-copy-page-site-pr`

Note: MkDocs build passes with existing autorefs warnings.