### PR TITLE
[misc]: Add Dreamverse deploy skill frontmatter

### DIFF
--- a/.agents/skills/dreamverse-deploy/SKILL.md
+++ b/.agents/skills/dreamverse-deploy/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dreamverse-deploy
+description: Use when redeploying the migrated Dreamverse app backend and frontend on a chosen local GPU; tears down existing ports, launches services, and waits for readiness checks.
+---
+
 # dreamverse-deploy — redeploy migrated Dreamverse on a chosen GPU
 
 **Scope:** project (lives in this repo at `.agents/skills/dreamverse-deploy/`)


### PR DESCRIPTION
## Summary
- Add required YAML frontmatter to the Dreamverse deploy skill so opencode can load and surface it correctly.
- Preserve the existing skill body unchanged.

## Test evidence
- `git diff upstream/main...HEAD -- .agents/skills/dreamverse-deploy/SKILL.md`
- Commit hooks ran via pre-commit; markdown-specific hooks reported no files to check and filename check passed.