### PR TITLE
[misc]: demote ROCm-unavailable startup message to DEBUG

### DIFF
--- a/fastvideo/platforms/__init__.py
+++ b/fastvideo/platforms/__init__.py
@@ -103,7 +103,7 @@ def rocm_platform_plugin() -> str | None:
         finally:
             amdsmi.amdsmi_shut_down()
     except Exception as e:
-        logger.info("ROCm platform is unavailable: %s", e)
+        logger.debug("ROCm platform is unavailable: %s", e)
 
     return "fastvideo.platforms.rocm.RocmPlatform" if is_rocm else None
 


### PR DESCRIPTION
## Purpose

On CUDA-only machines (most users), `fastvideo`'s platform detector emits this on every startup:

```
ROCm platform is unavailable: No module named 'amdsmi'
```

The exception is benign — the platform detector correctly falls through to CUDA when `amdsmi` is missing. The INFO-level message has no actionable signal for the user.

This PR demotes it to DEBUG. Users debugging AMD platform selection can still see it via `LOG_LEVEL=DEBUG` or by configuring the `fastvideo.platforms` logger.

## Test

- Manual: `python -c 'import fastvideo'` — no ROCm message on default log config.
- With `LOG_LEVEL=DEBUG` (or equivalent): message still emitted.

## Checklist

- [X] I ran `pre-commit run --files fastvideo/platforms/__init__.py` and fixed all issues
- [X] I added or updated tests for my changes (N/A — log-level demotion, no behavioral change)
- [X] I updated documentation if needed (N/A)
- [X] I considered GPU memory impact of my changes (N/A — log-level)