### PR TITLE
[infra] [dreamverse]: add instruction to install nasm and update ffmpeg installer to work in plain venv

### DIFF
--- a/apps/dreamverse/README.md
+++ b/apps/dreamverse/README.md
@@ -49,7 +49,27 @@ binary:
 bash apps/dreamverse/scripts/install_native_ffmpeg.sh
 ```
 
-This builds and installs into `~/opt/ffmpeg-native/` and writes
+The installer supports Linux `x86_64` and `aarch64`. It auto-detects either a
+conda-forge gcc triplet (if a conda env is active) or system `gcc`/`g++` (plain
+venv). On `x86_64`, x264's hand-tuned SIMD also requires `nasm`; install via
+whichever path fits your host:
+
+```bash
+sudo apt install nasm                       # Debian/Ubuntu
+conda install -c conda-forge nasm           # inside an active conda env
+```
+
+No sudo and no conda? Build `nasm` from source (~30s, installs into `$HOME`):
+
+```bash
+mkdir -p "$HOME/src" "$HOME/opt" && cd "$HOME/src"
+curl -fsSL -O https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.gz
+tar -xf nasm-2.16.03.tar.gz && cd nasm-2.16.03
+./configure --prefix="$HOME/opt/nasm" && make -j"$(nproc)" && make install
+export PATH="$HOME/opt/nasm/bin:$PATH"      # add to ~/.bashrc to persist
+```
+
+The installer writes to `~/opt/ffmpeg-native/` and emits
 `apps/dreamverse/scripts/ffmpeg-env.sh`. Source it before starting the backend
 so Dreamverse uses the custom FFmpeg binary:
 
@@ -59,8 +79,7 @@ dreamverse-server
 ```
 
 Docker images already run this FFmpeg build during image creation and source the
-generated environment file at container startup. The installer supports Linux
-`x86_64` and `aarch64`.
+generated environment file at container startup.
 
 ## Launch Dreamverse
 

--- a/apps/dreamverse/README.md
+++ b/apps/dreamverse/README.md
@@ -43,16 +43,17 @@ See `apps/dreamverse/docker/README.md` for Docker build and run option details.
 ## Optional: Building FFmpeg For Better Performance
 
 For full streaming performance in a non-Docker install, build a custom FFmpeg
-binary:
+binary from a FastVideo source checkout. The command below is repo-relative,
+so run it from the repository root:
 
 ```bash
 bash apps/dreamverse/scripts/install_native_ffmpeg.sh
 ```
 
-The installer supports Linux `x86_64` and `aarch64`. It auto-detects either a
-conda-forge gcc triplet (if a conda env is active) or system `gcc`/`g++` (plain
-venv). On `x86_64`, x264's hand-tuned SIMD also requires `nasm`; install via
-whichever path fits your host:
+The installer supports Linux `x86_64` and `aarch64`. It prefers conda-forge
+triplet compilers when those commands are on `PATH`, otherwise it falls back to
+system `gcc`/`g++` (plain venv). On `x86_64`, x264's hand-tuned SIMD also
+requires `nasm`; install via whichever path fits your host:
 
 ```bash
 sudo apt install nasm                       # Debian/Ubuntu
@@ -62,10 +63,12 @@ conda install -c conda-forge nasm           # inside an active conda env
 No sudo and no conda? Build `nasm` from source (~30s, installs into `$HOME`):
 
 ```bash
-mkdir -p "$HOME/src" "$HOME/opt" && cd "$HOME/src"
-curl -fsSL -O https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.gz
-tar -xf nasm-2.16.03.tar.gz && cd nasm-2.16.03
-./configure --prefix="$HOME/opt/nasm" && make -j"$(nproc)" && make install
+(
+  mkdir -p "$HOME/src" "$HOME/opt" && cd "$HOME/src"
+  curl -fsSL -O https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.gz
+  tar -xf nasm-2.16.03.tar.gz && cd nasm-2.16.03
+  ./configure --prefix="$HOME/opt/nasm" && make -j"$(nproc)" && make install
+)
 export PATH="$HOME/opt/nasm/bin:$PATH"      # add to ~/.bashrc to persist
 ```
 

--- a/apps/dreamverse/scripts/install_native_ffmpeg.sh
+++ b/apps/dreamverse/scripts/install_native_ffmpeg.sh
@@ -32,14 +32,21 @@
 #     FFMPEG_NATIVE_CC  explicit C compiler command for native builds
 #     FFMPEG_NATIVE_CXX explicit C++ compiler command for native builds
 #
-# Toolchain selection: CC / CXX / AS are pinned to the conda-forge
-# triplet matching `uname -m`. Inherited values are intentionally
-# ignored — conda envs that have BOTH `gcc_linux-64` and
-# `gcc_linux-aarch64` installed export the cross-compiler triplet on
-# every `conda activate` (the `aarch64` activation script sorts later
-# and wins), which silently breaks x264's compiler probe on the
-# opposite host. If you genuinely need a non-host toolchain, set
-# FFMPEG_NATIVE_CC and/or FFMPEG_NATIVE_CXX explicitly.
+# Toolchain selection (precedence, highest first):
+#   1. FFMPEG_NATIVE_CC / FFMPEG_NATIVE_CXX, if set — explicit override.
+#   2. The conda-forge triplet matching `uname -m`
+#      (`x86_64-conda-linux-gnu-cc` or `aarch64-conda-linux-gnu-cc`),
+#      if present on PATH. Pinning the triplet sidesteps a bug where
+#      conda envs with BOTH `gcc_linux-64` and `gcc_linux-aarch64`
+#      installed export the cross-compiler triplet on every
+#      `conda activate` (the `aarch64` activation script sorts later
+#      and wins), silently breaking x264's compiler probe on the
+#      opposite host.
+#   3. System `gcc` / `g++` — fallback so the script also works in a
+#      plain venv or bare shell with no conda toolchain installed.
+# Inherited bare CC / CXX from the caller environment are ignored in
+# cases (2) and (3); use FFMPEG_NATIVE_CC/CXX to inject a non-host
+# toolchain.
 set -euo pipefail
 
 # ─── Defaults (override via env) ──────────────────────────────────────────
@@ -61,8 +68,8 @@ MAKE_JOBS="${MAKE_JOBS:-$(( NPROC < 16 ? NPROC : 16 ))}"
 ARCH="$(uname -m)"
 case "$ARCH" in
   x86_64)
-    DEFAULT_CC=x86_64-conda-linux-gnu-cc
-    DEFAULT_CXX=x86_64-conda-linux-gnu-c++
+    CONDA_CC=x86_64-conda-linux-gnu-cc
+    CONDA_CXX=x86_64-conda-linux-gnu-c++
     AS=nasm
     X264_CFLAGS="-O3 -march=native -mtune=native -fPIC -flto"
     X264_LDFLAGS="-flto -fuse-linker-plugin"
@@ -70,8 +77,8 @@ case "$ARCH" in
     FFMPEG_LDFLAGS="-flto -Wl,-rpath,$INSTALL_PREFIX/lib"
     ;;
   aarch64)
-    DEFAULT_CC=aarch64-conda-linux-gnu-cc
-    DEFAULT_CXX=aarch64-conda-linux-gnu-c++
+    CONDA_CC=aarch64-conda-linux-gnu-cc
+    CONDA_CXX=aarch64-conda-linux-gnu-c++
     unset AS  # GNU as on ARM
     X264_CFLAGS="-O3 -mcpu=native -fPIC -flto"
     X264_LDFLAGS="-flto -fuse-linker-plugin"
@@ -84,8 +91,27 @@ case "$ARCH" in
     ;;
 esac
 
+# Prefer the conda-forge triplet when it's actually on PATH; otherwise fall
+# back to system gcc/g++ so a plain venv works too. FFMPEG_NATIVE_CC/CXX
+# overrides both.
+if command -v -- "$CONDA_CC" >/dev/null 2>&1 \
+   && command -v -- "$CONDA_CXX" >/dev/null 2>&1; then
+  DEFAULT_CC="$CONDA_CC"
+  DEFAULT_CXX="$CONDA_CXX"
+  default_source="conda-forge ($ARCH triplet)"
+else
+  DEFAULT_CC=gcc
+  DEFAULT_CXX=g++
+  default_source="system gcc/g++"
+fi
+
 CC="${FFMPEG_NATIVE_CC:-$DEFAULT_CC}"
 CXX="${FFMPEG_NATIVE_CXX:-$DEFAULT_CXX}"
+if [[ -n "${FFMPEG_NATIVE_CC:-}" || -n "${FFMPEG_NATIVE_CXX:-}" ]]; then
+  toolchain_source="FFMPEG_NATIVE_CC/CXX override"
+else
+  toolchain_source="$default_source"
+fi
 
 require_compiler() {
   local name="$1" compiler="$2"
@@ -107,7 +133,7 @@ require_compiler CC "$CC"
 require_compiler CXX "$CXX"
 export CC CXX
 [[ -n "${AS:-}" ]] && export AS
-echo "[install_native_ffmpeg] toolchain: CC=$CC CXX=$CXX AS=${AS:-<gnu-as>} (uname -m=$ARCH)"
+echo "[install_native_ffmpeg] toolchain: CC=$CC CXX=$CXX AS=${AS:-<gnu-as>} (uname -m=$ARCH, source: $toolchain_source)"
 
 # ─── Step 0: probe required tools ─────────────────────────────────────────
 required=("$CC" "$CXX" make pkg-config git)

--- a/apps/dreamverse/scripts/install_native_ffmpeg.sh
+++ b/apps/dreamverse/scripts/install_native_ffmpeg.sh
@@ -121,6 +121,8 @@ require_compiler() {
   fi
   if ! command -v -- "$compiler" >/dev/null 2>&1; then
     echo "[install_native_ffmpeg] $name is unavailable: $compiler" >&2
+    echo "[install_native_ffmpeg] install a compiler, or set FFMPEG_NATIVE_CC/FFMPEG_NATIVE_CXX" \
+      "to compiler commands on PATH." >&2
     exit 1
   fi
   if ! "$compiler" --version >/dev/null 2>&1; then
@@ -144,7 +146,12 @@ for cmd in "${required[@]}"; do
 done
 if (( ${#missing[@]} > 0 )); then
   echo "[install_native_ffmpeg] missing required tools: ${missing[*]}" >&2
-  echo "[install_native_ffmpeg] install them, or set FFMPEG_NATIVE_CC/FFMPEG_NATIVE_CXX explicitly." >&2
+  echo "[install_native_ffmpeg] install the missing tools. FFMPEG_NATIVE_CC/FFMPEG_NATIVE_CXX" \
+    "only override compiler selection; they do not provide make, pkg-config, git, or nasm." >&2
+  if [[ " ${missing[*]} " == *" nasm "* ]]; then
+    echo "[install_native_ffmpeg] nasm is required on x86_64 for x264 SIMD; install nasm" \
+      "(for example via apt or conda-forge) and retry." >&2
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- `apps/dreamverse/scripts/install_native_ffmpeg.sh`: replace the hard-pinned conda-forge gcc triplet with 3-tier toolchain auto-detection — explicit `FFMPEG_NATIVE_CC`/`FFMPEG_NATIVE_CXX` override → conda triplet if present on `PATH` → system `gcc`/`g++`. Lets the script run inside a plain uv venv while preserving the prior conda behavior and the cross-triplet activation-script workaround.
- `apps/dreamverse/README.md`: document the new auto-detection and add `nasm` install options (apt, conda, build-from-source) for hosts where `nasm` isn't already on `PATH`.

## Test plan
- [x] `bash -n` clean on the edited script.
- [x] Toolchain probe in three modes returns the correct compiler:
  - plain venv (no conda, no override) → `gcc` / `g++` (`source: system gcc/g++`)
  - conda env bin on `PATH` → `x86_64-conda-linux-gnu-cc` / `c++` (`source: conda-forge (x86_64 triplet)`)
  - `FFMPEG_NATIVE_CC=cc FFMPEG_NATIVE_CXX=c++` → `cc` / `c++` (`source: FFMPEG_NATIVE_CC/CXX override`)
- [x] End-to-end build on `x86_64` Ubuntu 24.04 in a uv venv produces `ffmpeg n7.1` with `libx264` + `h264_nvenc` + `hevc_nvenc` + LTO (verified by the script's existing sanity checks).
- [x] `pre-commit run --files apps/dreamverse/scripts/install_native_ffmpeg.sh apps/dreamverse/README.md` passes (codespell + PyMarkdown).