### PR TITLE
[bugfix] registry: infer workload_type from model registration instead of defaulting to T2V

### DIFF
--- a/fastvideo/registry.py
+++ b/fastvideo/registry.py
@@ -781,8 +781,16 @@ def get_model_info(
     elif isinstance(pipeline_type, str):
         pipeline_type = PipelineType.from_string(pipeline_type)
 
+    config_info = _get_config_info(model_path, raise_on_missing=True)
+    assert config_info is not None, "config_info must be resolved"
+
     if workload_type is None:
-        workload_type = WorkloadType.T2V
+        # Derive the workload from the model's registration instead of
+        # assuming T2V. A model registered for a single workload (e.g.
+        # Matrix-Game-2.0, which is I2V-only) otherwise fails pipeline
+        # resolution under the blanket T2V default.
+        registered = config_info.workload_types
+        workload_type = (registered[0] if len(registered) == 1 else WorkloadType.T2V)
 
     if os.path.exists(model_path):
         config = verify_model_config_and_directory(model_path)
@@ -800,9 +808,6 @@ def get_model_info(
 
     pipeline_registry = get_pipeline_registry(pipeline_type)
     pipeline_cls = pipeline_registry.resolve_pipeline_cls(pipeline_name, pipeline_type, workload_type)
-
-    config_info = _get_config_info(model_path, raise_on_missing=True)
-    assert config_info is not None, "config_info must be resolved"
 
     sampling_param_cls = config_info.sampling_param_cls or SamplingParam
 


### PR DESCRIPTION
## Problem

`bar-chart-ssim-tests` (full-suite) fails deterministically on `test_matrixgame_similarity.py::Matrix-Game-2.0-Diffusers-Base`:

```
ValueError: Pipeline 'MatrixGame2I2VPipeline' is not supported for
pipeline type 'basic' and workload type 't2v'
```

This blocks `full-suite-passed` on any PR that runs it (e.g. #1242).

## Root cause

`get_model_info()` in `fastvideo/registry.py` hard-defaults `workload_type` to `WorkloadType.T2V` when the caller doesn't pass one (`build_pipeline` forwards `fastvideo_args.workload_type`, which is `None` for the Matrix-Game-2.0 SSIM run). Matrix-Game-2.0 is registered I2V-only (`register_configs(..., workload_types=(WorkloadType.I2V,))`), so resolving its pipeline under the assumed `t2v` workload fails.

## Fix

When `workload_type is None`, derive it from the model's registered `ConfigInfo.workload_types` rather than assuming T2V:

- model registers exactly one workload → use it (Matrix-Game-2.0 → `I2V`)
- multiple / empty registration → keep the existing `T2V` fallback

Behavior is unchanged for every T2V model and for multi/empty registrations; only single-non-T2V models (the broken case) change. `config_info` is resolved once, slightly earlier — it was already required later in the same function.

## Test evidence

- `pre-commit run --files fastvideo/registry.py`: all hooks pass (yapf/ruff/codespell/mypy).
- Functional check (exact-path registry match, no GPU/network):
  - `FastVideo/Matrix-Game-2.0-Base-Diffusers` → registered `(I2V,)` → inferred `I2V` ✅ (previously `T2V` → the bug)
  - `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` → registered `(T2V,)` → inferred `T2V` ✅ (unchanged, no regression)

## Context

Pre-existing breakage unrelated to #1242; this unblocks the `full-suite-passed` gate there (minimal LoRA training support).
