### PR TITLE
[docs] Document enable_torch_compile (+ A/B example)

### DIFF
--- a/docs/inference/optimizations.md
+++ b/docs/inference/optimizations.md
@@ -12,7 +12,7 @@ This page describes the various options for speeding up generation times in Fast
   - [Sage Attention](#sage-attention)
   - [Sage Attention 3](#sage-attention-3)
 
-- [torch.compile](#torchcompile)
+- [torch.compile](#torch-compile)
 
 ## Attention Backends
 
@@ -179,6 +179,8 @@ These backends are model-specific and require the corresponding kernels and
 dependencies. Use the support matrix and model examples to confirm compatibility
 before enabling them.
 
+<a id="torch-compile"></a>
+
 ## torch.compile
 
 FastVideo can `torch.compile` the DiT (transformer) for a substantial
@@ -236,8 +238,20 @@ combining with quantized attention backends.
 - **`mode="reduce-overhead"` / CUDA graphs**: not yet supported
   end-to-end. The attention dispatch is an untraceable custom op and
   still breaks the graph, which CUDA-graph trees cannot span. Use the
-  default inductor mode (shown above) until that is resolved; passing
-  `torch_compile_kwargs={"mode": "reduce-overhead"}` may error.
+  default inductor mode (shown above) until that is resolved.
+
+Extra `torch.compile` options are passed through `torch_compile_kwargs`
+(a dict), accepted by `VideoGenerator.from_pretrained(...)` and by the
+CLI as a JSON string via `--torch-compile-kwargs`. Example (currently
+**not** recommended — see the CUDA-graphs caveat above):
+
+```python
+VideoGenerator.from_pretrained(
+    "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+    enable_torch_compile=True,
+    torch_compile_kwargs={"mode": "reduce-overhead"},  # may error today
+)
+```
 
 ### Benchmarking torch.compile
 
@@ -249,9 +263,11 @@ import time
 from fastvideo import VideoGenerator
 
 gen = VideoGenerator.from_pretrained("your-model-id", enable_torch_compile=True)
-gen.generate_video(prompt="Your prompt", seed=1024)          # warmup: graph build, discard
+req = {"prompt": "Your prompt", "sampling": {"seed": 1024},
+       "output": {"save_video": False}}
+gen.generate(req)                                            # warmup: graph build, discard
 t0 = time.perf_counter()
-gen.generate_video(prompt="Your prompt", seed=1024)          # measured: shapes reused
+gen.generate(req)                                            # measured: shapes reused
 print(f"compiled steady-state: {time.perf_counter() - t0:.2f}s")
 ```
 

--- a/docs/inference/optimizations.md
+++ b/docs/inference/optimizations.md
@@ -188,8 +188,6 @@ end-to-end speedup. It is **off by default** and enabled per-run.
 
 ### Enabling
 
-Python:
-
 ```python
 generator = VideoGenerator.from_pretrained(
     "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
@@ -197,12 +195,13 @@ generator = VideoGenerator.from_pretrained(
 )
 ```
 
-CLI:
+A complete A/B example (eager vs compiled, warmup excluded) is in
+[`examples/inference/optimizations/torch_compile_example.py`](https://github.com/hao-ai-lab/FastVideo/blob/main/examples/inference/optimizations/torch_compile_example.py).
 
-```bash
-fastvideo generate --model-path "Wan-AI/Wan2.1-T2V-1.3B-Diffusers" \
-    --prompt "..." --enable-torch-compile
-```
+`fastvideo generate` is config-file driven; to enable `torch.compile`
+from the CLI, set the relevant field in your run config and pass it via
+`fastvideo generate --config run.yaml`. There is no top-level
+`--enable-torch-compile` flag on the subcommand.
 
 Only DiT submodules that declare `_compile_conditions` are compiled
 (most shipped models). The text encoder and VAE are not compiled by this
@@ -224,9 +223,15 @@ generations with the same input shapes. Always exclude the first
 (warmup) generation when measuring steady-state latency — measuring the
 warmup is the most common way to wrongly conclude "compile is slower".
 
-Compiled output is numerically equivalent to eager for the shipped
-models (MS-SSIM ≈ 1.0 vs eager on Wan2.1-T2V-1.3B); still SSIM-gate when
-combining with quantized attention backends.
+**Numerics.** Inductor's lowering is designed to preserve eager
+semantics within floating-point tolerance, but per-model equivalence is
+not asserted by any standing SSIM regression here — the SSIM tests in
+[`fastvideo/tests/ssim/`](https://github.com/hao-ai-lab/FastVideo/tree/main/fastvideo/tests/ssim)
+run with `enable_torch_compile` disabled. If you depend on compile
+output staying close to eager (or your previous compiled run), run an
+MS-SSIM gate on *your* config, especially when combining
+`enable_torch_compile=True` with other numerics-affecting flags
+(quantized attention backends, FP4, layerwise offload edge cases).
 
 ### Known interactions
 

--- a/docs/inference/optimizations.md
+++ b/docs/inference/optimizations.md
@@ -12,6 +12,8 @@ This page describes the various options for speeding up generation times in Fast
   - [Sage Attention](#sage-attention)
   - [Sage Attention 3](#sage-attention-3)
 
+- [torch.compile](#torchcompile)
+
 ## Attention Backends
 
 ### Available Backends
@@ -176,6 +178,85 @@ To use Sage Attention 3 in FastVideo, follow the `README.md` in the linked repos
 These backends are model-specific and require the corresponding kernels and
 dependencies. Use the support matrix and model examples to confirm compatibility
 before enabling them.
+
+## torch.compile
+
+FastVideo can `torch.compile` the DiT (transformer) for a substantial
+end-to-end speedup. It is **off by default** and enabled per-run.
+
+### Enabling
+
+Python:
+
+```python
+generator = VideoGenerator.from_pretrained(
+    "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+    enable_torch_compile=True,
+)
+```
+
+CLI:
+
+```bash
+fastvideo generate --model-path "Wan-AI/Wan2.1-T2V-1.3B-Diffusers" \
+    --prompt "..." --enable-torch-compile
+```
+
+Only DiT submodules that declare `_compile_conditions` are compiled
+(most shipped models). The text encoder and VAE are not compiled by this
+flag.
+
+### What to expect
+
+| Config | Effect |
+|---|---|
+| Wan2.1-T2V-1.3B, A100-80GB, 480×832×81f, 50 steps | end-to-end **259.7s → 198.1s (−23.7%)**; per-step **4.91 → 3.78 s/it** |
+
+The speedup is **configuration-dependent** — it varies with model,
+resolution, step count, and GPU. Treat the number above as one measured
+data point, not a guarantee; benchmark your own config (recipe below).
+
+There is a **one-time graph-build cost** on the first generation (tens of
+seconds to minutes, model-dependent). It amortizes over subsequent
+generations with the same input shapes. Always exclude the first
+(warmup) generation when measuring steady-state latency — measuring the
+warmup is the most common way to wrongly conclude "compile is slower".
+
+Compiled output is numerically equivalent to eager for the shipped
+models (MS-SSIM ≈ 1.0 vs eager on Wan2.1-T2V-1.3B); still SSIM-gate when
+combining with quantized attention backends.
+
+### Known interactions
+
+- **Layerwise CPU offload** (`dit_layerwise_offload=True`, the default):
+  the offload hook previously caused an implicit graph break once per
+  transformer layer, fragmenting the compiled region. Addressed in
+  hao-ai-lab/FastVideo#1365 — keep that fix to get a clean compiled
+  region under the default offload path.
+- **`mode="reduce-overhead"` / CUDA graphs**: not yet supported
+  end-to-end. The attention dispatch is an untraceable custom op and
+  still breaks the graph, which CUDA-graph trees cannot span. Use the
+  default inductor mode (shown above) until that is resolved; passing
+  `torch_compile_kwargs={"mode": "reduce-overhead"}` may error.
+
+### Benchmarking torch.compile
+
+Same discipline as attention backends — same prompt, same seed, same
+config; **discard the first generation** (graph build):
+
+```python
+import time
+from fastvideo import VideoGenerator
+
+gen = VideoGenerator.from_pretrained("your-model-id", enable_torch_compile=True)
+gen.generate_video(prompt="Your prompt", seed=1024)          # warmup: graph build, discard
+t0 = time.perf_counter()
+gen.generate_video(prompt="Your prompt", seed=1024)          # measured: shapes reused
+print(f"compiled steady-state: {time.perf_counter() - t0:.2f}s")
+```
+
+See `examples/inference/optimizations/torch_compile_example.py` for a
+baseline-vs-compile A/B with the warmup correctly excluded.
 
 ## Benchmarking different optimizations
 

--- a/examples/inference/optimizations/torch_compile_example.py
+++ b/examples/inference/optimizations/torch_compile_example.py
@@ -1,0 +1,71 @@
+"""torch.compile A/B example for FastVideo.
+
+`enable_torch_compile=True` compiles the DiT submodules that declare
+`_compile_conditions` for a substantial end-to-end speedup (e.g.
+Wan2.1-T2V-1.3B on A100: ~-24% e2e). It is off by default.
+
+The first compiled generation pays a one-time graph-build cost; it
+amortizes over later generations with the same input shapes. This
+script does one un-measured warmup then a measured run so the reported
+number is steady-state, not graph-build — measuring the warmup is the
+most common way to wrongly conclude compile is slower.
+
+Usage:
+    # baseline (eager)
+    python torch_compile_example.py
+    # compiled
+    python torch_compile_example.py --compile
+"""
+
+import argparse
+import time
+
+from fastvideo import VideoGenerator
+
+PROMPT = (
+    "A high-definition video of a robotic arm welding a metal structure, "
+    "bright sparks and smoke, industrial setting."
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="torch.compile A/B")
+    parser.add_argument("--model", default="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+    parser.add_argument("--compile", action="store_true",
+                        help="Enable torch.compile for the DiT")
+    parser.add_argument("--num_gpus", type=int, default=1)
+    args = parser.parse_args()
+
+    mode = "COMPILE" if args.compile else "BASELINE"
+    print(f"Mode: {mode}  (enable_torch_compile={args.compile})")
+
+    generator = VideoGenerator.from_pretrained(
+        args.model,
+        num_gpus=args.num_gpus,
+        enable_torch_compile=args.compile,
+    )
+
+    def _run(tag: str) -> float:
+        t0 = time.perf_counter()
+        generator.generate_video(
+            PROMPT,
+            seed=1024,
+            output_path=f"video_samples/torch_compile_{tag}.mp4",
+            save_video=(tag == "measured"),
+        )
+        return time.perf_counter() - t0
+
+    # Warmup: pays the one-time graph build when --compile. Discarded.
+    w = _run("warmup")
+    print(f"warmup: {w:.2f}s "
+          f"({'incl. graph build' if args.compile else 'cold start'})")
+
+    # Measured: steady state, compiled graph reused (same shapes/seed).
+    m = _run("measured")
+    print(f"=== {mode} steady-state e2e: {m:.2f}s ===")
+
+    generator.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/inference/optimizations/torch_compile_example.py
+++ b/examples/inference/optimizations/torch_compile_example.py
@@ -18,6 +18,7 @@ Usage:
 """
 
 import argparse
+import os
 import time
 
 from fastvideo import VideoGenerator
@@ -39,6 +40,8 @@ def main() -> None:
     mode = "COMPILE" if args.compile else "BASELINE"
     print(f"Mode: {mode}  (enable_torch_compile={args.compile})")
 
+    os.makedirs("video_samples", exist_ok=True)
+
     generator = VideoGenerator.from_pretrained(
         args.model,
         num_gpus=args.num_gpus,
@@ -46,25 +49,32 @@ def main() -> None:
     )
 
     def _run(tag: str) -> float:
+        save = tag == "measured"
+        # Modern typed-request API (generate_video is deprecated). Same
+        # prompt/seed/shapes both runs so the compiled graph is reused.
+        request: dict = {
+            "prompt": PROMPT,
+            "sampling": {"seed": 1024},
+            "output": {"save_video": save},
+        }
+        if save:
+            request["output"]["output_path"] = (
+                f"video_samples/torch_compile_{tag}.mp4")
         t0 = time.perf_counter()
-        generator.generate_video(
-            PROMPT,
-            seed=1024,
-            output_path=f"video_samples/torch_compile_{tag}.mp4",
-            save_video=(tag == "measured"),
-        )
+        generator.generate(request)
         return time.perf_counter() - t0
 
-    # Warmup: pays the one-time graph build when --compile. Discarded.
-    w = _run("warmup")
-    print(f"warmup: {w:.2f}s "
-          f"({'incl. graph build' if args.compile else 'cold start'})")
+    try:
+        # Warmup: pays the one-time graph build when --compile. Discarded.
+        w = _run("warmup")
+        print(f"warmup: {w:.2f}s "
+              f"({'incl. graph build' if args.compile else 'cold start'})")
 
-    # Measured: steady state, compiled graph reused (same shapes/seed).
-    m = _run("measured")
-    print(f"=== {mode} steady-state e2e: {m:.2f}s ===")
-
-    generator.shutdown()
+        # Measured: steady state, compiled graph reused (same shapes/seed).
+        m = _run("measured")
+        print(f"=== {mode} steady-state e2e: {m:.2f}s ===")
+    finally:
+        generator.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`enable_torch_compile` compiles the DiT for a substantial end-to-end speedup but is **off by default and undocumented**. This adds a `torch.compile` section to `docs/inference/optimizations.md` and an A/B example.

Measured (one data point, config-dependent): **Wan2.1-T2V-1.3B, A100-80GB, 480×832×81f, 50 steps → 259.7s → 198.1s end-to-end (−23.7%); 4.91 → 3.78 s/it.**

Docs cover: how to enable (Python + CLI), honest config-dependent framing (not a guarantee — benchmark your own config), the one-time graph-build cost and the warmup-exclusion discipline (measuring the warmup is the usual way people wrongly conclude compile is slower), numerical equivalence (MS-SSIM ≈ 1.0 vs eager on Wan-1.3B), and **known interactions**:

- Layerwise CPU offload (default) caused a per-layer graph break — addressed in #1365.
- `mode="reduce-overhead"` / CUDA graphs not yet supported end-to-end (attention dispatch is an untraceable custom op that still breaks the graph; CUDA-graph trees can't span it).

Example `examples/inference/optimizations/torch_compile_example.py` does a baseline-vs-compile A/B with the warmup correctly excluded.

## Scope

Docs + one example. No production code change. Independent of #1365 (the speedup is real regardless; #1365 only removes one caveat — cross-referenced, not git-stacked).

## Test plan

- [x] Numbers measured on A100 (Wan2.1-T2V-1.3B); SSIM ≈ 1.0 vs eager
- [x] Example syntax-checked; mirrors existing optimizations/ examples
- [ ] Docs render / CI