### PR TITLE
[ci] Add Dreamverse Docker image workflow

### DIFF
--- a/.github/workflows/_template-build-image.yml
+++ b/.github/workflows/_template-build-image.yml
@@ -12,6 +12,10 @@ on:
       tag_suffix:
         required: true
         type: string
+      image_name:
+        required: false
+        type: string
+        default: fastvideo-dev
 
 jobs:
   build-and-push:
@@ -85,7 +89,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}/fastvideo-dev
+          images: ghcr.io/${{ github.repository }}/${{ inputs.image_name }}
           tags: ${{ steps.prepare-tags.outputs.tags }}
       
       - name: Build and push Docker image
@@ -102,5 +106,5 @@ jobs:
       
       - name: Success message
         run: |
-          echo "✅ Python ${{ inputs.python_version }} image successfully built and pushed to ghcr.io/${{ github.repository }}/fastvideo-dev:${{ inputs.tag_suffix }}-latest"
-          echo "To run tests with this image, manually trigger the 'Run Tests' workflow." 
+          echo "✅ Python ${{ inputs.python_version }} image successfully built and pushed to ghcr.io/${{ github.repository }}/${{ inputs.image_name }}:${{ inputs.tag_suffix }}-latest"
+          echo "To run tests with this image, manually trigger the 'Run Tests' workflow."

--- a/.github/workflows/infra-build-image.yml
+++ b/.github/workflows/infra-build-image.yml
@@ -23,6 +23,11 @@ on:
         required: false
         default: false
         type: boolean
+      dreamverse_cuda_12_9:
+        description: 'Build Dreamverse CUDA 12.9 image'
+        required: false
+        default: false
+        type: boolean
 
 
 permissions:
@@ -64,4 +69,14 @@ jobs:
       python_version: '3.12'
       dockerfile_path: docker/Dockerfile.python3.12.cuda12.9.1
       tag_suffix: py3.12-cuda12.9.1
+    secrets: inherit
+
+  build-dreamverse-cuda-12-9:
+    if: ${{ github.event.inputs.dreamverse_cuda_12_9 == 'true' }}
+    uses: ./.github/workflows/_template-build-image.yml
+    with:
+      python_version: '3.12'
+      dockerfile_path: apps/dreamverse/docker/Dockerfile
+      tag_suffix: dreamverse-cuda12.9.1
+      image_name: dreamverse
     secrets: inherit


### PR DESCRIPTION
## Purpose

Add Dreamverse to the supported Docker image publishing workflow so maintainers can manually build and push the Dreamverse container image to GHCR.

Fixes #

## Changes

- Add an optional `image_name` input to the reusable Docker image build workflow, defaulting to `fastvideo-dev` so existing image jobs keep the same publish target.
- Use `image_name` when generating Docker metadata and success output.
- Add a `dreamverse_cuda_12_9` manual workflow input and matching job in `infra-build-image.yml`.
- Configure the Dreamverse job to build `apps/dreamverse/docker/Dockerfile` and publish to `ghcr.io/${{ github.repository }}/dreamverse` with the `dreamverse-cuda12.9.1` tag suffix.

## Test Plan

```bash
python3 - <<'PY'
from pathlib import Path
import yaml
root = Path('.')
infra = yaml.safe_load((root/'.github/workflows/infra-build-image.yml').read_text())
template = yaml.safe_load((root/'.github/workflows/_template-build-image.yml').read_text())
assert isinstance(infra, dict) and isinstance(template, dict)
template_inputs = template[True]['workflow_call']['inputs']
for key in ['python_version', 'dockerfile_path', 'tag_suffix']:
    assert key in template_inputs, key
assert template_inputs['image_name']['required'] is False
assert template_inputs['image_name']['default'] == 'fastvideo-dev'
infra_inputs = infra[True]['workflow_dispatch']['inputs']
assert infra_inputs['dreamverse_cuda_12_9']['type'] == 'boolean'
assert infra_inputs['dreamverse_cuda_12_9']['default'] is False
job = infra['jobs']['build-dreamverse-cuda-12-9']
assert job['if'] == "${{ github.event.inputs.dreamverse_cuda_12_9 == 'true' }}"
assert job['with']['dockerfile_path'] == 'apps/dreamverse/docker/Dockerfile'
assert job['with']['python_version'] == '3.12'
assert job['with']['tag_suffix'] == 'dreamverse-cuda12.9.1'
assert job['with']['image_name'] == 'dreamverse'
for name, j in infra['jobs'].items():
    if name == 'build-dreamverse-cuda-12-9':
        continue
    if 'with' in j:
        for key in ['python_version', 'dockerfile_path', 'tag_suffix']:
            assert key in j['with'], (name, key)
        assert 'image_name' not in j['with'], name
print('workflow static validation passed')
PY

git diff --check
pre-commit run --files .github/workflows/_template-build-image.yml .github/workflows/infra-build-image.yml
```

## Test Results

<details>
<summary>Test output</summary>

```
workflow static validation passed

git diff --check
# passed with no output

pre-commit run --files .github/workflows/_template-build-image.yml .github/workflows/infra-build-image.yml
yapf.................................................(no files to check)Skipped
ruff (legacy alias)..................................(no files to check)Skipped
codespell................................................................Passed
PyMarkdown...........................................(no files to check)Skipped
Lint GitHub Actions workflow files.......................................Passed
mypy.................................................(no files to check)Skipped
Check for spaces in all filenames........................................Passed
Suggestion...............................................................Passed
```

</details>

## Checklist

- [ ] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model

Notes:
- This is a workflow-only change. I ran targeted pre-commit for the changed workflow files rather than `pre-commit run --all-files`.
- The Docker build was validated locally before this PR per implementation request; this PR only performed static workflow validation.
- Post-merge validation: manually dispatch `Build and Push Docker Images` with `dreamverse_cuda_12_9=true`, confirm the GHCR image is published, then pull/smoke-test it.