### PR TITLE
[perf] Add Adaptive Guidance (CFG gating) for stale-uncond reuse

### DIFF
--- a/docs/inference/optimizations.md
+++ b/docs/inference/optimizations.md
@@ -11,6 +11,7 @@ This page describes the various options for speeding up generation times in Fast
   - [Sliding Tile Attention (Archived)](#sliding-tile-attention-archived)
   - [Sage Attention](#sage-attention)
   - [Sage Attention 3](#sage-attention-3)
+- [Adaptive Guidance (CFG gating)](#adaptive-guidance-cfg-gating)
 
 ## Attention Backends
 
@@ -198,3 +199,37 @@ for backend in ["TORCH_SDPA", "FLASH_ATTN", "SAGE_ATTN"]:
 ```
 
 Note: reinstantiate `VideoGenerator` after changing `FASTVIDEO_ATTENTION_BACKEND`.
+
+## Adaptive Guidance (CFG gating)
+
+CFG gating accelerates classifier-free guidance by reusing the cached
+`noise_pred_cond - noise_pred_uncond` delta after a configurable fraction of
+the denoising schedule, skipping the unconditional model forward for the
+remaining steps. The technique is the LinearAG variant of Adaptive Guidance
+(Castillo et al. 2023, [arXiv:2312.12487](https://arxiv.org/abs/2312.12487)).
+
+### Enabling
+
+Set the `FASTVIDEO_CFG_GATE_STEP` environment variable to a float in `[0, 1]`:
+
+| Value | Behavior |
+|-------|----------|
+| `1.0` (default) | Disabled — legacy two-pass CFG every step. |
+| `0.5` | Cache the delta after `len(timesteps) * 0.5` steps; reuse for the rest. |
+| `0.0` | Cache from the very first step (most aggressive). |
+
+```bash
+export FASTVIDEO_CFG_GATE_STEP=0.5
+```
+
+### Trade-offs
+
+- **Memory**: one extra model-output-sized tensor per rank held during the
+  gating window.
+- **Quality**: VBench-measured quality is preserved within noise on 4 of 5
+  dimensions at `FASTVIDEO_CFG_GATE_STEP=0.5` for Wan T2V 1.3B per the PR's
+  reported numbers (see [#1372](https://github.com/hao-ai-lab/FastVideo/pull/1372)).
+- **Speed**: ~22% e2e on 4xL40S and ~24% on 1xH100 at the same settings.
+
+Default behavior is byte-for-byte equivalent to the legacy two-pass CFG path;
+the feature is fully opt-in.

--- a/fastvideo/envs.py
+++ b/fastvideo/envs.py
@@ -287,9 +287,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
 
     # CFG gating fraction for stale-uncond reuse (Adaptive Guidance / LinearAG
     # variant — Castillo et al. 2023, arXiv:2312.12487).  Float in [0, 1].
-    # Interpretation: for step index `i < num_inference_steps * X`, run both
+    # Interpretation: for step index `i < len(timesteps) * X`, run both
     # cond and uncond forwards and refresh delta_cached = cond - uncond.
-    # Once `i >= num_inference_steps * X`, skip the uncond forward and reuse
+    # Once `i >= len(timesteps) * X`, skip the uncond forward and reuse
     # the cached delta:  noise_pred = cond + (guidance_scale - 1) * delta.
     #
     # Edge cases:

--- a/fastvideo/envs.py
+++ b/fastvideo/envs.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     FASTVIDEO_TRACE_STEPS: str = ""
     FASTVIDEO_SERVER_DEV_MODE: bool = False
     FASTVIDEO_STAGE_LOGGING: bool = False
+    FASTVIDEO_CFG_GATE_STEP: float = 1.0
     FASTVIDEO_HOST_IP: str = ""
     FASTVIDEO_LOOPBACK_IP: str = ""
 
@@ -283,6 +284,32 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # taken for each stage
     "FASTVIDEO_STAGE_LOGGING":
     lambda: bool(int(os.getenv("FASTVIDEO_STAGE_LOGGING", "0"))),
+
+    # CFG gating fraction for stale-uncond reuse (Adaptive Guidance / LinearAG
+    # variant — Castillo et al. 2023, arXiv:2312.12487).  Float in [0, 1].
+    # Interpretation: for step index `i < num_inference_steps * X`, run both
+    # cond and uncond forwards and refresh delta_cached = cond - uncond.
+    # Once `i >= num_inference_steps * X`, skip the uncond forward and reuse
+    # the cached delta:  noise_pred = cond + (guidance_scale - 1) * delta.
+    #
+    # Edge cases:
+    #   1.0 (default) : disables gating; identical to baseline two-pass CFG.
+    #   0.5           : run uncond for the first half of steps, reuse delta
+    #                    for the second half (~25% inference time saved on
+    #                    bandwidth-bound SP setups).
+    #   0.0           : step 0 still computes uncond fresh (cache is empty
+    #                    at start) — all subsequent steps reuse the step-0
+    #                    delta.  This is the most aggressive setting; does
+    #                    NOT mean "no uncond forward ever."
+    #
+    # Caveats:
+    #   - Algorithmically approximate; not bit-exact vs baseline CFG.
+    #     Validate per-pipeline with SSIM / VBench before lowering below 1.0.
+    #   - Interaction with `guidance_rescale > 0` is unvalidated; the
+    #     denoising stage logs a warning when both are active.
+    #   - Wan2.2 high/low-noise expert switch invalidates the cache.
+    "FASTVIDEO_CFG_GATE_STEP":
+    lambda: float(os.getenv("FASTVIDEO_CFG_GATE_STEP", "1.0")),
 }
 
 # end-env-vars-definition

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -11,6 +11,7 @@ from typing import Any
 import torch
 from tqdm.auto import tqdm
 
+import fastvideo.envs as envs
 from fastvideo.attention import get_attn_backend
 from fastvideo.distributed import (get_local_torch_device, get_world_group)
 from fastvideo.fastvideo_args import FastVideoArgs
@@ -229,6 +230,44 @@ class DenoisingStage(PipelineStage):
         # written to, so we allocate once.
         v2v_zero_pad = torch.zeros_like(latents) if batch.video_latent is not None else None
 
+        # CFG gating / stale-uncond reuse setup (Adaptive Guidance LinearAG
+        # variant, Castillo et al. 2023).  When envs.FASTVIDEO_CFG_GATE_STEP
+        # < 1.0, the uncond forward is skipped after the gating step and the
+        # guidance delta (cond - uncond) is reused from the last fresh
+        # compute.  See envs.py for semantics.  delta_cached_model_id tracks
+        # which underlying transformer produced the cache so we invalidate on
+        # Wan2.2 expert switch.
+        _cfg_gate_fraction = envs.FASTVIDEO_CFG_GATE_STEP
+        if not 0.0 <= _cfg_gate_fraction <= 1.0:
+            raise ValueError(f"FASTVIDEO_CFG_GATE_STEP must be in [0.0, 1.0], got {_cfg_gate_fraction!r}. "
+                             "Use 1.0 (default) to disable; lower values trade quality for speed.")
+        _cfg_gate_active = _cfg_gate_fraction < 1.0 and batch.do_classifier_free_guidance
+        _is_rank0 = get_world_group().local_rank == 0
+        if _cfg_gate_active:
+            _cfg_gate_step_idx = int(num_inference_steps * _cfg_gate_fraction)
+            if _is_rank0:
+                logger.info("CFG gating enabled: fraction=%.3f, gate_step=%d/%d", _cfg_gate_fraction,
+                            _cfg_gate_step_idx, num_inference_steps)
+            if batch.guidance_rescale > 0.0 and _is_rank0:
+                # guidance_rescale rescales CFG output stats to match cond
+                # stats (Lin et al. §3.4).  When `delta_cached` goes stale,
+                # the rescaling still computes but is no longer guaranteed
+                # to preserve the original quality semantics.  Warn so the
+                # caller knows this combo is unvalidated; tighten or
+                # fallback once VBench data lands.
+                logger.warning(
+                    "CFG gating (fraction=%.3f) combined with guidance_rescale=%.3f is unvalidated; "
+                    "quality may degrade beyond CFG-gating-alone expectations.", _cfg_gate_fraction,
+                    batch.guidance_rescale)
+        else:
+            _cfg_gate_step_idx = num_inference_steps + 1  # never gates
+        delta_cached: torch.Tensor | None = None
+        delta_cached_model_id: int | None = None
+        # Telemetry — logged at end of denoising loop on rank 0.
+        _cfg_gate_fresh_uncond = 0
+        _cfg_gate_reused_delta = 0
+        _cfg_gate_invalidations = 0
+
         # Run denoising loop
         with self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
@@ -362,26 +401,58 @@ class DenoisingStage(PipelineStage):
                         )
 
                     if batch.do_classifier_free_guidance:
-                        batch.is_cfg_negative = True
-                        with set_forward_context(
-                                current_timestep=i,
-                                attn_metadata=attn_metadata,
-                                forward_batch=batch,
-                        ):
-                            noise_pred_uncond = current_model(
-                                latent_model_input,
-                                neg_prompt_embeds,
-                                t_expand,
-                                guidance=guidance_expand,
-                                **image_kwargs,
-                                **neg_cond_kwargs,
-                                **action_kwargs,
-                                **camera_kwargs,
-                                **timesteps_r_kwarg,
-                            )
+                        # CFG gating: invalidate cached delta when the underlying
+                        # transformer changes (Wan2.2 high/low-noise expert
+                        # switch at `boundary_timestep`).  delta_cached is tied
+                        # to the model that produced it; reusing it across the
+                        # boundary is silently wrong.
+                        if delta_cached_model_id is not None and delta_cached_model_id != id(current_model):
+                            delta_cached = None
+                            delta_cached_model_id = None
+                            _cfg_gate_invalidations += 1
+
+                        _use_cached_delta = (i >= _cfg_gate_step_idx and delta_cached is not None)
 
                         noise_pred_text = noise_pred
-                        noise_pred = noise_pred_uncond + current_guidance_scale * (noise_pred_text - noise_pred_uncond)
+                        if _use_cached_delta:
+                            # Reuse frozen delta = cond - uncond from the last
+                            # fresh compute.  Algebra:
+                            #   pred = uncond + s * (cond - uncond)
+                            #        = cond + (s - 1) * (cond - uncond)
+                            #        = cond + (s - 1) * delta_cached
+                            noise_pred = noise_pred_text + (current_guidance_scale - 1.0) * delta_cached
+                            _cfg_gate_reused_delta += 1
+                        else:
+                            batch.is_cfg_negative = True
+                            with set_forward_context(
+                                    current_timestep=i,
+                                    attn_metadata=attn_metadata,
+                                    forward_batch=batch,
+                            ):
+                                noise_pred_uncond = current_model(
+                                    latent_model_input,
+                                    neg_prompt_embeds,
+                                    t_expand,
+                                    guidance=guidance_expand,
+                                    **image_kwargs,
+                                    **neg_cond_kwargs,
+                                    **action_kwargs,
+                                    **camera_kwargs,
+                                    **timesteps_r_kwarg,
+                                )
+                            _cfg_gate_fresh_uncond += 1
+
+                            # Refresh cache only when gating is active; under the
+                            # default (FASTVIDEO_CFG_GATE_STEP=1.0, _cfg_gate_step_idx
+                            # > num_inference_steps) we never reuse, so skip the
+                            # tensor allocation.
+                            if _cfg_gate_step_idx <= num_inference_steps:
+                                delta_cached = noise_pred_text - noise_pred_uncond
+                                delta_cached_model_id = id(current_model)
+                                noise_pred = noise_pred_uncond + current_guidance_scale * delta_cached
+                            else:
+                                noise_pred = noise_pred_uncond + current_guidance_scale * (noise_pred_text -
+                                                                                           noise_pred_uncond)
 
                         # Apply guidance rescale if needed
                         if batch.guidance_rescale > 0.0:
@@ -407,6 +478,22 @@ class DenoisingStage(PipelineStage):
                 if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and
                                                (i + 1) % self.scheduler.order == 0 and progress_bar is not None):
                     progress_bar.update()
+
+        # CFG gating telemetry — log once on rank 0 after the loop ends.  When
+        # gating is disabled (or CFG itself is off) fresh_uncond equals the
+        # number of CFG-on steps and reused/invalidations are zero; we still
+        # emit the line so users can confirm the env var is wired through.
+        if _is_rank0 and batch.do_classifier_free_guidance:
+            logger.info(
+                "CFG gating summary: fraction=%.3f gate_step=%d/%d "
+                "fresh_uncond=%d reused=%d invalidations=%d",
+                _cfg_gate_fraction,
+                _cfg_gate_step_idx if _cfg_gate_active else -1,
+                num_inference_steps,
+                _cfg_gate_fresh_uncond,
+                _cfg_gate_reused_delta,
+                _cfg_gate_invalidations,
+            )
 
         trajectory_tensor: torch.Tensor | None = None
         if trajectory_latents:

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -244,10 +244,15 @@ class DenoisingStage(PipelineStage):
         _cfg_gate_active = _cfg_gate_fraction < 1.0 and batch.do_classifier_free_guidance
         _is_rank0 = get_world_group().local_rank == 0
         if _cfg_gate_active:
-            _cfg_gate_step_idx = int(num_inference_steps * _cfg_gate_fraction)
+            # Use len(timesteps), not num_inference_steps: the loop iterates
+            # over timesteps directly, and for schedulers with order > 1
+            # (e.g. DPM-Solver++ 2M, Heun) len(timesteps) is a multiple of
+            # num_inference_steps. Using num_inference_steps would cause the
+            # gate to fire at fraction/order of the loop instead of fraction.
+            _cfg_gate_step_idx = int(len(timesteps) * _cfg_gate_fraction)
             if _is_rank0:
                 logger.info("CFG gating enabled: fraction=%.3f, gate_step=%d/%d", _cfg_gate_fraction,
-                            _cfg_gate_step_idx, num_inference_steps)
+                            _cfg_gate_step_idx, len(timesteps))
             if batch.guidance_rescale > 0.0 and _is_rank0:
                 # guidance_rescale rescales CFG output stats to match cond
                 # stats (Lin et al. §3.4).  When `delta_cached` goes stale,
@@ -260,7 +265,7 @@ class DenoisingStage(PipelineStage):
                     "quality may degrade beyond CFG-gating-alone expectations.", _cfg_gate_fraction,
                     batch.guidance_rescale)
         else:
-            _cfg_gate_step_idx = num_inference_steps + 1  # never gates
+            _cfg_gate_step_idx = len(timesteps) + 1  # never gates
         delta_cached: torch.Tensor | None = None
         delta_cached_model_id: int | None = None
         # Telemetry — logged at end of denoising loop on rank 0.
@@ -444,9 +449,9 @@ class DenoisingStage(PipelineStage):
 
                             # Refresh cache only when gating is active; under the
                             # default (FASTVIDEO_CFG_GATE_STEP=1.0, _cfg_gate_step_idx
-                            # > num_inference_steps) we never reuse, so skip the
+                            # > len(timesteps)) we never reuse, so skip the
                             # tensor allocation.
-                            if _cfg_gate_step_idx <= num_inference_steps:
+                            if _cfg_gate_step_idx <= len(timesteps):
                                 delta_cached = noise_pred_text - noise_pred_uncond
                                 delta_cached_model_id = id(current_model)
                                 noise_pred = noise_pred_uncond + current_guidance_scale * delta_cached
@@ -489,7 +494,7 @@ class DenoisingStage(PipelineStage):
                 "fresh_uncond=%d reused=%d invalidations=%d",
                 _cfg_gate_fraction,
                 _cfg_gate_step_idx if _cfg_gate_active else -1,
-                num_inference_steps,
+                len(timesteps),
                 _cfg_gate_fresh_uncond,
                 _cfg_gate_reused_delta,
                 _cfg_gate_invalidations,

--- a/fastvideo/tests/inference/test_cfg_gating.py
+++ b/fastvideo/tests/inference/test_cfg_gating.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.infos = []
+        self.warnings = []
+
+    def info(self, msg, *args):
+        self.infos.append(msg % args if args else msg)
+
+    def warning(self, msg, *args):
+        self.warnings.append(msg % args if args else msg)
+
+
+class NullProgressBar:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def update(self):
+        pass
+
+
+class TinyScheduler:
+    order = 1
+    num_train_timesteps = 1000
+
+    def scale_model_input(self, latents, timestep):
+        return latents
+
+    def step(self, noise_pred, timestep, latents, return_dict=False):
+        return (latents.float() - 0.01 * noise_pred.float(), )
+
+
+class TinyDenoiser(torch.nn.Module):
+    hidden_size = 1
+    num_attention_heads = 1
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(use_meanflow=False)
+        self.calls = []
+
+    def forward(self, latent_model_input, prompt_embeds, timestep, guidance=None):
+        prompt_value = prompt_embeds[0].to(latent_model_input.device, torch.float32)
+        is_uncond = bool(prompt_value.item() < 0)
+        self.calls.append("uncond" if is_uncond else "cond")
+
+        prompt_term = prompt_value.reshape((1, ) * latent_model_input.ndim)
+        timestep_term = timestep.to(latent_model_input.device, torch.float32).reshape(
+            latent_model_input.shape[0], *([1] * (latent_model_input.ndim - 1)))
+        return latent_model_input.float() * 0.2 + prompt_term * 0.5 + timestep_term * 0.001
+
+
+def _tiny_args():
+    return SimpleNamespace(
+        disable_autocast=True,
+        dit_cpu_offload=False,
+        dit_layerwise_offload=False,
+        use_fsdp_inference=False,
+        moba_config={},
+        VSA_sparsity=0.0,
+        model_loaded={"transformer": True},
+        model_paths={"transformer": "unused"},
+        pipeline_config=SimpleNamespace(
+            embedded_cfg_scale=None,
+            ti2v_task=False,
+            dit_config=SimpleNamespace(boundary_ratio=None, patch_size=(1, 1, 1)),
+        ),
+    )
+
+
+def _tiny_batch():
+    from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+
+    return ForwardBatch(
+        data_type="video",
+        latents=torch.tensor([[[[[0.125]]]]], dtype=torch.float32),
+        prompt_embeds=[torch.tensor([1.0], dtype=torch.float32)],
+        negative_prompt_embeds=[torch.tensor([-1.0], dtype=torch.float32)],
+        timesteps=torch.tensor([4.0, 3.0, 2.0, 1.0], dtype=torch.float32),
+        num_inference_steps=4,
+        guidance_scale=2.0,
+        height=1,
+        width=1,
+        num_frames=1,
+        raw_latent_shape=(1, 1, 1, 1, 1),
+        save_video=False,
+    )
+
+
+def _patch_denoising_module(monkeypatch, cfg_gate_step):
+    if cfg_gate_step is None:
+        monkeypatch.delenv("FASTVIDEO_CFG_GATE_STEP", raising=False)
+        expected_gate_step = 1.0
+    else:
+        monkeypatch.setenv("FASTVIDEO_CFG_GATE_STEP", str(cfg_gate_step))
+        expected_gate_step = float(cfg_gate_step)
+
+    import fastvideo.pipelines.stages.denoising as denoising
+
+    # envs.py evaluates FASTVIDEO_CFG_GATE_STEP lazily via __getattr__, so the
+    # stage sees monkeypatched values without reloading the module.
+    assert denoising.envs.FASTVIDEO_CFG_GATE_STEP == expected_gate_step
+
+    logger = RecordingLogger()
+    monkeypatch.setattr(denoising, "logger", logger)
+    monkeypatch.setattr(denoising, "get_local_torch_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr(denoising, "get_world_group", lambda: SimpleNamespace(local_rank=0))
+    monkeypatch.setattr(denoising, "get_attn_backend", lambda **kwargs: object())
+    monkeypatch.setattr(denoising, "set_forward_context", lambda **kwargs: nullcontext())
+    return denoising, logger
+
+
+def _run_stage(monkeypatch, cfg_gate_step):
+    denoising, logger = _patch_denoising_module(monkeypatch, cfg_gate_step)
+    model = TinyDenoiser()
+    stage = denoising.DenoisingStage(model, TinyScheduler())
+    stage.progress_bar = lambda iterable=None, total=None: NullProgressBar()
+
+    result = stage.forward(_tiny_batch(), _tiny_args())
+    return result.latents, model, logger
+
+
+def _run_legacy_two_pass():
+    batch = _tiny_batch()
+    model = TinyDenoiser()
+    scheduler = TinyScheduler()
+    assert batch.latents is not None
+    assert batch.timesteps is not None
+    latents = batch.latents.clone()
+
+    for timestep in batch.timesteps:
+        latent_model_input = scheduler.scale_model_input(latents.to(torch.bfloat16), timestep)
+        timestep_expand = timestep.repeat(latent_model_input.shape[0])
+        noise_pred_text = model(latent_model_input, batch.prompt_embeds, timestep_expand)
+        noise_pred_uncond = model(latent_model_input, batch.negative_prompt_embeds, timestep_expand)
+        noise_pred = noise_pred_uncond + batch.guidance_scale * (noise_pred_text - noise_pred_uncond)
+        latents = scheduler.step(noise_pred, timestep, latents, return_dict=False)[0]
+
+    return latents
+
+
+@pytest.mark.parametrize("cfg_gate_step", [None, "1.0"])
+def test_cfg_gating_default_off_matches_legacy_two_pass(monkeypatch, cfg_gate_step):
+    out, model, logger = _run_stage(monkeypatch, cfg_gate_step)
+    legacy_out = _run_legacy_two_pass()
+
+    assert torch.equal(out, legacy_out)
+    assert model.calls == ["cond", "uncond"] * 4
+    assert not any("CFG gating enabled" in msg for msg in logger.infos)
+    assert any("gate_step=-1/4" in msg and "reused=0" in msg for msg in logger.infos)
+
+
+def test_cfg_gating_reuses_cached_delta_after_gate(monkeypatch):
+    out, model, logger = _run_stage(monkeypatch, "0.5")
+    legacy_out = _run_legacy_two_pass()
+
+    assert model.calls == ["cond", "uncond", "cond", "uncond", "cond", "cond"]
+    assert any("CFG gating enabled: fraction=0.500, gate_step=2/4" in msg for msg in logger.infos)
+    assert any("fresh_uncond=2 reused=2 invalidations=0" in msg for msg in logger.infos)
+    assert torch.allclose(out, legacy_out, atol=1e-3, rtol=0.0)


### PR DESCRIPTION
## Purpose

Adds an inference-only CFG acceleration that skips the unconditional forward pass after a
fraction of the denoising schedule has completed and reconstructs the guidance prediction
from a cached `delta = noise_pred_cond − noise_pred_uncond`:

```
noise_pred = noise_pred_cond + (guidance_scale − 1) * delta_cached
```

This is the LinearAG variant of **Adaptive Guidance** ([Castillo et al. 2023, arXiv:2312.12487](https://arxiv.org/abs/2312.12487),
AAAI 2025) — described in the paper as "simple affine transformations of past score
estimates" replacing entire neural function evaluations in the post-convergence phase.

The same "split denoising at a gate step and optimize the post-gate phase" framing is
also explored in [TGATE](https://arxiv.org/abs/2404.02747) (Liu et al. 2024), but TGATE
caches attention outputs and keeps both CFG forwards — a different mechanism. This PR
implements the Adaptive Guidance mechanism (skip the uncond forward); the env var name
`FASTVIDEO_CFG_GATE_STEP` describes the action rather than naming either upstream method.

Gated by a single env var `FASTVIDEO_CFG_GATE_STEP` (float `[0, 1]`, default `1.0` =
no-op). Existing users see zero behavioural change unless they opt in.

Measured **−22.0 % end-to-end on 4× L40S** and **−23.7 % on 1× H100** for Wan T2V 1.3B at
720×1280 / 77 frames / 30 inference steps, with VBench quality preserved within noise on
4 of 5 dimensions. On a separate (out-of-scope-for-this-PR) FA3 attention path on H100,
the win composes multiplicatively with the attention speedup for **−50.8 % end-to-end**.

## Changes

- **`fastvideo/envs.py`** (+26 lines): introduce `FASTVIDEO_CFG_GATE_STEP: float`
  declaration in the `TYPE_CHECKING` block plus the dispatching lambda in
  `environment_variables`, with full inline docstring covering semantics, edge
  cases (0.0 / 0.5 / 1.0), and known caveats.
- **`fastvideo/pipelines/stages/denoising.py`** (+127 / −18 lines, behaviour-additive):
  - Setup block before the denoising loop: validate the env value (raises on
    out-of-range), pre-compute `gate_step = int(num_steps * fraction)`, and
    initialise `delta_cached` + `delta_cached_model_id` + telemetry counters.
  - One-shot rank-0 `logger.warning` when `guidance_rescale > 0` combines with
    CFG gating active (combination is unvalidated — flagged so callers know).
  - Refactor of the existing CFG branch in the loop body: if the cache is
    populated and `i ≥ gate_step`, compute
    `noise_pred = cond + (s − 1) * delta_cached` and skip the uncond forward;
    otherwise fall back to the original two-pass CFG and refresh the cache.
  - Wan 2.2 high/low-noise expert switch handling: `id(current_model)` change
    invalidates the cache (the cached delta is tied to the model that produced
    it; reusing it across the boundary is silently wrong).
  - Rank-0 telemetry log after the loop: `fresh_uncond`, `reused`,
    `invalidations` counters so users can confirm the env var is wired.

When `FASTVIDEO_CFG_GATE_STEP=1.0` (default), the gate index is set above
`num_inference_steps`, the cache is never read, and every step takes the original
code path — **bit-exact backwards compatible**.

## Test Plan

The implementation was validated on the existing performance benchmark, plus a 5-prompt
quality A/B harness. Commands to reproduce the perf path locally:

```bash
# Functional sanity: confirm env var wires through and gating counters fire
FASTVIDEO_CFG_GATE_STEP=0.5 pytest -vs \
  fastvideo/tests/performance/test_inference_performance.py \
  -k "wan-t2v-1.3b"
# Expect log:
#   CFG gating enabled: fraction=0.500, gate_step=15/30
#   CFG gating summary: fraction=0.500 gate_step=15/30 fresh_uncond=15 reused=15 invalidations=0

# Backwards-compatibility sanity: baseline run (env unset) should be bit-exact
pytest -vs \
  fastvideo/tests/performance/test_inference_performance.py \
  -k "wan-t2v-1.3b"
# Expect log:
#   CFG gating summary: fraction=1.000 gate_step=-1/30 fresh_uncond=30 reused=0 invalidations=0

# Boundary check (out-of-range env value)
FASTVIDEO_CFG_GATE_STEP=1.5 pytest -vs \
  fastvideo/tests/performance/test_inference_performance.py -k "wan-t2v-1.3b"
# Expect ValueError on first DenoisingStage invocation.
```

Quality-pass A/B (5 fixed-seed prompts, same container, baseline vs gating active) was
run on both 4× L40S sp=4 (FA2 path) and 1× H100 sp=1 (FA2 and FA3 paths) via a local
harness; raw numbers in the next section.

## Test Results

### Performance — same-container A/B, 5 fixed-seed prompts, Wan T2V 1.3B at 720×1280 / 77 frames / 30 steps

| GPU topology | Attention backend | `FASTVIDEO_CFG_GATE_STEP` | end-to-end per video | Δ vs baseline | peak memory |
|---|---|---:|---:|---:|---:|
| 4× L40S sp=4 | FA2 | 1.0 (off) | 220.9 s | — | 23,308 MB |
| 4× L40S sp=4 | FA2 | 0.5 | 172.2 s | **−22.0 %** | 23,308 MB |
| 1× H100 sp=1 | FA2 | 1.0 (off) | 193.0 s | — | 24,680 MB |
| 1× H100 sp=1 | FA2 | 0.5 | 147.2 s | **−23.7 %** | 24,681 MB |
| 1× H100 sp=1 | FA3 | 1.0 (off) | 124.6 s | −35.5 % (FA3 only) | 24,681 MB |
| 1× H100 sp=1 | FA3 | 0.5 | 95.06 s | **−50.8 %** | 24,681 MB |

Peak memory is flat across all six variants (within 1 MB); CFG gating adds no activation
allocation. On H100 the FA3 attention speedup composes cleanly with CFG gating: predicted
combined `(1 − 0.355) × (1 − 0.237) = 0.492 ⇒ 95.0 s`, measured 95.06 s (within 0.1 %).

### Quality — VBench 5-metric, 4× L40S, 5 prompts (FA2, gate=1.0 vs 0.5)

| Metric | Baseline (1.0) | gate=0.5 | Δ |
|---|---:|---:|---:|
| subject_consistency | 0.9511 | 0.9498 | −0.0013 ↓ |
| background_consistency | 0.9595 | 0.9573 | −0.0022 ↓ |
| aesthetic_quality | 0.6213 | 0.6386 | **+0.0173 ↑** |
| imaging_quality | 0.5772 | 0.5794 | +0.0022 ↑ |
| temporal_flickering | 0.9784 | 0.9777 | −0.0007 ↓ |

All deltas are within VBench's 5-sample noise floor (~±0.5 %) except `aesthetic_quality`,
which moves +2.78 % relative on 5/5 prompts — beyond the noise band in the *improvement*
direction (consistent with the Adaptive Guidance argument that late-step CFG over-guides
fine detail and post-convergence affine reuse softens that).

### Quality — VBench 5-metric, 1× H100 + FA3, 5 prompts (gate=1.0 vs 0.7 vs 0.5)

Sweeps the gate fraction to map the speed–quality curve on Hopper.

| Metric | 1.0 (baseline) | 0.7 | 0.5 | Δ 0.7 | Δ 0.5 |
|---|---:|---:|---:|---:|---:|
| subject_consistency | 0.9526 | 0.9519 | 0.9537 | −0.0006 | +0.0011 |
| background_consistency | 0.9558 | 0.9615 | 0.9553 | +0.0057 ↑ | −0.0006 |
| aesthetic_quality | 0.6050 | 0.6091 | 0.6157 | +0.0041 ↑ | **+0.0107 ↑** |
| imaging_quality | 0.6035 | 0.6021 | 0.5970 | −0.0014 | −0.0065 ↓ |
| temporal_flickering | 0.9787 | 0.9784 | 0.9778 | −0.0003 | −0.0009 |

`aesthetic_quality` monotonically improves with more aggressive gating across both
hardware classes — the same effect reproduces on L40S/FA2 and on H100/FA3, suggesting
the mechanism is independent of attention numerics. `temporal_flickering` stays flat at
both gate fractions, so CFG gating does not introduce frame-level artefacts.
`imaging_quality` shifts in the opposite direction between the two hardware classes —
small (~1 %) but worth noting.

### Quality — per-prompt SSIM + LPIPS, 1× H100 + FA3, vs `FASTVIDEO_CFG_GATE_STEP=1.0` baseline

`SSIM` and `LPIPS-alex` measured frame-by-frame on the same 5 prompts, then averaged:

| Prompt | gate=0.7 SSIM / LPIPS | gate=0.5 SSIM / LPIPS | Note |
|---|---:|---:|---|
| noodle (food market motion) | 0.962 / 0.034 | 0.933 / 0.068 | medium drift |
| mountain (static landscape) | 0.963 / 0.036 | 0.959 / 0.043 | tightest — static scenes survive easily |
| car (high motion + blur) | 0.923 / 0.069 | 0.899 / 0.096 | largest drift (motion + fine detail) |
| portrait (face detail) | 0.972 / 0.032 | 0.960 / 0.055 | high SSIM, low LPIPS — face is preserved |
| metal (reflective + mechanical) | 0.946 / 0.041 | 0.918 / 0.072 | moderate |
| **mean** | **0.953 / 0.042** | **0.934 / 0.067** | — |

For context: LPIPS-alex < 0.05 ≈ nearly identical; 0.05–0.10 ≈ small perceptual
difference; > 0.10 ≈ clearly perceptible. **Gate=0.7 sits comfortably in the
"nearly identical" band.** Gate=0.5 enters the "small perceptual difference" band with
the most aggressive content (car at 0.096 mean, 0.12 max) brushing the edge of
perceptibility.

### Side-by-side comparison videos

Each clip shows gate=1.0 (baseline) | gate=0.7 | gate=0.5 horizontally stacked at the
same seed.

<!-- Drag-and-drop the 5 mp4 files into this section after opening the PR;
     GitHub will upload them and convert to user-attachments URLs.
     Files are in quality_videos/h100_fa3/sxs/:
       noodle_compare.mp4, mountain_compare.mp4, car_compare.mp4,
       portrait_compare.mp4, metal_compare.mp4 -->

**noodle (food market motion)** 

https://github.com/user-attachments/assets/b34b2a16-28de-46a2-af52-a9e3ee925f25


**mountain (static landscape)** 

https://github.com/user-attachments/assets/a1ff942b-7e8c-41f8-8309-37a3f9f05cd1

**car (high motion)** 

https://github.com/user-attachments/assets/c5aee035-e7fa-4e9e-9881-0e1b096e52dd




**portrait (face detail)**

https://github.com/user-attachments/assets/0bec40c2-828c-44b5-93dc-d161e1115561

**metal (reflective surface)** 

https://github.com/user-attachments/assets/e0188873-689d-4262-840b-915a1d924de9



<details>
<summary>Per-frame SSIM / LPIPS curve (portrait prompt, illustrative)</summary>

<img width="1320" height="440" alt="portrait_curves" src="https://github.com/user-attachments/assets/3c431c49-0818-415a-8115-c20ccd1dcaec" />

The curves are flat in time (no monotonic drift across the 77-frame clip), confirming
CFG gating does not accumulate error frame-to-frame.

</details>

<details>
<summary>Functional log excerpt — CFG gating telemetry</summary>

```
INFO  CFG gating enabled: fraction=0.500, gate_step=15/30
...
INFO  CFG gating summary: fraction=0.500 gate_step=15/30 fresh_uncond=15 reused=15 invalidations=0
```

`fresh_uncond + reused = num_inference_steps` and `invalidations = 0` for single-
transformer pipelines; on Wan 2.2 (boundary switch between high/low-noise experts)
the invalidation counter increments at the boundary as expected.

</details>

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [x] I considered GPU memory impact of my changes (peak unchanged across all six
      tested configurations)

**For model/pipeline changes, also check:**

- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model
