### PR TITLE
[perf]: register FA2/FA3 default flash_attn_func as a torch.library custom op

### DIFF
--- a/fastvideo/attention/backends/flash_attn.py
+++ b/fastvideo/attention/backends/flash_attn.py
@@ -83,8 +83,7 @@ if fa_version in ("2", "3"):
         # dynamo graph break on the training path — i.e. pre-PR behavior, no
         # regression. Full autograd parity for the custom op (mirroring the FP4
         # cute template) is a tracked follow-up.
-        if torch.is_grad_enabled() and (q.requires_grad or k.requires_grad
-                                        or v.requires_grad):
+        if torch.is_grad_enabled() and (q.requires_grad or k.requires_grad or v.requires_grad):
             return _fa_default(q, k, v, softmax_scale=softmax_scale, causal=causal)
         return torch.ops.fastvideo._flash_attn_default_forward(q, k, v, softmax_scale, causal)
 elif fa_version == "4":

--- a/fastvideo/attention/backends/flash_attn.py
+++ b/fastvideo/attention/backends/flash_attn.py
@@ -73,6 +73,19 @@ if fa_version in ("2", "3"):
         return q.new_empty(q.shape[0], q.shape[1], q.shape[2], v.shape[-1])
 
     def flash_attn_func_compilable(q, k, v, softmax_scale=None, causal=False):
+        # Autograd carve-out. The custom op above registers a forward + fake
+        # kernel but NO backward (register_autograd), so it is opaque to
+        # autograd. Inference runs under no_grad / inference_mode and routes
+        # through the traceable custom op — that is the torch.compile win, and
+        # the only path this PR claims. Training backprops through attention,
+        # so route grad-enabled calls to the original FA2/FA3 `flash_attn_func`
+        # (itself an autograd.Function, so backward is correct) at the cost of a
+        # dynamo graph break on the training path — i.e. pre-PR behavior, no
+        # regression. Full autograd parity for the custom op (mirroring the FP4
+        # cute template) is a tracked follow-up.
+        if torch.is_grad_enabled() and (q.requires_grad or k.requires_grad
+                                        or v.requires_grad):
+            return _fa_default(q, k, v, softmax_scale=softmax_scale, causal=causal)
         return torch.ops.fastvideo._flash_attn_default_forward(q, k, v, softmax_scale, causal)
 elif fa_version == "4":
     # FA4 path: `flash_attn_func` is already a torch.library custom op

--- a/fastvideo/attention/backends/flash_attn.py
+++ b/fastvideo/attention/backends/flash_attn.py
@@ -22,6 +22,55 @@ except ImportError:
         flash_attn_func = flash_attn_2_func
         fa_version = "2"
 
+
+# torch.compile traceability: the FA4/cute path (fa_version=="4") is
+# already a registered torch.library custom op, so dynamo treats it as a
+# graph node. The external FA2/FA3 `flash_attn_func` is NOT — dynamo
+# breaks the graph at the call site (observed: wanvideo.py self-attn,
+# once per layer every step), which fragments the compiled region and
+# blocks CUDA-graph capture. Wrap the FA2/FA3 default call in a custom
+# op (mirrors the FP4 `flash_attn_cute` template) so it becomes an
+# opaque-but-traceable node. The kernel still runs eager inside the op
+# (correct — flash-attn must run eager); only dynamo's treatment of the
+# boundary changes, so numerics are unchanged (SSIM-gate to confirm).
+if fa_version in ("2", "3"):
+    _fa_default = flash_attn_func
+
+    @torch.library.custom_op(
+        "fastvideo::_flash_attn_default_forward",
+        mutates_args=(),
+        device_types="cuda",
+    )
+    def _flash_attn_default_forward(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        softmax_scale: float | None,
+        causal: bool,
+    ) -> torch.Tensor:
+        return _fa_default(q, k, v, softmax_scale=softmax_scale, causal=causal)
+
+    @torch.library.register_fake("fastvideo::_flash_attn_default_forward")
+    def _flash_attn_default_forward_fake(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        softmax_scale: float | None,
+        causal: bool,
+    ) -> torch.Tensor:
+        del softmax_scale, causal
+        # FA2/FA3 default path: [batch, seqlen_q, nheads, head_dim_v],
+        # same dtype/device as q (head dim taken from v).
+        return q.new_empty(q.shape[0], q.shape[1], q.shape[2], v.shape[-1])
+
+    def flash_attn_func_compilable(q, k, v, softmax_scale=None, causal=False):
+        return torch.ops.fastvideo._flash_attn_default_forward(
+            q, k, v, softmax_scale, causal)
+else:
+    # fa_version == "4": flash_attn_func is already a custom op.
+    def flash_attn_func_compilable(q, k, v, softmax_scale=None, causal=False):
+        return flash_attn_func(q, k, v, softmax_scale=softmax_scale, causal=causal)
+
 from fastvideo.attention.backends.abstract import (
     AttentionBackend,
     AttentionImpl,
@@ -228,7 +277,10 @@ class FlashAttentionImpl(AttentionImpl):
             output = self._forward_nvfp4(query, key, value)
 
         else:
-            output = flash_attn_func(
+            # Route through the compilable wrapper so dynamo sees a
+            # registered op (no graph break) for FA2/FA3; identical
+            # kernel + numerics, op runs eager internally.
+            output = flash_attn_func_compilable(
                 query,  # type: ignore[no-untyped-call]
                 key,
                 value,

--- a/fastvideo/attention/backends/flash_attn.py
+++ b/fastvideo/attention/backends/flash_attn.py
@@ -22,7 +22,6 @@ except ImportError:
         flash_attn_func = flash_attn_2_func
         fa_version = "2"
 
-
 # torch.compile traceability: the FA4/cute path (fa_version=="4") is
 # already a registered torch.library custom op, so dynamo treats it as a
 # graph node. The external FA2/FA3 `flash_attn_func` is NOT — dynamo
@@ -36,6 +35,16 @@ except ImportError:
 if fa_version in ("2", "3"):
     _fa_default = flash_attn_func
 
+    # Scope: this op covers exactly the q/k/v + softmax_scale + causal
+    # call shape used by FlashAttentionImpl.forward's default branch
+    # (see `flash_attn_func_compilable(...)` call site below). The
+    # masked/no-pad and varlen / cross-attn paths use different
+    # entry points (`flash_attn_no_pad`, `flash_attn_varlen_*`) which
+    # are intentionally out of scope for this PR — wrapping them is a
+    # natural follow-up. The wrapper's signature is the contract: any
+    # extra kwarg (dropout_p, window_size, alibi_slopes, deterministic,
+    # return_attn_probs, ...) raises TypeError at the call site, so
+    # silent loss of kwargs is not a failure mode.
     @torch.library.custom_op(
         "fastvideo::_flash_attn_default_forward",
         mutates_args=(),
@@ -64,12 +73,19 @@ if fa_version in ("2", "3"):
         return q.new_empty(q.shape[0], q.shape[1], q.shape[2], v.shape[-1])
 
     def flash_attn_func_compilable(q, k, v, softmax_scale=None, causal=False):
-        return torch.ops.fastvideo._flash_attn_default_forward(
-            q, k, v, softmax_scale, causal)
-else:
-    # fa_version == "4": flash_attn_func is already a custom op.
+        return torch.ops.fastvideo._flash_attn_default_forward(q, k, v, softmax_scale, causal)
+elif fa_version == "4":
+    # FA4 path: `flash_attn_func` is already a torch.library custom op
+    # (registered in `fastvideo.attention.utils.flash_attn_cute`), so a
+    # passthrough is enough — no extra registration needed.
     def flash_attn_func_compilable(q, k, v, softmax_scale=None, causal=False):
         return flash_attn_func(q, k, v, softmax_scale=softmax_scale, causal=causal)
+else:
+    # Defensive: the probe above only ever sets fa_version to "2", "3",
+    # or "4"; an unexpected value means an import/probe regression and
+    # we want a loud error at import, not a silent NameError later.
+    raise RuntimeError(f"Unsupported FlashAttention version: {fa_version!r} — expected "
+                       f"'2', '3', or '4' from the import probe above.")
 
 from fastvideo.attention.backends.abstract import (
     AttentionBackend,

--- a/fastvideo/tests/attention/test_flash_attn_default_custom_op.py
+++ b/fastvideo/tests/attention/test_flash_attn_default_custom_op.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression guard for the FA2/FA3 default-path custom op (PR #1373).
+
+`flash_attn_func_compilable` wraps the default FA2/FA3 `flash_attn_func` in a
+`torch.library.custom_op` so dynamo sees a traceable node (no graph break)
+during inference. That custom op registers a forward + fake kernel but *no*
+backward, so it is opaque to autograd. To keep training working, the
+dispatcher routes grad-enabled calls to the original `flash_attn_func` (an
+autograd.Function) and only sends grad-free (inference) calls through the
+custom op.
+
+These tests pin both halves of that contract:
+  - inference (no grad): output goes through the custom op and matches the
+    original kernel;
+  - training (requires_grad): gradients flow and match the original kernel;
+  - the custom op itself is schema/fake-consistent under torch.library.opcheck.
+
+GPU assumptions: requires CUDA and an active FA2/FA3 backend
+(fa_version in {"2","3"}). Skips on CPU and on FA4/cute boxes (which take a
+different, already-traceable path).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+@pytest.fixture(scope="module")
+def fa_default_impls():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required for the FA2/FA3 default custom-op tests")
+
+    try:
+        from fastvideo.attention.backends import flash_attn as fa_backend
+    except ImportError as exc:
+        pytest.skip(f"flash_attn backend not importable: {exc}")
+
+    if fa_backend.fa_version not in ("2", "3"):
+        pytest.skip(
+            f"FA2/FA3 default custom op only exists for fa_version in (2, 3); "
+            f"got {fa_backend.fa_version!r}"
+        )
+
+    # compilable dispatcher, the original FA wrapper it falls back to, and
+    # the raw custom op for opcheck.
+    return (
+        fa_backend.flash_attn_func_compilable,
+        fa_backend._fa_default,
+        torch.ops.fastvideo._flash_attn_default_forward,
+    )
+
+
+def _qkv(dtype, requires_grad):
+    device = torch.device("cuda")
+    batch, seqlen, nheads, headdim = 2, 64, 4, 64
+    q = torch.randn(batch, seqlen, nheads, headdim, device=device,
+                    dtype=dtype, requires_grad=requires_grad)
+    k = torch.randn_like(q, requires_grad=requires_grad)
+    v = torch.randn_like(q, requires_grad=requires_grad)
+    return q, k, v
+
+
+def _clone(*tensors):
+    return tuple(t.detach().clone().requires_grad_(t.requires_grad) for t in tensors)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+def test_default_compilable_inference_matches_original(fa_default_impls, dtype, causal):
+    """No-grad path routes through the custom op and is numerically identical."""
+    if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("bfloat16 is not supported on this GPU")
+    compilable, original, _ = fa_default_impls
+
+    torch.manual_seed(0)
+    q, k, v = _qkv(dtype, requires_grad=False)
+    with torch.inference_mode():
+        out_ref = original(q, k, v, softmax_scale=None, causal=causal)
+        out_test = compilable(q, k, v, softmax_scale=None, causal=causal)
+    torch.testing.assert_close(out_test, out_ref, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+def test_default_compilable_training_backward_flows(fa_default_impls, dtype, causal):
+    """Grad-enabled path falls back to the autograd.Function: grads flow + match.
+
+    This is the exact regression PR #1373 introduced and this fix closes — a
+    bare custom op with no registered backward breaks loss.backward().
+    """
+    if dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("bfloat16 is not supported on this GPU")
+    compilable, original, _ = fa_default_impls
+
+    torch.manual_seed(0)
+    q_ref, k_ref, v_ref = _qkv(dtype, requires_grad=True)
+    q_test, k_test, v_test = _clone(q_ref, k_ref, v_ref)
+
+    out_ref = original(q_ref, k_ref, v_ref, softmax_scale=None, causal=causal)
+    out_test = compilable(q_test, k_test, v_test, softmax_scale=None, causal=causal)
+
+    dout = torch.randn_like(out_ref)
+    dq_ref, dk_ref, dv_ref = torch.autograd.grad(
+        (out_ref * dout).sum(), (q_ref, k_ref, v_ref))
+    dq_test, dk_test, dv_test = torch.autograd.grad(
+        (out_test * dout).sum(), (q_test, k_test, v_test))
+
+    atol = rtol = 6e-3 if dtype == torch.float16 else 2e-2
+    torch.testing.assert_close(dq_test, dq_ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(dk_test, dk_ref, atol=atol, rtol=rtol)
+    torch.testing.assert_close(dv_test, dv_ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_default_forward_opcheck(fa_default_impls, causal):
+    """Schema / fake-kernel consistency for the custom op (forward only)."""
+    _, _, op = fa_default_impls
+    torch.manual_seed(0)
+    q, k, v = _qkv(torch.float16, requires_grad=False)
+    torch.library.opcheck(op, (q, k, v, None, causal))


### PR DESCRIPTION
## What

Wraps the FA2/FA3 default `flash_attn_func` in a
`fastvideo::_flash_attn_default_forward` `torch.library.custom_op`
(+ `register_fake`), mirroring the existing FP4 `flash_attn_cute`
custom-op template. The external flash-attn call becomes an
opaque-but-traceable graph node instead of forcing a Dynamo graph
break at the call site, bringing the FA2/FA3 path to parity with the
already-registered FP4 path.

## What this does NOT claim (scope, deliberately narrow)

- **Output-neutral.** SSIM mean/min/max = `1.000000` over all frames,
  under both `torch.compile` and eager, hardware-validated on **FA2**
  (H100, Wan2.1-T2V-1.3B).
- **FA3 path:** same wrapper / same code path; FA3's `flash_attn_func`
  has the same single-tensor return (Dao-AILab unified the API). Not
  hardware-validated here — the FA3 from-source build OOM'd on this
  torch 2.10 / cu128 box. Covered by code symmetry and a maintainer's
  separate in-flight FA3 run.
- **Does NOT remove the `wanvideo.py:363` graph break.** Validated on
  H100: break inventory unchanged (128 → 128). That break is dominated
  by the independent `@torch.compiler.disable` on
  `DistributedAttention.forward`, which breaks at the same call site
  and masks the flash-attn opacity addressed here. **No break-count or
  performance claim is made.**

## Why land it independently

Parity with the FP4 path, and a prerequisite/enabler for downstream
`torch.compile` work (the FA2/FA3 call must be a traceable node before
any region containing it can be fused / captured). Aligned with
maintainer feedback that this is a reasonable minimum to land on its
own.

## Test evidence

- SSIM 1.000000 (mean/min/max, all frames), `torch.compile` + eager,
  FA2, H100 / Wan2.1-T2V-1.3B.
- Graph-break inventory diff BASE vs this change: identical
  (128 total, `wanvideo.py:363` unchanged) — documents the no-op on
  break count, consistent with the cause analysis above.

Env: H100 80GB, torch 2.10.0+cu128, flash_attn 2.8.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
