### PR TITLE
[perf]: wire in-worker profiler regions for inference forward

### DIFF
--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -504,8 +504,35 @@ class ComposedPipelineBase(ABC):
         # Execute each stage
         logger.info("Running pipeline stages: %s", self._stage_name_mapping.keys())
         # logger.info("Batch: %s", batch)
-        for stage in self.stages:
-            batch = stage(batch, fastvideo_args)
+        # Bracket the loop with the three documented inference regions so
+        # `FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_*`
+        # actually traces inference. The denoise stage is identified by
+        # the project-wide convention `add_stage(stage_name="denoising_
+        # stage", ...)`; everything before it counts as pre-denoising and
+        # everything after as post-denoising. If a pipeline does not
+        # register a "denoising_stage" (rare; some preprocess pipelines
+        # override forward entirely), fall back to wrapping the whole
+        # loop under `denoising` so the env-var still produces a trace
+        # rather than silently doing nothing.
+        # The regions are no-ops at zero overhead when not enabled (see
+        # `TorchProfilerController.region`'s early `yield`).
+        denoise_idx = next(
+            (i for i, s in enumerate(self.stages) if getattr(s, "_pipeline_stage_name", "") == "denoising_stage"),
+            None,
+        )
+        if denoise_idx is None:
+            with self.profiler_controller.region("profiler_region_inference_denoising"):
+                for stage in self.stages:
+                    batch = stage(batch, fastvideo_args)
+        else:
+            with self.profiler_controller.region("profiler_region_inference_pre_denoising"):
+                for stage in self.stages[:denoise_idx]:
+                    batch = stage(batch, fastvideo_args)
+            with self.profiler_controller.region("profiler_region_inference_denoising"):
+                batch = self.stages[denoise_idx](batch, fastvideo_args)
+            with self.profiler_controller.region("profiler_region_inference_post_denoising"):
+                for stage in self.stages[denoise_idx + 1:]:
+                    batch = stage(batch, fastvideo_args)
 
         # Return the output
         return batch

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -482,16 +482,27 @@ class ComposedPipelineBase(ABC):
             if self.local_rank == 0:
                 print(self.profiler.key_averages().table(sort_by="self_cuda_time_total"))
 
-    def _find_denoise_stage_index(self) -> int | None:
-        """Index of the canonical ``"denoising_stage"`` in
-        ``self.stages``, or ``None`` if no stage by that name is
-        registered (rare — some preprocess pipelines override
-        ``forward`` entirely and never call ``add_stage``).
+    def _find_denoise_stage_span(self) -> tuple[int | None, int | None]:
+        """Return ``(first_idx, last_idx)`` (inclusive) of the contiguous
+        denoising span in ``self.stages``, or ``(None, None)`` if no
+        denoising stage is registered.
+
+        The project uses several denoise stage names (``denoising_stage``
+        is the canonical one but pipelines also register
+        ``ltx2_refine_denoising_stage`` (LTX-2 refine pass) and
+        ``sr_denoising_stage`` (Hunyuan-1.5 SR, Magi-Human SR)). All of
+        these are real denoising work, so we identify the span by
+        substring match on ``"denois"`` (covers ``denoise``/``denoising``
+        variants) and take the index of the first such stage and the
+        index of the last such stage. Stages between two denoise stages
+        (e.g. a refine-prep step) end up inside the denoise span — that
+        is intentional: ``post_denoising`` is reserved for things that
+        run *after all* denoising work (decoders, post-processing).
         """
-        for i, stage in enumerate(self.stages):
-            if getattr(stage, "_pipeline_stage_name", "") == "denoising_stage":
-                return i
-        return None
+        indices = [i for i, stage in enumerate(self.stages) if "denois" in getattr(stage, "_pipeline_stage_name", "")]
+        if not indices:
+            return None, None
+        return indices[0], indices[-1]
 
     # TODO(will): don't hardcode no_grad
     @torch.no_grad()
@@ -516,32 +527,39 @@ class ComposedPipelineBase(ABC):
         logger.info("Running pipeline stages: %s", self._stage_name_mapping.keys())
         # logger.info("Batch: %s", batch)
         # Bracket the loop with the three documented inference regions
-        # so `FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_*`
-        # actually traces inference. The denoise stage is identified by
-        # the project-wide convention: a stage registered as
-        # ``"denoising_stage"`` via ``add_stage(stage_name=...)`` (see
-        # the ``fastvideo/pipelines/`` tree). Stages registered before
-        # it count as pre-denoising, stages after as post-denoising.
-        # If a pipeline does not register a ``"denoising_stage"`` (rare
-        # — some preprocess pipelines override ``forward`` entirely),
-        # fall back to wrapping the whole loop under ``denoising`` so
-        # the env var still produces a trace rather than silently doing
-        # nothing. Each region is a no-op at zero overhead when not
-        # enabled (see ``TorchProfilerController.region``'s early
-        # ``yield``).
-        denoise_idx = self._find_denoise_stage_index()
-        if denoise_idx is None:
+        # so ``FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_*``
+        # (or any subset) produces an inference trace. The denoise span
+        # is identified by substring match on ``"denois"`` so that all
+        # denoise stages in the project naming convention are captured
+        # — canonical ``denoising_stage`` plus ``ltx2_refine_denoising_
+        # stage`` (LTX-2 refine pass), ``sr_denoising_stage``
+        # (Hunyuan-1.5 SR / Magi-Human SR), etc. Stages before the first
+        # denoise stage count as pre-denoising; stages after the last
+        # denoise stage as post-denoising; the span between them
+        # (including any non-denoise prep step between two denoise
+        # stages) belongs to the denoise region by design — that keeps
+        # refine work *out* of ``post_denoising``, which is reserved
+        # for things that run after all denoising (decoders, etc.).
+        # If a pipeline registers no denoise stage at all (rare — some
+        # preprocess pipelines override ``forward`` entirely), fall
+        # back to wrapping the whole loop under ``denoising`` so the
+        # env var still produces a trace. Each region is a no-op at
+        # zero overhead when not enabled (see
+        # ``TorchProfilerController.region``'s early ``yield``).
+        denoise_first, denoise_last = self._find_denoise_stage_span()
+        if denoise_first is None or denoise_last is None:
             with self.profiler_controller.region("profiler_region_inference_denoising"):
                 for stage in self.stages:
                     batch = stage(batch, fastvideo_args)
         else:
             with self.profiler_controller.region("profiler_region_inference_pre_denoising"):
-                for stage in self.stages[:denoise_idx]:
+                for stage in self.stages[:denoise_first]:
                     batch = stage(batch, fastvideo_args)
             with self.profiler_controller.region("profiler_region_inference_denoising"):
-                batch = self.stages[denoise_idx](batch, fastvideo_args)
+                for stage in self.stages[denoise_first:denoise_last + 1]:
+                    batch = stage(batch, fastvideo_args)
             with self.profiler_controller.region("profiler_region_inference_post_denoising"):
-                for stage in self.stages[denoise_idx + 1:]:
+                for stage in self.stages[denoise_last + 1:]:
                     batch = stage(batch, fastvideo_args)
 
         # Return the output

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -482,6 +482,17 @@ class ComposedPipelineBase(ABC):
             if self.local_rank == 0:
                 print(self.profiler.key_averages().table(sort_by="self_cuda_time_total"))
 
+    def _find_denoise_stage_index(self) -> int | None:
+        """Index of the canonical ``"denoising_stage"`` in
+        ``self.stages``, or ``None`` if no stage by that name is
+        registered (rare — some preprocess pipelines override
+        ``forward`` entirely and never call ``add_stage``).
+        """
+        for i, stage in enumerate(self.stages):
+            if getattr(stage, "_pipeline_stage_name", "") == "denoising_stage":
+                return i
+        return None
+
     # TODO(will): don't hardcode no_grad
     @torch.no_grad()
     def forward(
@@ -504,22 +515,21 @@ class ComposedPipelineBase(ABC):
         # Execute each stage
         logger.info("Running pipeline stages: %s", self._stage_name_mapping.keys())
         # logger.info("Batch: %s", batch)
-        # Bracket the loop with the three documented inference regions so
-        # `FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_*`
+        # Bracket the loop with the three documented inference regions
+        # so `FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_*`
         # actually traces inference. The denoise stage is identified by
-        # the project-wide convention `add_stage(stage_name="denoising_
-        # stage", ...)`; everything before it counts as pre-denoising and
-        # everything after as post-denoising. If a pipeline does not
-        # register a "denoising_stage" (rare; some preprocess pipelines
-        # override forward entirely), fall back to wrapping the whole
-        # loop under `denoising` so the env-var still produces a trace
-        # rather than silently doing nothing.
-        # The regions are no-ops at zero overhead when not enabled (see
-        # `TorchProfilerController.region`'s early `yield`).
-        denoise_idx = next(
-            (i for i, s in enumerate(self.stages) if getattr(s, "_pipeline_stage_name", "") == "denoising_stage"),
-            None,
-        )
+        # the project-wide convention: a stage registered as
+        # ``"denoising_stage"`` via ``add_stage(stage_name=...)`` (see
+        # the ``fastvideo/pipelines/`` tree). Stages registered before
+        # it count as pre-denoising, stages after as post-denoising.
+        # If a pipeline does not register a ``"denoising_stage"`` (rare
+        # — some preprocess pipelines override ``forward`` entirely),
+        # fall back to wrapping the whole loop under ``denoising`` so
+        # the env var still produces a trace rather than silently doing
+        # nothing. Each region is a no-op at zero overhead when not
+        # enabled (see ``TorchProfilerController.region``'s early
+        # ``yield``).
+        denoise_idx = self._find_denoise_stage_index()
         if denoise_idx is None:
             with self.profiler_controller.region("profiler_region_inference_denoising"):
                 for stage in self.stages:

--- a/fastvideo/profiler.py
+++ b/fastvideo/profiler.py
@@ -21,6 +21,7 @@ and wrap the corresponding code in :meth:`TorchProfilerController.region`.
 from __future__ import annotations
 
 import contextlib
+import fnmatch
 from dataclasses import dataclass
 from typing import Any
 from collections.abc import Callable
@@ -248,11 +249,24 @@ class TorchProfilerConfig:
         available_names = ", ".join(region.name for region in available_regions)
 
         for token in requested_regions:
+            # Exact match first (preserves existing behaviour for
+            # callers that pass concrete region names).
             resolved = resolve_profiler_region(token)
-            if resolved is None:
-                logger.warning("Unknown profiler region '%s'; available regions: %s", token, available_names)
+            if resolved is not None:
+                regions[resolved.name] = True
                 continue
-            regions[resolved.name] = True
+            # Otherwise interpret the token as an fnmatch glob so that
+            # convenient bulk selections like
+            # ``profiler_region_inference_*`` enable every region whose
+            # canonical name matches the pattern. We use
+            # ``fnmatchcase`` because region names are already
+            # lower-case-normalised by ``register_profiler_region``.
+            glob_matches = [r for r in available_regions if fnmatch.fnmatchcase(r.name, token)]
+            if glob_matches:
+                for r in glob_matches:
+                    regions[r.name] = True
+                continue
+            logger.warning("Unknown profiler region '%s'; available regions: %s", token, available_names)
 
         if not regions:
             raise ValueError("FASTVIDEO_TORCH_PROFILE_REGIONS did not match any known regions; "

--- a/fastvideo/profiler.py
+++ b/fastvideo/profiler.py
@@ -124,19 +124,18 @@ register_profiler_region(
     description="Module/model loading during pipeline initialization.",
     default_enabled=False,
 )
-# register_profiler_region(
-#     name="profiler_region_inference_pre_denoising",
-#     description="Pre-denoising inference steps (conditioning, preprocessing).",
-# )
-# register_profiler_region(
-#     name="profiler_region_inference_denoising",
-#     description="The main inference denoising loop.",
-# )
-# register_profiler_region(
-#     name="profiler_region_inference_post_denoising",
-#     description=
-#     "Post-processing after denoising (decoder, conditioning restores).",
-# )
+register_profiler_region(
+    name="profiler_region_inference_pre_denoising",
+    description="Pre-denoising inference steps (conditioning, preprocessing).",
+)
+register_profiler_region(
+    name="profiler_region_inference_denoising",
+    description="The main inference denoising loop.",
+)
+register_profiler_region(
+    name="profiler_region_inference_post_denoising",
+    description="Post-processing after denoising (decoder, conditioning restores).",
+)
 register_profiler_region(
     name="profiler_region_training_save_checkpoint",
     description="Training save checkpoint operations.",


### PR DESCRIPTION
## What

`FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_*` previously produced no trace for inference: the three documented regions (`pre_denoising`, `denoising`, `post_denoising`) were commented out in `fastvideo/profiler.py`, `ComposedPipelineBase.forward` didn't bracket the stage loop, and `TorchProfilerConfig.from_env()` only exact-matched tokens (so even after the regions were registered, the wildcard would still fail). The in-worker profiler infrastructure worked for *training* and *model loading* but silently no-op'd for *inference* — which is where most users want to use it.

## Change

- **Register** the three inference regions in `fastvideo/profiler.py` (uncomment the existing definitions).
- **Bracket** the stage loop in `ComposedPipelineBase.forward` by the **denoise span** rather than a single stage. The project registers several denoise stages under the same convention — `denoising_stage` (canonical), `ltx2_refine_denoising_stage` (LTX-2 refine pass), `sr_denoising_stage` (Hunyuan-1.5 SR, Magi-Human SR). `_find_denoise_stage_span` substring-matches `"denois"` and returns `(first_idx, last_idx)` so:
  - stages before the first denoise → `profiler_region_inference_pre_denoising`
  - the inclusive span from first to last denoise → `profiler_region_inference_denoising` (refine + any intermediate prep step land here, by design)
  - stages after the last denoise → `profiler_region_inference_post_denoising`
- **Glob support** in `TorchProfilerConfig.from_env()`: each token in `FASTVIDEO_TORCH_PROFILE_REGIONS` is tried as an exact match first (preserves all existing behaviour for concrete region names), then on miss falls through to `fnmatch.fnmatchcase` against the registered names. Unknown tokens still warn. Makes the wildcard usage (`profiler_region_inference_*`) actually work.
- **Fallback:** pipelines that register no denoise stage at all (rare — some preprocess pipelines override `forward` entirely) wrap the whole loop under `denoising`.

## Zero overhead when not used

Each `controller.region(...)` is an early-`yield` no-op when its region isn't enabled (see `TorchProfilerController.region` in `fastvideo/profiler.py`). So this is a pure infrastructure unlock — no behavior change for users who don't set `FASTVIDEO_TORCH_PROFILE_REGIONS`.

## Usage examples

All three inference regions:
```bash
FASTVIDEO_TORCH_PROFILER_DIR=/tmp/trace \
FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_* \
python your_inference_script.py
```

Just the denoise loop:
```bash
FASTVIDEO_TORCH_PROFILER_DIR=/tmp/trace \
FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_denoising \
python your_inference_script.py
```

Mix exact + glob:
```bash
FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_model_loading,profiler_region_inference_*
```

A TensorBoard trace lands in `$FASTVIDEO_TORCH_PROFILER_DIR`.

## Test plan

- [x] Pre-commit (yapf / ruff / codespell / mypy) passing.
- [x] No behavior change when `FASTVIDEO_TORCH_PROFILE_REGIONS` is unset (regions are early-`yield` no-ops).
- [x] Exact-match tokens behave identically (glob is a fall-through).
- [ ] Manual smoke: run a Wan / Cosmos inference with `profiler_region_inference_*` and confirm the produced trace contains the three `fastvideo.region::profiler_region_inference_*` annotations around the appropriate stages (pending GPU).
- [ ] Manual smoke on an LTX-2 refine pipeline to confirm `ltx2_refine_denoising_stage` lands inside `denoising`, not `post_denoising` (pending GPU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
