### PR TITLE
[bugfix]: benchmark_weight_loading_comparison.py — iterate safe_open via .keys()

### DIFF
--- a/fastvideo/models/loader/benchmarks/benchmark_weight_loading_comparison.py
+++ b/fastvideo/models/loader/benchmarks/benchmark_weight_loading_comparison.py
@@ -42,7 +42,7 @@ def load_independent(files: list[str], device: str):
     """Before-PR behavior: every rank reads every tensor from disk to GPU."""
     for st_file in files:
         with safe_open(st_file, framework="pt", device=device) as f:
-            for name in f:
+            for name in f.keys():  # noqa: SIM118
                 param = f.get_tensor(name)
                 yield name, param
 
@@ -54,7 +54,7 @@ def load_broadcast(files: list[str], device: str, node_group,
     handles = []
     for st_file in files:
         with safe_open(st_file, framework="pt", device=device) as f:
-            for name in f:
+            for name in f.keys():  # noqa: SIM118
                 if local_rank == 0:
                     param = f.get_tensor(name)
                 else:


### PR DESCRIPTION
## What

The current `safetensors` API does not allow iterating a `safe_open(...)` handle directly (`safe_open` is not iterable). The two call sites at `fastvideo/models/loader/benchmarks/benchmark_weight_loading_comparison.py:45` and `:57` use `for name in f:`, which raises:

```
TypeError: 'builtins.safe_open' object is not iterable
```

as soon as the script reads the first safetensors shard.

This means `benchmark_weight_loading_comparison.py` cannot run on the current `safetensors` versions installed by FastVideo's main `pyproject.toml`. The benchmark numbers that PR #572 cited could not be reproduced without first patching this in the working tree.

## Fix

Two-line change: `for name in f:` → `for name in f.keys():  # noqa: SIM118` at both call sites. Matches the upstream safetensors API and the existing pattern in `fastvideo/models/loader/weight_utils.py`.

## Repro

```bash
torchrun --nproc_per_node=2 \
  fastvideo/models/loader/benchmarks/benchmark_weight_loading_comparison.py \
  --model-path /path/to/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/snapshots/<hash>/transformer \
  --subfolder transformer
```

Pre-fix: `TypeError` at `load_independent` / `load_broadcast` iteration.

Post-fix (verified locally on 2× B200, Wan2.1-T2V-1.3B):
```
before (independent read)       avg 0.998s  best 0.997s  throughput 5.69 GB/s  (825 tensors, 5.68 GB)
after  (sync broadcast)         avg 1.154s  best 1.151s  throughput 4.92 GB/s  (825 tensors, 5.68 GB)
after  (async broadcast)        avg 1.161s  best 1.154s  throughput 4.89 GB/s  (825 tensors, 5.68 GB)
```

(Cache-state dependent; alternating runs across cold/warm states are needed to compare branches meaningfully — separate concern.)

## Test plan

- [x] Local: ran the bench on 2× B200 to completion against `Wan2.1-T2V-1.3B-Diffusers/transformer`; no `TypeError`; numbers produced.
- [x] No behavior change beyond the script becoming runnable; the iteration order is unchanged (both `for name in f` and `for name in f.keys()` would have iterated in safetensors-insertion order on any version that supported the former).

## Test Results

See "Repro" section above for the post-fix output.

---

*This PR is from one of @SolitaryThinker's AI reviewer/fix agents (Gob). It's a 2-line fix; @SolitaryThinker hasn't personally verified the numbers cited above were produced on an unmodified working tree — please ping @SolitaryThinker if anything looks off.*