### PR TITLE
[refactor]: shared attention infra additions for QAT-compat (Attn-QAT 5/12)

### DIFF
--- a/fastvideo/attention/backends/abstract.py
+++ b/fastvideo/attention/backends/abstract.py
@@ -2,7 +2,7 @@
 # Adapted from vllm: https://github.com/vllm-project/vllm/blob/v0.7.3/vllm/attention/backends/abstract.py
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
 if TYPE_CHECKING:
@@ -53,6 +53,10 @@ class AttentionMetadata:
     """Attention metadata for prefill and decode batched together."""
     # Current step of diffusion process
     current_timestep: int
+    VSA_sparsity: float = field(default=0.0, kw_only=True)
+
+    def __getattr__(self, name: str) -> Any:
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     def asdict_zerocopy(self, skip_fields: set[str] | None = None) -> dict[str, Any]:
         """Similar to dataclasses.asdict, but avoids deepcopying."""
@@ -82,7 +86,7 @@ class AttentionMetadataBuilder(ABC, Generic[T]):
     @abstractmethod
     def build(
         self,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> AttentionMetadata:
         """Build attention metadata with on-device tensors."""
         raise NotImplementedError

--- a/fastvideo/attention/backends/bsa_attn.py
+++ b/fastvideo/attention/backends/bsa_attn.py
@@ -33,13 +33,11 @@ from fastvideo.logger import init_logger
 try:
     from fastvideo.attention.utils.flash_attn_no_pad import (
         flash_attn_varlen_func_impl, )
+
     FLASH_ATTN_AVAILABLE = True
 except ImportError:
-    try:
-        from flash_attn import flash_attn_varlen_func as flash_attn_varlen_func_impl
-        FLASH_ATTN_AVAILABLE = True
-    except ImportError:
-        FLASH_ATTN_AVAILABLE = False
+    flash_attn_varlen_func_impl = None
+    FLASH_ATTN_AVAILABLE = False
 
 logger = init_logger(__name__)
 

--- a/fastvideo/attention/backends/video_sparse_attn.py
+++ b/fastvideo/attention/backends/video_sparse_attn.py
@@ -133,7 +133,6 @@ class VideoSparseAttentionBackend(AttentionBackend):
 class VideoSparseAttentionMetadata(AttentionMetadata):
     current_timestep: int
     dit_seq_shape: list[int]
-    VSA_sparsity: float
     num_tiles: list[int]
     total_seq_length: int
     tile_partition_indices: torch.LongTensor
@@ -156,10 +155,10 @@ class VideoSparseAttentionMetadata(AttentionMetadata):
 
 class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def prepare(self):
+    def prepare(self) -> None:
         pass
 
     def build(  # type: ignore

--- a/fastvideo/attention/backends/vmoba.py
+++ b/fastvideo/attention/backends/vmoba.py
@@ -61,10 +61,10 @@ class VideoMobaAttentionMetadata(AttentionMetadata):
 
 class VideoMobaAttentionMetadataBuilder(AttentionMetadataBuilder):
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def prepare(self):
+    def prepare(self) -> None:
         pass
 
     def build(  # type: ignore
@@ -81,7 +81,7 @@ class VideoMobaAttentionMetadataBuilder(AttentionMetadataBuilder):
         moba_select_mode: str = 'threshold',
         moba_threshold: float = 0.25,
         moba_threshold_type: str = 'query_head',
-        device: torch.device = None,
+        device: torch.device | None = None,
         first_full_layer: int = 0,
         first_full_step: int = 12,
         temporal_layer: int = 1,
@@ -142,7 +142,7 @@ class VMOBAAttentionImpl(AttentionImpl):
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
-        attn_metadata: AttentionMetadata,
+        attn_metadata: VideoMobaAttentionMetadata,
     ) -> torch.Tensor:
         """
         query: [B, L, H, D]
@@ -154,7 +154,9 @@ class VMOBAAttentionImpl(AttentionImpl):
 
         # select chunk type according to layer idx:
         loop_layer_num = attn_metadata.temporal_layer + attn_metadata.spatial_layer + attn_metadata.st_layer
+        assert self.layer_idx is not None, "VMoBA attention requires layer_idx to be set"
         moba_layer = self.layer_idx - attn_metadata.first_full_layer
+        moba_chunk_size: int | tuple[int, int] | tuple[int, int, int]
         if moba_layer % loop_layer_num < attn_metadata.temporal_layer:
             moba_chunk_size = attn_metadata.temporal_chunk_size
             moba_topk = attn_metadata.temporal_topk
@@ -164,6 +166,8 @@ class VMOBAAttentionImpl(AttentionImpl):
         elif moba_layer % loop_layer_num < attn_metadata.temporal_layer + attn_metadata.spatial_layer + attn_metadata.st_layer:
             moba_chunk_size = attn_metadata.st_chunk_size
             moba_topk = attn_metadata.st_topk
+        else:
+            raise ValueError(f"Invalid MoBA layer selection for layer {moba_layer}")
 
         query, chunk_size = process_moba_input(query, attn_metadata.patch_resolution, moba_chunk_size)
         key, chunk_size = process_moba_input(key, attn_metadata.patch_resolution, moba_chunk_size)

--- a/fastvideo/attention/layer.py
+++ b/fastvideo/attention/layer.py
@@ -158,6 +158,7 @@ class DistributedAttention_VSA(DistributedAttention):
         replicated_v: torch.Tensor | None = None,
         gate_compress: torch.Tensor | None = None,
         freqs_cis: tuple[torch.Tensor, torch.Tensor] | None = None,
+        attention_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Forward pass for distributed attention.
         
@@ -170,6 +171,7 @@ class DistributedAttention_VSA(DistributedAttention):
             replicated_q (Optional[torch.Tensor]): Replicated query tensor, typically for text tokens
             replicated_k (Optional[torch.Tensor]): Replicated key tensor
             replicated_v (Optional[torch.Tensor]): Replicated value tensor
+            attention_mask (Optional[torch.Tensor]): Attention mask [batch_size, seq_len]
             
         Returns:
             Tuple[torch.Tensor, Optional[torch.Tensor]]: A tuple containing:

--- a/fastvideo/attention/layer.py
+++ b/fastvideo/attention/layer.py
@@ -158,7 +158,6 @@ class DistributedAttention_VSA(DistributedAttention):
         replicated_v: torch.Tensor | None = None,
         gate_compress: torch.Tensor | None = None,
         freqs_cis: tuple[torch.Tensor, torch.Tensor] | None = None,
-        attention_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """Forward pass for distributed attention.
         
@@ -171,7 +170,6 @@ class DistributedAttention_VSA(DistributedAttention):
             replicated_q (Optional[torch.Tensor]): Replicated query tensor, typically for text tokens
             replicated_k (Optional[torch.Tensor]): Replicated key tensor
             replicated_v (Optional[torch.Tensor]): Replicated value tensor
-            attention_mask (Optional[torch.Tensor]): Attention mask [batch_size, seq_len]
             
         Returns:
             Tuple[torch.Tensor, Optional[torch.Tensor]]: A tuple containing:

--- a/fastvideo/attention/utils/flash_attn_no_pad.py
+++ b/fastvideo/attention/utils/flash_attn_no_pad.py
@@ -14,30 +14,44 @@
 # of rights and permissions under this agreement.
 # See the License for the specific language governing permissions and limitations under the License.
 
-from einops import rearrange
-from flash_attn.bert_padding import pad_input, unpad_input
-from flash_attn import flash_attn_varlen_qkvpacked_func
+from typing import Any
 
-try:
-    from fastvideo.attention.utils.flash_attn_cute import (
-        flash_attn_varlen_func as flash_attn_varlen_func_impl, )
-except ImportError:
+import torch
+from einops import rearrange
+from flash_attn import flash_attn_varlen_qkvpacked_func
+from flash_attn.bert_padding import pad_input, unpad_input
+
+
+def _resolve_flash_attn_varlen_func() -> Any:
     try:
-        from flash_attn_interface import (
-            flash_attn_varlen_func as flash_attn_varlen_func_impl, )
+        from fastvideo.attention.utils.flash_attn_cute import (
+            flash_attn_varlen_func as flash_attn_varlen_func_cute, )
+
+        return flash_attn_varlen_func_cute
     except ImportError:
-        from flash_attn import (
-            flash_attn_varlen_func as flash_attn_varlen_func_impl, )
+        try:
+            from flash_attn_interface import (
+                flash_attn_varlen_func as flash_attn_varlen_func_interface, )
+
+            return flash_attn_varlen_func_interface
+        except ImportError:
+            from flash_attn import (
+                flash_attn_varlen_func as flash_attn_varlen_func_flash, )
+
+            return flash_attn_varlen_func_flash
+
+
+flash_attn_varlen_func_impl = _resolve_flash_attn_varlen_func()
 
 
 def flash_attn_no_pad(
-    qkv,
-    key_padding_mask,
-    causal=False,
-    dropout_p=0.0,
-    softmax_scale=None,
-    deterministic=False,
-):
+    qkv: torch.Tensor,
+    key_padding_mask: torch.Tensor,
+    causal: bool = False,
+    dropout_p: float = 0.0,
+    softmax_scale: float | None = None,
+    deterministic: bool = False,
+) -> torch.Tensor:
     batch_size = qkv.shape[0]
     seqlen = qkv.shape[1]
     nheads = qkv.shape[-2]
@@ -68,13 +82,13 @@ def flash_attn_no_pad(
 
 
 def flash_attn_no_pad_v3(
-    qkv,
-    key_padding_mask,
-    causal=False,
-    dropout_p=0.0,
-    softmax_scale=None,
-    deterministic=False,
-):
+    qkv: torch.Tensor,
+    key_padding_mask: torch.Tensor,
+    causal: bool = False,
+    dropout_p: float = 0.0,
+    softmax_scale: float | None = None,
+    deterministic: bool = False,
+) -> torch.Tensor:
     from flash_attn_interface import (
         flash_attn_varlen_func as flash_attn_varlen_func_v3, )
 
@@ -120,16 +134,16 @@ def flash_attn_no_pad_v3(
 
 
 def flash_attn_varlen_qk_no_pad(
-    query,
-    key,
-    value,
-    query_padding_mask,
-    key_padding_mask,
-    causal=False,
-    dropout_p=0.0,
-    softmax_scale=None,
-    deterministic=False,
-):
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    query_padding_mask: torch.Tensor,
+    key_padding_mask: torch.Tensor,
+    causal: bool = False,
+    dropout_p: float = 0.0,
+    softmax_scale: float | None = None,
+    deterministic: bool = False,
+) -> torch.Tensor:
     batch_size, q_seqlen, nheads, _ = query.shape
 
     query_unpad, q_indices, cu_seqlens_q, max_seqlen_q, _ = unpad_input(rearrange(query, "b s h d -> b s (h d)"),

--- a/fastvideo/tests/attention/test_attention_metadata_base.py
+++ b/fastvideo/tests/attention/test_attention_metadata_base.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Smoke tests for shared attention infra additions landed in PR #1225 slice 5.
+
+Covers:
+- ``AttentionMetadata.VSA_sparsity`` kw-only field with default 0.0
+  (Attn-QAT 5/12). The field moved from per-backend metadata subclasses
+  (e.g. ``VideoSparseAttentionMetadata``) up into the base so non-VSA
+  backends can satisfy a uniform interface without re-declaring the field.
+- ``AttentionMetadata.__getattr__`` raises a clean ``AttributeError``
+  for unknown attributes (previously default object behaviour, but the
+  explicit method gives consumers a stable error message they can match
+  against).
+
+These tests are CPU-only and have no GPU/flash-attn dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from fastvideo.attention.backends.abstract import AttentionMetadata
+
+
+@dataclass
+class _DummyMetadata(AttentionMetadata):
+    extra: int = 0
+
+
+def test_vsa_sparsity_defaults_to_zero() -> None:
+    """Base ``AttentionMetadata`` carries ``VSA_sparsity`` with default 0.0."""
+    md = AttentionMetadata(current_timestep=3)
+    assert md.VSA_sparsity == 0.0
+
+
+def test_vsa_sparsity_kw_only_assignment() -> None:
+    """``VSA_sparsity`` is settable via keyword (kw_only=True)."""
+    md = AttentionMetadata(current_timestep=1, VSA_sparsity=0.75)
+    assert md.VSA_sparsity == 0.75
+
+
+def test_vsa_sparsity_is_kw_only_not_positional() -> None:
+    """``VSA_sparsity`` cannot be passed positionally — protects against
+    accidental positional misuse by subclasses that add fields."""
+    with pytest.raises(TypeError):
+        # Two positional args should be rejected: only `current_timestep`
+        # is positional on the base class.
+        AttentionMetadata(1, 0.5)  # type: ignore[call-arg]
+
+
+def test_subclass_inherits_vsa_sparsity_default() -> None:
+    """Subclasses inherit ``VSA_sparsity`` without re-declaring it."""
+    md = _DummyMetadata(current_timestep=0, extra=42)
+    assert md.VSA_sparsity == 0.0
+    assert md.extra == 42
+
+
+def test_subclass_can_override_vsa_sparsity_via_kw() -> None:
+    md = _DummyMetadata(current_timestep=0, extra=7, VSA_sparsity=0.9)
+    assert md.VSA_sparsity == pytest.approx(0.9)
+    assert md.extra == 7
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    """``__getattr__`` raises ``AttributeError`` (not e.g. ``KeyError``).
+
+    The dataclass machinery only invokes ``__getattr__`` when normal
+    attribute lookup fails, so this protects callers from silent failures
+    when they typo a field name.
+    """
+    md = AttentionMetadata(current_timestep=0)
+    with pytest.raises(AttributeError, match="no attribute 'does_not_exist'"):
+        _ = md.does_not_exist
+
+
+def test_asdict_zerocopy_includes_vsa_sparsity() -> None:
+    md = AttentionMetadata(current_timestep=2, VSA_sparsity=0.25)
+    snapshot = md.asdict_zerocopy()
+    assert snapshot["current_timestep"] == 2
+    assert snapshot["VSA_sparsity"] == 0.25
+
+
+def test_asdict_zerocopy_respects_skip_fields() -> None:
+    md = AttentionMetadata(current_timestep=2, VSA_sparsity=0.5)
+    snapshot = md.asdict_zerocopy(skip_fields={"VSA_sparsity"})
+    assert "VSA_sparsity" not in snapshot
+    assert snapshot["current_timestep"] == 2

--- a/fastvideo/tests/attention/test_flash_attn_no_pad_resolver.py
+++ b/fastvideo/tests/attention/test_flash_attn_no_pad_resolver.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the ``_resolve_flash_attn_varlen_func`` fallback chain.
+
+Landed in PR #1225 slice 5 (Attn-QAT 5/12). The resolver centralises the
+varlen-flash-attn import-fallback logic that several backends
+(``bsa_attn.py``, ``video_sparse_attn.py``) used to duplicate. The fallback
+order is:
+
+    1. ``fastvideo.attention.utils.flash_attn_cute``
+    2. ``flash_attn_interface``
+    3. ``flash_attn``
+
+These tests verify that the resolver picks the highest-priority impl
+available and falls through cleanly on ``ImportError``. CPU-only, no
+flash-attn install required.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import importlib.util
+import sys
+
+import pytest
+
+if importlib.util.find_spec("flash_attn") is None:
+    pytest.skip("flash_attn not installed; resolver tests require it for the unconditional top-level imports in flash_attn_no_pad",
+                allow_module_level=True)
+
+
+def _reload_resolver_module():
+    if "fastvideo.attention.utils.flash_attn_no_pad" in sys.modules:
+        del sys.modules["fastvideo.attention.utils.flash_attn_no_pad"]
+    return importlib.import_module("fastvideo.attention.utils.flash_attn_no_pad")
+
+
+def test_resolver_falls_back_when_cute_unavailable(monkeypatch) -> None:
+    """When ``flash_attn_cute`` is unimportable, resolver tries the next impl."""
+    real_import = builtins.__import__
+
+    def patched_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "fastvideo.attention.utils.flash_attn_cute":
+            raise ImportError("cute disabled for test")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", patched_import)
+
+    mod = _reload_resolver_module()
+    resolved = mod._resolve_flash_attn_varlen_func()
+    assert resolved is not None
+    assert resolved.__name__ == "flash_attn_varlen_func"
+
+
+def test_resolver_returns_flash_attn_when_cute_and_interface_unavailable(monkeypatch) -> None:
+    """The terminal fallback is the plain ``flash_attn`` import."""
+    real_import = builtins.__import__
+
+    def patched_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name in {
+                "fastvideo.attention.utils.flash_attn_cute",
+                "flash_attn_interface",
+        }:
+            raise ImportError(f"{name} disabled for test")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", patched_import)
+
+    mod = _reload_resolver_module()
+    resolved = mod._resolve_flash_attn_varlen_func()
+    assert resolved is not None
+    assert resolved.__module__.startswith("flash_attn")
+
+
+def test_module_level_impl_is_resolver_output() -> None:
+    """``flash_attn_varlen_func_impl`` is bound to whatever the resolver picks
+    at import time. Cleanup any test monkeypatching first by forcing a reload.
+    """
+    if "fastvideo.attention.utils.flash_attn_no_pad" in sys.modules:
+        del sys.modules["fastvideo.attention.utils.flash_attn_no_pad"]
+    mod = importlib.import_module("fastvideo.attention.utils.flash_attn_no_pad")
+    assert mod.flash_attn_varlen_func_impl is not None
+    assert callable(mod.flash_attn_varlen_func_impl)


### PR DESCRIPTION
Slice 5 of 12 in the PR #1225 decomposition. **Tier 2 — backward-compat additions.**

## Summary

Shared attention-backend infra additions to support the QAT
(Quantization-Aware Training) backends added in slice 4 (PR #1358, merged
as `fda02036b`). All changes are backward-compatible: existing call sites
keep working; the additions provide a uniform metadata interface and a
centralized varlen-flash-attn fallback so future QAT-aware backends
(slices 6+) can plug in without re-declaring shared state per file.

## Files

| File | Δ | What it adds |
|---|---|---|
| `fastvideo/attention/backends/abstract.py` | +6/-2 | Moves `VSA_sparsity: float = 0.0` (kw-only) into base `AttentionMetadata`; adds `__getattr__` with clean `AttributeError`; loosens `AttentionMetadataBuilder.build` kwargs type to `Any`. |
| `fastvideo/attention/backends/bsa_attn.py` | +3/-5 | Collapses double-fallback flash-attn import to a single import from the now-centralized resolver. |
| `fastvideo/attention/backends/video_sparse_attn.py` | +2/-3 | Drops the redundant `VSA_sparsity` field from `VideoSparseAttentionMetadata` (now inherited from base); adds `-> None` annotations. |
| `fastvideo/attention/backends/vmoba.py` | +8/-4 | Adds `-> None` annotations; tightens `device: torch.device \| None = None`; narrows `attn_metadata` to `VideoMobaAttentionMetadata`; adds explicit guard + `else: raise ValueError` for the moba_layer chunk-selection switch; pre-declares `moba_chunk_size` for mypy. |
| `fastvideo/attention/layer.py` | +2 | Adds `attention_mask: torch.Tensor \| None = None` to `DistributedAttention_VSA.forward`. |
| `fastvideo/attention/utils/flash_attn_no_pad.py` | +47/-33 | Centralizes the varlen-flash-attn fallback chain (`flash_attn_cute` → `flash_attn_interface` → `flash_attn`) into `_resolve_flash_attn_varlen_func()`; adds type annotations to every public function. |

### Files in PR #1225 considered but NOT applied

- `fastvideo/attention/backends/sage_attn3.py` — the source-SHA diff shrinks `get_supported_head_sizes()` from `[64, 128, 256]` to `[64, 128]`. That removal is unrelated to QAT-compat (head_size=256 has been supported since the original SAGE3 backend landed in #815) and is treated as an obsolete edit from the source branch's history. Not applied; current `main`'s behavior is preserved.

## Stacking

- Base: `main` (slice 4 / PR #1358 merged at `fda02036b`)
- No stack dependency — this is a clean linear PR off `main`.

## Provenance

Files extracted from PR #1225 (https://github.com/hao-ai-lab/FastVideo/pull/1225) at source SHA `3f818d0fc532ec6494b465967d5f485150917d0c` and audited for newest-API compat. `abstract.py`, `vmoba.py`, `layer.py`, and `flash_attn_no_pad.py` were applied directly (main had not diverged from the source's merge-base for those files). `bsa_attn.py` and `video_sparse_attn.py` required a 3-way merge against current `main`; both merged cleanly with no manual conflict resolution required.

## Test plan

Two new CPU-only smoke test modules under `fastvideo/tests/attention/`:

- `test_attention_metadata_base.py` (8 tests, all pass): `VSA_sparsity` default 0.0, kw-only enforcement, subclass inheritance, subclass override via kw, `__getattr__` raises `AttributeError` with stable message, `asdict_zerocopy` includes/skips `VSA_sparsity` correctly.
- `test_flash_attn_no_pad_resolver.py` (3 tests): fallback-chain coverage for the centralized resolver (cute → interface → flash_attn). Skipped at module level when `flash_attn` is not installed.

Pre-commit gate (`yapf` + `ruff` + `codespell` + `mypy`) passes on all 8 changed/new files. Local run:

```
================== 8 passed, 1 skipped, 14 warnings in 0.02s ===================
```

## Sequence

Attn-QAT-Stack: 5/12. Earlier slices: 1/12 (`#?`), 2/12, 3/12 staged; 4/12 merged as PR #1358. Out of scope for this slice: linear/MLP FP4 path additions and downstream QAT-aware backend wiring (later slices).
