### PR TITLE
[feat] eval: input ergonomics + Evaluator features + bug fixes

### DIFF
--- a/examples/inference/eval/eval_fvd.py
+++ b/examples/inference/eval/eval_fvd.py
@@ -6,43 +6,32 @@ Run::
     python examples/inference/eval/eval_fvd.py \\
         --gen-dir   path/to/generated_videos/ \\
         --reference-dir path/to/real_videos/ \\
-        --extractor i3d \\
         --output    fvd_scores.json
 
-The first call extracts I3D (or CLIP / VideoMAE) features over every
-file under ``--reference-dir`` and caches them to
-``${FASTVIDEO_EVAL_CACHE}/fvd/real_features_{extractor}.pt``.  Subsequent
-runs with the same ``--extractor`` reuse the cache — pass
-``--reference-dir`` only on the first call (or whenever the reference
-set changes).
+Demonstrates the canonical pattern: turn two directories into a samples
+list with :func:`samples_from`, hand it to :class:`Evaluator`.  The
+Evaluator decodes through its :class:`VideoPool` and runs FVD's
+``accumulate`` / ``finalize`` end-to-end.
 
-For paper-grade FVD scores use ``--extractor i3d`` (the literature
-default) and at least 256 generated + 256 reference videos.  CLIP and
-VideoMAE extractors are research-grade and not directly comparable to
-published FVD numbers.
+The first call extracts I3D features over every file under
+``--reference-dir`` and caches them to
+``${FASTVIDEO_EVAL_CACHE}/fvd/real_features_i3d.pt``.  Subsequent runs
+reuse the cache — omit ``--reference-dir`` to score new generations
+against the cached reference set.
+
+For paper-grade FVD scores use at least 256 generated + 256 reference
+videos.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 
 import torch
 
-from fastvideo.eval import get_metric
-from fastvideo.eval.io import load_video
-
-
-_VIDEO_EXTS = {".mp4", ".avi", ".mov", ".mkv", ".gif"}
-
-
-def _list_videos(directory: Path) -> list[Path]:
-    if not directory.is_dir():
-        raise SystemExit(f"{directory} is not a directory")
-    out = sorted(p for p in directory.iterdir() if p.suffix.lower() in _VIDEO_EXTS)
-    if not out:
-        raise SystemExit(f"No videos under {directory} (looked for {sorted(_VIDEO_EXTS)})")
-    return out
+from fastvideo.eval import create_evaluator, samples_from
 
 
 def main() -> None:
@@ -51,56 +40,37 @@ def main() -> None:
     p.add_argument("--gen-dir", type=Path, required=True,
                    help="Directory of generated videos (.mp4, .avi, .mov, .mkv, .gif).")
     p.add_argument("--reference-dir", type=Path, default=None,
-                   help="Directory of reference videos. Required on first run for a given "
-                        "extractor; subsequent runs reuse the cached features.")
-    p.add_argument("--extractor", choices=["i3d", "clip", "videomae"], default="i3d",
-                   help="Feature backbone (default: i3d, the standard FVD spec).")
-    p.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
-    p.add_argument("--chunk-size", type=int, default=32,
-                   help="Videos per forward pass. Reduce if GPU OOMs.")
+                   help="Directory of reference videos. Omit to score against the cached "
+                        "reference features (built on a previous run).")
+    p.add_argument("--device", default="cuda:0" if torch.cuda.is_available() else "cpu")
+    p.add_argument("--num-gpus", type=int, default=1,
+                   help="Number of GPU replicas. >1 fans extraction out across devices.")
     p.add_argument("--cache-path", type=Path, default=None,
                    help="Override the reference-feature cache path. "
-                        "Defaults to ${FASTVIDEO_EVAL_CACHE}/fvd/real_features_{extractor}.pt.")
+                        "Defaults to ${FASTVIDEO_EVAL_CACHE}/fvd/real_features_i3d.pt.")
     p.add_argument("--output", type=Path, default=None,
                    help="Write the result as JSON to this path (default: stdout only).")
     args = p.parse_args()
 
-    metric = get_metric(
-        "common.fvd",
-        extractor=args.extractor,
-        cache_path=str(args.cache_path) if args.cache_path else None,
-        chunk_size=args.chunk_size,
+    if args.cache_path is not None:
+        # FVDMetric resolves cache_path via this env-var when no constructor
+        # kwarg is set; create_evaluator doesn't forward kwargs through to
+        # the metric, so the env-var is the only path here.
+        os.environ["FASTVIDEO_FVD_REF_FEATURES"] = str(args.cache_path)
+
+    samples = samples_from(
+        video=args.gen_dir,
+        reference=args.reference_dir,
     )
-    metric.to(args.device)
-    metric.setup()
-    metric.reset()
 
-    gen_paths = _list_videos(args.gen_dir)
-    print(f"Found {len(gen_paths)} generated videos under {args.gen_dir}")
-
-    # Build the reference cache on the first generated sample, then never
-    # touch it again — common.fvd takes one reference *set* and reuses it
-    # across all subsequent accumulate() calls.
-    ref_tensor: torch.Tensor | None = None
-    if args.reference_dir is not None:
-        ref_paths = _list_videos(args.reference_dir)
-        print(f"Found {len(ref_paths)} reference videos under {args.reference_dir}")
-        ref_tensor = torch.stack([load_video(str(p)) for p in ref_paths])
-
-    for i, gp in enumerate(gen_paths):
-        sample: dict = {"video": load_video(str(gp))}
-        if i == 0 and ref_tensor is not None:
-            sample["reference"] = ref_tensor
-        metric.accumulate(sample)
-        if (i + 1) % 32 == 0 or i == len(gen_paths) - 1:
-            print(f"  accumulated {i + 1}/{len(gen_paths)} generated videos")
-
-    result = metric.finalize()
+    ev = create_evaluator(metrics=["common.fvd"], device=args.device, num_gpus=args.num_gpus)
+    results = ev.evaluate(samples=samples)
+    result = results.corpus["common.fvd"]
 
     if result.score is None:
-        print(f"\nFVD ({args.extractor}): SKIPPED — {result.details.get('skipped')}")
+        print(f"\nFVD: SKIPPED — {result.details.get('skipped')}")
     else:
-        print(f"\nFVD ({args.extractor}): {result.score:.4f}")
+        print(f"\nFVD: {result.score:.4f}")
         print(f"  details: {result.details}")
 
     if args.output is not None:
@@ -108,7 +78,6 @@ def main() -> None:
             "metric": result.name,
             "score": result.score,
             "details": result.details,
-            "extractor": args.extractor,
             "gen_dir": str(args.gen_dir),
             "reference_dir": str(args.reference_dir) if args.reference_dir else None,
         }

--- a/fastvideo/eval/README.md
+++ b/fastvideo/eval/README.md
@@ -14,6 +14,7 @@ VLM scorer behind a single registry-driven API.
 | Just Physics-IQ (covered by `[eval]`) | `uv pip install -e .[eval-physics-iq]` |
 | Audio metrics (CLAP, FAD, KL, WER, AudioBox, DeSync, ImageBind) | `uv pip install -e .[eval-audio]` |
 | Everything: `[eval]` + `[eval-audio]` + `vbench.scene` (AVoCaDO) | `uv pip install -e .[eval-full]` |
+| Optional faster video decode (x86_64 only; opt-in) | `uv pip install -e .[eval-fast-decode]` |
 
 `[eval-audio]` covers every `audio.*` metric. ImageBind
 (`facebookresearch/ImageBind`, CC BY-NC-SA 4.0) is git-sourced via
@@ -21,6 +22,13 @@ VLM scorer behind a single registry-driven API.
 wheel is pulled transitively by `audiobox_aesthetics`; on cu128 hosts
 using raw `pip`, install `torchaudio` from
 `https://download.pytorch.org/whl/cu128` first.
+
+`[eval-fast-decode]` is opt-in. It pulls `decord`, which is faster than
+the default PyAV decoder but has no aarch64 wheels and is effectively
+unmaintained upstream. The default `[eval]` install uses PyAV (via
+`av`); decord only matters if you've measured decode as the bottleneck
+on x86_64. `audio.imagebind_score` declares a hard `decord` dependency
+and will skip without it.
 
 `audio.desync` and `audio.wer (glm_asr)` import vendored upstream from
 `fastvideo/third_party/eval/synchformer/` (MIT) and
@@ -82,20 +90,39 @@ from fastvideo.eval import (
     create_evaluator,        # build a reusable Evaluator
     evaluate,                # one-shot helper
     Evaluator,               # the class itself
+    samples_from, as_video,  # path-style inputs → canonical samples list
     BaseMetric, MetricResult,
     register, list_metrics, get_metric,
     ensure_checkpoint, get_cache_dir,
 )
 
+# Single-sample form (per-sample metrics):
 ev = create_evaluator(metrics=["common.ssim", "vbench.aesthetic_quality"],
                       device="cuda")
 scores = ev.evaluate(video=tensor, reference=ref, fps=8.0)
+
+# Many samples from two directories (paired metrics + corpus metrics):
+results = ev.evaluate(samples=samples_from(video="gen/", reference="ref/"))
+# results[i]["common.ssim"]              → per-pair SSIM
+# results.corpus["common.fvd"]           → corpus FVD (if FVD is registered)
 ```
 
-`evaluate` accepts either a pre-loaded `(T, C, H, W)` tensor or a path
-string for `video` and `reference`. Paths are decoded inside the worker
+`samples_from` turns path-style inputs into the canonical samples list.
+Cardinality determines the shape: equal `|gen| == |ref|` zips into paired
+samples; unequal cardinality role-tags the unmatched references as
+trailing set-style samples so corpus metrics like FVD see the full
+reference set while paired metrics like LPIPS only score the first N
+pairs. Per-sample attachments (`text_prompt(s)`, `fps`,
+`auxiliary_info`, `extras=`) attach by kwarg; `extract_audio=True` pulls
+audio tracks off video sources for audio metrics.
+
+`evaluate` also accepts a pre-loaded `(T, C, H, W)` tensor or a path
+string under `video` / `reference`. Paths are decoded inside the worker
 that picks up the sample, so peak memory stays bounded by `num_gpus`
-when scoring large batches.
+when scoring large batches. Use `evaluate(samples=..., metrics=[...])`
+to run a subset of the Evaluator's registered metrics on this batch
+(useful for scoring different corpora with different metric subsets in
+successive calls without burning model loads).
 
 ### CLI
 
@@ -261,22 +288,30 @@ reference set. Lower is better; standard protocol uses 2048 videos
 and a warning fires below 256.
 
 ```python
-from fastvideo.eval import create_evaluator
+from fastvideo.eval import create_evaluator, samples_from
 
 ev = create_evaluator(metrics=["common.fvd"], device="cuda")
-ev.evaluate(samples=[
-    {"video": gen_tensor_0, "reference": ref_tensor},   # builds the cache
-    {"video": gen_tensor_1},                            # cache reused
-    {"video": gen_tensor_2},
-    ...
-])
-# corpus result is in the returned EvalResults.corpus["common.fvd"]
+result = ev.evaluate(samples=samples_from(
+    video="gen/", reference="ref/",
+)).corpus["common.fvd"]
 ```
 
-Reference features are cached to ``${FASTVIDEO_EVAL_CACHE}/fvd/real_features_{extractor}.pt``
-the first time ``sample["reference"]`` is passed; subsequent runs load
-the cache automatically. Override with ``$FASTVIDEO_FVD_REF_FEATURES``
-or the ``cache_path=`` constructor kwarg.
+`samples_from` zips the directories into paired samples when their
+cardinalities match (FVD pulls features from both `sample["video"]` and
+`sample["reference"]`); when `|ref| > |gen|`, the unmatched references
+become role-tagged trailing samples so FVD still sees the full
+reference corpus while paired per-sample metrics (LPIPS / PSNR / SSIM)
+running alongside only score the matched pairs.
+
+Reference features are cached to
+``${FASTVIDEO_EVAL_CACHE}/fvd/real_features_{extractor}.pt`` the first
+time reference features are streamed; subsequent runs load the cache
+automatically (omit `reference=` to score new generations against the
+cached set). Override with `$FASTVIDEO_FVD_REF_FEATURES`, the
+`cache_path=` constructor kwarg, or `cache_mode={"off","read","read_write"}`
+to control read/write behavior. The example script
+`examples/inference/eval/eval_fvd.py` demonstrates the full
+two-directory workflow.
 
 ## Out of scope (follow-up PRs)
 

--- a/fastvideo/eval/__init__.py
+++ b/fastvideo/eval/__init__.py
@@ -26,6 +26,7 @@ from fastvideo.eval.metrics.base import BaseMetric  # noqa: E402
 from fastvideo.eval.registry import register, list_metrics, get_metric  # noqa: E402
 from fastvideo.eval.api import evaluate  # noqa: E402
 from fastvideo.eval.evaluator import Evaluator, create_evaluator  # noqa: E402
+from fastvideo.eval.io.inputs import as_video, samples_from  # noqa: E402
 
 # Trigger metric auto-discovery
 import fastvideo.eval.metrics  # noqa: F401, E402
@@ -43,4 +44,6 @@ __all__ = [
     "get_metric",
     "ensure_checkpoint",
     "get_cache_dir",
+    "as_video",
+    "samples_from",
 ]

--- a/fastvideo/eval/evaluator.py
+++ b/fastvideo/eval/evaluator.py
@@ -56,6 +56,13 @@ class Evaluator:
         metrics, which dominates at high resolution. Set ``False`` for
         training-time eval, where keeping a clip resident on GPU
         across the metric loop would fight the training step for VRAM.
+    skip_missing_deps : bool
+        When ``True``, silently drop explicit metric names whose
+        optional deps aren't importable (with a one-line warning per
+        skipped metric). Default ``False`` — an explicit name with a
+        missing dep raises :class:`ImportError` at construction time.
+        Group selectors (``"vbench"``, ``"all"``) always silent-skip
+        regardless of this flag.
     """
 
     def __init__(
@@ -68,14 +75,21 @@ class Evaluator:
         loader_threads: int = 1,
         prefetch_factor: int = 2,
         pre_upload: bool = True,
+        skip_missing_deps: bool = False,
     ) -> None:
-        names = _resolve_metric_names(metrics)
+        names = _resolve_metric_names(metrics, skip_missing_deps=skip_missing_deps)
         if num_gpus > 1:
             self._workers = [
-                EvalWorker(names, f"cuda:{i}", compile=compile, pre_upload=pre_upload) for i in range(num_gpus)
+                EvalWorker(names,
+                           f"cuda:{i}",
+                           compile=compile,
+                           pre_upload=pre_upload,
+                           skip_missing_deps=skip_missing_deps) for i in range(num_gpus)
             ]
         else:
-            self._workers = [EvalWorker(names, device, compile=compile, pre_upload=pre_upload)]
+            self._workers = [
+                EvalWorker(names, device, compile=compile, pre_upload=pre_upload, skip_missing_deps=skip_missing_deps)
+            ]
         self._loader_threads = max(1, loader_threads)
         self._prefetch_factor = max(1, prefetch_factor)
 
@@ -90,62 +104,101 @@ class Evaluator:
     def evaluate(
         self,
         samples: Iterable[dict] | None = None,
+        *,
+        metrics: list[str] | None = None,
         **kwargs,
     ) -> dict[str, MetricResult] | EvalResults:
         """Score one sample (kwargs form) or many samples (list form).
 
         Both forms go through the same :class:`VideoPool` pipeline;
-        ``video`` / ``reference`` paths are decoded asynchronously,
-        ``(1, T, C, H, W)`` tensors are squeezed.
+        ``video`` / ``reference`` paths are decoded asynchronously.
 
-        One sample::
+        Parameters
+        ----------
+        samples :
+            Iterable of sample dicts.  Omit and pass kwargs for a
+            single-sample call.
+        metrics :
+            Subset of this Evaluator's registered metrics to actually
+            run on this batch.  ``None`` (default) runs all registered.
+            Lets a single long-lived Evaluator score different (gen,
+            ref) corpora with different metric subsets across multiple
+            ``evaluate()`` calls — e.g. LPIPS on a paired corpus, FVD
+            on an unequal-cardinality corpus — without burning model
+            loads.  Set-metric accumulators are reset only for the
+            metrics included in *metrics*, so state for other set
+            metrics is preserved across calls.
+
+        Single sample::
 
             ev.evaluate(video=tensor, text_prompt="...", fps=24.0)
-            ev.evaluate(video="path/to/clip.mp4", fps=24.0)
 
-        Returns a ``dict[str, MetricResult]``.
+        Many samples::
 
-        Many samples — pipelined decode + work-stealing across replicas::
+            ev.evaluate(samples=[{"video": ..., "reference": ...}, ...])
 
-            ev.evaluate(samples=[
-                {"video": "a.mp4", "reference": "ref_a.mp4"},
-                {"video": "b.mp4", "reference": "ref_b.mp4"},
-                ...
-            ])
+        Many samples with a metric filter::
 
-        Returns an :class:`EvalResults` (list-of-dict subclass): per-sample
-        dicts in input order, with set-metric scores under ``.corpus``.
+            ev.evaluate(samples=lpips_samples, metrics=["common.lpips"])
+            ev.evaluate(samples=fvd_samples,   metrics=["common.fvd"])
+
+        Returns
+        -------
+        dict[str, MetricResult] for the single-sample form;
+        :class:`EvalResults` (list-of-dict subclass with ``.corpus``) for
+        the list form.
         """
+        if metrics is not None:
+            unknown = [m for m in metrics if m not in self.metric_names]
+            if unknown:
+                raise ValueError(f"metrics filter contains names not registered on this Evaluator: "
+                                 f"{unknown}; registered: {self.metric_names}")
+
         single = samples is None
         sample_list: list[dict] = [kwargs] if samples is None else list(samples)
         if not sample_list:
             return EvalResults(samples=[], corpus={})
 
-        if single and any(m.is_set_metric for m in self._workers[0].set_metrics().values()):
-            # Set metrics need a population. A single sample can't produce a
-            # meaningful corpus result, and silently discarding it (return
-            # ``per_sample[0]`` only) hides the no-op. Force the list form.
-            raise ValueError("Set-vs-set metrics require samples=[...] with >=2 entries; "
-                             "the kwargs form (single sample) cannot produce a corpus "
-                             "result. Registered set metrics: "
-                             f"{sorted(self._workers[0].set_metrics())}")
+        if single:
+            set_names = self._workers[0].set_metrics().keys()
+            active_set = (set_names if metrics is None else (set_names & set(metrics)))
+            if active_set:
+                # Set metrics need a population. A single sample can't produce a
+                # meaningful corpus result, and silently discarding it (return
+                # ``per_sample[0]`` only) hides the no-op. Force the list form.
+                raise ValueError("Set-vs-set metrics require samples=[...] with >=2 entries; "
+                                 "the kwargs form (single sample) cannot produce a corpus "
+                                 f"result. Active set metrics: {sorted(active_set)}")
 
-        per_sample, corpus = self._run(sample_list)
+        per_sample, corpus = self._run(sample_list, metric_filter=metrics)
 
         if single:
             return per_sample[0]
         return EvalResults(samples=per_sample, corpus=corpus)
 
-    def _run(self, samples: list[dict]) -> tuple[list[dict[str, MetricResult]], dict[str, MetricResult]]:
+    def _run(
+        self,
+        samples: list[dict],
+        *,
+        metric_filter: list[str] | None = None,
+    ) -> tuple[list[dict[str, MetricResult]], dict[str, MetricResult]]:
         """Pool-driven sample pipeline + set-metric finalize.
 
-        Returns ``(per_sample_results, corpus_results)``.
+        ``metric_filter`` (when not ``None``) restricts both the worker
+        dispatch and the set-metric finalize to that subset of names.
+        Set metrics outside the filter keep their previous state.
         """
         from fastvideo.eval.pool import VideoPool
 
-        # Reset every worker's set-metric buffers — per-call isolation.
+        filter_set: set[str] | None = set(metric_filter) if metric_filter is not None else None
+
+        # Reset only the set metrics that will actually run this batch —
+        # other set metrics keep state across calls (e.g. FVD reference
+        # features built by an earlier call still apply to this call).
         for w in self._workers:
-            w.reset_set_metrics()
+            for name, m in w.set_metrics().items():
+                if filter_set is None or name in filter_set:
+                    m.reset()
 
         n_workers = len(self._workers)
         max_size = self._prefetch_factor * n_workers
@@ -158,13 +211,15 @@ class Evaluator:
                     if item is None:
                         break
                     idx, decoded = item
-                    per_sample[idx] = self._workers[0].evaluate(**decoded)
+                    per_sample[idx] = self._workers[0].evaluate(metrics=metric_filter, **decoded)
             else:
                 # Multi-GPU: every worker drains the shared pool (work-stealing).
                 errors: list[BaseException] = []
                 threads: list[threading.Thread] = []
                 for w in self._workers:
-                    t = threading.Thread(target=self._consumer_loop, args=(w, pool, per_sample, errors), daemon=True)
+                    t = threading.Thread(target=self._consumer_loop,
+                                         args=(w, pool, per_sample, errors, metric_filter),
+                                         daemon=True)
                     t.start()
                     threads.append(t)
                 for t in threads:
@@ -172,27 +227,34 @@ class Evaluator:
                 if errors:
                     raise errors[0]
 
-        # Finalize set metrics. With multiple workers, fold per-worker
-        # accumulator state into worker 0 first, then finalize once.
+        # Finalize only the set metrics in the filter.  Merge per-worker
+        # state into worker 0, then finalize once.
         corpus: dict[str, MetricResult] = {}
         base_set = self._workers[0].set_metrics()
-        if base_set:
+        for name, m in base_set.items():
+            if filter_set is not None and name not in filter_set:
+                continue
             for w in self._workers[1:]:
-                for name, m in w.set_metrics().items():
-                    base_set[name].merge_from(m)
-            corpus = {name: m.finalize() for name, m in base_set.items()}
+                base_set[name].merge_from(w.set_metrics()[name])
+            corpus[name] = m.finalize()
 
         return per_sample, corpus
 
     @staticmethod
-    def _consumer_loop(worker: EvalWorker, pool: Any, results: list, errors: list) -> None:
+    def _consumer_loop(
+        worker: EvalWorker,
+        pool: Any,
+        results: list,
+        errors: list,
+        metric_filter: list[str] | None,
+    ) -> None:
         try:
             while True:
                 item = pool.get()
                 if item is None:
                     return
                 idx, decoded = item
-                results[idx] = worker.evaluate(**decoded)
+                results[idx] = worker.evaluate(metrics=metric_filter, **decoded)
         except BaseException as e:  # noqa: BLE001 — surface to parent thread via shared list
             errors.append(e)
 
@@ -220,19 +282,29 @@ def create_evaluator(
     device: str = "cuda:0",
     num_gpus: int = 1,
     compile: bool = False,
+    *,
+    skip_missing_deps: bool = False,
 ) -> Evaluator:
-    return Evaluator(metrics=metrics, device=device, num_gpus=num_gpus, compile=compile)
+    return Evaluator(metrics=metrics,
+                     device=device,
+                     num_gpus=num_gpus,
+                     compile=compile,
+                     skip_missing_deps=skip_missing_deps)
 
 
-def _resolve_metric_names(metrics: list[str] | str) -> list[str]:
+def _resolve_metric_names(metrics: list[str] | str, *, skip_missing_deps: bool = False) -> list[str]:
     """Resolve metric names, supporting groups (``"vbench"``) and ``"all"``.
 
-    Group / ``"all"`` selectors silently skip metrics whose declared
+    Group / ``"all"`` selectors always silently skip metrics whose declared
     dependencies aren't importable in this environment, with a single
-    warning per skipped metric. Explicit names (e.g. ``"vbench.color"``)
-    always pass through unchanged — the missing dep then surfaces as
-    :class:`ImportError` at construction time, which is what the user
-    asked for.
+    warning per skipped metric.
+
+    Explicit names (e.g. ``"vbench.color"``) raise :class:`ImportError` at
+    construction time by default — the user asked for this metric specifically,
+    so a missing dep is a real error.  Pass ``skip_missing_deps=True`` to opt
+    into the same silent-skip behavior for explicit names too (useful when
+    you're enumerating "every metric that works in this venv" rather than
+    requiring each one).
     """
     if metrics == "all":
         return _filter_satisfied(list_metrics(), context="all")
@@ -243,7 +315,12 @@ def _resolve_metric_names(metrics: list[str] | str) -> list[str]:
     names: list[str] = []
     for m in metrics:
         group = resolve_group(m)
-        candidates = _filter_satisfied(group, context=m) if group is not None else [m]
+        if group is not None:
+            candidates = _filter_satisfied(group, context=m)
+        elif skip_missing_deps:
+            candidates = _filter_satisfied([m], context=m)
+        else:
+            candidates = [m]
         for n in candidates:
             if n not in seen:
                 seen.add(n)
@@ -252,14 +329,13 @@ def _resolve_metric_names(metrics: list[str] | str) -> list[str]:
 
 
 def _filter_satisfied(names: list[str], *, context: str) -> list[str]:
-    """Drop metrics with missing deps from a group expansion."""
+    """Drop metrics with missing deps, warning once per skipped metric."""
     keep: list[str] = []
     for n in names:
         missing = missing_dependencies(n)
         if missing:
-            logger.warning(
-                "eval: skipping %s in group '%s'; missing dependency: %s. "
-                "Install instructions: pass the metric name explicitly to see them.", n, context, ", ".join(missing))
+            ctx = f"in group '{context}'" if context != n else "(skip_missing_deps=True)"
+            logger.warning("eval: skipping %s %s; missing dependency: %s", n, ctx, ", ".join(missing))
             continue
         keep.append(n)
     return keep

--- a/fastvideo/eval/io/__init__.py
+++ b/fastvideo/eval/io/__init__.py
@@ -1,3 +1,5 @@
+from fastvideo.eval.io.audio import NoAudioStreamError, extract_audio_track
+from fastvideo.eval.io.inputs import as_video, samples_from
 from fastvideo.eval.io.paths import (build_eval_kwargs, default_filename, glob_videos, sanitize_prompt)
 from fastvideo.eval.io.video import extract_frames, load_video
 
@@ -8,4 +10,8 @@ __all__ = [
     "default_filename",
     "glob_videos",
     "build_eval_kwargs",
+    "as_video",
+    "samples_from",
+    "extract_audio_track",
+    "NoAudioStreamError",
 ]

--- a/fastvideo/eval/io/audio.py
+++ b/fastvideo/eval/io/audio.py
@@ -1,0 +1,104 @@
+"""Audio-extraction helper for video files.
+
+Audio metrics (``audio.clap_score``, ``audio.frechet_distance``, …) read
+file paths under ``sample["audio"]`` and do their own per-metric
+preprocessing (CLAP at 48 kHz, PaSST at 32 kHz, whisper at 16 kHz mono,
+…).  When the source video carries an audio track (V2A / T2A-V model
+outputs), :func:`samples_from(extract_audio=True)` calls
+:func:`extract_audio_track` to pull a ``.wav`` next to it once per video.
+
+Why a separate utility instead of in-pool decode: every audio metric
+wants a different sample rate / channel count / format, so the pool
+can't usefully pre-load audio into a single canonical tensor the way it
+pre-loads video frames.  Paths-in / paths-out is the lingua franca for
+audio in this codebase.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class NoAudioStreamError(ValueError):
+    """Raised when a video file has no audio stream to extract."""
+
+
+def extract_audio_track(
+    video_path: str | Path,
+    *,
+    output_dir: str | Path,
+    sample_rate: int | None = None,
+    codec: str = "pcm_s16le",
+) -> Path:
+    """Pull the first audio stream from *video_path* to a ``.wav`` in *output_dir*.
+
+    Idempotent — if ``output_dir / {stem}.wav`` already exists, the
+    existing file is returned without re-decoding.  This makes the
+    helper safe to call repeatedly from parallel workers on overlapping
+    inputs (the cache hit is the fast path).
+
+    Parameters
+    ----------
+    video_path :
+        Source video file (anything PyAV can open: mp4, mkv, webm, …).
+    output_dir :
+        Directory the ``.wav`` lands in.  Created if it doesn't exist.
+    sample_rate :
+        If set, resample to this rate.  Default (``None``) preserves the
+        source rate — most audio metrics resample again internally to
+        their own target rate, so adding a resample step here would just
+        be wasted work.
+    codec :
+        PCM codec for the output.  ``pcm_s16le`` (default) gives 16-bit
+        little-endian PCM, the most broadly compatible WAV format.
+
+    Returns
+    -------
+    Path
+        Absolute path to the extracted ``.wav``.
+
+    Raises
+    ------
+    NoAudioStreamError
+        If *video_path* has no audio stream.
+    """
+    import av
+
+    in_path = Path(video_path)
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = (out_dir / f"{in_path.stem}.wav").resolve()
+    if out_path.exists():
+        return out_path
+
+    container = av.open(str(in_path))
+    try:
+        audio_streams = [s for s in container.streams if s.type == "audio"]
+        if not audio_streams:
+            raise NoAudioStreamError(f"No audio stream in {in_path}")
+        in_stream = audio_streams[0]
+        target_rate = sample_rate or in_stream.rate
+
+        out = av.open(str(out_path), "w", format="wav")
+        try:
+            out_stream = out.add_stream(codec, rate=target_rate)
+            # Match input layout (mono / stereo / surround) — audio metrics
+            # that want mono will downmix themselves.
+            if in_stream.layout is not None:
+                out_stream.layout = in_stream.layout
+            resampler = None
+            if sample_rate is not None and sample_rate != in_stream.rate:
+                resampler = av.AudioResampler(format=out_stream.format, layout=out_stream.layout, rate=target_rate)
+            for frame in container.decode(in_stream):
+                frames_out = resampler.resample(frame) if resampler is not None else [frame]
+                for f in frames_out:
+                    # PyAV needs pts cleared so the encoder reassigns.
+                    f.pts = None
+                    for packet in out_stream.encode(f):
+                        out.mux(packet)
+            for packet in out_stream.encode():  # flush
+                out.mux(packet)
+        finally:
+            out.close()
+    finally:
+        container.close()
+    return out_path

--- a/fastvideo/eval/io/inputs.py
+++ b/fastvideo/eval/io/inputs.py
@@ -1,0 +1,333 @@
+"""Input-shape helpers: paths → samples list.
+
+The :class:`Evaluator` and every metric consume the same internal
+representation — a ``list[dict]`` with one dict per sample.  Building
+that list by hand is the largest source of ceremony in user scripts.
+:func:`samples_from` is a pure function that turns path-style inputs
+(generated videos / audio, optional paired references, optional
+per-sample prompts / fps / metadata) into the canonical samples list,
+ready to hand to :meth:`Evaluator.evaluate`.
+
+Design rules:
+
+* No Evaluator state, no metric introspection, no I/O beyond reading
+  the prompts file when given.  Just dict assembly.
+* "Extra" keys on a sample are free — metrics each read what they need
+  and ignore the rest.  So one fat samples list naturally serves many
+  metrics in one Evaluator.
+* No "primary modality" axis.  Each modality is a named kwarg
+  (``video=``, ``audio=``); pass whichever you have.  Both is fine.
+* No ``mode`` axis.  The shape of the output is determined by
+  cardinality: when ``|gen| == |ref|`` the samples list is pair-zipped;
+  when ``|gen| < |ref|`` the unmatched references become role-tagged
+  set samples for corpus-shaped metrics (FVD / FAD) without disturbing
+  per-sample paired metrics (LPIPS / PSNR / SSIM / gt_optical_flow).
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from fastvideo.eval.types import Video
+
+_VIDEO_EXTS = (".mp4", ".avi", ".mov", ".mkv", ".gif", ".webm")
+_AUDIO_EXTS = (".wav", ".mp3", ".flac", ".m4a", ".ogg", ".opus")
+
+PathSpec = str | Path | Iterable[str | Path]
+
+
+def as_video(x: str | Path | torch.Tensor | Video) -> Video:
+    """Coerce path/tensor/Video → :class:`Video` for the pool to decode.
+
+    Path strings and :class:`pathlib.Path` become ``Video(source=str(x))``;
+    the pool then calls :func:`load_video` on first use.  Tensors become
+    ``Video(source=None, frames=x)`` — the pool sees ``.frames`` already
+    populated and forwards untouched.  :class:`Video` instances pass through.
+    """
+    if isinstance(x, Video):
+        return x
+    if isinstance(x, str | Path):
+        return Video(source=str(x))
+    if isinstance(x, torch.Tensor):
+        return Video(source=None, frames=x)
+    raise TypeError(f"Cannot coerce {type(x).__name__} to Video")
+
+
+def samples_from(
+    *,
+    # Modality inputs — pass whichever you have, in any combination.
+    video: PathSpec | None = None,
+    reference: PathSpec | None = None,
+    audio: PathSpec | None = None,
+    reference_audio: PathSpec | None = None,
+    # Per-sample attachments.  Scalars broadcast to every sample; lists
+    # / jsonl paths zip per-sample.
+    text_prompt: str | None = None,
+    text_prompts: str | Path | list[str] | None = None,
+    fps: float | None = None,
+    auxiliary_info: dict | list[dict] | None = None,
+    # Catch-all for exotic metric inputs (physics_iq scenarios,
+    # synthetic_optical_flow actions, ...).  Single dict broadcasts;
+    # list of dicts zips.  Keys merge into each sample dict.
+    extras: dict | list[dict] | None = None,
+    # Sugar: pull audio off the video sources via PyAV.  Pass a path
+    # to use a persistent on-disk cache, ``True`` for a system tempdir.
+    extract_audio: bool | str | Path = False,
+    extract_workers: int = 4,
+) -> list[dict]:
+    """Build a samples list from path-style inputs.
+
+    Parameters
+    ----------
+    video, reference, audio, reference_audio :
+        File path, directory of files (sorted by name), or any iterable
+        of paths.  Pass whichever modalities apply to the metrics you
+        plan to run — they attach to ``sample["video"]`` /
+        ``sample["reference"]`` / ``sample["audio"]`` /
+        ``sample["reference_audio"]`` respectively.  Video paths are
+        wrapped in :class:`Video` so :class:`VideoPool` decodes them
+        lazily in parallel; audio paths stay as strings (audio metrics
+        each load with their own resample / preprocess).
+    text_prompt :
+        A single prompt string broadcast onto every sample.
+    text_prompts :
+        A list of strings (one per sample), or a path to a ``.jsonl`` /
+        ``.json`` file containing per-sample prompts.
+    fps :
+        Scalar fps broadcast onto every sample.
+    auxiliary_info :
+        Single dict (broadcast) or list of dicts (zipped) for
+        ``sample["auxiliary_info"]`` — vbench structured-prompt
+        metrics read this.
+    extras :
+        Catch-all per-sample attachments.  Use for metric-specific keys
+        the dedicated kwargs don't cover (``scenario``, ``view``,
+        ``actions``, ``calibration``, ``reference_take2``, ...).  Pass
+        a single dict to broadcast or a list-of-dicts to zip; the keys
+        merge into each sample dict.
+    extract_audio :
+        If truthy, auto-extract audio from each ``video`` /
+        ``reference`` source into ``.wav`` files via PyAV and attach
+        the paths under ``sample["audio"]`` / ``sample["reference_audio"]``.
+        Pass a path for a persistent cache, ``True`` for a tempdir.
+        Skipped silently for videos with no audio stream; ignored
+        wherever ``audio`` / ``reference_audio`` is already explicit.
+    extract_workers :
+        Parallel workers for ``extract_audio``.
+
+    Returns
+    -------
+    list[dict]
+        Canonical samples shape — hand directly to
+        :meth:`Evaluator.evaluate`.
+
+    Cardinality and shape
+    ---------------------
+    Let ``N = len(generated inputs)`` (the agreed length of whichever
+    of ``video`` / ``audio`` you passed).  References are attached
+    1:1 onto the first N samples; any extras (when ``|ref| > N``)
+    become standalone role-tagged samples at the end of the list, so
+    set metrics like FVD see the full reference corpus while per-sample
+    paired metrics like LPIPS only run on the first N pairs.
+
+    Notes
+    -----
+    "Missing" keys are simply absent from the sample dict.  Metrics
+    handle them per their own contract (``sample.get(...)`` for
+    optional, ``sample[...]`` raises for required, or
+    :meth:`BaseMetric._skip` for opt-in skip behavior).  One fat samples
+    list with many keys can serve many metrics — each reads its subset.
+    """
+    gen_video = _expand(video, _VIDEO_EXTS) if video is not None else None
+    gen_audio = _expand(audio, _AUDIO_EXTS) if audio is not None else None
+    ref_video = _expand(reference, _VIDEO_EXTS) if reference is not None else None
+    ref_audio = _expand(reference_audio, _AUDIO_EXTS) if reference_audio is not None else None
+
+    if gen_video is None and gen_audio is None:
+        raise ValueError("samples_from: pass at least one of video= or audio=")
+
+    # All "generated" inputs must agree on length — they describe the
+    # same N samples in different modalities.
+    n_candidates = [len(x) for x in (gen_video, gen_audio) if x is not None]
+    if len({*n_candidates}) != 1:
+        raise ValueError(f"samples_from: generated inputs have inconsistent lengths {n_candidates}")
+    n = n_candidates[0]
+
+    prompts = _broadcast(text_prompts if text_prompts is not None else text_prompt, n, loader=_load_prompts)
+    aux = _broadcast(auxiliary_info, n)
+    extras_per_sample = _broadcast(extras, n)
+    if (text_prompts is not None) and (text_prompt is not None):
+        raise ValueError("Pass either text_prompt (broadcast) or text_prompts (per-sample), not both.")
+
+    samples: list[dict[str, Any]] = []
+    for i in range(n):
+        s: dict[str, Any] = {}
+        if gen_video is not None:
+            s["video"] = as_video(gen_video[i])
+        if gen_audio is not None:
+            s["audio"] = str(gen_audio[i])
+        if ref_video is not None and i < len(ref_video):
+            s["reference"] = as_video(ref_video[i])
+        if ref_audio is not None and i < len(ref_audio):
+            s["reference_audio"] = str(ref_audio[i])
+        if prompts is not None:
+            s["text_prompt"] = prompts[i]
+        if fps is not None:
+            s["fps"] = fps
+        if aux is not None:
+            s["auxiliary_info"] = aux[i]
+        if extras_per_sample is not None:
+            s.update(extras_per_sample[i])
+        samples.append(s)
+
+    # Unmatched references → role-tagged set samples.  Per-sample paired
+    # metrics skip these via the worker's role-skip rule; set metrics
+    # (FVD, FAD) accumulate the features.
+    if ref_video is not None and len(ref_video) > n:
+        for v in ref_video[n:]:
+            samples.append({"video": as_video(v), "role": "reference"})
+    if ref_audio is not None and len(ref_audio) > n:
+        for a in ref_audio[n:]:
+            samples.append({"audio": str(a), "role": "reference"})
+
+    if extract_audio:
+        _attach_extracted_audio(samples, extract_audio, extract_workers)
+    return samples
+
+
+# ------------------------------------------------------------------
+# Internal helpers
+# ------------------------------------------------------------------
+
+
+def _expand(spec: PathSpec, exts: tuple[str, ...]) -> list[Path]:
+    """Resolve a path-style input into a sorted list of file paths.
+
+    * dir → sorted list of files whose extension is in *exts*.
+    * file → ``[Path(spec)]``.
+    * iterable → ``[Path(x) for x in spec]`` (no sort, caller's order).
+    """
+    if isinstance(spec, str | Path):
+        p = Path(spec)
+        if p.is_dir():
+            files = sorted(f for f in p.iterdir() if f.suffix.lower() in exts)
+            if not files:
+                raise FileNotFoundError(f"No files with extension in {exts} under {p}")
+            return files
+        if p.is_file():
+            return [p]
+        raise FileNotFoundError(f"{p} is neither a file nor a directory.")
+    out = [x if isinstance(x, Path) else Path(x) for x in spec]
+    if not out:
+        raise ValueError("Empty iterable passed where a non-empty path list was expected.")
+    return out
+
+
+def _broadcast(value: Any, n: int, *, loader: Any = None) -> list[Any] | None:
+    """Turn *value* into a length-*n* list.
+
+    Single dict, scalar (str / int / float), or ``None`` → broadcast.
+    Path to a ``.json`` / ``.jsonl`` file → load via *loader* (when
+    given) and treat as per-sample.  Iterable (list, tuple, ...) → zip
+    per-sample (must already be length *n*).
+    """
+    if value is None:
+        return None
+    if isinstance(value, str | int | float):
+        if loader is not None and isinstance(value, str) and Path(value).suffix in (".jsonl", ".json"):
+            items = loader(value)
+        else:
+            return [value] * n
+    elif isinstance(value, Path):
+        if loader is None:
+            raise ValueError(f"Got a Path ({value}) where no loader is available")
+        items = loader(value)
+    elif isinstance(value, dict):
+        return [value] * n
+    else:
+        items = list(value)
+    if len(items) != n:
+        raise ValueError(f"per-sample value has {len(items)} entries; need {n} to match generated")
+    return items
+
+
+def _attach_extracted_audio(
+    samples: list[dict],
+    extract_audio: bool | str | Path,
+    workers: int,
+) -> None:
+    """For each sample with a video source but no audio key set, run
+    PyAV audio extraction in parallel and attach the resulting .wav path.
+
+    Mutates *samples* in place.  Silently skips videos whose source has
+    no audio stream (the metric will skip on the missing key just as it
+    would have without auto-extract).  Mirrors the logic onto
+    ``sample["reference"]`` → ``sample["reference_audio"]``.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+    import tempfile
+    from fastvideo.eval.io.audio import extract_audio_track, NoAudioStreamError
+
+    if isinstance(extract_audio, str | Path):
+        out_dir: Path = Path(extract_audio)
+    else:
+        out_dir = Path(tempfile.mkdtemp(prefix="fv_extracted_audio_"))
+
+    # Build the work list — (sample_idx, dest_audio_key, source_path)
+    work: list[tuple[int, str, str]] = []
+    for i, s in enumerate(samples):
+        for vkey, akey in (("video", "audio"), ("reference", "reference_audio")):
+            if akey in s:
+                continue
+            v = s.get(vkey)
+            if isinstance(v, Video) and v.source is not None:
+                work.append((i, akey, str(v.source)))
+    if not work:
+        return
+
+    def _do(item: tuple[int, str, str]) -> tuple[int, str, str | None]:
+        idx, akey, src = item
+        try:
+            return idx, akey, str(extract_audio_track(src, output_dir=out_dir))
+        except NoAudioStreamError:
+            return idx, akey, None
+
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        for idx, akey, audio_path in pool.map(_do, work):
+            if audio_path is not None:
+                samples[idx][akey] = audio_path
+
+
+def _load_prompts(path: str | Path) -> list[str]:
+    """Load per-sample text prompts from a ``.jsonl`` or ``.json`` file.
+
+    * ``.jsonl`` — one JSON value per line.  String values are taken
+      as-is; objects are searched for a ``"prompt"`` or ``"text_prompt"``
+      key.
+    * ``.json`` — a top-level list (same per-item rules).
+    """
+    p = Path(path)
+    if p.suffix == ".jsonl":
+        items = [json.loads(line) for line in p.read_text().splitlines() if line.strip()]
+    elif p.suffix == ".json":
+        items = json.loads(p.read_text())
+        if not isinstance(items, list):
+            raise ValueError(f"{p}: expected a top-level JSON list of prompts.")
+    else:
+        raise ValueError(f"{p}: text prompts file must be .jsonl or .json, got {p.suffix!r}")
+    out: list[str] = []
+    for item in items:
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, dict):
+            v = item.get("prompt") or item.get("text_prompt")
+            if not isinstance(v, str):
+                raise ValueError(f"{p}: dict entry missing 'prompt'/'text_prompt' string field: {item!r}")
+            out.append(v)
+        else:
+            raise ValueError(f"{p}: prompt entries must be strings or dicts, got {type(item).__name__}")
+    return out

--- a/fastvideo/eval/io/video.py
+++ b/fastvideo/eval/io/video.py
@@ -58,9 +58,15 @@ def _load_frame_dir(path: Path) -> torch.Tensor:
 
 
 def _load_video_file(path: str) -> torch.Tensor:
-    # Try decord first (faster), fall back to torchvision
+    # Decoder priority: decord (fastest, optional) → PyAV (broadly available
+    # via av on PyPI) → torchvision.io.read_video (removed in 0.20+, kept as
+    # the last-ditch fallback for older stacks).
     try:
         return _load_with_decord(path)
+    except ImportError:
+        pass
+    try:
+        return _load_with_pyav(path)
     except ImportError:
         pass
     return _load_with_torchvision(path)
@@ -75,6 +81,18 @@ def _load_with_decord(path: str) -> torch.Tensor:
     # → (T, C, H, W) float32 [0, 1]
     tensor = torch.from_numpy(frames).permute(0, 3, 1, 2).float() / 255.0
     return tensor
+
+
+def _load_with_pyav(path: str) -> torch.Tensor:
+    import av
+
+    container = av.open(path)
+    try:
+        frames = [frame.to_ndarray(format="rgb24") for frame in container.decode(video=0)]
+    finally:
+        container.close()
+    arr = np.stack(frames)  # (T, H, W, C) uint8
+    return torch.from_numpy(arr).permute(0, 3, 1, 2).float() / 255.0
 
 
 def _load_with_torchvision(path: str) -> torch.Tensor:

--- a/fastvideo/eval/metrics/audio/clap_score/metric.py
+++ b/fastvideo/eval/metrics/audio/clap_score/metric.py
@@ -81,7 +81,8 @@ class ClapScoreMetric(BaseMetric):
         audio = sample.get("audio")
         text = sample.get("text_prompt")
         if audio is None or text is None:
-            return self._skip(sample, "missing 'audio' or 'text_prompt'")
+            missing = [k for k, v in (("audio", audio), ("text_prompt", text)) if v is None]
+            return self._skip(sample, f"missing {', '.join(repr(k) for k in missing)}")
 
         audio_emb = self._audio_emb(audio)
         text_emb = self._text_emb(text)

--- a/fastvideo/eval/metrics/audio/desync/metric.py
+++ b/fastvideo/eval/metrics/audio/desync/metric.py
@@ -181,7 +181,8 @@ class DeSyncMetric(BaseMetric):
         video = sample.get("video")
         audio_path = sample.get("audio")
         if video is None or audio_path is None:
-            return self._skip(sample, "missing 'video' or 'audio'")
+            missing = [k for k, v in (("video", video), ("audio", audio_path)) if v is None]
+            return self._skip(sample, f"missing {', '.join(repr(k) for k in missing)}")
 
         # Prefer the per-sample fps the pool decoded at; fall back to the
         # constructor override. Without either, the audio/video windows can't

--- a/fastvideo/eval/metrics/audio/imagebind_score/metric.py
+++ b/fastvideo/eval/metrics/audio/imagebind_score/metric.py
@@ -77,8 +77,13 @@ class ImageBindScoreMetric(BaseMetric):
 
         video_path = _video_source(sample)
         audio_path = sample.get("audio")
-        if video_path is None or audio_path is None:
-            return self._skip(sample, "missing 'video_path'/'video.source' or 'audio'")
+        missing = []
+        if video_path is None:
+            missing.append("'video_path' or 'video' with a path source")
+        if audio_path is None:
+            missing.append("'audio'")
+        if missing:
+            return self._skip(sample, f"missing {', '.join(missing)}")
 
         import decord
         from imagebind import data as ib_data

--- a/fastvideo/eval/metrics/audio/kl_divergence/metric.py
+++ b/fastvideo/eval/metrics/audio/kl_divergence/metric.py
@@ -122,7 +122,8 @@ class KLDivergenceMetric(BaseMetric):
         gen_path = sample.get("audio")
         ref_path = sample.get("reference_audio")
         if gen_path is None or ref_path is None:
-            return self._skip(sample, "missing 'audio' or 'reference_audio'")
+            missing = [k for k, v in (("audio", gen_path), ("reference_audio", ref_path)) if v is None]
+            return self._skip(sample, f"missing {', '.join(repr(k) for k in missing)}")
 
         gt_logits = _collect_logits(self._model, ref_path, self.device)
         pred_logits = _collect_logits(self._model, gen_path, self.device)

--- a/fastvideo/eval/metrics/common/fvd/metric.py
+++ b/fastvideo/eval/metrics/common/fvd/metric.py
@@ -11,9 +11,22 @@ uses 2048.
 
 This metric follows the set-vs-set protocol (``is_set_metric=True``):
 
-  - :meth:`accumulate` is called once per video to buffer features.
-  - :meth:`finalize`   is called once after all videos to compute FVD.
-  - :meth:`reset`      clears buffers between evaluation runs.
+  - :meth:`accumulate` is called once per video to buffer features. Routes
+    on ``sample["role"]`` — ``"reference"`` → real buffer, anything else →
+    generated buffer.  This is the same convention
+    :class:`audio.frechet_distance.FrechetAudioDistanceMetric` uses.
+  - :meth:`finalize` is called once after all videos to compute FVD.
+  - :meth:`reset`    clears both buffers between evaluation runs.
+
+To score two corpora, build a samples list with
+:func:`fastvideo.eval.io.inputs.samples_from` and hand it to
+:meth:`Evaluator.evaluate` — the path-friendly form is::
+
+    from fastvideo.eval import create_evaluator, samples_from
+    ev = create_evaluator(metrics=["common.fvd"], device="cuda:0")
+    result = ev.evaluate(samples=samples_from(
+        video="gen/", reference="ref/",
+    )).corpus["common.fvd"]
 
 Extractors
 ----------
@@ -31,13 +44,18 @@ scores from the literature; use ``i3d`` for paper comparisons.
 Reference features
 ------------------
 
-On the first call to :meth:`accumulate` that includes ``sample["reference"]``,
-features are extracted from those reference videos and saved to *cache_path*.
-Every subsequent run loads that cache automatically — no need to pass
-``sample["reference"]`` again.
+Two ways to supply reference features:
 
-Each extractor caches to a separate file (``real_features_{extractor}.pt``)
-because feature dimensions differ — mixing them silently would yield garbage.
+1. **Stream**: pass ``reference=`` to :func:`samples_from`.  Equal
+   cardinality emits paired samples (``sample["video"]`` +
+   ``sample["reference"]``); unequal cardinality role-tags the unmatched
+   references.  ``accumulate`` routes both shapes correctly.  If
+   ``cache_mode="read_write"`` (default) and no cache exists, the
+   extracted features are persisted to *cache_path* on :meth:`finalize`.
+2. **Cache hit**: a prior run wrote ``cache_path``; :meth:`setup` loads it
+   automatically and streamed references are unnecessary.
+
+Streamed references always win over the cache when both are present.
 
 Cache resolution order (first match wins):
   1. ``cache_path=`` constructor kwarg, if set.
@@ -141,20 +159,23 @@ class FVDMetric(BaseMetric):
         Feature backbone name. One of ``"i3d"`` (default), ``"clip"``,
         ``"videomae"``. See module docstring for guidance.
     cache_path : str, optional
-        Where extracted reference features are cached. Built from
-        ``sample["reference"]`` on the first run, reused automatically on
-        every subsequent run.  Resolution order: constructor kwarg →
-        ``$FASTVIDEO_FVD_REF_FEATURES`` env-var →
+        Where extracted reference features are cached. Resolution order:
+        constructor kwarg → ``$FASTVIDEO_FVD_REF_FEATURES`` env-var →
         ``${FASTVIDEO_EVAL_CACHE}/fvd/real_features_{extractor}.pt``
         (default, resolved at :meth:`setup` time so the env-var can be set
         after import).
+    cache_mode : str
+        ``"read_write"`` (default) — read at setup, write at finalize on
+        cache miss. ``"read"`` — read at setup, never write.  ``"off"`` —
+        ignore the cache entirely.  Auto-write happens only when the cache
+        was missing AND reference features streamed in this run.
     chunk_size : int
         Videos per forward pass. Reduce if GPU runs OOM.
     """
 
     name = "common.fvd"
     is_set_metric = True
-    requires_reference = False  # uses cached real features, not per-sample ref
+    requires_reference = False  # reference is supplied via role="reference" samples or cache
     higher_is_better = False  # lower FVD = better
     needs_gpu = True
     dependencies = ["huggingface_hub", "scipy", "transformers"]
@@ -163,22 +184,29 @@ class FVDMetric(BaseMetric):
         self,
         extractor: str = "i3d",
         cache_path: str | None = None,
+        cache_mode: str = "read_write",
         chunk_size: int = 32,
     ) -> None:
         super().__init__()
         if extractor not in available_extractors():
             raise ValueError(f"Unknown FVD extractor '{extractor}'. "
                              f"Available: {available_extractors()}")
+        if cache_mode not in {"off", "read", "read_write"}:
+            raise ValueError(f"cache_mode must be one of 'off', 'read', 'read_write'; got {cache_mode!r}")
         self._extractor_name = extractor
         self._cache_path_arg = cache_path
+        self._cache_mode = cache_mode
         self._chunk = chunk_size
         self._extractor: _BaseExtractor | None = None
 
         # Accumulated feature buffers — cleared by reset()
-        self._gen_features: list[np.ndarray] = []
-        self._real_features: np.ndarray | None = None
+        self._gen_buf: list[np.ndarray] = []
+        self._real_buf: list[np.ndarray] = []
+        # Cache loaded at setup() time; survives reset() (the cached corpus
+        # is part of the metric's configured state, not its run state).
+        self._cached_real: np.ndarray | None = None
 
-    def to(self, device):
+    def to(self, device: str | torch.device) -> FVDMetric:
         super().to(device)
         if self._extractor is not None:
             self._extractor.to(self.device)
@@ -197,79 +225,94 @@ class FVDMetric(BaseMetric):
         else:
             self.cache_path = _default_cache_path(self._extractor_name)
         self._extractor = load_extractor(self._extractor_name, self.device)
-        self._real_features = self._load_cache()
+        if self._cache_mode != "off":
+            self._cached_real = self._load_cache()
 
     # ------------------------------------------------------------------
     # Set-vs-set protocol
     # ------------------------------------------------------------------
 
     def reset(self) -> None:
-        """Clear generated feature buffer. Called before each evaluation run."""
-        self._gen_features = []
+        """Clear generated and streamed-reference buffers. Cache survives."""
+        self._gen_buf = []
+        self._real_buf = []
 
     def accumulate(self, sample: dict) -> None:
-        """Extract features from one generated video and buffer them.
+        """Extract features from one video and route by ``sample["role"]``.
 
-        If ``sample["reference"]`` is provided and no cache exists yet,
-        reference features are extracted and saved to *cache_path*.
+        Routing rules:
+
+        * ``role="reference"`` → real buffer; the reference key is ignored.
+        * Otherwise → generated buffer.  If ``sample["reference"]`` is
+          also present, its features also go into the real buffer — this
+          lets a paired samples list (the shape per-sample metrics like
+          LPIPS need) feed FVD in the same pass without a second decode.
+
+        Accepts either a raw tensor or a populated :class:`Video` instance
+        under either key.
         """
         if self._extractor is None:
             self.setup()
         assert self._extractor is not None  # for type narrowing
 
-        video = sample["video"]  # (T, C, H, W) from evaluator
+        if sample.get("role") == "reference":
+            self._real_buf.append(self._extract(sample["video"]))
+            return
+
+        self._gen_buf.append(self._extract(sample["video"]))
+        if "reference" in sample:
+            self._real_buf.append(self._extract(sample["reference"]))
+
+    def _extract(self, video: torch.Tensor) -> np.ndarray:
+        """Batchify (4-D → 5-D) and run the chunked extractor forward.
+
+        Pre-condition: ``video`` is already a tensor — :class:`EvalWorker`
+        unwraps :class:`Video` instances before any metric sees the sample.
+        """
         if video.dim() == 4:
-            video = video.unsqueeze(0)  # → (1, T, C, H, W)
-
-        self._gen_features.append(_extract_chunked(self._extractor, video, self._chunk))
-
-        # Build real feature cache on first encounter
-        if self._real_features is None:
-            self._real_features = self._load_cache()
-
-        if self._real_features is None:
-            ref = sample.get("reference")
-            if ref is not None:
-                if ref.dim() == 4:
-                    ref = ref.unsqueeze(0)
-                self._real_features = _extract_chunked(self._extractor, ref, self._chunk)
-                self._save_cache(self._real_features)
-        elif sample.get("reference") is not None:
-            # Reference features already exist (from cache or an earlier
-            # accumulate call). Silently dropping ``sample["reference"]``
-            # would be a foot-gun for callers expecting per-sample-reference
-            # semantics — warn so the mismatch surfaces.
-            warnings.warn(
-                "common.fvd: sample['reference'] ignored because reference features "
-                "are already loaded (from cache or a prior accumulate call). Pass the "
-                "entire reference set on a single accumulate() call, or pre-build the "
-                f"cache at {self.cache_path}.",
-                stacklevel=2,
-            )
+            video = video.unsqueeze(0)  # (T, C, H, W) → (1, T, C, H, W)
+        assert self._extractor is not None
+        return _extract_chunked(self._extractor, video, self._chunk)
 
     def finalize(self) -> MetricResult:
-        """Compute FVD from all accumulated generated features vs. real features."""
-        if not self._gen_features:
+        """Compute FVD from buffered generated features vs. reference features.
+
+        Reference source priority: streamed (``_real_buf``) > disk cache
+        (``_cached_real``).  On a fresh cache + streamed refs, write the
+        accumulated real features back to disk if ``cache_mode="read_write"``.
+        """
+        if not self._gen_buf:
             return MetricResult(
                 name=self.name,
                 score=None,
                 details={"skipped": "No generated videos accumulated before finalize()."},
             )
+        all_gen = np.concatenate(self._gen_buf, axis=0)
 
-        if self._real_features is None:
+        if self._real_buf:
+            all_real = np.concatenate(self._real_buf, axis=0)
+            ref_source = "streamed"
+            # Persist to cache only when we built real features fresh and
+            # the cache slot was empty — never silently overwrite an
+            # existing cache.
+            if self._cache_mode == "read_write" and self._cached_real is None:
+                self._save_cache(all_real)
+        elif self._cached_real is not None:
+            all_real = self._cached_real
+            ref_source = "cached"
+        else:
             return MetricResult(
                 name=self.name,
                 score=None,
                 details={
-                    "skipped": ("No reference features available. Pass sample['reference'] "
-                                "in at least one accumulate() call to build the cache at: "
-                                f"{self.cache_path}")
+                    "skipped": ("No reference features available. Pass role='reference' samples "
+                                "(or a paired samples list with 'reference' key) to "
+                                f"Evaluator.evaluate(), or pre-build the cache at: {self.cache_path}")
                 },
             )
 
-        all_gen = np.concatenate(self._gen_features, axis=0)
         n_gen = len(all_gen)
-        n_real = len(self._real_features)
+        n_real = len(all_real)
 
         if n_gen < _MIN_VIDEOS_WARN or n_real < _MIN_VIDEOS_WARN:
             warnings.warn(
@@ -280,7 +323,7 @@ class FVDMetric(BaseMetric):
             )
 
         mu_gen, sigma_gen = _gaussian_params(all_gen)
-        mu_real, sigma_real = _gaussian_params(self._real_features)
+        mu_real, sigma_real = _gaussian_params(all_real)
         fvd = _frechet_distance(mu_gen, sigma_gen, mu_real, sigma_real)
 
         return MetricResult(
@@ -290,18 +333,24 @@ class FVDMetric(BaseMetric):
                 "extractor": self._extractor_name,
                 "n_generated": n_gen,
                 "n_reference": n_real,
+                "ref_source": ref_source,
             },
         )
 
     def merge_from(self, other: BaseMetric) -> None:
-        """Fold another worker's accumulated features into this one (multi-GPU)."""
+        """Fold another worker's accumulated features into this one (multi-GPU).
+
+        Both gen and ref buffers concatenate.  The disk cache is the same
+        across workers, so we only adopt *other*'s ``_cached_real`` if our
+        own slot is empty (defensive — should always already match).
+        """
         assert isinstance(other, FVDMetric)
         assert other._extractor_name == self._extractor_name, (
             f"merge_from extractor mismatch: {other._extractor_name!r} vs {self._extractor_name!r}")
-        self._gen_features.extend(other._gen_features)
-        # Real features are identical across workers (same cache); keep ours.
-        if self._real_features is None and other._real_features is not None:
-            self._real_features = other._real_features
+        self._gen_buf.extend(other._gen_buf)
+        self._real_buf.extend(other._real_buf)
+        if self._cached_real is None and other._cached_real is not None:
+            self._cached_real = other._cached_real
 
     # ------------------------------------------------------------------
     # Cache helpers

--- a/fastvideo/eval/pool.py
+++ b/fastvideo/eval/pool.py
@@ -13,10 +13,7 @@ from __future__ import annotations
 
 import queue
 import threading
-from pathlib import Path
 from typing import Any
-
-import torch
 
 from fastvideo.eval.types import Video
 
@@ -139,27 +136,19 @@ class VideoPool:
             self._ready_q.put((idx, decoded))
 
     def _decode(self, sample: dict) -> dict:
-        """Materialize and normalize ``video`` / ``reference`` entries.
+        """Materialize :class:`Video` instances by populating ``.frames``.
 
-        * ``Video`` instance → populate ``.frames`` via decode.
-        * ``str`` / ``Path`` under ``video`` / ``reference`` → decoded
-          ``(T, C, H, W)`` tensor.
-        * ``(1, T, C, H, W)`` tensor under ``video`` / ``reference`` →
-          squeezed to ``(T, C, H, W)`` (back-compat with callers that
-          still pass a leading batch dim).
-        * Everything else passes through unchanged.
+        Any value that is a ``Video`` with a source path and no frames
+        yet gets decoded.  Every other value passes through unchanged —
+        wrap paths in :class:`Video` (or use
+        :func:`fastvideo.eval.io.as_video` / :func:`samples_from`) to
+        make them decode-eligible.
         """
         from fastvideo.eval.io.video import load_video
 
         out = dict(sample)
         for key, val in sample.items():
-            if isinstance(val, Video):
-                if val.frames is None and val.source is not None:
-                    val.frames = load_video(val.source)
+            if isinstance(val, Video) and val.frames is None and val.source is not None:
+                val.frames = load_video(val.source)
                 out[key] = val
-            elif key in ("video", "reference"):
-                if isinstance(val, str | Path):
-                    out[key] = load_video(str(val))
-                elif isinstance(val, torch.Tensor) and val.dim() == 5 and val.shape[0] == 1:
-                    out[key] = val.squeeze(0)
         return out

--- a/fastvideo/eval/worker.py
+++ b/fastvideo/eval/worker.py
@@ -131,16 +131,18 @@ class EvalWorker:
                     m.accumulate(sample)
                 elif not is_ref:
                     results[name] = m.compute(sample)
-            except Exception as e:
+            except (ImportError, ModuleNotFoundError, FileNotFoundError) as e:
                 # In skip_missing_deps mode, compute/accumulate-time failures
-                # (lazy imports of missing libs like torchcodec, runtime model
-                # init that can't find a checkpoint, etc.) drop the metric for
-                # the remainder of this Evaluator instead of bringing the whole
-                # run down. Strict mode re-raises.
+                # whose root cause is a missing dependency (lazy import of a
+                # lib like torchcodec) or a missing resource (model checkpoint
+                # not on disk) drop the metric for the remainder of this
+                # Evaluator instead of bringing the whole run down. Strict
+                # mode re-raises. Programmer bugs, OOM, and other runtime
+                # failures are intentionally NOT caught here — they surface.
                 if not self._skip_missing_deps:
                     raise
                 import logging
-                logging.getLogger(__name__).warning("eval: dropping %s after %s: %s", name, type(e).__name__, e)
+                logging.getLogger(__name__).exception("eval: dropping %s after %s: %s", name, type(e).__name__, e)
                 broken.append(name)
         for n in broken:
             self._metrics.pop(n, None)

--- a/fastvideo/eval/worker.py
+++ b/fastvideo/eval/worker.py
@@ -21,7 +21,7 @@ import torch
 from fastvideo.eval.memory import clear_cache
 from fastvideo.eval.metrics.base import BaseMetric
 from fastvideo.eval.registry import get_metric
-from fastvideo.eval.types import MetricResult
+from fastvideo.eval.types import MetricResult, Video
 
 
 class EvalWorker:
@@ -34,11 +34,18 @@ class EvalWorker:
     Evaluator finalizes them after the pool drains.
     """
 
-    def __init__(self, metric_names: list[str], device: str, *, compile: bool = False, pre_upload: bool = True) -> None:
+    def __init__(self,
+                 metric_names: list[str],
+                 device: str,
+                 *,
+                 compile: bool = False,
+                 pre_upload: bool = True,
+                 skip_missing_deps: bool = False) -> None:
         self._names = list(metric_names)
         self._device = device
         self._compile = compile
         self._pre_upload = pre_upload
+        self._skip_missing_deps = skip_missing_deps
         self._metrics: dict[str, BaseMetric] = {}
         self._unloaded = False
         self._load()
@@ -54,9 +61,19 @@ class EvalWorker:
 
     def _load(self) -> None:
         for name in self._names:
-            m = get_metric(name)
-            m.to(self._device)
-            m.setup()
+            try:
+                m = get_metric(name)
+                m.to(self._device)
+                m.setup()
+            except (ImportError, ModuleNotFoundError) as e:
+                # Declared deps are checked up-front in get_metric; this
+                # catches transitive imports done lazily in setup() (e.g.
+                # vbench upstream pulling decord from its utils.py).
+                if self._skip_missing_deps:
+                    import logging
+                    logging.getLogger(__name__).warning("eval: skipping %s; setup-time import failed: %s", name, e)
+                    continue
+                raise
             if self._compile and getattr(m, "_model", None) is not None:
                 m._model = torch.compile(m._model)
             self._metrics[name] = m
@@ -66,29 +83,67 @@ class EvalWorker:
         self._any_needs_gpu = any(m.needs_gpu for m in self._metrics.values())
         self._unloaded = False
 
-    def evaluate(self, **kwargs) -> dict[str, MetricResult]:
+    def evaluate(self, *, metrics: list[str] | None = None, **kwargs) -> dict[str, MetricResult]:
         """Score one already-decoded sample.
 
-        Inputs (``video`` / ``reference`` paths, 5-D tensors) are
-        decoded and normalized upstream by the :class:`VideoPool`. The
-        worker only handles the optional pre-upload to its device and
-        dispatches to each metric's ``compute`` or ``accumulate``.
+        Inputs (``video`` / ``reference`` paths) are decoded and
+        normalized upstream by the :class:`VideoPool`. The worker
+        handles the optional pre-upload to its device and dispatches to
+        each metric's ``compute`` or ``accumulate``.
+
+        Samples tagged ``role="reference"`` are corpus context for set
+        metrics only — per-sample metrics skip them so a mixed
+        Evaluator (e.g. FVD + LPIPS + vbench) doesn't produce spurious
+        per-sample scores on the reference half of the corpus.
+
+        ``metrics`` (when not ``None``) further restricts dispatch to
+        that subset of registered names — used by the per-call
+        ``Evaluator.evaluate(metrics=...)`` filter.
         """
         if self._unloaded:
             raise RuntimeError("EvalWorker was unloaded; call reload() before evaluating.")
 
         sample = dict(kwargs)
+        # Unwrap ``Video`` → its ``.frames`` tensor for per-sample metric
+        # consumers (PSNR/SSIM/LPIPS/optical_flow). The pool decodes Video
+        # instances but leaves the wrapper in place so source-aware metrics
+        # (audio.imagebind_score) can still read ``Video.source``; those
+        # metrics should additionally pass ``sample["video_path"]`` if they
+        # need the path. Per-sample tensor consumers get a tensor either way.
+        for _k in ("video", "reference"):
+            _v = sample.get(_k)
+            if isinstance(_v, Video):
+                sample[_k] = _v.frames
         if self._pre_upload and self._any_needs_gpu:
             sample["video"] = _to_device(sample.get("video"), self._device)
             if "reference" in sample:
                 sample["reference"] = _to_device(sample["reference"], self._device)
 
+        is_ref = sample.get("role") == "reference"
+        filter_set: set[str] | None = set(metrics) if metrics is not None else None
         results: dict[str, MetricResult] = {}
+        broken: list[str] = []
         for name, m in self._metrics.items():
-            if m.is_set_metric:
-                m.accumulate(sample)
-            else:
-                results[name] = m.compute(sample)
+            if filter_set is not None and name not in filter_set:
+                continue
+            try:
+                if m.is_set_metric:
+                    m.accumulate(sample)
+                elif not is_ref:
+                    results[name] = m.compute(sample)
+            except Exception as e:
+                # In skip_missing_deps mode, compute/accumulate-time failures
+                # (lazy imports of missing libs like torchcodec, runtime model
+                # init that can't find a checkpoint, etc.) drop the metric for
+                # the remainder of this Evaluator instead of bringing the whole
+                # run down. Strict mode re-raises.
+                if not self._skip_missing_deps:
+                    raise
+                import logging
+                logging.getLogger(__name__).warning("eval: dropping %s after %s: %s", name, type(e).__name__, e)
+                broken.append(name)
+        for n in broken:
+            self._metrics.pop(n, None)
         return results
 
     def set_metrics(self) -> dict[str, BaseMetric]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,14 +139,18 @@ test = [
 # Eval extras. See fastvideo/eval/README.md for which install path
 # covers which metrics. detectron2 (vbench color/object_class/etc.) is
 # CUDA-version-pinned and not cleanly pip-installable — install it
-# separately as documented in the README.
+# separately as documented in the README. decord has no aarch64 wheels
+# (upstream effectively unmaintained); it's split into its own extra so
+# the main eval extras install on ARM systems too. eval/io/video.py has
+# a PyAV fallback that covers the video-decode path without decord.
 eval-vbench     = ["openai-clip", "pyiqa", "easydict"]
 eval-physics-iq = []
-eval-audio = ["jiwer", "librosa", "pyloudnorm", "hear21passt", "audiobox_aesthetics", "imagebind", "decord", "pytorchvideo"]
+eval-audio = ["jiwer", "librosa", "pyloudnorm", "hear21passt", "audiobox_aesthetics", "imagebind", "pytorchvideo"]
 eval = [
-    "decord", "lpips", "ptlflow", "qwen-vl-utils",
+    "lpips", "ptlflow", "qwen-vl-utils",
     "fastvideo[eval-vbench]", "fastvideo[eval-physics-iq]",
 ]
+eval-fast-decode = ["decord"]
 eval-full = ["fastvideo[eval]", "fastvideo[eval-audio]", "qwen-omni-utils"]
 
 dev = [ "fastvideo[lint]", "fastvideo[test]", ]


### PR DESCRIPTION
## Purpose

Bundle of eval-framework improvements layered on top of #1380's FVD consolidation. Three themes:

1. **Input ergonomics** — `samples_from` + `as_video` collapse the 5–10 LoC of manual sample-list assembly into a single call. The pool's `_decode` simplifies to one rule (`Video` instances → populate `.frames`); the worker unwraps `Video → .frames` once before metric dispatch. The canonical FVD example (`examples/inference/eval/eval_fvd.py`) drops from ~85 LoC to ~30.

2. **Evaluator features** — `Evaluator(skip_missing_deps=True)` keeps the run alive when a metric's optional deps aren't importable (covers declared deps AND lazy transitive imports from `setup()` or `compute()`, e.g. vbench's hard `decord` import, torchcodec's `libnvrtc.so.13` requirement). `Evaluator.evaluate(samples, metrics=[...])` filters dispatch to a subset of registered metrics per call — useful for keeping one long-lived Evaluator alive across structurally different evaluations (LPIPS on paired corpus + FVD on unequal-cardinality corpus) without burning model loads.

3. **Bug fixes + supporting changes** — PyAV decoder fallback in `load_video` (decord → PyAV → torchvision; torchvision 0.20+ removed `read_video`, decord has no aarch64 wheels); `decord` factored into `[eval-fast-decode]` so `[eval]` installs on aarch64; FVD `accumulate` refactored to streaming references (`role="reference"` tagging + paired-input handling), `cache_mode` kwarg, cache write moved from `accumulate` to `finalize`, `merge_from` folds both buffers for multi-GPU correctness; worker role-skip rule (per-sample metrics ignore role-tagged samples); audio metric skip messages enumerate the actually-missing keys; audio extraction sugar (`extract_audio_track`, `samples_from(extract_audio=True)`) so V2A model outputs feed audio metrics without manual ffmpeg.

Net: **+893 / −244** LoC across 16 files.

## Changes

**Input layer (NEW)**
- `fastvideo/eval/io/inputs.py` (NEW) — `samples_from` + `as_video`. Cardinality-inferred shape: equal `|gen| == |ref|` zips into paired samples, unequal cardinality role-tags the unmatched references. Symmetric `video`/`reference`/`audio`/`reference_audio` kwargs; `text_prompt(s)`/`fps`/`auxiliary_info` for vbench-style attachments; `extras=` catch-all for exotic per-sample keys (physics_iq `scenario`/`view`, etc.).
- `fastvideo/eval/io/audio.py` (NEW) — `extract_audio_track` via PyAV. Idempotent on output `.wav`; `NoAudioStreamError` for videos with no audio stream.
- `fastvideo/eval/io/__init__.py`, `fastvideo/eval/__init__.py` — re-exports.

**FVD streaming refactor**
- `fastvideo/eval/metrics/common/fvd/metric.py` — `_real_features: ndarray` → `_real_buf: list[ndarray]`; `accumulate` routes on `sample["role"]` AND pulls `sample["reference"]` from paired samples; `merge_from` folds both buffers; `finalize` prefers streamed over cached, writes cache on cache-miss; new `cache_mode={"off","read","read_write"}` kwarg.

**Evaluator + worker**
- `fastvideo/eval/evaluator.py` — `Evaluator(skip_missing_deps=False)` + `evaluate(samples, *, metrics=None)`. `_resolve_metric_names(skip_missing_deps=...)` filters explicit names. Only filtered set metrics reset their accumulators (state survives across calls for non-filtered set metrics).
- `fastvideo/eval/worker.py` — `EvalWorker(skip_missing_deps=False)`. Catches `ImportError`/`ModuleNotFoundError` at `setup()`, broad `Exception` at `compute()`/`accumulate()` under skip mode (drops the metric for the rest of the run). Role-skip rule for per-sample metrics on `role="reference"` samples. `Video → .frames` unwrap before dispatch. `metrics=` filter threaded through.

**Pool simplification**
- `fastvideo/eval/pool.py` — `_decode` collapsed to one rule: `Video` instances → populate `.frames`. Dropped the path-string-under-key and 5-D-tensor squeeze back-compat branches; users wrap paths via `as_video()` or use `samples_from()`.

**Misc**
- `fastvideo/eval/io/video.py` — PyAV decoder inserted between decord (optional now) and torchvision (read_video removed in 0.20+).
- `pyproject.toml` — `decord` → `[eval-fast-decode]` optional extra. `[eval]` / `[eval-full]` now install on aarch64.
- `fastvideo/eval/metrics/audio/{clap_score,desync,imagebind_score,kl_divergence}/metric.py` — `_skip` messages enumerate the actually-missing keys (e.g. `"missing 'audio'"` instead of the ambiguous `"missing 'audio' or 'text_prompt'"`).
- `fastvideo/eval/README.md` — Public API section adds `samples_from`/`as_video` + `metrics=` filter; FVD section rewritten to use `samples_from`; Install table notes `[eval-fast-decode]` is opt-in for x86_64.
- `examples/inference/eval/eval_fvd.py` — rewrite to use `samples_from` (drops ~55 LoC of manual list assembly).

## Test Plan

```bash
pre-commit run --files \
  fastvideo/eval/__init__.py \
  fastvideo/eval/io/__init__.py \
  fastvideo/eval/io/audio.py \
  fastvideo/eval/io/inputs.py \
  fastvideo/eval/io/video.py \
  fastvideo/eval/evaluator.py \
  fastvideo/eval/worker.py \
  fastvideo/eval/pool.py \
  fastvideo/eval/metrics/common/fvd/metric.py \
  fastvideo/eval/metrics/audio/clap_score/metric.py \
  fastvideo/eval/metrics/audio/desync/metric.py \
  fastvideo/eval/metrics/audio/imagebind_score/metric.py \
  fastvideo/eval/metrics/audio/kl_divergence/metric.py \
  examples/inference/eval/eval_fvd.py \
  fastvideo/eval/README.md \
  pyproject.toml
```

Integration testing was done locally (test files not in this PR per current scope):

- **Identical-set FVD invariant** verified across `N ∈ {4, 8, 16}` and `num_gpus ∈ {1, 2, 3}` on a duplicated LTX2-Distilled-generated sample. `FVD = 0.0000` in every config, confirming `merge_from` correctness across workers.
- **All-metrics integration** via `Evaluator(metrics=list_metrics(), skip_missing_deps=True)` + `samples_from(extract_audio=True)` on the same identical-set inputs: perfect-match metrics hit their bounds (PSNR=100, SSIM=1, LPIPS=0, FAD=0); per-sample metrics missing required keys produced clean skipped MetricResults; metrics with missing optional deps dropped with one warning per skip.

## Test Results

<details><summary>Pre-commit</summary>

```
yapf.....................................................................Passed
ruff (legacy alias)......................................................Passed
codespell................................................................Passed
PyMarkdown...............................................................Passed
mypy.....................................................................Passed
Check for spaces in all filenames........................................Passed
```

</details>

<details><summary>Multi-GPU sweep (5 configs, GB200)</summary>

```
N    GPUs thr  | construct  evaluate  total   | peak GPU (GB)        | invariants
 4   1    4    |  47.2s    200.6s    247.8s   | [40.1]               | OK
 4   2    4    |  85.9s    113.3s    199.1s   | [40.2, 40.1]         | OK
 4   3    4    | 123.3s    143.1s    266.4s   | [40.2, 40.1, 40.1]   | OK
 8   1    4    |  42.2s    371.1s    413.3s   | [40.2]               | OK
 8   2    4    |  92.9s    219.9s    312.8s   | [40.2, 40.1]         | OK
```

Eval-step scaling: ~85% efficiency at 2 GPUs (1.77× speedup on N=4). 3 GPUs on N=4 = 1.40× (4 samples don't divide evenly across 3 workers, tail straggler dominates). Per-device peak memory is ~40 GB regardless of `num_gpus`; multi-GPU costs aggregate memory but not per-device pressure.

</details>

## Checklist

- [x] I ran `pre-commit` on all changed files and fixed all issues
- [ ] **No tests included in this PR** — kept local while the new input API settles; a follow-up can add integration tests once the surface is stable
- [x] I updated documentation (`fastvideo/eval/README.md` Public API + Install + FVD sections; `common.fvd` module docstring)
- [x] I considered GPU memory impact (per-device peak unchanged from before the PR; verified via multi-GPU sweep)