### PR TITLE
[perf]: route SP all-to-all NCCL on a dedicated comm stream

### DIFF
--- a/fastvideo/distributed/device_communicators/base_device_communicator.py
+++ b/fastvideo/distributed/device_communicators/base_device_communicator.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Adapted from https://github.com/vllm-project/vllm/blob/v0.7.3/vllm/distributed/device_communicators/base_device_communicator.py
 
+import threading
 from typing import Any
 
 import torch
@@ -17,23 +18,34 @@ class DistributedAutograd:
     proper forward and backward implementations.
     """
 
-    # Dedicated stream for SP all-to-all collectives. Lazily created on first
-    # use to avoid touching CUDA before the device is selected. NCCL kernels
-    # issued on this stream no longer serialize with compute on the default
-    # stream, freeing GPU launch queue pressure.
+    # Dedicated streams for SP all-to-all collectives, cached PER DEVICE.
+    # CUDA streams are device-bound, so a single global stream would crash
+    # the second device in any multi-GPU / single-process multi-device
+    # context. Lazily created on first use to avoid touching CUDA before
+    # the device is selected; protected by a lock for thread-safe init.
+    # NCCL kernels issued on these streams no longer serialize with compute
+    # on the default stream, freeing GPU launch queue pressure.
     #
     # NOTE: we intentionally do NOT call .record_stream() on the input/output
     # tensors. PyTorch's NCCL backend now defaults TORCH_NCCL_AVOID_RECORD_STREAMS=1
     # and handles cross-stream lifetime via its own mechanism — calling
     # record_stream() explicitly forces the deprecated slow path and inflates
     # caching-allocator bookkeeping by 2× per collective.
-    _comm_stream: "torch.cuda.Stream | None" = None
+    _comm_streams: "dict[torch.device, torch.cuda.Stream]" = {}
+    _comm_streams_lock = threading.Lock()
 
     @staticmethod
-    def _get_comm_stream() -> "torch.cuda.Stream":
-        if DistributedAutograd._comm_stream is None:
-            DistributedAutograd._comm_stream = torch.cuda.Stream()
-        return DistributedAutograd._comm_stream
+    def _get_comm_stream(device: torch.device) -> "torch.cuda.Stream":
+        stream = DistributedAutograd._comm_streams.get(device)
+        if stream is not None:
+            return stream
+        with DistributedAutograd._comm_streams_lock:
+            stream = DistributedAutograd._comm_streams.get(device)
+            if stream is None:
+                with torch.cuda.device(device):
+                    stream = torch.cuda.Stream(device=device)
+                DistributedAutograd._comm_streams[device] = stream
+        return stream
 
     class AllReduce(torch.autograd.Function):
         """Differentiable all_reduce operation.
@@ -146,10 +158,16 @@ class DistributedAutograd:
         if world_size == 1:
             return input_
 
-        assert input_.dim() == 4, f"input must be 4D tensor, got {input_.dim()} and shape {input_.shape}"
+        if input_.dim() != 4:
+            raise ValueError(f"input must be 4D tensor, got {input_.dim()} and shape {input_.shape}")
 
-        comm = DistributedAutograd._get_comm_stream()
-        curr = torch.cuda.current_stream()
+        # Stream-scheduling path only meaningful on CUDA tensors. CPU inputs
+        # (used by some unit-test paths) fall through to a plain
+        # dist.all_to_all_single without the dedicated-stream wrap.
+        use_cuda = input_.is_cuda
+        if use_cuda:
+            comm = DistributedAutograd._get_comm_stream(input_.device)
+            curr = torch.cuda.current_stream(device=input_.device)
 
         if scatter_dim == 2 and gather_dim == 1:
             bs, shard_seqlen, hn, hd = input_.shape
@@ -160,11 +178,14 @@ class DistributedAutograd:
 
             # Issue NCCL on the dedicated comm stream so it doesn't serialize
             # with compute on the default stream. No record_stream — see the
-            # _comm_stream class docstring for why.
-            comm.wait_stream(curr)
-            with torch.cuda.stream(comm):
-                dist.all_to_all_single(output, input_, group=group)  # hn, shard_seqlen, bs, hd
-            curr.wait_stream(comm)
+            # _comm_streams class docstring for why.
+            if use_cuda:
+                comm.wait_stream(curr)
+                with torch.cuda.stream(comm):
+                    dist.all_to_all_single(output, input_, group=group)  # hn, shard_seqlen, bs, hd
+                curr.wait_stream(comm)
+            else:
+                dist.all_to_all_single(output, input_, group=group)
 
             output = torch.cat(output.split(shard_hn), dim=1)  # sharded hn, seqlen, bs, hd
 
@@ -183,10 +204,13 @@ class DistributedAutograd:
 
             output = torch.empty_like(input_)
 
-            comm.wait_stream(curr)
-            with torch.cuda.stream(comm):
+            if use_cuda:
+                comm.wait_stream(curr)
+                with torch.cuda.stream(comm):
+                    dist.all_to_all_single(output, input_, group=group)
+                curr.wait_stream(comm)
+            else:
                 dist.all_to_all_single(output, input_, group=group)
-            curr.wait_stream(comm)
 
             output = output.transpose(0, 2).contiguous()  # bs, seqlen, sharded_hn, hd
 

--- a/fastvideo/distributed/device_communicators/base_device_communicator.py
+++ b/fastvideo/distributed/device_communicators/base_device_communicator.py
@@ -11,11 +11,29 @@ from torch.distributed import ProcessGroup, ReduceOp
 
 class DistributedAutograd:
     """Collection of autograd functions for distributed operations.
-    
+
     This class provides custom autograd functions for distributed operations like all_reduce,
     all_gather, and all_to_all. Each operation is implemented as a static inner class with
     proper forward and backward implementations.
     """
+
+    # Dedicated stream for SP all-to-all collectives. Lazily created on first
+    # use to avoid touching CUDA before the device is selected. NCCL kernels
+    # issued on this stream no longer serialize with compute on the default
+    # stream, freeing GPU launch queue pressure.
+    #
+    # NOTE: we intentionally do NOT call .record_stream() on the input/output
+    # tensors. PyTorch's NCCL backend now defaults TORCH_NCCL_AVOID_RECORD_STREAMS=1
+    # and handles cross-stream lifetime via its own mechanism — calling
+    # record_stream() explicitly forces the deprecated slow path and inflates
+    # caching-allocator bookkeeping by 2× per collective.
+    _comm_stream: "torch.cuda.Stream | None" = None
+
+    @staticmethod
+    def _get_comm_stream() -> "torch.cuda.Stream":
+        if DistributedAutograd._comm_stream is None:
+            DistributedAutograd._comm_stream = torch.cuda.Stream()
+        return DistributedAutograd._comm_stream
 
     class AllReduce(torch.autograd.Function):
         """Differentiable all_reduce operation.
@@ -120,12 +138,70 @@ class DistributedAutograd:
 
             return None, grad_input.movedim(0, ctx.dim), None, None, None
 
+    @staticmethod
+    def _all_to_all_4D_forward(group: ProcessGroup, input_: Tensor, world_size: int, scatter_dim: int,
+                               gather_dim: int) -> Tensor:
+        """Pure forward logic for 4D all-to-all. Used by both the autograd
+        Function and the inference fast-path that bypasses autograd."""
+        if world_size == 1:
+            return input_
+
+        assert input_.dim() == 4, f"input must be 4D tensor, got {input_.dim()} and shape {input_.shape}"
+
+        comm = DistributedAutograd._get_comm_stream()
+        curr = torch.cuda.current_stream()
+
+        if scatter_dim == 2 and gather_dim == 1:
+            bs, shard_seqlen, hn, hd = input_.shape
+            shard_hn = hn // world_size
+
+            input_ = input_.transpose(0, 2).contiguous()  # hn, shard_seqlen, bs, hd
+            output = torch.empty_like(input_)
+
+            # Issue NCCL on the dedicated comm stream so it doesn't serialize
+            # with compute on the default stream. No record_stream — see the
+            # _comm_stream class docstring for why.
+            comm.wait_stream(curr)
+            with torch.cuda.stream(comm):
+                dist.all_to_all_single(output, input_, group=group)  # hn, shard_seqlen, bs, hd
+            curr.wait_stream(comm)
+
+            output = torch.cat(output.split(shard_hn), dim=1)  # sharded hn, seqlen, bs, hd
+
+            output = output.transpose(0, 2).contiguous()  # bs, seqlen, sharded_hn, hd
+
+            return output
+        elif scatter_dim == 1 and gather_dim == 2:
+            bs, seqlen, shard_hn, hd = input_.shape
+            shard_seqlen = seqlen // world_size
+
+            input_ = input_.transpose(0, 2).contiguous()  # shard_hn, seqlen, bs, hd
+
+            input_ = input_.reshape(shard_hn, world_size, shard_seqlen, bs,
+                                    hd).transpose(0, 1).reshape(shard_hn * world_size, shard_seqlen, bs,
+                                                                hd).contiguous()
+
+            output = torch.empty_like(input_)
+
+            comm.wait_stream(curr)
+            with torch.cuda.stream(comm):
+                dist.all_to_all_single(output, input_, group=group)
+            curr.wait_stream(comm)
+
+            output = output.transpose(0, 2).contiguous()  # bs, seqlen, sharded_hn, hd
+
+            return output
+        else:
+            raise RuntimeError(
+                f"Invalid scatter_dim={scatter_dim}, gather_dim={gather_dim}. "
+                f"Only (scatter_dim=2, gather_dim=1) and (scatter_dim=1, gather_dim=2) are supported.")
+
     class AllToAll4D(torch.autograd.Function):
         """Differentiable all_to_all operation specialized for 4D tensors.
-        
+
         This operation is particularly useful for attention operations where we need to
         redistribute data across ranks for efficient parallel processing.
-        
+
         The operation supports two modes:
         1. scatter_dim=2, gather_dim=1: Used for redistributing attention heads
         2. scatter_dim=1, gather_dim=2: Used for redistributing sequence dimensions
@@ -138,49 +214,7 @@ class DistributedAutograd:
             ctx.world_size = world_size
             ctx.scatter_dim = scatter_dim
             ctx.gather_dim = gather_dim
-
-            if world_size == 1:
-                return input_
-
-            assert input_.dim() == 4, f"input must be 4D tensor, got {input_.dim()} and shape {input_.shape}"
-
-            if scatter_dim == 2 and gather_dim == 1:
-                bs, shard_seqlen, hn, hd = input_.shape
-                seqlen = shard_seqlen * world_size
-                shard_hn = hn // world_size
-
-                input_ = input_.transpose(0, 2).contiguous()  # hn, shard_seqlen, bs, hd
-                output = torch.empty_like(input_)
-
-                dist.all_to_all_single(output, input_, group=group)  # hn, shard_seqlen, bs, hd
-
-                output = torch.cat(output.split(shard_hn), dim=1)  # sharded hn, seqlen, bs, hd
-
-                output = output.transpose(0, 2).contiguous()  # bs, seqlen, sharded_hn, hd
-
-                return output
-            elif scatter_dim == 1 and gather_dim == 2:
-                bs, seqlen, shard_hn, hd = input_.shape
-                hn = shard_hn * world_size
-                shard_seqlen = seqlen // world_size
-
-                input_ = input_.transpose(0, 2).contiguous()  # shard_hn, seqlen, bs, hd
-
-                input_ = input_.reshape(shard_hn, world_size, shard_seqlen, bs,
-                                        hd).transpose(0, 1).reshape(shard_hn * world_size, shard_seqlen, bs,
-                                                                    hd).contiguous()
-
-                output = torch.empty_like(input_)
-
-                dist.all_to_all_single(output, input_, group=group)
-
-                output = output.transpose(0, 2).contiguous()  # bs, seqlen, sharded_hn, hd
-
-                return output
-            else:
-                raise RuntimeError(
-                    f"Invalid scatter_dim={scatter_dim}, gather_dim={gather_dim}. "
-                    f"Only (scatter_dim=2, gather_dim=1) and (scatter_dim=1, gather_dim=2) are supported.")
+            return DistributedAutograd._all_to_all_4D_forward(group, input_, world_size, scatter_dim, gather_dim)
 
         @staticmethod
         def backward(ctx: Any, grad_output: Tensor) -> tuple[None, Tensor, None, None, None]:
@@ -234,8 +268,17 @@ class DeviceCommunicatorBase:
         return DistributedAutograd.Slice.apply(self.device_group, input_, self.world_size, dim, scale_grad)
 
     def all_to_all_4D(self, input_: torch.Tensor, scatter_dim: int = 2, gather_dim: int = 1) -> torch.Tensor:
-        """Performs a 4D all-to-all operation with gradient support."""
-        return DistributedAutograd.AllToAll4D.apply(self.device_group, input_, self.world_size, scatter_dim, gather_dim)
+        """Performs a 4D all-to-all operation with gradient support.
+
+        In inference (no grad enabled), bypasses the autograd.Function dispatch
+        overhead by calling the forward helper directly. The autograd path is
+        only used when a backward pass might be needed.
+        """
+        if torch.is_grad_enabled():
+            return DistributedAutograd.AllToAll4D.apply(self.device_group, input_, self.world_size, scatter_dim,
+                                                        gather_dim)
+        return DistributedAutograd._all_to_all_4D_forward(self.device_group, input_, self.world_size, scatter_dim,
+                                                          gather_dim)
 
     def gather(self, input_: torch.Tensor, dst: int = 0, dim: int = -1) -> torch.Tensor | None:
         """


### PR DESCRIPTION
## Summary

Routes the SP all-to-all NCCL collective onto a dedicated comm stream so it no longer serializes with compute on the default stream. Lays the infrastructure for future overlap-based work (e.g. Hybrid Ulysses-Ring rotation) without itself claiming an e2e perf delta on PCIe-bound topologies.

## Scope (intentionally narrow)

Wraps only `AllToAll4D` — the two `dist.all_to_all_single` calls inside `_all_to_all_4D_forward`. Other NCCL collectives (`AllReduce`, `AllGather`, `Slice.backward`) are left untouched. Per [`@rich7420`'s NCCL optimization status doc](https://github.com/rich7420/fastvideo/blob/inference-profile/nccl-optimization-status.md), SendRecv from `all_to_all_4D` is **97.7% of NCCL time** on the 4× L40S Wan T2V SP=4 baseline; the others are <3% combined. Wrapping them would add noise without measurable benefit.

## Mechanism

A per-device stream cache on `DistributedAutograd` (lazily created on first use, avoids touching CUDA before device selection; thread-safe via a lock). The two `dist.all_to_all_single` call sites inside the SP forward path are bracketed with the standard cross-stream discipline:

```python
comm = DistributedAutograd._get_comm_stream(input_.device)
curr = torch.cuda.current_stream(device=input_.device)
comm.wait_stream(curr)                      # comm waits for compute side
with torch.cuda.stream(comm):
    dist.all_to_all_single(output, input_, group=group)
curr.wait_stream(comm)                      # compute side waits for comm
```

Also extracts the forward shape-munging into a static `_all_to_all_4D_forward` helper so the inference path can bypass `autograd.Function.apply` dispatch overhead when grad is off (`DeviceCommunicatorBase.all_to_all_4D` branches on `torch.is_grad_enabled()`).

## Two design choices worth flagging

**No `record_stream`.** Modern PyTorch defaults `TORCH_NCCL_AVOID_RECORD_STREAMS=1` (deprecation warning visible in worker logs); the NCCL backend tracks cross-stream tensor lifetime itself. Explicit `record_stream()` on collective inputs/outputs would force the deprecated slow path and inflate caching-allocator per-collective bookkeeping ~2×. `wait_stream` ordering alone is sufficient. (Earlier internal design notes prescribed `record_stream`; that was wrong, corrected in this PR.)

**AllToAll4D-only scope** (vs all 5 NCCL sites). Per the SendRecv-97.7%-of-NCCL number above. The `_functional_collectives` alternative path was already tried in [@rich7420's exploration](https://github.com/rich7420/fastvideo/blob/inference-profile/nccl-optimization-status.md) and rolled back (+~1% wall regression from `AsyncCollectiveTensor` wrapper overhead).

## A/B validation — 4× L40S sp=4 PCIe (Wan T2V 1.3B)

Thanks to @rich7420 for the Modal A/B run. Harness: `fastvideo/tests/modal/nccl_stream_ab.py` (single-container overlay-swap pattern, generic for validating single-file PRs). Baseline = `bc5ea6bf^` (commit-parent) so the delta isolates this one-file change. 5 prompts × Wan T2V 1.3B 720×1280 / 77 frames / 30 steps, seed-pinned, same Modal container (no cross-host variance).

| metric                | baseline (bc5ea6bf^) | + nccl-comm-stream    | Δ          |
|-----------------------|----------------------|-----------------------|------------|
| gen_only wall (avg)   | 153.405 s            | 153.344 s             | −0.040 %   |
| full wall (incl load) | 209.771 s            | 209.442 s             | −0.156 %   |
| SSIM mean-of-means    | —                    | 1.000000 (worst 1.000000) | —      |
| LPIPS mean-of-means   | —                    | 0.000000 (worst 0.000000) | —      |

**Reading:** bit-exact output (NCCL is deterministic across streams for the same nranks / topology / algorithm). Wall delta inside run-to-run noise — exactly matches the PR thesis that a dedicated stream is necessary-but-not-sufficient for overlap on bandwidth-bound PCIe. No regression on quality or wall; lands cleanly as infrastructure.

Peak-memory was deliberately not re-measured: this patch touches only stream scheduling (no `record_stream`, tensor lifetimes unchanged) — a null hypothesis there. Easy to add if a reviewer asks.

(A/B reflects the original `bc5ea6bf` tip. The review-feedback fixes at `29c752f5` are scheduling/lifecycle only — per-device stream cache, CPU-path guard, `ValueError`, thread-safe init — and do not change collective semantics or output. Happy to re-run Kuan's harness against the new tip if maintainers want a refreshed table.)

## Review-feedback fixes (`29c752f5` on top of `bc5ea6bf`)

Addresses the four open review comments on `base_device_communicator.py`:

1. **Per-device stream cache** (gemini-high + Copilot-high). CUDA streams are device-bound, so the single global `_comm_stream` would crash any multi-GPU / single-process multi-device context. Replaced with `_comm_streams: dict[torch.device, Stream]`, lazily populated under `with torch.cuda.device(device):`.
2. **CPU-path guard** (gemini-high). `use_cuda = input_.is_cuda`; stream wait/wrap only on CUDA, plain `dist.all_to_all_single` fallback for CPU paths used by some unit tests.
3. **`assert` → `ValueError`** (Copilot-medium). Asserts strip under `python -O`; `ValueError` is the correct runtime validation.
4. **Thread-safe lazy init** (Copilot-medium). `threading.Lock` + double-checked locking around dict insertion.

## Correctness

The diff is stream-scheduling-only. `dist.all_to_all_single(output, input_, group=group)` is called with identical arguments to before; only the stream context differs. `comm.wait_stream(curr)` / `curr.wait_stream(comm)` ensures cross-stream ordering. No tensor math changes; no NCCL arguments change. SSIM 1.000000 / LPIPS 0.000000 in the A/B above confirms bit-exactness.

## Files

- `fastvideo/distributed/device_communicators/base_device_communicator.py` — per-device `_comm_streams` dict + thread-safe `_get_comm_stream(device)` on `DistributedAutograd`; `_all_to_all_4D_forward` static helper extracted; `wait_stream` discipline at the two `dist.all_to_all_single` sites, gated on `input_.is_cuda` with a CPU fallback; `DeviceCommunicatorBase.all_to_all_4D` adds the inference fast-path.

## Credit

Patch authored by @rich7420 on his `inference-profile` branch (the corrections re: `record_stream` deprecation + AllToAll4D-only scope are entirely his). This PR is the clean-extraction-+-PR-shepherding of his draft. A/B validation on Modal 4× L40S also by @rich7420.
