### PR TITLE
[feat] LTX-2.3 transformer support (config-gated extension of LTX-2)

### DIFF
--- a/fastvideo/configs/models/dits/ltx2.py
+++ b/fastvideo/configs/models/dits/ltx2.py
@@ -23,8 +23,17 @@ class LTX2VideoArchConfig(DiTArchConfig):
     _compile_conditions: list = field(default_factory=lambda: [is_ltx2_blocks])
 
     # Parameter name mapping for weight conversion (hf/comfy -> FastVideo)
+    # The leading ``to_gate_compress``->``to_gate_logits`` rules load the
+    # LTX-2.3 gated-attention checkpoint weights (named ``to_gate_compress``
+    # upstream) into the FastVideo ``to_gate_logits`` parameter. They are
+    # no-ops for LTX-2.0 checkpoints, which contain no ``to_gate_compress``
+    # weights, so the default behavior is unchanged.
     param_names_mapping: dict = field(
         default_factory=lambda: {
+            r"^model\.diffusion_model\.(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
+            r"^diffusion_model\.(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
+            r"^model\.(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
+            r"^(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
             r"^model\.diffusion_model\.(.*)$": r"model.\1",
             r"^diffusion_model\.(.*)$": r"model.\1",
             r"^model\.(.*)$": r"model.\1",
@@ -44,6 +53,9 @@ class LTX2VideoArchConfig(DiTArchConfig):
     attention_type: str = "default"
     rope_type: str = "split"
     double_precision_rope: bool = True
+    # LTX-2.3 gated extensions. All default OFF == LTX-2.0 behavior.
+    cross_attention_adaln: bool = False
+    caption_proj_before_connector: bool = False
 
     positional_embedding_theta: float = 10000.0
     positional_embedding_max_pos: list[int] = field(default_factory=lambda: [20, 2048, 2048])
@@ -64,6 +76,27 @@ class LTX2VideoArchConfig(DiTArchConfig):
     audio_cross_attention_dim: int = 2048
     audio_positional_embedding_max_pos: list[int] = field(default_factory=lambda: [20])
     av_ca_timestep_scale_multiplier: int = 1
+    # LTX-2.3 gated self-attention (distinct from the VSA-QAT to_gate_compress
+    # gate). Default OFF == LTX-2.0 behavior.
+    apply_gated_attention: bool = False
+
+    # Text connector/feature extractor compatibility fields carried in some
+    # transformer configs (used by the LTX-2.3 text stack). Defaults match
+    # the LTX-2.0 connector layout.
+    caption_projection_first_linear: bool = True
+    caption_proj_input_norm: bool = True
+    caption_projection_second_linear: bool = True
+    connector_num_attention_heads: int = 30
+    connector_attention_head_dim: int = 128
+    connector_num_layers: int = 2
+    audio_connector_num_attention_heads: int = 30
+    audio_connector_attention_head_dim: int = 128
+    audio_connector_num_layers: int = 2
+
+    # STG perturbation block index differs across model versions.
+    # LTX-2.0 defaults to block 29; LTX-2.3 (caption_proj_before_connector)
+    # uses block 28. ``None`` resolves in __post_init__.
+    stg_block_idx: int | None = None
 
     def __post_init__(self):
         super().__post_init__()
@@ -72,6 +105,8 @@ class LTX2VideoArchConfig(DiTArchConfig):
             self.in_channels = self.num_channels_latents * patch_volume
         if self.out_channels is None:
             self.out_channels = self.in_channels
+        if self.stg_block_idx is None:
+            self.stg_block_idx = 28 if self.caption_proj_before_connector else 29
 
 
 @dataclass

--- a/fastvideo/configs/models/dits/ltx2.py
+++ b/fastvideo/configs/models/dits/ltx2.py
@@ -22,18 +22,17 @@ class LTX2VideoArchConfig(DiTArchConfig):
     _fsdp_shard_conditions: list = field(default_factory=lambda: [is_ltx2_blocks])
     _compile_conditions: list = field(default_factory=lambda: [is_ltx2_blocks])
 
-    # Parameter name mapping for weight conversion (hf/comfy -> FastVideo)
-    # The leading ``to_gate_compress``->``to_gate_logits`` rules load the
-    # LTX-2.3 gated-attention checkpoint weights (named ``to_gate_compress``
-    # upstream) into the FastVideo ``to_gate_logits`` parameter. They are
-    # no-ops for LTX-2.0 checkpoints, which contain no ``to_gate_compress``
-    # weights, so the default behavior is unchanged.
+    # Parameter name mapping for weight conversion (hf/comfy -> FastVideo).
+    # The ``to_gate_compress`` -> ``to_gate_logits`` rules for the LTX-2.3
+    # gated-attention path are inserted at the front of this dict in
+    # ``__post_init__`` only when ``apply_gated_attention=True``.  Without
+    # that flag the target model has no ``to_gate_logits`` slot, *and* the
+    # same-named ``to_gate_compress`` already lives on the LTX-2.0 VSA-QAT
+    # gate path (plus it is in the default ``lora_target_modules`` list).
+    # Applying the rename unconditionally silently breaks LTX-2.0 VSA
+    # checkpoints and default-target LoRAs.
     param_names_mapping: dict = field(
         default_factory=lambda: {
-            r"^model\.diffusion_model\.(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
-            r"^diffusion_model\.(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
-            r"^model\.(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
-            r"^(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
             r"^model\.diffusion_model\.(.*)$": r"model.\1",
             r"^diffusion_model\.(.*)$": r"model.\1",
             r"^model\.(.*)$": r"model.\1",
@@ -107,6 +106,27 @@ class LTX2VideoArchConfig(DiTArchConfig):
             self.out_channels = self.in_channels
         if self.stg_block_idx is None:
             self.stg_block_idx = 28 if self.caption_proj_before_connector else 29
+
+        # LTX-2.3 stores the gated-attention weight under ``to_gate_compress``
+        # upstream; FastVideo's internal name is ``to_gate_logits``.  Only
+        # enable the rename when the gated path is actually configured: the
+        # LTX-2.0 attention module's own ``to_gate_compress`` parameter
+        # (created when the backend is ``VIDEO_SPARSE_ATTN``) and the default
+        # ``to_gate_compress`` LoRA target both share the upstream name, so
+        # an unconditional rename would silently retarget them.  Inserted at
+        # the front so first-match-wins matching fires the rename before the
+        # generic prefix-strip rules.
+        if self.apply_gated_attention:
+            gate_rules = {
+                r"^model\.diffusion_model\.(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
+                r"^diffusion_model\.(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
+                r"^model\.(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
+                r"^(.*)\.to_gate_compress\.(.*)$": r"model.\1.to_gate_logits.\2",
+            }
+            self.param_names_mapping = {
+                **gate_rules,
+                **self.param_names_mapping,
+            }
 
 
 @dataclass

--- a/fastvideo/configs/models/encoders/gemma.py
+++ b/fastvideo/configs/models/encoders/gemma.py
@@ -8,7 +8,13 @@ from fastvideo.configs.models.encoders.base import (
 
 
 def _is_feature_extractor_linear(n: str, m) -> bool:
-    return n.endswith("feature_extractor_linear")
+    # LTX-2.3 (caption_proj_before_connector) introduces separate
+    # video/audio feature extractor linears; keep the LTX-2.0 name too.
+    return (
+        n.endswith("feature_extractor_linear")
+        or n.endswith("video_feature_extractor_linear")
+        or n.endswith("audio_feature_extractor_linear")
+    )
 
 
 def _is_embeddings(n: str, m) -> bool:
@@ -35,14 +41,26 @@ class LTX2GemmaArchConfig(TextEncoderArchConfig):
 
     feature_extractor_in_features: int = 3840 * 49
     feature_extractor_out_features: int = 3840
+    # LTX-2.3 text-stack connector fields (default OFF == LTX-2.0 behavior).
+    video_feature_extractor_out_features: int | None = None
+    audio_feature_extractor_out_features: int | None = None
+    caption_proj_before_connector: bool = False
+    caption_projection_first_linear: bool = True
+    caption_proj_input_norm: bool = True
+    caption_projection_second_linear: bool = True
 
     connector_num_attention_heads: int = 30
     connector_attention_head_dim: int = 128
     connector_num_layers: int = 2
+    # Separate audio connector geometry (None falls back to the video values).
+    audio_connector_num_attention_heads: int | None = None
+    audio_connector_attention_head_dim: int | None = None
+    audio_connector_num_layers: int | None = None
     connector_positional_embedding_theta: float = 10000.0
     connector_positional_embedding_max_pos: list[int] = field(default_factory=lambda: [4096])
     connector_rope_type: str = "split"
     connector_double_precision_rope: bool = False
+    connector_apply_gated_attention: bool = False
     connector_num_learnable_registers: int | None = 128
 
     _fsdp_shard_conditions: list = field(

--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -36,6 +36,65 @@ from fastvideo.platforms import AttentionBackendEnum
 
 logger = init_logger(__name__)
 
+# QuACK provides a fast NVFP4 RMSNorm used only for the LTX-2.3 refine stage.
+# Import defensively: upstream installs without QuACK must still work, simply
+# falling back to ``torch.nn.functional.rms_norm`` (the non-refine path).
+try:
+    from quack import rmsnorm as _quack_rmsnorm
+except Exception:  # pragma: no cover - optional dependency
+    _quack_rmsnorm = None
+
+
+def _is_ltx2_refine_stage() -> bool:
+    """Return True when running LTX-2 stage-2 refinement denoising.
+
+    Only the refine stage uses the QuACK fast path; everything else (and any
+    install lacking QuACK) uses the standard Torch RMSNorm, which reproduces
+    LTX-2.0 numerics exactly.
+    """
+    if _quack_rmsnorm is None:
+        return False
+    try:
+        forward_ctx = get_forward_context()
+    except AssertionError:
+        return False
+    forward_batch = forward_ctx.forward_batch
+    if forward_batch is None:
+        return False
+    return forward_batch.extra.get("ltx2_fp4_stage_profile") == "refine"
+
+
+def _rms_norm_dispatch(
+    x: torch.Tensor,
+    eps: float,
+    weight: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Use QuACK RMSNorm only for LTX-2 refine stage, else Torch RMSNorm."""
+    if _is_ltx2_refine_stage():
+        return _quack_rmsnorm(x, weight=weight, eps=eps)
+    return torch.nn.functional.rms_norm(
+        x, (x.shape[-1], ), weight=weight, eps=eps)
+
+
+class StageAwareRMSNorm(nn.RMSNorm):
+    """Use torch.nn.RMSNorm for base stage and QuACK for refine stage.
+
+    When QuACK is unavailable or outside the refine stage this behaves
+    identically to ``torch.nn.RMSNorm`` (LTX-2.0 q_norm/k_norm behavior).
+    """
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__(hidden_size, eps=eps)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if _is_ltx2_refine_stage():
+            return _quack_rmsnorm(
+                x,
+                weight=self.weight,
+                eps=self.eps,
+            )
+        return super().forward(x)
+
 
 def _supports_prequantized_input(linear: ReplicatedLinear) -> bool:
     """Whether ``linear``'s quant method is willing to accept a
@@ -192,6 +251,18 @@ class AdaLayerNormSingle(torch.nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         embedded_timestep = self.emb(timestep, hidden_dtype=hidden_dtype)
         return self.linear(self.silu(embedded_timestep)), embedded_timestep
+
+
+# Number of AdaLN scale/shift/gate rows. LTX-2.0 emits 6 (shift/scale/gate for
+# self-attn and FFN). LTX-2.3 with cross_attention_adaln emits 3 extra rows for
+# the text cross-attention shift/scale/gate.
+ADALN_NUM_BASE_PARAMS = 6
+ADALN_NUM_CROSS_ATTN_PARAMS = 3
+
+
+def adaln_embedding_coefficient(cross_attention_adaln: bool) -> int:
+    return ADALN_NUM_BASE_PARAMS + (ADALN_NUM_CROSS_ATTN_PARAMS
+                                    if cross_attention_adaln else 0)
 
 
 class PixArtAlphaTextProjection(torch.nn.Module):
@@ -832,6 +903,8 @@ class TransformerArgs:
     cross_scale_shift_timestep: torch.Tensor | None
     cross_gate_timestep: torch.Tensor | None
     enabled: bool
+    # LTX-2.3 cross-attention AdaLN prompt timestep embedding (None for 2.0).
+    prompt_timestep: torch.Tensor | None = None
 
 
 @dataclass(frozen=True)
@@ -843,6 +916,8 @@ class Modality:
     positions: torch.Tensor
     context: torch.Tensor
     context_mask: torch.Tensor | None = None
+    # LTX-2.3 cross-attention AdaLN sigma timestep (None for 2.0).
+    sigma: torch.Tensor | None = None
 
 
 class TransformerArgsPreprocessor:
@@ -860,6 +935,7 @@ class TransformerArgsPreprocessor:
         double_precision_rope: bool,
         positional_embedding_theta: float,
         rope_type: LTXRopeType,
+        prompt_adaln: AdaLayerNormSingle | None = None,
     ) -> None:
         self.patchify_proj = patchify_proj
         self.adaln = adaln
@@ -872,12 +948,19 @@ class TransformerArgsPreprocessor:
         self.double_precision_rope = double_precision_rope
         self.positional_embedding_theta = positional_embedding_theta
         self.rope_type = rope_type
+        # LTX-2.3 cross-attention AdaLN prompt timestep embedder (None for 2.0).
+        self.prompt_adaln = prompt_adaln
 
     def _prepare_timestep(
-        self, timestep: torch.Tensor, batch_size: int, hidden_dtype: torch.dtype
+        self,
+        timestep: torch.Tensor,
+        batch_size: int,
+        hidden_dtype: torch.dtype,
+        adaln: AdaLayerNormSingle | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        adaln = self.adaln if adaln is None else adaln
         timestep = timestep * self.timestep_scale_multiplier
-        timestep, embedded_timestep = self.adaln(timestep.flatten(), hidden_dtype=hidden_dtype)
+        timestep, embedded_timestep = adaln(timestep.flatten(), hidden_dtype=hidden_dtype)
         timestep = timestep.view(batch_size, -1, timestep.shape[-1])
         embedded_timestep = embedded_timestep.view(batch_size, -1, embedded_timestep.shape[-1])
         return timestep, embedded_timestep
@@ -895,8 +978,11 @@ class TransformerArgsPreprocessor:
             context = context.to(x.dtype)
         if attention_mask is not None and attention_mask.device != x.device:
             attention_mask = attention_mask.to(x.device)
-        context = self.caption_projection(context)
-        context = context.view(batch_size, -1, x.shape[-1])
+        # When ``caption_proj_before_connector`` is set the caption projection
+        # lives in the text encoder, so it is None here and we skip it.
+        if self.caption_projection is not None:
+            context = self.caption_projection(context)
+            context = context.view(batch_size, -1, x.shape[-1])
         return context, attention_mask
 
     def _prepare_attention_mask(self, attention_mask: torch.Tensor | None, x_dtype: torch.dtype) -> torch.Tensor | None:
@@ -939,7 +1025,16 @@ class TransformerArgsPreprocessor:
         if not latent.is_contiguous():
             latent = latent.contiguous()
         x = self.patchify_proj(latent)
-        timestep, embedded_timestep = self._prepare_timestep(modality.timesteps, x.shape[0], modality.latent.dtype)
+        timestep, embedded_timestep = self._prepare_timestep(
+            modality.timesteps, x.shape[0], modality.latent.dtype, self.adaln)
+        prompt_timestep = None
+        if self.prompt_adaln is not None and modality.sigma is not None:
+            prompt_timestep, _ = self._prepare_timestep(
+                modality.sigma,
+                x.shape[0],
+                modality.latent.dtype,
+                self.prompt_adaln,
+            )
         context, attention_mask = self._prepare_context(modality.context, x, modality.context_mask)
         attention_mask = self._prepare_attention_mask(attention_mask, modality.latent.dtype)
         pe = self._prepare_positional_embeddings(
@@ -961,6 +1056,7 @@ class TransformerArgsPreprocessor:
             cross_scale_shift_timestep=None,
             cross_gate_timestep=None,
             enabled=modality.enabled,
+            prompt_timestep=prompt_timestep,
         )
 
 
@@ -985,6 +1081,7 @@ class MultiModalTransformerArgsPreprocessor:
         positional_embedding_theta: float,
         rope_type: LTXRopeType,
         av_ca_timestep_scale_multiplier: int,
+        prompt_adaln: AdaLayerNormSingle | None = None,
     ) -> None:
         self.simple_preprocessor = TransformerArgsPreprocessor(
             patchify_proj=patchify_proj,
@@ -998,6 +1095,7 @@ class MultiModalTransformerArgsPreprocessor:
             double_precision_rope=double_precision_rope,
             positional_embedding_theta=positional_embedding_theta,
             rope_type=rope_type,
+            prompt_adaln=prompt_adaln,
         )
         self.cross_scale_shift_adaln = cross_scale_shift_adaln
         self.cross_gate_adaln = cross_gate_adaln
@@ -1062,6 +1160,9 @@ class TransformerConfig:
     heads: int
     d_head: int
     context_dim: int
+    # LTX-2.3 gated extensions (default OFF == LTX-2.0 behavior).
+    apply_gated_attention: bool = False
+    cross_attention_adaln: bool = False
 
 
 class LTXDistributedAttention(DistributedAttention):
@@ -1324,6 +1425,7 @@ class LTXSelfAttention(nn.Module):
         norm_eps: float,
         rope_type: LTXRopeType,
         supported_attention_backends: tuple[AttentionBackendEnum, ...],
+        apply_gated_attention: bool = False,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
@@ -1335,8 +1437,10 @@ class LTXSelfAttention(nn.Module):
         self.dim_head = dim_head
         self.rope_type = rope_type
 
-        self.q_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
-        self.k_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
+        # StageAwareRMSNorm is identical to torch.nn.RMSNorm outside the
+        # LTX-2.3 refine stage, so default-off behavior matches LTX-2.0.
+        self.q_norm = StageAwareRMSNorm(inner_dim, eps=norm_eps)
+        self.k_norm = StageAwareRMSNorm(inner_dim, eps=norm_eps)
         self.to_q = ReplicatedLinear(
             query_dim,
             inner_dim,
@@ -1358,6 +1462,18 @@ class LTXSelfAttention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.to_v",
         )
+        # LTX-2.3 gated attention. DISTINCT from the VSA-QAT to_gate_compress
+        # gate below: this gate multiplies the *self-attention output* by
+        # 2*sigmoid(to_gate_logits(x)). None (default) == LTX-2.0 behavior.
+        self.to_gate_logits: ReplicatedLinear | None = None
+        if apply_gated_attention:
+            self.to_gate_logits = ReplicatedLinear(
+                query_dim,
+                heads,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.to_gate_logits",
+            )
         self.to_out = nn.ModuleList([
             ReplicatedLinear(
                 inner_dim,
@@ -1422,6 +1538,8 @@ class LTXSelfAttention(nn.Module):
         q = _linear_project_with_optional_prequant(self.to_q, x, q_pre_quantized)
         k = _linear_project_with_optional_prequant(self.to_k, context, kv_pre_quantized)
         v = _linear_project_with_optional_prequant(self.to_v, context, kv_pre_quantized)
+        gate_logits = (self.to_gate_logits(x)[0]
+                       if self.to_gate_logits is not None else None)
         gate_compress = (self.to_gate_compress(context)[0]
                          if self.to_gate_compress is not None else None)
 
@@ -1471,6 +1589,12 @@ class LTXSelfAttention(nn.Module):
                             gate_compress=gate_compress,
                             ltx_freqs_cis=pe,
                             ltx_k_freqs_cis=k_pe)
+        # LTX-2.3 gated attention: scale the attention output per-head by
+        # 2*sigmoid(gate_logits). No-op for LTX-2.0 (gate_logits is None).
+        if gate_logits is not None:
+            out = out.view(b, q_len, self.heads, self.dim_head)
+            gates = 2.0 * torch.sigmoid(gate_logits).to(out.dtype)
+            out = out * gates.unsqueeze(-1)
         out = out.reshape(b, q_len, -1)
         out = self.to_out[0](out)[0]
         return self.to_out[1](out)
@@ -1488,6 +1612,7 @@ class LTXDistributedSelfAttention(nn.Module):
         norm_eps: float,
         rope_type: LTXRopeType,
         supported_attention_backends: tuple[AttentionBackendEnum, ...],
+        apply_gated_attention: bool = False,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ) -> None:
@@ -1499,8 +1624,10 @@ class LTXDistributedSelfAttention(nn.Module):
         self.dim_head = dim_head
         self.rope_type = rope_type
 
-        self.q_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
-        self.k_norm = torch.nn.RMSNorm(inner_dim, eps=norm_eps)
+        # StageAwareRMSNorm == torch.nn.RMSNorm outside the LTX-2.3 refine
+        # stage, preserving LTX-2.0 numerics by default.
+        self.q_norm = StageAwareRMSNorm(inner_dim, eps=norm_eps)
+        self.k_norm = StageAwareRMSNorm(inner_dim, eps=norm_eps)
         self.to_q = ReplicatedLinear(
             query_dim,
             inner_dim,
@@ -1522,6 +1649,16 @@ class LTXDistributedSelfAttention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.to_v",
         )
+        # LTX-2.3 gated attention (distinct from VSA-QAT to_gate_compress).
+        self.to_gate_logits: ReplicatedLinear | None = None
+        if apply_gated_attention:
+            self.to_gate_logits = ReplicatedLinear(
+                query_dim,
+                heads,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.to_gate_logits",
+            )
         self.to_out = nn.ModuleList([
             ReplicatedLinear(
                 inner_dim,
@@ -1586,6 +1723,8 @@ class LTXDistributedSelfAttention(nn.Module):
         q = _linear_project_with_optional_prequant(self.to_q, x, q_pre_quantized)
         k = _linear_project_with_optional_prequant(self.to_k, context, kv_pre_quantized)
         v = _linear_project_with_optional_prequant(self.to_v, context, kv_pre_quantized)
+        gate_logits = (self.to_gate_logits(x)[0]
+                       if self.to_gate_logits is not None else None)
         gate_compress = (self.to_gate_compress(context)[0]
                          if self.to_gate_compress is not None else None)
 
@@ -1616,6 +1755,11 @@ class LTXDistributedSelfAttention(nn.Module):
             ltx_freqs_cis=pe,
         )
 
+        # LTX-2.3 gated attention (no-op for LTX-2.0).
+        if gate_logits is not None:
+            out = out.view(b, q_len, self.heads, self.dim_head)
+            gates = 2.0 * torch.sigmoid(gate_logits).to(out.dtype)
+            out = out * gates.unsqueeze(-1)
         out = out.reshape(b, q_len, -1)
         out = self.to_out[0](out)[0]
         return self.to_out[1](out)
@@ -1632,12 +1776,17 @@ class BasicAVTransformerBlock(torch.nn.Module):
         rope_type: LTXRopeType = LTXRopeType.INTERLEAVED,
         norm_eps: float = 1e-6,
         use_distributed_attention: bool = False,
+        cross_attention_adaln: bool = False,
+        stg_block_idx: int = 29,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ):
         super().__init__()
         self.idx = idx
         self.use_distributed_attention = use_distributed_attention
+        # LTX-2.3 cross-attention AdaLN + per-sample STG (defaults reproduce 2.0).
+        self.cross_attention_adaln = cross_attention_adaln
+        self.stg_block_idx = stg_block_idx
 
         # Choose attention class based on SP mode
         # Self-attention and audio-video cross-attention use DistributedAttention when SP > 1
@@ -1664,6 +1813,7 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=video_self_attn_backends,
+                apply_gated_attention=video.apply_gated_attention,
                 quant_config=quant_config,
                 prefix=f"{prefix}.blocks.{idx}.attn1",
             )
@@ -1676,6 +1826,7 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
+                apply_gated_attention=video.apply_gated_attention,
                 quant_config=quant_config,
                 prefix=f"{prefix}.blocks.{idx}.attn2",
             )
@@ -1685,7 +1836,11 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 quant_config=quant_config,
                 prefix=f"{prefix}.blocks.{idx}",
             )
-            self.scale_shift_table = torch.nn.Parameter(torch.empty(6, video.dim))
+            # 6 rows for LTX-2.0; 9 rows when cross_attention_adaln adds the
+            # text cross-attention shift/scale/gate.
+            video_sst_size = adaln_embedding_coefficient(cross_attention_adaln)
+            self.scale_shift_table = torch.nn.Parameter(
+                torch.empty(video_sst_size, video.dim))
 
         if audio is not None:
             # Audio self-attention - use distributed when SP > 1
@@ -1697,6 +1852,7 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
+                apply_gated_attention=audio.apply_gated_attention,
                 quant_config=quant_config,
                 prefix=f"{prefix}.blocks.{idx}.audio_attn1",
             )
@@ -1709,6 +1865,7 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
+                apply_gated_attention=audio.apply_gated_attention,
                 quant_config=quant_config,
                 prefix=f"{prefix}.blocks.{idx}.audio_attn2",
             )
@@ -1718,7 +1875,9 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 quant_config=quant_config,
                 prefix=f"{prefix}.blocks.{idx}.audio",
             )
-            self.audio_scale_shift_table = torch.nn.Parameter(torch.empty(6, audio.dim))
+            audio_sst_size = adaln_embedding_coefficient(cross_attention_adaln)
+            self.audio_scale_shift_table = torch.nn.Parameter(
+                torch.empty(audio_sst_size, audio.dim))
 
         if audio is not None and video is not None:
             # Audio-to-video cross-attention
@@ -1731,6 +1890,7 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
+                apply_gated_attention=video.apply_gated_attention,
                 quant_config=quant_config,
                 prefix=f"{prefix}.blocks.{idx}.audio_to_video_attn",
             )
@@ -1744,11 +1904,21 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 norm_eps=norm_eps,
                 rope_type=rope_type,
                 supported_attention_backends=dense_attn_backends,
+                apply_gated_attention=audio.apply_gated_attention,
                 quant_config=quant_config,
                 prefix=f"{prefix}.blocks.{idx}.video_to_audio_attn",
             )
             self.scale_shift_table_a2v_ca_audio = torch.nn.Parameter(torch.empty(5, audio.dim))
             self.scale_shift_table_a2v_ca_video = torch.nn.Parameter(torch.empty(5, video.dim))
+
+        # LTX-2.3 cross-attention AdaLN prompt scale/shift tables (only created
+        # when cross_attention_adaln is enabled, so absent for LTX-2.0).
+        if self.cross_attention_adaln and video is not None:
+            self.prompt_scale_shift_table = torch.nn.Parameter(
+                torch.empty(2, video.dim))
+        if self.cross_attention_adaln and audio is not None:
+            self.audio_prompt_scale_shift_table = torch.nn.Parameter(
+                torch.empty(2, audio.dim))
 
         self.norm_eps = norm_eps
 
@@ -1802,6 +1972,44 @@ class BasicAVTransformerBlock(torch.nn.Module):
 
         return (*scale_shift_chunks, *gate_ada_values)
 
+    def _apply_text_cross_attention(
+        self,
+        x: torch.Tensor,
+        context: torch.Tensor,
+        attn: Callable,
+        scale_shift_table: torch.Tensor,
+        prompt_scale_shift_table: torch.Tensor | None,
+        timestep: torch.Tensor,
+        prompt_timestep: torch.Tensor | None,
+        context_mask: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Text cross-attention with optional LTX-2.3 cross-attention AdaLN.
+
+        When ``cross_attention_adaln`` is False this is exactly the LTX-2.0
+        path: ``attn(rms_norm(x), context=context, mask=context_mask)``.
+        """
+        if self.cross_attention_adaln:
+            # The 3 extra AdaLN rows (6..9) carry text cross-attn shift/scale/gate.
+            shift_q, scale_q, gate = self.get_ada_values(
+                scale_shift_table, x.shape[0], timestep, slice(6, 9))
+            return apply_cross_attention_adaln(
+                x=x,
+                context=context,
+                attn=attn,
+                q_shift=shift_q,
+                q_scale=scale_q,
+                q_gate=gate,
+                prompt_scale_shift_table=prompt_scale_shift_table,
+                prompt_timestep=prompt_timestep,
+                context_mask=context_mask,
+                norm_eps=self.norm_eps,
+            )
+        return attn(
+            _rms_norm_dispatch(x, eps=self.norm_eps),
+            context=context,
+            mask=context_mask,
+        )
+
     def forward(
         self,
         video: TransformerArgs | None,
@@ -1809,8 +2017,8 @@ class BasicAVTransformerBlock(torch.nn.Module):
         video_original_seq_len: int | None = None,
         audio_original_seq_len: int | None = None,
         skip_cross_modal_attn: bool = False,
-        skip_video_self_attn: bool = False,
-        skip_audio_self_attn: bool = False,
+        skip_video_self_attn: bool | torch.Tensor = False,
+        skip_audio_self_attn: bool | torch.Tensor = False,
     ) -> tuple[TransformerArgs | None, TransformerArgs | None]:
         """Forward pass for transformer block.
 
@@ -1834,51 +2042,97 @@ class BasicAVTransformerBlock(torch.nn.Module):
         run_a2v = run_vx and run_ax
         run_v2a = run_ax and run_vx
 
+        def _build_attn_keep_mask(
+            values: torch.Tensor,
+            skip_flag: bool | torch.Tensor,
+        ) -> torch.Tensor:
+            """STG keep-mask for self-attention.
+
+            Returns a per-sample multiplier (1 keep, 0 perturb) broadcastable
+            over ``values``. Only the configured ``stg_block_idx`` is perturbed.
+            Supports both the LTX-2.0 bool flag and an LTX-2.3 per-sample
+            tensor ``[B]`` (1/True == perturb). When skip_flag is False/0 the
+            multiplier is all ones, reproducing the un-skipped LTX-2.0 path.
+            """
+            bsz = values.shape[0]
+            keep = torch.ones((bsz, ), device=values.device, dtype=values.dtype)
+            if self.idx == self.stg_block_idx:
+                if torch.is_tensor(skip_flag):
+                    if skip_flag.ndim == 0:
+                        perturb = skip_flag.reshape(1).expand(bsz)
+                    else:
+                        if skip_flag.shape[0] != bsz:
+                            raise ValueError(
+                                "Per-sample STG mask batch size mismatch: "
+                                f"got {skip_flag.shape[0]}, expected {bsz}")
+                        perturb = skip_flag.reshape(bsz)
+                    keep = 1.0 - perturb.to(device=values.device,
+                                            dtype=values.dtype)
+                elif bool(skip_flag):
+                    keep.zero_()
+            return keep.view(bsz, *([1] * (values.ndim - 1)))
+
         if run_vx:
             vshift_msa, vscale_msa, vgate_msa = self.get_ada_values(
                 self.scale_shift_table, vx.shape[0], video.timesteps, slice(0, 3)
             )
-            if not skip_video_self_attn:
-                norm_vx = torch.nn.functional.rms_norm(vx, (vx.shape[-1],), eps=self.norm_eps) * (1 + vscale_msa) + vshift_msa
-                if self.use_distributed_attention:
-                    vx = vx + self.attn1(
-                        norm_vx,
-                        pe=video.positional_embeddings,
-                        original_seq_len=video_original_seq_len,
-                    ) * vgate_msa
-                else:
-                    vx = vx + self.attn1(norm_vx, pe=video.positional_embeddings) * vgate_msa
-            # Text cross-attention: no SP mask needed (text is replicated, uses local attention)
-            vx = vx + self.attn2(
-                torch.nn.functional.rms_norm(vx, (vx.shape[-1],), eps=self.norm_eps),
+            norm_vx = _rms_norm_dispatch(vx, eps=self.norm_eps) * (
+                1 + vscale_msa) + vshift_msa
+            video_self_attn_mask = _build_attn_keep_mask(vx, skip_video_self_attn)
+            if self.use_distributed_attention:
+                vx_attn1_out = self.attn1(
+                    norm_vx,
+                    pe=video.positional_embeddings,
+                    original_seq_len=video_original_seq_len,
+                )
+            else:
+                vx_attn1_out = self.attn1(norm_vx, pe=video.positional_embeddings)
+            vx = vx + vx_attn1_out * vgate_msa * video_self_attn_mask
+            # Text cross-attention: no SP mask needed (text is replicated).
+            vx = vx + self._apply_text_cross_attention(
+                x=vx,
                 context=video.context,
-                mask=video.context_mask,
+                attn=self.attn2,
+                scale_shift_table=self.scale_shift_table,
+                prompt_scale_shift_table=getattr(
+                    self, "prompt_scale_shift_table", None),
+                timestep=video.timesteps,
+                prompt_timestep=video.prompt_timestep,
+                context_mask=video.context_mask,
             )
 
         if run_ax:
             ashift_msa, ascale_msa, agate_msa = self.get_ada_values(
                 self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(0, 3)
             )
-            if not skip_audio_self_attn:
-                norm_ax = torch.nn.functional.rms_norm(ax, (ax.shape[-1],), eps=self.norm_eps) * (1 + ascale_msa) + ashift_msa
-                if self.use_distributed_attention:
-                    ax = ax + self.audio_attn1(
-                        norm_ax,
-                        pe=audio.positional_embeddings,
-                        original_seq_len=audio_original_seq_len,
-                    ) * agate_msa
-                else:
-                    ax = ax + self.audio_attn1(norm_ax, pe=audio.positional_embeddings) * agate_msa
-            # Text cross-attention: no SP mask needed (text is replicated, uses local attention)
-            ax = ax + self.audio_attn2(
-                torch.nn.functional.rms_norm(ax, (ax.shape[-1],), eps=self.norm_eps),
+            norm_ax = _rms_norm_dispatch(ax, eps=self.norm_eps) * (
+                1 + ascale_msa) + ashift_msa
+            audio_self_attn_mask = _build_attn_keep_mask(ax, skip_audio_self_attn)
+            if self.use_distributed_attention:
+                ax_attn1_out = self.audio_attn1(
+                    norm_ax,
+                    pe=audio.positional_embeddings,
+                    original_seq_len=audio_original_seq_len,
+                )
+            else:
+                ax_attn1_out = self.audio_attn1(norm_ax, pe=audio.positional_embeddings)
+            ax = ax + ax_attn1_out * agate_msa * audio_self_attn_mask
+            # Text cross-attention: no SP mask needed (text is replicated).
+            ax = ax + self._apply_text_cross_attention(
+                x=ax,
                 context=audio.context,
-                mask=audio.context_mask,
+                attn=self.audio_attn2,
+                scale_shift_table=self.audio_scale_shift_table,
+                prompt_scale_shift_table=getattr(
+                    self, "audio_prompt_scale_shift_table", None),
+                timestep=audio.timesteps,
+                prompt_timestep=audio.prompt_timestep,
+                context_mask=audio.context_mask,
             )
 
         if (run_a2v or run_v2a) and not skip_cross_modal_attn:
-            vx_norm3 = torch.nn.functional.rms_norm(vx, (vx.shape[-1],), eps=self.norm_eps)
-            ax_norm3 = torch.nn.functional.rms_norm(ax, (ax.shape[-1],), eps=self.norm_eps)
+            vx_norm3 = _rms_norm_dispatch(vx, eps=self.norm_eps)
+            ax_norm3 = _rms_norm_dispatch(ax, eps=self.norm_eps)
 
             (
                 scale_ca_audio_hidden_states_a2v,
@@ -1996,17 +2250,22 @@ class BasicAVTransformerBlock(torch.nn.Module):
                     )
 
         if run_vx:
+            # slice(3, 6) selects the FFN shift/scale/gate. Identical to
+            # slice(3, None) for the 6-row LTX-2.0 table, but correct for the
+            # 9-row cross_attention_adaln table (rows 6..9 are the cross-attn).
             vshift_mlp, vscale_mlp, vgate_mlp = self.get_ada_values(
-                self.scale_shift_table, vx.shape[0], video.timesteps, slice(3, None)
+                self.scale_shift_table, vx.shape[0], video.timesteps, slice(3, 6)
             )
-            vx_scaled = torch.nn.functional.rms_norm(vx, (vx.shape[-1],), eps=self.norm_eps) * (1 + vscale_mlp) + vshift_mlp
+            vx_scaled = _rms_norm_dispatch(vx, eps=self.norm_eps) * (
+                1 + vscale_mlp) + vshift_mlp
             vx = vx + self.ff(vx_scaled) * vgate_mlp
 
         if run_ax:
             ashift_mlp, ascale_mlp, agate_mlp = self.get_ada_values(
-                self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(3, None)
+                self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(3, 6)
             )
-            ax_scaled = torch.nn.functional.rms_norm(ax, (ax.shape[-1],), eps=self.norm_eps) * (1 + ascale_mlp) + ashift_mlp
+            ax_scaled = _rms_norm_dispatch(ax, eps=self.norm_eps) * (
+                1 + ascale_mlp) + ashift_mlp
             ax = ax + self.audio_ff(ax_scaled) * agate_mlp
 
         if os.getenv("LTX2_PIPELINE_DEBUG_LOG", "0") == "1":
@@ -2025,6 +2284,39 @@ class BasicAVTransformerBlock(torch.nn.Module):
             replace(video, x=vx) if video is not None else None,
             replace(audio, x=ax) if audio is not None else None,
         )
+
+
+def apply_cross_attention_adaln(
+    x: torch.Tensor,
+    context: torch.Tensor,
+    attn: Callable,
+    q_shift: torch.Tensor,
+    q_scale: torch.Tensor,
+    q_gate: torch.Tensor,
+    prompt_scale_shift_table: torch.Tensor | None,
+    prompt_timestep: torch.Tensor | None,
+    context_mask: torch.Tensor | None = None,
+    norm_eps: float = 1e-6,
+) -> torch.Tensor:
+    """LTX-2.3 cross-attention AdaLN: modulate query (x) and key/value
+    (context) by AdaLN scale/shift and gate the output.
+
+    Only reached when ``cross_attention_adaln`` is enabled, so it never
+    affects the LTX-2.0 path.
+    """
+    if prompt_scale_shift_table is None or prompt_timestep is None:
+        raise ValueError(
+            "cross_attention_adaln requires prompt scale/shift tables and prompt_timestep."
+        )
+    batch_size = x.shape[0]
+    shift_kv, scale_kv = (
+        prompt_scale_shift_table[None, None].to(device=x.device, dtype=x.dtype)
+        + prompt_timestep.reshape(batch_size, prompt_timestep.shape[1], 2, -1)
+    ).unbind(dim=2)
+    attn_input = _rms_norm_dispatch(x, eps=norm_eps) * (1 + q_scale) + q_shift
+    encoder_hidden_states = context * (1 + scale_kv) + shift_kv
+    return attn(attn_input, context=encoder_hidden_states,
+                mask=context_mask) * q_gate
 
 
 class LTXModelType(Enum):
@@ -2068,12 +2360,21 @@ class LTXModel(torch.nn.Module):
         av_ca_timestep_scale_multiplier: int = 1,
         rope_type: LTXRopeType = LTXRopeType.INTERLEAVED,
         double_precision_rope: bool = False,
+        cross_attention_adaln: bool = False,
+        caption_proj_before_connector: bool = False,
+        apply_gated_attention: bool = False,
+        stg_block_idx: int = 29,
         use_distributed_attention: bool = False,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ):
         super().__init__()
         self._enable_gradient_checkpointing = False
+        # LTX-2.3 gated extensions (all default OFF == LTX-2.0 behavior).
+        self.cross_attention_adaln = cross_attention_adaln
+        self.caption_proj_before_connector = caption_proj_before_connector
+        self.apply_gated_attention = apply_gated_attention
+        self.stg_block_idx = stg_block_idx
         self.use_middle_indices_grid = use_middle_indices_grid
         self.rope_type = rope_type
         self.double_precision_rope = double_precision_rope
@@ -2093,6 +2394,7 @@ class LTXModel(torch.nn.Module):
                 out_channels=out_channels,
                 caption_channels=caption_channels,
                 norm_eps=norm_eps,
+                create_caption_projection=not caption_proj_before_connector,
             )
 
         if model_type.is_audio_enabled():
@@ -2106,6 +2408,7 @@ class LTXModel(torch.nn.Module):
                 out_channels=audio_out_channels,
                 caption_channels=caption_channels,
                 norm_eps=norm_eps,
+                create_caption_projection=not caption_proj_before_connector,
             )
 
         if model_type.is_video_enabled() and model_type.is_audio_enabled():
@@ -2133,13 +2436,26 @@ class LTXModel(torch.nn.Module):
         out_channels: int,
         caption_channels: int,
         norm_eps: float,
+        create_caption_projection: bool = True,
     ) -> None:
         self.patchify_proj = torch.nn.Linear(in_channels, self.inner_dim, bias=True)
-        self.adaln_single = AdaLayerNormSingle(self.inner_dim)
-        self.caption_projection = PixArtAlphaTextProjection(
-            in_features=caption_channels,
-            hidden_size=self.inner_dim,
+        self.adaln_single = AdaLayerNormSingle(
+            self.inner_dim,
+            embedding_coefficient=adaln_embedding_coefficient(
+                self.cross_attention_adaln),
         )
+        # When caption_proj_before_connector is set the caption projection
+        # lives in the text encoder, so it is omitted here (LTX-2.3 layout).
+        if create_caption_projection:
+            self.caption_projection = PixArtAlphaTextProjection(
+                in_features=caption_channels,
+                hidden_size=self.inner_dim,
+            )
+        if self.cross_attention_adaln:
+            self.prompt_adaln_single = AdaLayerNormSingle(
+                self.inner_dim,
+                embedding_coefficient=2,
+            )
         self.scale_shift_table = torch.nn.Parameter(torch.empty(2, self.inner_dim))
         self.norm_out = torch.nn.LayerNorm(self.inner_dim, elementwise_affine=False, eps=norm_eps)
         self.proj_out = torch.nn.Linear(self.inner_dim, out_channels)
@@ -2150,13 +2466,24 @@ class LTXModel(torch.nn.Module):
         out_channels: int,
         caption_channels: int,
         norm_eps: float,
+        create_caption_projection: bool = True,
     ) -> None:
         self.audio_patchify_proj = torch.nn.Linear(in_channels, self.audio_inner_dim, bias=True)
-        self.audio_adaln_single = AdaLayerNormSingle(self.audio_inner_dim)
-        self.audio_caption_projection = PixArtAlphaTextProjection(
-            in_features=caption_channels,
-            hidden_size=self.audio_inner_dim,
+        self.audio_adaln_single = AdaLayerNormSingle(
+            self.audio_inner_dim,
+            embedding_coefficient=adaln_embedding_coefficient(
+                self.cross_attention_adaln),
         )
+        if create_caption_projection:
+            self.audio_caption_projection = PixArtAlphaTextProjection(
+                in_features=caption_channels,
+                hidden_size=self.audio_inner_dim,
+            )
+        if self.cross_attention_adaln:
+            self.audio_prompt_adaln_single = AdaLayerNormSingle(
+                self.audio_inner_dim,
+                embedding_coefficient=2,
+            )
         self.audio_scale_shift_table = torch.nn.Parameter(torch.empty(2, self.audio_inner_dim))
         self.audio_norm_out = torch.nn.LayerNorm(self.audio_inner_dim, elementwise_affine=False, eps=norm_eps)
         self.audio_proj_out = torch.nn.Linear(self.audio_inner_dim, out_channels)
@@ -2184,7 +2511,7 @@ class LTXModel(torch.nn.Module):
             self.video_args_preprocessor = MultiModalTransformerArgsPreprocessor(
                 patchify_proj=self.patchify_proj,
                 adaln=self.adaln_single,
-                caption_projection=self.caption_projection,
+                caption_projection=getattr(self, "caption_projection", None),
                 cross_scale_shift_adaln=self.av_ca_video_scale_shift_adaln_single,
                 cross_gate_adaln=self.av_ca_a2v_gate_adaln_single,
                 inner_dim=self.inner_dim,
@@ -2198,11 +2525,12 @@ class LTXModel(torch.nn.Module):
                 positional_embedding_theta=self.positional_embedding_theta,
                 rope_type=self.rope_type,
                 av_ca_timestep_scale_multiplier=self.av_ca_timestep_scale_multiplier,
+                prompt_adaln=getattr(self, "prompt_adaln_single", None),
             )
             self.audio_args_preprocessor = MultiModalTransformerArgsPreprocessor(
                 patchify_proj=self.audio_patchify_proj,
                 adaln=self.audio_adaln_single,
-                caption_projection=self.audio_caption_projection,
+                caption_projection=getattr(self, "audio_caption_projection", None),
                 cross_scale_shift_adaln=self.av_ca_audio_scale_shift_adaln_single,
                 cross_gate_adaln=self.av_ca_v2a_gate_adaln_single,
                 inner_dim=self.audio_inner_dim,
@@ -2216,12 +2544,13 @@ class LTXModel(torch.nn.Module):
                 positional_embedding_theta=self.positional_embedding_theta,
                 rope_type=self.rope_type,
                 av_ca_timestep_scale_multiplier=self.av_ca_timestep_scale_multiplier,
+                prompt_adaln=getattr(self, "audio_prompt_adaln_single", None),
             )
         elif self.model_type.is_video_enabled():
             self.video_args_preprocessor = TransformerArgsPreprocessor(
                 patchify_proj=self.patchify_proj,
                 adaln=self.adaln_single,
-                caption_projection=self.caption_projection,
+                caption_projection=getattr(self, "caption_projection", None),
                 inner_dim=self.inner_dim,
                 max_pos=self.positional_embedding_max_pos,
                 num_attention_heads=self.num_attention_heads,
@@ -2230,12 +2559,13 @@ class LTXModel(torch.nn.Module):
                 double_precision_rope=self.double_precision_rope,
                 positional_embedding_theta=self.positional_embedding_theta,
                 rope_type=self.rope_type,
+                prompt_adaln=getattr(self, "prompt_adaln_single", None),
             )
         elif self.model_type.is_audio_enabled():
             self.audio_args_preprocessor = TransformerArgsPreprocessor(
                 patchify_proj=self.audio_patchify_proj,
                 adaln=self.audio_adaln_single,
-                caption_projection=self.audio_caption_projection,
+                caption_projection=getattr(self, "audio_caption_projection", None),
                 inner_dim=self.audio_inner_dim,
                 max_pos=self.audio_positional_embedding_max_pos,
                 num_attention_heads=self.audio_num_attention_heads,
@@ -2244,6 +2574,7 @@ class LTXModel(torch.nn.Module):
                 double_precision_rope=self.double_precision_rope,
                 positional_embedding_theta=self.positional_embedding_theta,
                 rope_type=self.rope_type,
+                prompt_adaln=getattr(self, "audio_prompt_adaln_single", None),
             )
 
     def _init_transformer_blocks(
@@ -2264,6 +2595,8 @@ class LTXModel(torch.nn.Module):
                 heads=self.num_attention_heads,
                 d_head=attention_head_dim,
                 context_dim=cross_attention_dim,
+                apply_gated_attention=self.apply_gated_attention,
+                cross_attention_adaln=self.cross_attention_adaln,
             )
             if self.model_type.is_video_enabled()
             else None
@@ -2274,6 +2607,8 @@ class LTXModel(torch.nn.Module):
                 heads=self.audio_num_attention_heads,
                 d_head=audio_attention_head_dim,
                 context_dim=audio_cross_attention_dim,
+                apply_gated_attention=self.apply_gated_attention,
+                cross_attention_adaln=self.cross_attention_adaln,
             )
             if self.model_type.is_audio_enabled()
             else None
@@ -2288,6 +2623,8 @@ class LTXModel(torch.nn.Module):
                     rope_type=self.rope_type,
                     norm_eps=norm_eps,
                     use_distributed_attention=use_distributed_attention,
+                    cross_attention_adaln=self.cross_attention_adaln,
+                    stg_block_idx=self.stg_block_idx,
                     quant_config=quant_config,
                     prefix=prefix,
                 )
@@ -2476,6 +2813,10 @@ class LTX2Transformer3DModel(BaseDiT):
             audio_cross_attention_dim=arch.audio_cross_attention_dim,
             audio_positional_embedding_max_pos=arch.audio_positional_embedding_max_pos,
             av_ca_timestep_scale_multiplier=arch.av_ca_timestep_scale_multiplier,
+            cross_attention_adaln=arch.cross_attention_adaln,
+            caption_proj_before_connector=arch.caption_proj_before_connector,
+            apply_gated_attention=arch.apply_gated_attention,
+            stg_block_idx=arch.stg_block_idx,
             use_distributed_attention=use_distributed_attention,
             quant_config=config.quant_config,
             prefix=config.prefix,

--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -2902,6 +2902,8 @@ class LTX2Transformer3DModel(BaseDiT):
         audio_encoder_hidden_states: torch.Tensor | None = None,
         audio_timestep: torch.Tensor | None = None,
         audio_encoder_attention_mask: torch.Tensor | None = None,
+        video_sigma: torch.Tensor | None = None,
+        audio_sigma: torch.Tensor | None = None,
         skip_cross_modal_attn: bool = False,
         skip_video_self_attn_blocks: list[int] | None = None,
         skip_audio_self_attn_blocks: list[int] | None = None,
@@ -2928,6 +2930,12 @@ class LTX2Transformer3DModel(BaseDiT):
         # Patchify video latents
         video_shape = VideoLatentShape.from_torch_shape(hidden_states.shape)
         latents = self.patchifier.patchify(hidden_states)
+        # LTX-2.3 cross-attention AdaLN consumes a per-sample sigma timestep.
+        # When the denoising stage does not supply one (LTX-2.0, or any caller
+        # that omits it) derive it from the video timestep. The downstream
+        # ``prompt_adaln`` is None for LTX-2.0 so this value is ignored there.
+        if video_sigma is None:
+            video_sigma = timestep[:, 0] if timestep.ndim > 1 else timestep
 
         # Shard video latents and timestep across SP ranks
         video_original_seq_len = latents.shape[1]
@@ -2966,6 +2974,7 @@ class LTX2Transformer3DModel(BaseDiT):
             positions=positions,
             context=encoder_hidden_states,
             context_mask=encoder_attention_mask,
+            sigma=video_sigma,
         )
         if os.getenv("LTX2_PIPELINE_DEBUG_LOG", "0") == "1":
             video_head = latents.flatten()[:8].float().tolist()
@@ -2989,6 +2998,11 @@ class LTX2Transformer3DModel(BaseDiT):
         if audio_hidden_states is not None and audio_encoder_hidden_states is not None and audio_timestep is not None:
             audio_shape = AudioLatentShape.from_torch_shape(audio_hidden_states.shape)
             audio_latents = self.audio_patchifier.patchify(audio_hidden_states)
+            if audio_sigma is None:
+                audio_sigma = (
+                    audio_timestep[:, 0]
+                    if audio_timestep.ndim > 1 else audio_timestep
+                )
 
             # Shard audio latents and timestep across SP ranks
             audio_original_seq_len = audio_latents.shape[1]
@@ -3011,6 +3025,7 @@ class LTX2Transformer3DModel(BaseDiT):
                 positions=audio_positions,
                 context=audio_encoder_hidden_states,
                 context_mask=audio_encoder_attention_mask,
+                sigma=audio_sigma,
             )
             if os.getenv("LTX2_PIPELINE_DEBUG_LOG", "0") == "1":
                 audio_head = audio_latents.flatten()[:8].float().tolist()

--- a/fastvideo/models/encoders/gemma.py
+++ b/fastvideo/models/encoders/gemma.py
@@ -22,6 +22,7 @@ from fastvideo.models.dits.ltx2 import (
 from fastvideo.models.loader.weight_utils import default_weight_loader
 from fastvideo.platforms import AttentionBackendEnum
 from fastvideo.distributed import get_local_torch_device
+import math
 
 
 def _debug_log_line(message: str) -> None:
@@ -58,6 +59,8 @@ class GemmaConnectorConfig:
     rope_type: LTXRopeType
     double_precision_rope: bool
     num_learnable_registers: int | None
+    # LTX-2.3 connector gated attention (default False == LTX-2.0 behavior).
+    apply_gated_attention: bool = False
 
 
 class GemmaFeaturesExtractorProjLinear(nn.Module):
@@ -71,6 +74,26 @@ class GemmaFeaturesExtractorProjLinear(nn.Module):
         return self.aggregate_embed(x)
 
 
+def _norm_and_concat_per_token_rms(
+    encoded_text: torch.Tensor,
+    attention_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Per-token RMS normalization used by LTX-2.3 feature extraction."""
+    variance = torch.mean(encoded_text**2, dim=2, keepdim=True)
+    normed = encoded_text * torch.rsqrt(variance + 1e-6)
+    normed = normed.reshape(encoded_text.shape[0], encoded_text.shape[1], -1)
+    mask_3d = attention_mask.bool().unsqueeze(-1)
+    return torch.where(mask_3d, normed, torch.zeros_like(normed))
+
+
+def _rescale_norm(
+    x: torch.Tensor,
+    target_dim: int,
+    source_dim: int,
+) -> torch.Tensor:
+    return x * math.sqrt(target_dim / source_dim)
+
+
 class _BasicTransformerBlock1D(nn.Module):
     """1D transformer block for connector processing."""
 
@@ -80,6 +103,7 @@ class _BasicTransformerBlock1D(nn.Module):
         heads: int,
         dim_head: int,
         rope_type: LTXRopeType,
+        apply_gated_attention: bool = False,
         norm_eps: float = 1e-6,
     ) -> None:
         super().__init__()
@@ -90,6 +114,7 @@ class _BasicTransformerBlock1D(nn.Module):
             dim_head=dim_head,
             norm_eps=norm_eps,
             rope_type=rope_type,
+            apply_gated_attention=apply_gated_attention,
         )
         self.ff = FeedForward(dim, dim_out=dim)
         self.norm_eps = norm_eps
@@ -136,6 +161,7 @@ class _GemmaAttention(nn.Module):
         dim_head: int,
         norm_eps: float,
         rope_type: LTXRopeType,
+        apply_gated_attention: bool = False,
     ) -> None:
         super().__init__()
         inner_dim = dim_head * heads
@@ -150,6 +176,11 @@ class _GemmaAttention(nn.Module):
         self.to_q = nn.Linear(query_dim, inner_dim, bias=True)
         self.to_k = nn.Linear(context_dim, inner_dim, bias=True)
         self.to_v = nn.Linear(context_dim, inner_dim, bias=True)
+        # LTX-2.3 connector gated attention (None default == LTX-2.0).
+        if apply_gated_attention:
+            self.to_gate_logits = nn.Linear(query_dim, heads, bias=True)
+        else:
+            self.to_gate_logits = None
         self.to_out = nn.Sequential(nn.Linear(inner_dim, query_dim, bias=True), nn.Identity())
 
     def forward(
@@ -192,7 +223,12 @@ class _GemmaAttention(nn.Module):
             dropout_p=0.0,
             is_causal=False,
         )
-        out = out.transpose(1, 2).reshape(b, q_len, -1)
+        out = out.transpose(1, 2)
+        if self.to_gate_logits is not None:
+            gate_logits = self.to_gate_logits(x)
+            gates = 2.0 * torch.sigmoid(gate_logits)
+            out = out * gates.unsqueeze(-1)
+        out = out.reshape(b, q_len, -1)
         return self.to_out(out)
 
 
@@ -216,6 +252,7 @@ class Embeddings1DConnector(nn.Module):
                     heads=config.num_attention_heads,
                     dim_head=config.attention_head_dim,
                     rope_type=config.rope_type,
+                    apply_gated_attention=config.apply_gated_attention,
                 )
                 for _ in range(config.num_layers)
             ]
@@ -330,12 +367,37 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
         super().__init__(config)
         arch = config.arch_config
 
-        self.feature_extractor_linear = GemmaFeaturesExtractorProjLinear(
-            in_features=arch.feature_extractor_in_features,
-            out_features=arch.feature_extractor_out_features,
-        )
+        # LTX-2.3 routes the caption projection before the connector and uses
+        # separate per-modality feature extractor linears. Default (False)
+        # keeps the single LTX-2.0 GemmaFeaturesExtractorProjLinear.
+        self.use_v2_feature_extractor = bool(
+            getattr(arch, "caption_proj_before_connector", False))
+        if self.use_v2_feature_extractor:
+            video_out_features = (
+                getattr(arch, "video_feature_extractor_out_features", None)
+                or arch.feature_extractor_out_features)
+            audio_out_features = (
+                getattr(arch, "audio_feature_extractor_out_features", None)
+                or video_out_features)
+            self.video_feature_extractor_linear = nn.Linear(
+                arch.feature_extractor_in_features,
+                video_out_features,
+                bias=True,
+            )
+            self.audio_feature_extractor_linear = nn.Linear(
+                arch.feature_extractor_in_features,
+                audio_out_features,
+                bias=True,
+            )
+        else:
+            self.feature_extractor_linear = GemmaFeaturesExtractorProjLinear(
+                in_features=arch.feature_extractor_in_features,
+                out_features=arch.feature_extractor_out_features,
+            )
 
-        connector_config = GemmaConnectorConfig(
+        connector_apply_gated_attention = bool(
+            getattr(arch, "connector_apply_gated_attention", False))
+        video_connector_config = GemmaConnectorConfig(
             num_attention_heads=arch.connector_num_attention_heads,
             attention_head_dim=arch.connector_attention_head_dim,
             num_layers=arch.connector_num_layers,
@@ -344,9 +406,26 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
             rope_type=LTXRopeType(arch.connector_rope_type),
             double_precision_rope=arch.connector_double_precision_rope,
             num_learnable_registers=arch.connector_num_learnable_registers,
+            apply_gated_attention=connector_apply_gated_attention,
         )
-        self.embeddings_connector = Embeddings1DConnector(connector_config)
-        self.audio_embeddings_connector = Embeddings1DConnector(connector_config)
+        audio_connector_config = GemmaConnectorConfig(
+            num_attention_heads=getattr(
+                arch, "audio_connector_num_attention_heads", None)
+            or arch.connector_num_attention_heads,
+            attention_head_dim=getattr(
+                arch, "audio_connector_attention_head_dim", None)
+            or arch.connector_attention_head_dim,
+            num_layers=getattr(arch, "audio_connector_num_layers", None)
+            or arch.connector_num_layers,
+            positional_embedding_theta=arch.connector_positional_embedding_theta,
+            positional_embedding_max_pos=arch.connector_positional_embedding_max_pos,
+            rope_type=LTXRopeType(arch.connector_rope_type),
+            double_precision_rope=arch.connector_double_precision_rope,
+            num_learnable_registers=arch.connector_num_learnable_registers,
+            apply_gated_attention=connector_apply_gated_attention,
+        )
+        self.embeddings_connector = Embeddings1DConnector(video_connector_config)
+        self.audio_embeddings_connector = Embeddings1DConnector(audio_connector_config)
 
         self.gemma_model_path = arch.gemma_model_path
         self.gemma_dtype = arch.gemma_dtype
@@ -388,7 +467,11 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
                     self._gemma_model.config.attn_implementation = "sdpa"
                 if hasattr(self._gemma_model.config, "_attn_implementation"):
                     self._gemma_model.config._attn_implementation = "sdpa"
-            device = next(self.feature_extractor_linear.parameters()).device
+            if self.use_v2_feature_extractor:
+                device = next(
+                    self.video_feature_extractor_linear.parameters()).device
+            else:
+                device = next(self.feature_extractor_linear.parameters()).device
             self._gemma_model.to(device=device)
             self._gemma_model.eval()
         return self._gemma_model
@@ -398,7 +481,7 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
         hidden_states: tuple[torch.Tensor, ...],
         attention_mask: torch.Tensor,
         padding_side: str,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         encoded_text_features = torch.stack(hidden_states, dim=-1)
         if os.getenv("LTX2_FASTVIDEO_GEMMA_LOG", ""):
             for idx, layer in enumerate(hidden_states):
@@ -411,13 +494,37 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
                 f":sum={encoded_text_features.float().sum().item():.6f}"
             )
         encoded_text_features_dtype = encoded_text_features.dtype
+        if self.use_v2_feature_extractor:
+            # LTX-2.3: per-token RMS norm then separate video/audio linears.
+            normed_text_features = _norm_and_concat_per_token_rms(
+                encoded_text_features, attention_mask).to(
+                    encoded_text_features_dtype)
+            video_out_dim = self.video_feature_extractor_linear.out_features
+            audio_out_dim = self.audio_feature_extractor_linear.out_features
+            video_features = self.video_feature_extractor_linear(
+                _rescale_norm(
+                    normed_text_features,
+                    target_dim=video_out_dim,
+                    source_dim=self.config.arch_config.hidden_size,
+                ))
+            audio_features = self.audio_feature_extractor_linear(
+                _rescale_norm(
+                    normed_text_features,
+                    target_dim=audio_out_dim,
+                    source_dim=self.config.arch_config.hidden_size,
+                ))
+            return video_features, audio_features
+
+        # LTX-2.0: shared min-max norm + single aggregate linear. The two
+        # returned tensors are the same object (video == audio source).
         sequence_lengths = attention_mask.sum(dim=-1)
         normed_text_features = _norm_and_concat_padded_batch(
             encoded_text_features, sequence_lengths, padding_side=padding_side
         )
-        return self.feature_extractor_linear(
+        shared_features = self.feature_extractor_linear(
             normed_text_features.to(encoded_text_features_dtype)
         )
+        return shared_features, shared_features
 
     def _convert_to_additive_mask(
         self, attention_mask: torch.Tensor, dtype: torch.dtype
@@ -428,14 +535,15 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
 
     def _run_connectors(
         self,
-        encoded_input: torch.Tensor,
+        video_features: torch.Tensor,
+        audio_features: torch.Tensor | None,
         attention_mask: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         connector_attention_mask = self._convert_to_additive_mask(
-            attention_mask, encoded_input.dtype
+            attention_mask, video_features.dtype
         )
         encoded, encoded_connector_attention_mask = self.embeddings_connector(
-            encoded_input, connector_attention_mask
+            video_features, connector_attention_mask
         )
 
         attention_mask = (encoded_connector_attention_mask < 0.000001).to(
@@ -446,8 +554,13 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
         )
         encoded = encoded * attention_mask
 
+        # For LTX-2.0 audio_features is the same tensor as video_features, so
+        # this reproduces the prior behavior (audio connector fed the shared
+        # features). For LTX-2.3 it is fed the separate audio features.
+        audio_features = (audio_features
+                          if audio_features is not None else video_features)
         encoded_for_audio, _ = self.audio_embeddings_connector(
-            encoded_input, connector_attention_mask
+            audio_features, connector_attention_mask
         )
 
         return encoded, encoded_for_audio, attention_mask.squeeze(-1)
@@ -491,12 +604,12 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
             output_hidden_states=True,
             return_dict=True,
         )
-        prompt_embeds = self._run_feature_extractor(
+        video_features, _ = self._run_feature_extractor(
             outputs.hidden_states,
             attention_mask,
             padding_side=target_padding_side,
         )
-        return prompt_embeds, attention_mask
+        return video_features, attention_mask
 
     def run_connectors(
         self,
@@ -504,7 +617,7 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
         attention_mask: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Apply embedding connectors to precomputed Gemma features."""
-        return self._run_connectors(encoded_input, attention_mask)
+        return self._run_connectors(encoded_input, encoded_input, attention_mask)
 
     def forward(
         self,
@@ -536,7 +649,7 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
             return_dict=True,
         )
 
-        encoded_inputs = self._run_feature_extractor(
+        encoded_video, encoded_audio = self._run_feature_extractor(
             outputs.hidden_states,
             attention_mask,
             padding_side=self.padding_side,
@@ -544,11 +657,11 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
         if os.getenv("LTX2_PIPELINE_DEBUG_LOG", "0") == "1":
             _debug_log_line(
                 "fastvideo:gemma_feature"
-                f":sum={encoded_inputs.float().sum().item():.6f} "
-                f"shape={tuple(encoded_inputs.shape)}"
+                f":sum={encoded_video.float().sum().item():.6f} "
+                f"shape={tuple(encoded_video.shape)}"
             )
         video_encoding, audio_encoding, attention_mask = self._run_connectors(
-            encoded_inputs, attention_mask
+            encoded_video, encoded_audio, attention_mask
         )
         if os.getenv("LTX2_PIPELINE_DEBUG_LOG", "0") == "1":
             _debug_log_line(
@@ -577,6 +690,32 @@ class LTX2GemmaTextEncoderModel(TextEncoder):
         for name, loaded_weight in weights:
             if name == "aggregate_embed.weight":
                 name = "feature_extractor_linear.aggregate_embed.weight"
+            # LTX-2.3 separate video/audio feature extractors. These names
+            # do not appear in LTX-2.0 checkpoints, so they are no-ops there.
+            elif name == "video_aggregate_embed.weight":
+                name = "video_feature_extractor_linear.weight"
+            elif name == "video_aggregate_embed.bias":
+                name = "video_feature_extractor_linear.bias"
+            elif name == "audio_aggregate_embed.weight":
+                name = "audio_feature_extractor_linear.weight"
+            elif name == "audio_aggregate_embed.bias":
+                name = "audio_feature_extractor_linear.bias"
+            elif name == "feature_extractor.video_aggregate_embed.weight":
+                name = "video_feature_extractor_linear.weight"
+            elif name == "feature_extractor.video_aggregate_embed.bias":
+                name = "video_feature_extractor_linear.bias"
+            elif name == "feature_extractor.audio_aggregate_embed.weight":
+                name = "audio_feature_extractor_linear.weight"
+            elif name == "feature_extractor.audio_aggregate_embed.bias":
+                name = "audio_feature_extractor_linear.bias"
+            elif name == "feature_extractor.aggregate_embed.weight":
+                name = "feature_extractor_linear.aggregate_embed.weight"
+            elif name.startswith("video_connector."):
+                name = name.replace(
+                    "video_connector.", "embeddings_connector.", 1)
+            elif name.startswith("audio_connector."):
+                name = name.replace(
+                    "audio_connector.", "audio_embeddings_connector.", 1)
             if name not in params_dict:
                 continue
             param = params_dict[name]

--- a/fastvideo/models/vaes/ltx2vae.py
+++ b/fastvideo/models/vaes/ltx2vae.py
@@ -1169,17 +1169,21 @@ def _make_decoder_block(
             spatial_padding_mode=spatial_padding_mode,
         )
     elif block_name == "compress_time":
+        out_channels = in_channels // block_config.get("multiplier", 1)
         block = DepthToSpaceUpsample(
             dims=convolution_dimensions,
             in_channels=in_channels,
             stride=(2, 1, 1),
+            out_channels_reduction_factor=block_config.get("multiplier", 1),
             spatial_padding_mode=spatial_padding_mode,
         )
     elif block_name == "compress_space":
+        out_channels = in_channels // block_config.get("multiplier", 1)
         block = DepthToSpaceUpsample(
             dims=convolution_dimensions,
             in_channels=in_channels,
             stride=(1, 2, 2),
+            out_channels_reduction_factor=block_config.get("multiplier", 1),
             spatial_padding_mode=spatial_padding_mode,
         )
     elif block_name == "compress_all":
@@ -1373,6 +1377,10 @@ class VideoDecoder(nn.Module):
             if block_name == "res_x_y":
                 feature_channels = feature_channels * block_config.get("multiplier", 2)
             if block_name == "compress_all":
+                feature_channels = feature_channels * block_config.get("multiplier", 1)
+            if block_name == "compress_space":
+                feature_channels = feature_channels * block_config.get("multiplier", 1)
+            if block_name == "compress_time":
                 feature_channels = feature_channels * block_config.get("multiplier", 1)
 
         self.conv_in = make_conv_nd(

--- a/fastvideo/pipelines/basic/ltx2/presets.py
+++ b/fastvideo/pipelines/basic/ltx2/presets.py
@@ -67,6 +67,36 @@ LTX2_BASE = InferencePreset(
     },
 )
 
+LTX2_3_BASE = InferencePreset(
+    name="ltx2_3_base",
+    version=1,
+    model_family="ltx2",
+    description="LTX-2.3 base at 512x768",
+    workload_type="t2v",
+    stage_schemas=(_DENOISE_STAGE, ),
+    defaults={
+        "seed": 10,
+        "height": 512,
+        "width": 768,
+        "num_frames": 121,
+        "fps": 24,
+        # LTX-2.3 base: 30 steps (vs 40 for LTX-2.0 base) + CFG 3.0 + negative
+        # prompt; STG perturbs block 28 (vs 29 for LTX-2.0).
+        "guidance_scale": 3.0,
+        "num_inference_steps": 30,
+        "negative_prompt": _LTX2_NEGATIVE_PROMPT,
+        "ltx2_cfg_scale_video": 3.0,
+        "ltx2_cfg_scale_audio": 7.0,
+        "ltx2_modality_scale_video": 3.0,
+        "ltx2_modality_scale_audio": 3.0,
+        "ltx2_rescale_scale": 0.7,
+        "ltx2_stg_scale_video": 1.0,
+        "ltx2_stg_scale_audio": 1.0,
+        "ltx2_stg_blocks_video": [28],
+        "ltx2_stg_blocks_audio": [28],
+    },
+)
+
 LTX2_DISTILLED = InferencePreset(
     name="ltx2_distilled",
     version=1,
@@ -111,4 +141,4 @@ LTX2_TWO_STAGE = InferencePreset(
     },
 )
 
-ALL_PRESETS = (LTX2_BASE, LTX2_DISTILLED, LTX2_TWO_STAGE)
+ALL_PRESETS = (LTX2_BASE, LTX2_3_BASE, LTX2_DISTILLED, LTX2_TWO_STAGE)

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_denoising.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_denoising.py
@@ -475,6 +475,9 @@ class LTX2DenoisingStage(PipelineStage):
         for step_index in tqdm(range(len(sigmas) - 1)):
             sigma = sigmas[step_index]
             sigma_next = sigmas[step_index + 1]
+            # Per-sample sigma for LTX-2.3 cross-attention AdaLN prompt
+            # timestep. Ignored by LTX-2.0 (prompt_adaln is None).
+            sigma_batch = sigma.reshape(1).expand(latents.shape[0])
             timestep = timestep_template * sigma
             audio_timestep = (audio_timestep_template * sigma if audio_timestep_template is not None else None)
             latent_model_input = latents.to(target_dtype)
@@ -507,6 +510,8 @@ class LTX2DenoisingStage(PipelineStage):
                         audio_hidden_states=audio_latents,
                         audio_encoder_hidden_states=audio_context_p,
                         audio_timestep=audio_timestep,
+                        video_sigma=sigma_batch,
+                        audio_sigma=sigma_batch,
                         video_position_offset_sec=video_position_offset_sec,
                     )
                 if isinstance(pos_outputs, tuple):
@@ -534,6 +539,8 @@ class LTX2DenoisingStage(PipelineStage):
                                 audio_hidden_states=audio_latents,
                                 audio_encoder_hidden_states=audio_context_n,
                                 audio_timestep=audio_timestep,
+                                video_sigma=sigma_batch,
+                                audio_sigma=sigma_batch,
                                 video_position_offset_sec=video_position_offset_sec,
                             )
                         if isinstance(neg_outputs, tuple):
@@ -553,6 +560,8 @@ class LTX2DenoisingStage(PipelineStage):
                                 audio_hidden_states=audio_latents,
                                 audio_encoder_hidden_states=audio_context_p,
                                 audio_timestep=audio_timestep,
+                                video_sigma=sigma_batch,
+                                audio_sigma=sigma_batch,
                                 skip_cross_modal_attn=True,
                                 video_position_offset_sec=video_position_offset_sec,
                             )
@@ -573,6 +582,8 @@ class LTX2DenoisingStage(PipelineStage):
                                 audio_hidden_states=audio_latents,
                                 audio_encoder_hidden_states=audio_context_p,
                                 audio_timestep=audio_timestep,
+                                video_sigma=sigma_batch,
+                                audio_sigma=sigma_batch,
                                 skip_video_self_attn_blocks=(stg_blocks_video if do_stg_video else None),
                                 skip_audio_self_attn_blocks=(stg_blocks_audio if do_stg_audio else None),
                                 video_position_offset_sec=video_position_offset_sec,

--- a/fastvideo/registry.py
+++ b/fastvideo/registry.py
@@ -230,6 +230,9 @@ def _register_configs() -> None:
         workload_types=(WorkloadType.T2V, ),
         hf_model_paths=[
             "FastVideo/LTX2-Distilled-Diffusers",
+            # LTX-2.3 distilled aliases share the distilled pipeline/preset.
+            "FastVideo/LTX2.3-Distilled-Diffusers",
+            "FastVideo/LTX-2.3-Distilled-Diffusers",
         ],
         model_detectors=[
             lambda path: ("ltx2" in path.lower() or "ltx-2" in path.lower()) and "distilled" in path.lower(),
@@ -237,7 +240,30 @@ def _register_configs() -> None:
         model_family="ltx2",
         default_preset="ltx2_distilled",
     )
-    # LTX-2 (base)
+    # LTX-2.3 (base) — registered before the LTX-2.0 base entry so its more
+    # specific 2.3 detector wins. Uses the same pipeline config; the new
+    # arch flags are read from the checkpoint config.json.
+    register_configs(
+        sampling_param_cls=None,
+        pipeline_config_cls=LTX2T2VConfig,
+        workload_types=(WorkloadType.T2V, ),
+        hf_model_paths=[
+            "Lightricks/LTX-2.3",
+            "FastVideo/LTX2.3-base",
+            "FastVideo/LTX2.3-Diffusers",
+        ],
+        model_detectors=[
+            lambda path: (any(token in path.lower() for token in (
+                "lightricks/ltx-2.3",
+                "ltx2.3-base",
+                "ltx2.3-diffusers",
+                "ltx-2.3-diffusers",
+            )) and "distilled" not in path.lower()),
+        ],
+        model_family="ltx2",
+        default_preset="ltx2_3_base",
+    )
+    # LTX-2 (base) — excludes 2.3 so the dedicated 2.3 entry above wins.
     register_configs(
         sampling_param_cls=None,
         pipeline_config_cls=LTX2T2VConfig,
@@ -248,7 +274,8 @@ def _register_configs() -> None:
             "FastVideo/LTX2-Diffusers",
         ],
         model_detectors=[
-            lambda path: ("ltx2" in path.lower() or "ltx-2" in path.lower()) and "distilled" not in path.lower(),
+            lambda path: ("ltx2" in path.lower() or "ltx-2" in path.lower())
+            and "distilled" not in path.lower() and "2.3" not in path.lower(),
         ],
         model_family="ltx2",
         default_preset="ltx2_base",

--- a/fastvideo/tests/api/test_ltx2_param_mapping.py
+++ b/fastvideo/tests/api/test_ltx2_param_mapping.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for ``LTX2VideoArchConfig.param_names_mapping``.
+
+The ``to_gate_compress`` -> ``to_gate_logits`` rename is the LTX-2.3 gated
+attention loader rule.  It must only fire when ``apply_gated_attention=True``;
+otherwise it would silently retarget:
+
+- LTX-2.0 ``VIDEO_SPARSE_ATTN`` checkpoints, whose attention modules
+  legitimately carry a ``to_gate_compress`` VSA-QAT gate (a sibling of
+  ``attn_masked`` in ``fastvideo/models/dits/ltx2.py``).
+- LoRAs trained with the default ``lora_target_modules`` list (which
+  includes ``to_gate_compress``; see ``fastvideo/train/utils/lora.py:36``
+  and ``fastvideo/pipelines/lora_pipeline.py:171``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fastvideo.configs.models.dits.ltx2 import LTX2VideoArchConfig
+from fastvideo.models.loader.utils import get_param_names_mapping
+
+
+def _map(name: str, *, apply_gated_attention: bool) -> str:
+    """Run ``name`` through a fresh config's mapping function."""
+    cfg = LTX2VideoArchConfig(apply_gated_attention=apply_gated_attention)
+    mapper = get_param_names_mapping(cfg.param_names_mapping)
+    target, _, _ = mapper(name)
+    return target
+
+
+class TestLTX20ParamMappingDefault:
+    """``apply_gated_attention=False`` (LTX-2.0 default): ``to_gate_compress``
+    must pass through unmodified except for prefix normalization."""
+
+    @pytest.mark.parametrize("source", [
+        "transformer_blocks.0.attn1.to_gate_compress.weight",
+        "model.transformer_blocks.5.attn1.to_gate_compress.bias",
+        "diffusion_model.transformer_blocks.10.attn1.to_gate_compress.weight",
+        "model.diffusion_model.transformer_blocks.2.attn1.to_gate_compress.weight",
+    ])
+    def test_vsa_gate_weight_not_renamed(self, source):
+        target = _map(source, apply_gated_attention=False)
+        assert "to_gate_logits" not in target, (
+            f"LTX-2.0 VSA gate {source!r} was rewritten to {target!r}; "
+            "expected pass-through with only prefix normalization.")
+        assert ".to_gate_compress." in target, (
+            f"LTX-2.0 VSA gate {source!r} lost its identity in {target!r}.")
+
+    @pytest.mark.parametrize("source", [
+        "transformer_blocks.0.attn1.to_gate_compress.lora_A.weight",
+        "transformer_blocks.0.attn1.to_gate_compress.lora_B.weight",
+        "model.transformer_blocks.3.attn1.to_gate_compress.lora_A.weight",
+    ])
+    def test_default_lora_target_not_renamed(self, source):
+        """``to_gate_compress`` is in ``DEFAULT_LORA_TARGET_MODULES``, so LoRAs
+        trained with default targets ship these keys."""
+        target = _map(source, apply_gated_attention=False)
+        assert "to_gate_logits" not in target, (
+            f"Default-target LoRA key {source!r} was rewritten to {target!r}; "
+            "this would break every LTX-2.0 LoRA in the wild.")
+
+    def test_unrelated_param_still_prefix_stripped(self):
+        """Generic prefix-strip behavior is unchanged in LTX-2.0 mode."""
+        assert (_map("diffusion_model.transformer_blocks.0.attn1.to_q.weight",
+                     apply_gated_attention=False) ==
+                "model.transformer_blocks.0.attn1.to_q.weight")
+
+
+class TestLTX23ParamMappingGated:
+    """``apply_gated_attention=True`` (LTX-2.3): the gated-attention
+    ``to_gate_compress`` upstream key is renamed to ``to_gate_logits``."""
+
+    @pytest.mark.parametrize("source,expected", [
+        # No upstream prefix
+        ("transformer_blocks.0.attn1.to_gate_compress.weight",
+         "model.transformer_blocks.0.attn1.to_gate_logits.weight"),
+        # ``model.`` prefix
+        ("model.transformer_blocks.0.attn1.to_gate_compress.weight",
+         "model.transformer_blocks.0.attn1.to_gate_logits.weight"),
+        # ``diffusion_model.`` prefix
+        ("diffusion_model.transformer_blocks.0.attn1.to_gate_compress.weight",
+         "model.transformer_blocks.0.attn1.to_gate_logits.weight"),
+        # ``model.diffusion_model.`` prefix
+        ("model.diffusion_model.transformer_blocks.0.attn1.to_gate_compress.weight",
+         "model.transformer_blocks.0.attn1.to_gate_logits.weight"),
+    ])
+    def test_gate_rename_fires(self, source, expected):
+        assert _map(source, apply_gated_attention=True) == expected
+
+    def test_non_gate_param_still_prefix_stripped(self):
+        """Non-gate params still get the prefix-strip behavior."""
+        assert (_map("diffusion_model.transformer_blocks.0.attn1.to_q.weight",
+                     apply_gated_attention=True) ==
+                "model.transformer_blocks.0.attn1.to_q.weight")
+
+
+class TestParamMappingRuleOrdering:
+    """The gate rules must be inserted *before* the generic prefix-strip rules
+    so first-match-wins matching fires the rename first."""
+
+    def test_gate_rule_wins_over_prefix_strip_when_enabled(self):
+        cfg = LTX2VideoArchConfig(apply_gated_attention=True)
+        # The first key in the dict iteration order should be a gate rule
+        # (not a generic prefix-strip rule), so that ``transformer_blocks
+        # .0.attn1.to_gate_compress.weight`` is renamed rather than just
+        # prefix-normalized to ``model.transformer_blocks.0.attn1
+        # .to_gate_compress.weight``.
+        first_pattern = next(iter(cfg.param_names_mapping))
+        assert "to_gate_compress" in first_pattern, (
+            "gate rename rule must be inserted at the front of "
+            "param_names_mapping; got first pattern: "
+            f"{first_pattern!r}")


### PR DESCRIPTION
## Summary
Adds **LTX-2.3** transformer support on top of the existing LTX-2 implementation as a **config-gated extension** — every new field defaults off, so with defaults the model reproduces LTX-2.0 exactly.

### Changes
- **DiT 2.3 arch** (`models/dits/ltx2.py`, `configs/models/dits/ltx2.py`): per-head gated attention (`apply_gated_attention` → `to_gate_logits`, **distinct** from upstream's `to_gate_compress` VSA gate); cross-attention AdaLN (`cross_attention_adaln` → 6→9-row scale_shift table + prompt-side modulation, fed by a `sigma`/`prompt_timestep` path); STG block 28 (`stg_block_idx`) + per-sample STG mask; `StageAwareRMSNorm` refine fast-path (defensive QuACK import → torch rms_norm fallback).
- **Gemma text connector** (`models/encoders/gemma.py`, config): `caption_proj_before_connector`, gated connector, per-modality feature extractor.
- **Sigma threading** (`models/dits/ltx2.py` forward + `pipelines/basic/ltx2/stages/ltx2_denoising.py`): `video_sigma`/`audio_sigma` populate `Modality.sigma` to drive the prompt AdaLN. No-op for 2.0 (`sigma` unused when `prompt_adaln is None`).
- **VAE decoder** (`models/vaes/ltx2vae.py`, +8 lines): apply the existing `compress_all` channel-multiplier scheme to `compress_space`/`compress_time` too (the 2.3 base VAE grows decoder channels 128→1024 via these). No-op when `multiplier=1` (2.0).
- **Registration** (`presets.py`, `registry.py`): `LTX2_3_BASE` preset (30 steps, CFG 3.0 + negative prompt, STG [28]) + 2.3 model entry + distilled detector aliases.

## Backward compatibility
Every 2.3 path is gated by a config flag (default off) or no-ops for 2.0 (sigma/VAE multipliers). Existing LTX2 tests pass on this branch.

## Test plan — what IS validated
- [x] py_compile + import all touched modules
- [x] 35 existing LTX2 tests pass (LTX-2.0 unaffected): `test_ltx2_stage_overrides` (12), `test_ltx2_continuation` (17), `test_nvfp4_ltx2_wiring` (6)
- [x] **E2E — single-GPU, eager**: generates coherent LTX-2.3 base t2v (832×1280, 30 steps, CFG 3, `num_gpus=1`, `enable_torch_compile=False`), e2e ≈ 103s, output matches prompt

## NOT yet validated (reviewer attention)
- [ ] **Sequence-parallel / multi-GPU**: this PR keeps upstream's `original_seq_len` SP attention-mask path and does **not** port internal's diverged scheme (`create_attention_mask_for_padding`, `skip_*_self_attn_blocks` lists). The new gated-attn / cross-attn-AdaLN / STG-mask paths are **untested under SP** — needs a multi-GPU run.
- [ ] **torch.compile (`fullgraph=True`)**: compile-enable showed no *setup-time* graph break, but a full warmup+measured compiled run was not completed — graph-break behavior of the new 2.3 paths is unverified.
- [ ] Functional 2.3 generation against the official 2.3 weights in CI.

## Review notes
1. `to_gate_logits` (2.3 per-head gate on `x`) is **distinct** from `to_gate_compress` (VSA gate on `context`) — kept separate, not cross-wired.
2. STG: the hard `if not skip_video_self_attn` branch became an always-compute multiply-mask (skip→×0 equivalent), so `attn1` always runs on the perturbed pass; confirm acceptable.
3. VAE `compress_space`/`compress_time` now mirror the existing `compress_all` channel-multiplier convention.

Excludes: i2v conditioning + LoRA fix + NVFP4 per-stage profile (already upstream), training/distillation, demo UI. Audio BWE is the companion PR (#1398).