### PR TITLE
[feat] LTX-2.3 audio: BWE vocoder path

### DIFF
--- a/fastvideo/models/audio/ltx2_audio_vae.py
+++ b/fastvideo/models/audio/ltx2_audio_vae.py
@@ -1534,14 +1534,100 @@ class Vocoder(nn.Module):
 # =============================================================================
 
 
+def _build_stft_basis(filter_length: int,
+                      win_length: int) -> torch.Tensor:
+    """Hann-windowed FFT basis used by ``_STFTFn`` as a Conv1d kernel.
+
+    Returns a ``(2*(filter_length//2 + 1), 1, filter_length)`` float32 tensor
+    that ``F.conv1d`` projects a 1-D waveform onto, producing real (rows
+    ``[:n_freqs]``) and imaginary (rows ``[n_freqs:]``) STFT coefficients.
+
+    Initialising the buffer deterministically here, rather than relying on a
+    ``register_buffer(torch.zeros(...))`` placeholder, makes the BWE mel
+    front-end safe against ``VocoderLoader``'s ``strict=False`` load: a
+    checkpoint that omits ``forward_basis`` no longer leaves the buffer at
+    zero (which would silently feed a constant-zero magnitude into BWE).
+    """
+    n_freqs = filter_length // 2 + 1
+    # FFT matrix: row k is e^{-2*pi*j*k*n / filter_length} for n in [0, filter_length)
+    fft_matrix = torch.fft.fft(torch.eye(filter_length, dtype=torch.float32))
+    fft_basis = fft_matrix[:n_freqs]  # (n_freqs, filter_length) complex
+    window = torch.hann_window(win_length,
+                               periodic=True,
+                               dtype=torch.float32)
+    if win_length < filter_length:
+        pad_left = (filter_length - win_length) // 2
+        pad_right = filter_length - win_length - pad_left
+        window = F.pad(window, (pad_left, pad_right))
+    elif win_length > filter_length:
+        window = window[:filter_length]
+    windowed_basis = fft_basis * window.unsqueeze(0)
+    forward_basis = torch.cat(
+        [windowed_basis.real, windowed_basis.imag],
+        dim=0,
+    ).unsqueeze(1).contiguous()
+    return forward_basis
+
+
+def _build_mel_basis(sampling_rate: int,
+                     n_fft: int,
+                     n_mel_channels: int,
+                     fmin: float = 0.0,
+                     fmax: float | None = None) -> torch.Tensor:
+    """Slaney-normalised triangular mel filterbank (librosa-compatible defaults).
+
+    Returns a ``(n_mel_channels, n_fft // 2 + 1)`` float32 tensor of weights
+    that maps an STFT magnitude spectrogram to mel bands.  Like
+    ``_build_stft_basis``, this deterministic initialisation makes the
+    ``mel_basis`` buffer safe under ``VocoderLoader``'s ``strict=False`` load.
+    """
+    if fmax is None:
+        fmax = sampling_rate / 2.0
+    n_freqs = n_fft // 2 + 1
+    fft_freqs = torch.linspace(0.0,
+                               sampling_rate / 2.0,
+                               n_freqs,
+                               dtype=torch.float32)
+
+    def _hz_to_mel(hz: float) -> float:
+        return 2595.0 * math.log10(1.0 + hz / 700.0)
+
+    def _mel_to_hz(mel: torch.Tensor) -> torch.Tensor:
+        return 700.0 * (torch.pow(torch.tensor(10.0), mel / 2595.0) - 1.0)
+
+    mel_lo = _hz_to_mel(fmin)
+    mel_hi = _hz_to_mel(fmax)
+    mel_edges_hz = _mel_to_hz(
+        torch.linspace(mel_lo,
+                       mel_hi,
+                       n_mel_channels + 2,
+                       dtype=torch.float32))
+
+    weights = torch.zeros(n_mel_channels, n_freqs, dtype=torch.float32)
+    for i in range(n_mel_channels):
+        f_lo = mel_edges_hz[i]
+        f_ctr = mel_edges_hz[i + 1]
+        f_hi = mel_edges_hz[i + 2]
+        lower = (fft_freqs - f_lo) / (f_ctr - f_lo)
+        upper = (f_hi - fft_freqs) / (f_hi - f_ctr)
+        weights[i] = torch.clamp(torch.minimum(lower, upper), min=0.0)
+    enorm = 2.0 / (mel_edges_hz[2:n_mel_channels + 2] -
+                   mel_edges_hz[:n_mel_channels])
+    return weights * enorm.unsqueeze(1)
+
+
 class _STFTFn(nn.Module):
     def __init__(self, filter_length: int, hop_length: int, win_length: int) -> None:
         super().__init__()
         self.hop_length = hop_length
         self.win_length = win_length
-        n_freqs = filter_length // 2 + 1
-        self.register_buffer("forward_basis", torch.zeros(n_freqs * 2, 1, filter_length))
-        self.register_buffer("inverse_basis", torch.zeros(n_freqs * 2, 1, filter_length))
+        forward_basis = _build_stft_basis(filter_length, win_length)
+        # ``inverse_basis`` is kept for state-dict compatibility but is
+        # currently unused at runtime.  Initialise it to the same windowed
+        # FFT basis so a checkpoint that omits it produces sane fallback
+        # behaviour rather than a silent zero buffer.
+        self.register_buffer("forward_basis", forward_basis)
+        self.register_buffer("inverse_basis", forward_basis.clone())
 
     def forward(self, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         if y.dim() == 2:
@@ -1563,11 +1649,16 @@ class MelSTFT(nn.Module):
         hop_length: int,
         win_length: int,
         n_mel_channels: int,
+        sampling_rate: int,
     ) -> None:
         super().__init__()
         self.stft_fn = _STFTFn(filter_length, hop_length, win_length)
-        n_freqs = filter_length // 2 + 1
-        self.register_buffer("mel_basis", torch.zeros(n_mel_channels, n_freqs))
+        # Deterministic Slaney-normalised mel filterbank — see ``_build_mel_basis``
+        # for why this replaces the prior ``torch.zeros(...)`` placeholder.
+        self.register_buffer(
+            "mel_basis",
+            _build_mel_basis(sampling_rate, filter_length, n_mel_channels),
+        )
 
     def mel_spectrogram(
         self, y: torch.Tensor
@@ -1785,6 +1876,7 @@ class VocoderConfigurator:
                 hop_length=bwe_cfg.get("hop_length", 80),
                 win_length=bwe_cfg.get("n_fft", 512),
                 n_mel_channels=bwe_cfg.get("num_mels", 64),
+                sampling_rate=bwe_cfg.get("input_sampling_rate", 16000),
             )
             return VocoderWithBWE(
                 vocoder=base_vocoder,

--- a/fastvideo/models/audio/ltx2_audio_vae.py
+++ b/fastvideo/models/audio/ltx2_audio_vae.py
@@ -475,6 +475,329 @@ class ResBlock2(nn.Module):
 
 
 # =============================================================================
+# BigVGAN v2 / BWE helpers
+# =============================================================================
+
+
+def get_padding(kernel_size: int, dilation: int = 1) -> int:
+    return int((kernel_size * dilation - dilation) / 2)
+
+
+def _sinc(x: torch.Tensor) -> torch.Tensor:
+    return torch.where(
+        x == 0,
+        torch.tensor(1.0, device=x.device, dtype=x.dtype),
+        torch.sin(math.pi * x) / math.pi / x,
+    )
+
+
+def kaiser_sinc_filter1d(
+    cutoff: float, half_width: float, kernel_size: int
+) -> torch.Tensor:
+    even = kernel_size % 2 == 0
+    half_size = kernel_size // 2
+    delta_f = 4 * half_width
+    amplitude = 2.285 * (half_size - 1) * math.pi * delta_f + 7.95
+    if amplitude > 50.0:
+        beta = 0.1102 * (amplitude - 8.7)
+    elif amplitude >= 21.0:
+        beta = 0.5842 * (amplitude - 21) ** 0.4 + 0.07886 * (
+            amplitude - 21.0
+        )
+    else:
+        beta = 0.0
+    window = torch.kaiser_window(kernel_size, beta=beta, periodic=False)
+    time = (
+        torch.arange(-half_size, half_size) + 0.5
+        if even
+        else torch.arange(kernel_size) - half_size
+    )
+    if cutoff == 0:
+        filter_ = torch.zeros_like(time)
+    else:
+        filter_ = 2 * cutoff * window * _sinc(2 * cutoff * time)
+        filter_ /= filter_.sum()
+    return filter_.view(1, 1, kernel_size)
+
+
+class LowPassFilter1d(nn.Module):
+    def __init__(
+        self,
+        cutoff: float = 0.5,
+        half_width: float = 0.6,
+        stride: int = 1,
+        padding: bool = True,
+        padding_mode: str = "replicate",
+        kernel_size: int = 12,
+    ) -> None:
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.even = kernel_size % 2 == 0
+        self.pad_left = kernel_size // 2 - int(self.even)
+        self.pad_right = kernel_size // 2
+        self.stride = stride
+        self.padding = padding
+        self.padding_mode = padding_mode
+        self.register_buffer(
+            "filter",
+            kaiser_sinc_filter1d(cutoff, half_width, kernel_size),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        _, n_channels, _ = x.shape
+        if self.padding:
+            x = F.pad(x, (self.pad_left, self.pad_right), mode=self.padding_mode)
+        return F.conv1d(
+            x,
+            self.filter.expand(n_channels, -1, -1),
+            stride=self.stride,
+            groups=n_channels,
+        )
+
+
+class UpSample1d(nn.Module):
+    def __init__(
+        self,
+        ratio: int = 2,
+        kernel_size: int | None = None,
+        persistent: bool = True,
+        window_type: str = "kaiser",
+    ) -> None:
+        super().__init__()
+        self.ratio = ratio
+        self.stride = ratio
+
+        if window_type == "hann":
+            rolloff = 0.99
+            lowpass_filter_width = 6
+            width = math.ceil(lowpass_filter_width / rolloff)
+            self.kernel_size = 2 * width * ratio + 1
+            self.pad = width
+            self.pad_left = 2 * width * ratio
+            self.pad_right = self.kernel_size - ratio
+            time_axis = (torch.arange(self.kernel_size) / ratio - width) * rolloff
+            time_clamped = time_axis.clamp(
+                -lowpass_filter_width, lowpass_filter_width
+            )
+            window = (
+                torch.cos(time_clamped * math.pi / lowpass_filter_width / 2) ** 2
+            )
+            sinc_filter = (
+                torch.sinc(time_axis) * window * rolloff / ratio
+            ).view(1, 1, -1)
+        else:
+            self.kernel_size = (
+                int(6 * ratio // 2) * 2 if kernel_size is None else kernel_size
+            )
+            self.pad = self.kernel_size // ratio - 1
+            self.pad_left = self.pad * self.stride + (
+                self.kernel_size - self.stride
+            ) // 2
+            self.pad_right = self.pad * self.stride + (
+                self.kernel_size - self.stride + 1
+            ) // 2
+            sinc_filter = kaiser_sinc_filter1d(
+                cutoff=0.5 / ratio,
+                half_width=0.6 / ratio,
+                kernel_size=self.kernel_size,
+            )
+
+        self.register_buffer("filter", sinc_filter, persistent=persistent)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        _, n_channels, _ = x.shape
+        x = F.pad(x, (self.pad, self.pad), mode="replicate")
+        filt = self.filter.to(dtype=x.dtype, device=x.device).expand(
+            n_channels, -1, -1
+        )
+        x = self.ratio * F.conv_transpose1d(
+            x, filt, stride=self.stride, groups=n_channels
+        )
+        return x[..., self.pad_left : -self.pad_right]
+
+
+class DownSample1d(nn.Module):
+    def __init__(self, ratio: int = 2, kernel_size: int | None = None) -> None:
+        super().__init__()
+        self.ratio = ratio
+        self.kernel_size = (
+            int(6 * ratio // 2) * 2 if kernel_size is None else kernel_size
+        )
+        self.lowpass = LowPassFilter1d(
+            cutoff=0.5 / ratio,
+            half_width=0.6 / ratio,
+            stride=ratio,
+            kernel_size=self.kernel_size,
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.lowpass(x)
+
+
+class Activation1d(nn.Module):
+    def __init__(
+        self,
+        activation: nn.Module,
+        up_ratio: int = 2,
+        down_ratio: int = 2,
+        up_kernel_size: int = 12,
+        down_kernel_size: int = 12,
+    ) -> None:
+        super().__init__()
+        self.act = activation
+        self.upsample = UpSample1d(up_ratio, up_kernel_size)
+        self.downsample = DownSample1d(down_ratio, down_kernel_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.upsample(x)
+        x = self.act(x)
+        return self.downsample(x)
+
+
+class Snake(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        alpha: float = 1.0,
+        alpha_trainable: bool = True,
+        alpha_logscale: bool = True,
+    ) -> None:
+        super().__init__()
+        self.alpha_logscale = alpha_logscale
+        self.alpha = nn.Parameter(
+            torch.zeros(in_features)
+            if alpha_logscale
+            else torch.ones(in_features) * alpha
+        )
+        self.alpha.requires_grad = alpha_trainable
+        self.eps = 1e-9
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        alpha = self.alpha.unsqueeze(0).unsqueeze(-1)
+        if self.alpha_logscale:
+            alpha = torch.exp(alpha)
+        return x + (1.0 / (alpha + self.eps)) * torch.sin(x * alpha).pow(2)
+
+
+class SnakeBeta(nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        alpha: float = 1.0,
+        alpha_trainable: bool = True,
+        alpha_logscale: bool = True,
+    ) -> None:
+        super().__init__()
+        self.alpha_logscale = alpha_logscale
+        self.alpha = nn.Parameter(
+            torch.zeros(in_features)
+            if alpha_logscale
+            else torch.ones(in_features) * alpha
+        )
+        self.alpha.requires_grad = alpha_trainable
+        self.beta = nn.Parameter(
+            torch.zeros(in_features)
+            if alpha_logscale
+            else torch.ones(in_features) * alpha
+        )
+        self.beta.requires_grad = alpha_trainable
+        self.eps = 1e-9
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        alpha = self.alpha.unsqueeze(0).unsqueeze(-1)
+        beta = self.beta.unsqueeze(0).unsqueeze(-1)
+        if self.alpha_logscale:
+            alpha = torch.exp(alpha)
+            beta = torch.exp(beta)
+        return x + (1.0 / (beta + self.eps)) * torch.sin(x * alpha).pow(2)
+
+
+class AMPBlock1(nn.Module):
+    def __init__(
+        self,
+        channels: int,
+        kernel_size: int = 3,
+        dilation: tuple[int, int, int] = (1, 3, 5),
+        activation: str = "snake",
+    ) -> None:
+        super().__init__()
+        act_cls = SnakeBeta if activation == "snakebeta" else Snake
+        self.convs1 = nn.ModuleList(
+            [
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    1,
+                    dilation=dilation[0],
+                    padding=get_padding(kernel_size, dilation[0]),
+                ),
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    1,
+                    dilation=dilation[1],
+                    padding=get_padding(kernel_size, dilation[1]),
+                ),
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    1,
+                    dilation=dilation[2],
+                    padding=get_padding(kernel_size, dilation[2]),
+                ),
+            ]
+        )
+        self.convs2 = nn.ModuleList(
+            [
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    1,
+                    dilation=1,
+                    padding=get_padding(kernel_size, 1),
+                ),
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    1,
+                    dilation=1,
+                    padding=get_padding(kernel_size, 1),
+                ),
+                nn.Conv1d(
+                    channels,
+                    channels,
+                    kernel_size,
+                    1,
+                    dilation=1,
+                    padding=get_padding(kernel_size, 1),
+                ),
+            ]
+        )
+        self.acts1 = nn.ModuleList(
+            [Activation1d(act_cls(channels)) for _ in range(len(self.convs1))]
+        )
+        self.acts2 = nn.ModuleList(
+            [Activation1d(act_cls(channels)) for _ in range(len(self.convs2))]
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for c1, c2, a1, a2 in zip(
+            self.convs1, self.convs2, self.acts1, self.acts2, strict=True
+        ):
+            xt = a1(x)
+            xt = c1(xt)
+            xt = a2(xt)
+            xt = c2(xt)
+            x = x + xt
+        return x
+
+
+# =============================================================================
 # Downsampling
 # =============================================================================
 
@@ -1096,6 +1419,10 @@ class Vocoder(nn.Module):
         stereo: bool = True,
         resblock: str = "1",
         output_sample_rate: int = 24000,
+        activation: str = "snake",
+        use_tanh_at_final: bool = True,
+        apply_final_activation: bool = True,
+        use_bias_at_final: bool = True,
     ):
         super().__init__()
 
@@ -1112,9 +1439,17 @@ class Vocoder(nn.Module):
         self.output_sample_rate = output_sample_rate
         self.num_kernels = len(resblock_kernel_sizes)
         self.num_upsamples = len(upsample_rates)
+        self.use_tanh_at_final = use_tanh_at_final
+        self.apply_final_activation = apply_final_activation
+        self.is_amp = resblock == "AMP1"
         in_channels = 128 if stereo else 64
         self.conv_pre = nn.Conv1d(in_channels, upsample_initial_channel, 7, 1, padding=3)
-        resblock_class = ResBlock1 if resblock == "1" else ResBlock2
+        if resblock == "1":
+            resblock_class = ResBlock1
+        elif resblock == "AMP1":
+            resblock_class = AMPBlock1
+        else:
+            resblock_class = ResBlock2
 
         self.ups = nn.ModuleList()
         for i, (stride, kernel_size) in enumerate(zip(upsample_rates, upsample_kernel_sizes, strict=True)):
@@ -1132,11 +1467,27 @@ class Vocoder(nn.Module):
         for i, _ in enumerate(self.ups):
             ch = upsample_initial_channel // (2 ** (i + 1))
             for kernel_size, dilations in zip(resblock_kernel_sizes, resblock_dilation_sizes, strict=True):
-                self.resblocks.append(resblock_class(ch, kernel_size, dilations))
+                if self.is_amp:
+                    self.resblocks.append(
+                        resblock_class(ch, kernel_size, dilations, activation=activation)
+                    )
+                else:
+                    self.resblocks.append(resblock_class(ch, kernel_size, dilations))
 
         out_channels = 2 if stereo else 1
         final_channels = upsample_initial_channel // (2**self.num_upsamples)
-        self.conv_post = nn.Conv1d(final_channels, out_channels, 7, 1, padding=3)
+        if self.is_amp:
+            self.act_post: nn.Module = Activation1d(SnakeBeta(final_channels))
+        else:
+            self.act_post = nn.LeakyReLU()
+        self.conv_post = nn.Conv1d(
+            final_channels,
+            out_channels,
+            7,
+            1,
+            padding=3,
+            bias=use_bias_at_final,
+        )
 
         self.upsample_factor = math.prod(layer.stride[0] for layer in self.ups)
 
@@ -1157,7 +1508,8 @@ class Vocoder(nn.Module):
         x = self.conv_pre(x)
 
         for i in range(self.num_upsamples):
-            x = F.leaky_relu(x, LRELU_SLOPE)
+            if not self.is_amp:
+                x = F.leaky_relu(x, LRELU_SLOPE)
             x = self.ups[i](x)
             start = i * self.num_kernels
             end = start + self.num_kernels
@@ -1170,8 +1522,122 @@ class Vocoder(nn.Module):
 
             x = block_outputs.mean(dim=0)
 
-        x = self.conv_post(F.leaky_relu(x))
-        return torch.tanh(x)
+        x = self.act_post(x)
+        x = self.conv_post(x)
+        if self.apply_final_activation:
+            x = torch.tanh(x) if self.use_tanh_at_final else torch.clamp(x, -1, 1)
+        return x
+
+
+# =============================================================================
+# BWE STFT / MelSTFT / VocoderWithBWE
+# =============================================================================
+
+
+class _STFTFn(nn.Module):
+    def __init__(self, filter_length: int, hop_length: int, win_length: int) -> None:
+        super().__init__()
+        self.hop_length = hop_length
+        self.win_length = win_length
+        n_freqs = filter_length // 2 + 1
+        self.register_buffer("forward_basis", torch.zeros(n_freqs * 2, 1, filter_length))
+        self.register_buffer("inverse_basis", torch.zeros(n_freqs * 2, 1, filter_length))
+
+    def forward(self, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if y.dim() == 2:
+            y = y.unsqueeze(1)
+        left_pad = max(0, self.win_length - self.hop_length)
+        y = F.pad(y, (left_pad, 0))
+        spec = F.conv1d(y, self.forward_basis, stride=self.hop_length, padding=0)
+        n_freqs = spec.shape[1] // 2
+        real, imag = spec[:, :n_freqs], spec[:, n_freqs:]
+        magnitude = torch.sqrt(real**2 + imag**2)
+        phase = torch.atan2(imag.float(), real.float()).to(real.dtype)
+        return magnitude, phase
+
+
+class MelSTFT(nn.Module):
+    def __init__(
+        self,
+        filter_length: int,
+        hop_length: int,
+        win_length: int,
+        n_mel_channels: int,
+    ) -> None:
+        super().__init__()
+        self.stft_fn = _STFTFn(filter_length, hop_length, win_length)
+        n_freqs = filter_length // 2 + 1
+        self.register_buffer("mel_basis", torch.zeros(n_mel_channels, n_freqs))
+
+    def mel_spectrogram(
+        self, y: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        magnitude, phase = self.stft_fn(y)
+        energy = torch.norm(magnitude, dim=1)
+        mel = torch.matmul(self.mel_basis.to(magnitude.dtype), magnitude)
+        log_mel = torch.log(torch.clamp(mel, min=1e-5))
+        return log_mel, magnitude, phase, energy
+
+
+class VocoderWithBWE(nn.Module):
+    def __init__(
+        self,
+        vocoder: Vocoder,
+        bwe_generator: Vocoder,
+        mel_stft: MelSTFT,
+        input_sampling_rate: int,
+        output_sampling_rate: int,
+        hop_length: int,
+    ) -> None:
+        super().__init__()
+        self.vocoder = vocoder
+        self.bwe_generator = bwe_generator
+        self.mel_stft = mel_stft
+        self.input_sampling_rate = input_sampling_rate
+        self.output_sampling_rate = output_sampling_rate
+        self.hop_length = hop_length
+        with torch.device("cpu"):
+            self.resampler = UpSample1d(
+                ratio=output_sampling_rate // input_sampling_rate,
+                persistent=False,
+                window_type="hann",
+            )
+
+    @property
+    def conv_pre(self) -> nn.Conv1d:
+        return self.vocoder.conv_pre
+
+    @property
+    def conv_post(self) -> nn.Conv1d:
+        return self.vocoder.conv_post
+
+    def _compute_mel(self, audio: torch.Tensor) -> torch.Tensor:
+        batch, n_channels, _ = audio.shape
+        flat = audio.reshape(batch * n_channels, -1)
+        mel, _, _, _ = self.mel_stft.mel_spectrogram(flat)
+        return mel.reshape(batch, n_channels, mel.shape[1], mel.shape[2])
+
+    def forward(self, mel_spec: torch.Tensor) -> torch.Tensor:
+        x = self.vocoder(mel_spec)
+        _, _, length_low_rate = x.shape
+        output_length = (
+            length_low_rate
+            * self.output_sampling_rate
+            // self.input_sampling_rate
+        )
+
+        remainder = length_low_rate % self.hop_length
+        if remainder != 0:
+            x = F.pad(x, (0, self.hop_length - remainder))
+
+        mel = self._compute_mel(x)
+        mel_for_bwe = mel.transpose(2, 3)
+        residual = self.bwe_generator(mel_for_bwe)
+        skip = self.resampler(x)
+        assert residual.shape == skip.shape, (
+            f"residual {residual.shape} != skip {skip.shape}"
+        )
+        return torch.clamp(residual + skip, -1, 1)[..., :output_length]
 
 
 # =============================================================================
@@ -1264,8 +1730,71 @@ class VocoderConfigurator:
     """Factory for Vocoder from checkpoint config."""
 
     @classmethod
-    def from_config(cls, config: dict) -> Vocoder:
+    def from_config(cls, config: dict) -> nn.Module:
         vocoder_cfg = config.get("vocoder", {})
+        if "bwe" in vocoder_cfg:
+            nested_vocoder_cfg = vocoder_cfg.get("vocoder", {})
+            bwe_cfg = vocoder_cfg.get("bwe", {})
+            base_vocoder = Vocoder(
+                resblock_kernel_sizes=nested_vocoder_cfg.get(
+                    "resblock_kernel_sizes", [3, 7, 11]),
+                upsample_rates=nested_vocoder_cfg.get(
+                    "upsample_rates", [6, 5, 2, 2, 2]),
+                upsample_kernel_sizes=nested_vocoder_cfg.get(
+                    "upsample_kernel_sizes", [16, 15, 8, 4, 4]),
+                resblock_dilation_sizes=nested_vocoder_cfg.get(
+                    "resblock_dilation_sizes", [[1, 3, 5], [1, 3, 5], [1, 3, 5]]),
+                upsample_initial_channel=nested_vocoder_cfg.get(
+                    "upsample_initial_channel", 1024),
+                stereo=nested_vocoder_cfg.get("stereo", True),
+                resblock=nested_vocoder_cfg.get("resblock", "AMP1"),
+                output_sample_rate=bwe_cfg.get(
+                    "input_sampling_rate",
+                    nested_vocoder_cfg.get("output_sampling_rate", 24000),
+                ),
+                activation=nested_vocoder_cfg.get("activation", "snakebeta"),
+                use_tanh_at_final=nested_vocoder_cfg.get(
+                    "use_tanh_at_final", True),
+                apply_final_activation=nested_vocoder_cfg.get(
+                    "apply_final_activation", True),
+                use_bias_at_final=nested_vocoder_cfg.get(
+                    "use_bias_at_final", True),
+            )
+            bwe_generator = Vocoder(
+                resblock_kernel_sizes=bwe_cfg.get(
+                    "resblock_kernel_sizes", [3, 7, 11]),
+                upsample_rates=bwe_cfg.get(
+                    "upsample_rates", [6, 5, 2, 2, 2]),
+                upsample_kernel_sizes=bwe_cfg.get(
+                    "upsample_kernel_sizes", [16, 15, 8, 4, 4]),
+                resblock_dilation_sizes=bwe_cfg.get(
+                    "resblock_dilation_sizes", [[1, 3, 5], [1, 3, 5], [1, 3, 5]]),
+                upsample_initial_channel=bwe_cfg.get(
+                    "upsample_initial_channel", 1024),
+                stereo=bwe_cfg.get("stereo", True),
+                resblock=bwe_cfg.get("resblock", "AMP1"),
+                output_sample_rate=bwe_cfg.get("output_sampling_rate", 24000),
+                activation=bwe_cfg.get("activation", "snakebeta"),
+                use_tanh_at_final=bwe_cfg.get("use_tanh_at_final", True),
+                apply_final_activation=bwe_cfg.get(
+                    "apply_final_activation", False),
+                use_bias_at_final=bwe_cfg.get("use_bias_at_final", True),
+            )
+            mel_stft = MelSTFT(
+                filter_length=bwe_cfg.get("n_fft", 512),
+                hop_length=bwe_cfg.get("hop_length", 80),
+                win_length=bwe_cfg.get("n_fft", 512),
+                n_mel_channels=bwe_cfg.get("num_mels", 64),
+            )
+            return VocoderWithBWE(
+                vocoder=base_vocoder,
+                bwe_generator=bwe_generator,
+                mel_stft=mel_stft,
+                input_sampling_rate=bwe_cfg.get("input_sampling_rate", 16000),
+                output_sampling_rate=bwe_cfg.get("output_sampling_rate", 48000),
+                hop_length=bwe_cfg.get("hop_length", 80),
+            )
+
         return Vocoder(
             resblock_kernel_sizes=vocoder_cfg.get("resblock_kernel_sizes", [3, 7, 11]),
             upsample_rates=vocoder_cfg.get("upsample_rates", [6, 5, 2, 2, 2]),
@@ -1275,6 +1804,10 @@ class VocoderConfigurator:
             stereo=vocoder_cfg.get("stereo", True),
             resblock=vocoder_cfg.get("resblock", "1"),
             output_sample_rate=vocoder_cfg.get("output_sample_rate", 24000),
+            activation=vocoder_cfg.get("activation", "snake"),
+            use_tanh_at_final=vocoder_cfg.get("use_tanh_at_final", True),
+            apply_final_activation=vocoder_cfg.get("apply_final_activation", True),
+            use_bias_at_final=vocoder_cfg.get("use_bias_at_final", True),
         )
 
 

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_audio_decoding.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_audio_decoding.py
@@ -9,8 +9,6 @@ import os
 
 import torch
 
-from fastvideo.models.dits.ltx2 import DEFAULT_LTX2_VOCODER_OUTPUT_SAMPLE_RATE
-
 from fastvideo.distributed import get_local_torch_device
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
@@ -20,6 +18,19 @@ from fastvideo.pipelines.stages.validators import StageValidators as V
 from fastvideo.pipelines.stages.validators import VerificationResult
 
 logger = init_logger(__name__)
+
+
+def _resolve_audio_sample_rate(vocoder) -> int:
+    model = getattr(vocoder, "model", vocoder)
+    for attr in ("output_sampling_rate", "output_sample_rate"):
+        if hasattr(model, attr):
+            return int(getattr(model, attr))
+    nested_vocoder = getattr(model, "vocoder", None)
+    if nested_vocoder is not None:
+        for attr in ("output_sampling_rate", "output_sample_rate"):
+            if hasattr(nested_vocoder, attr):
+                return int(getattr(nested_vocoder, attr))
+    return 24000
 
 
 class LTX2AudioDecodingStage(PipelineStage):
@@ -55,7 +66,7 @@ class LTX2AudioDecodingStage(PipelineStage):
 
         # Move to CPU for pickling across process boundary
         batch.extra["audio"] = audio_wave.cpu()
-        batch.extra["audio_sample_rate"] = DEFAULT_LTX2_VOCODER_OUTPUT_SAMPLE_RATE
+        batch.extra["audio_sample_rate"] = _resolve_audio_sample_rate(self.vocoder)
         return batch
 
     def verify_input(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> VerificationResult:

--- a/fastvideo/tests/audio/test_ltx2_bwe.py
+++ b/fastvideo/tests/audio/test_ltx2_bwe.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the LTX-2 BWE mel front-end.
+
+Targets Gob's S1 finding on #1398: ``_STFTFn.forward_basis`` and
+``MelSTFT.mel_basis`` were registered as zeros and used immediately by
+``F.conv1d`` / ``torch.matmul``.  Because ``VocoderLoader`` loads with
+``strict=False``, a converted checkpoint that omits these deterministic
+signal-processing buffers does not raise — instead BWE silently sees an
+all-zero magnitude spectrogram and a constant log-mel.  These tests pin
+the deterministic initialisation that fixes that.
+
+CPU-only: no checkpoint weights or GPU kernels are needed.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from fastvideo.models.audio.ltx2_audio_vae import (
+    MelSTFT,
+    _STFTFn,
+    _build_mel_basis,
+    _build_stft_basis,
+)
+
+
+_FILTER_LENGTH = 512
+_HOP_LENGTH = 80
+_WIN_LENGTH = 512
+_N_MELS = 64
+_SAMPLING_RATE = 16000
+
+
+class TestSTFTBasisDeterministic:
+    """``_STFTFn`` no longer leaves ``forward_basis`` as zeros."""
+
+    def test_forward_basis_is_not_zero(self):
+        stft = _STFTFn(_FILTER_LENGTH, _HOP_LENGTH, _WIN_LENGTH)
+        assert torch.any(stft.forward_basis != 0), (
+            "forward_basis is all-zero — the BWE STFT will silently produce "
+            "zero magnitudes (regression of #1398's S1 bug).")
+
+    def test_forward_basis_shape(self):
+        stft = _STFTFn(_FILTER_LENGTH, _HOP_LENGTH, _WIN_LENGTH)
+        n_freqs = _FILTER_LENGTH // 2 + 1
+        assert stft.forward_basis.shape == (2 * n_freqs, 1, _FILTER_LENGTH)
+
+    def test_forward_produces_nonzero_magnitude(self):
+        """A non-trivial waveform must yield a non-zero magnitude spectrum."""
+        stft = _STFTFn(_FILTER_LENGTH, _HOP_LENGTH, _WIN_LENGTH)
+        # 0.5 s of a 1 kHz tone at 16 kHz sample rate
+        n = _SAMPLING_RATE // 2
+        t = torch.arange(n, dtype=torch.float32) / _SAMPLING_RATE
+        wave = torch.sin(2 * math.pi * 1000.0 * t).unsqueeze(0)  # (1, n)
+        magnitude, phase = stft(wave)
+        assert torch.any(magnitude != 0), (
+            "STFT magnitude was zero for a non-zero waveform — basis init "
+            "regressed.")
+        assert magnitude.shape == phase.shape
+        assert magnitude.shape[1] == _FILTER_LENGTH // 2 + 1
+
+
+class TestMelBasisDeterministic:
+    """``MelSTFT`` no longer leaves ``mel_basis`` as zeros."""
+
+    def test_mel_basis_is_not_zero(self):
+        mel = MelSTFT(_FILTER_LENGTH,
+                      _HOP_LENGTH,
+                      _WIN_LENGTH,
+                      _N_MELS,
+                      sampling_rate=_SAMPLING_RATE)
+        assert torch.any(mel.mel_basis != 0), (
+            "mel_basis is all-zero — log-mel will collapse to log(1e-5) "
+            "(regression of #1398's S1 bug).")
+
+    def test_mel_basis_shape(self):
+        mel = MelSTFT(_FILTER_LENGTH,
+                      _HOP_LENGTH,
+                      _WIN_LENGTH,
+                      _N_MELS,
+                      sampling_rate=_SAMPLING_RATE)
+        assert mel.mel_basis.shape == (_N_MELS, _FILTER_LENGTH // 2 + 1)
+
+    def test_mel_basis_is_non_negative(self):
+        """Triangular mel filters are non-negative everywhere."""
+        mel = MelSTFT(_FILTER_LENGTH,
+                      _HOP_LENGTH,
+                      _WIN_LENGTH,
+                      _N_MELS,
+                      sampling_rate=_SAMPLING_RATE)
+        assert torch.all(mel.mel_basis >= 0)
+
+    def test_mel_basis_changes_with_sampling_rate(self):
+        """Different sample rates -> different mel filterbanks."""
+        mel_16k = MelSTFT(_FILTER_LENGTH,
+                          _HOP_LENGTH,
+                          _WIN_LENGTH,
+                          _N_MELS,
+                          sampling_rate=16000)
+        mel_48k = MelSTFT(_FILTER_LENGTH,
+                          _HOP_LENGTH,
+                          _WIN_LENGTH,
+                          _N_MELS,
+                          sampling_rate=48000)
+        assert not torch.allclose(mel_16k.mel_basis, mel_48k.mel_basis)
+
+
+class TestMelSpectrogramSanity:
+    """End-to-end sanity: a 1 kHz tone produces a peaked log-mel, not constant."""
+
+    def _build(self) -> MelSTFT:
+        return MelSTFT(_FILTER_LENGTH,
+                       _HOP_LENGTH,
+                       _WIN_LENGTH,
+                       _N_MELS,
+                       sampling_rate=_SAMPLING_RATE)
+
+    def test_log_mel_is_not_constant(self):
+        mel = self._build()
+        n = _SAMPLING_RATE  # 1 second
+        t = torch.arange(n, dtype=torch.float32) / _SAMPLING_RATE
+        wave = torch.sin(2 * math.pi * 1000.0 * t).unsqueeze(0)
+        log_mel, magnitude, phase, energy = mel.mel_spectrogram(wave)
+        # If forward_basis or mel_basis were zero, log_mel would collapse
+        # to log(1e-5) ≈ -11.51 (a constant).
+        assert log_mel.std().item() > 1e-3, (
+            "log-mel is effectively constant; the deterministic basis init "
+            "did not take effect (regression of #1398's S1 bug).")
+
+    def test_log_mel_shapes_match_input(self):
+        mel = self._build()
+        n = _SAMPLING_RATE
+        wave = torch.randn(2, n)
+        log_mel, magnitude, _, energy = mel.mel_spectrogram(wave)
+        # n_mels along channel axis; energy collapses freq dim.
+        assert log_mel.shape[0] == 2
+        assert log_mel.shape[1] == _N_MELS
+        assert magnitude.shape[0] == 2
+        assert energy.shape[0] == 2
+
+
+class TestStandaloneBasisHelpers:
+    """Cover the standalone helpers directly so a future zero-init regression
+    is caught even if ``_STFTFn`` / ``MelSTFT`` constructors change."""
+
+    def test_stft_basis_helper_nonzero(self):
+        basis = _build_stft_basis(_FILTER_LENGTH, _WIN_LENGTH)
+        assert torch.any(basis != 0)
+        assert basis.shape == (2 * (_FILTER_LENGTH // 2 + 1), 1,
+                               _FILTER_LENGTH)
+        assert basis.dtype == torch.float32
+
+    def test_mel_basis_helper_nonzero(self):
+        basis = _build_mel_basis(_SAMPLING_RATE, _FILTER_LENGTH, _N_MELS)
+        assert torch.any(basis != 0)
+        assert basis.shape == (_N_MELS, _FILTER_LENGTH // 2 + 1)
+        assert basis.dtype == torch.float32


### PR DESCRIPTION
## Summary
Adds the LTX-2.3 audio **BWE (bandwidth-extension) vocoder** path to `ltx2_audio_vae.py`. Additive + backward-compatible: it only activates when a vocoder config contains a `"bwe"` key; the existing non-BWE `Vocoder` path is behavior-identical.

- New: `VocoderWithBWE`, `MelSTFT` / `_STFTFn`, `Snake` / `SnakeBeta`, `AMPBlock1`, anti-alias resampling (`LowPassFilter1d` / `UpSample1d` / `DownSample1d` / `Activation1d`, `kaiser_sinc_filter1d`).
- `VocoderConfigurator.from_config` gains the `if "bwe" in vocoder_cfg` branch (16 kHz base + BWE generator + mel re-analysis → 48 kHz).
- Audio decoding stage: `_resolve_audio_sample_rate` (handles 48 kHz BWE vs the 24 kHz default).

## Backward compatibility
Non-BWE `Vocoder` is unchanged: the in-loop `leaky_relu(x, LRELU_SLOPE)` is gated `if not is_amp`, and the final path stays `leaky_relu() → conv_post → tanh` (verified against the original forward). BWE classes are inert unless the checkpoint config carries a `bwe` block.

## Test plan
- [x] `py_compile` + import (`VocoderWithBWE` present)
- [x] Existing LTX2 tests pass on this branch: `test_ltx2_continuation` + `test_ltx2_stage_overrides` (29)
- [ ] Functional BWE decode on a 2.3 checkpoint (needs GPU validation)

Independent of the DiT-2.3 PR; can be reviewed/merged separately.