### PR TITLE
[docs]: highlight Dreamverse deployment paths + add Server B200 (SSH) guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ FastVideo has the following features:
   - Support H100, A100, 4090
   - Support Linux, Windows, MacOS
   - See this [page](https://hao-ai-lab.github.io/FastVideo/inference/support_matrix/) for full list of supported models, hardware assumptions, and optimization compatibility.
+- Realtime video generation & editing
+  - [Dreamverse](apps/dreamverse/README.md): stream and "vibe direct" video in realtime ([live demo](https://dreamverse.fastvideo.org/)), deployable on local GPU, a self-hosted B200 server, Docker, or serverless Modal
 
 ## Getting Started
 
@@ -68,6 +70,19 @@ See below for recipes and datasets:
 | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | [FastWan2.1-T2V-1.3B](https://huggingface.co/FastVideo/FastWan2.1-T2V-1.3B-Diffusers) | [Recipe](https://github.com/hao-ai-lab/FastVideo/tree/main/examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P)       | [FastVideo Synthetic Wan2.1 480P](https://huggingface.co/datasets/FastVideo/Wan-Syn_77x448x832_600k)     |
 | [FastWan2.2-TI2V-5B](https://huggingface.co/FastVideo/FastWan2.2-TI2V-5B-Diffusers)   | [Recipe](https://github.com/hao-ai-lab/FastVideo/tree/main/examples/distill/Wan2.2-TI2V-5B-Diffusers/Data-free) | [FastVideo Synthetic Wan2.2 720P](https://huggingface.co/datasets/FastVideo/Wan2.2-Syn-121x704x1280_32k) |
+
+## Dreamverse — Realtime Video Generation & Editing
+
+[Dreamverse](apps/dreamverse/README.md) is FastVideo's realtime video generation
+and editing platform — "vibe directing" a video as it streams. It lives in the
+monorepo under [`apps/dreamverse/`](apps/dreamverse/) and ships its own backend
+(`dreamverse-server`) plus a web UI.
+
+Try the [live demo](https://dreamverse.fastvideo.org/), read the
+[blog](https://haoailab.com/blogs/dreamverse/), or run it yourself. Dreamverse
+deploys on a local GPU, a self-hosted B200 server over SSH, Docker, or
+serverless [Modal](apps/dreamverse/scripts/modal/README.md) — see the
+[Dreamverse README](apps/dreamverse/README.md).
 
 ## Inference
 

--- a/apps/dreamverse/README.md
+++ b/apps/dreamverse/README.md
@@ -93,6 +93,14 @@ dreamverse-server --port 8009
 dreamverse-mock-server --port 8009
 ```
 
+> **Expect a slow first boot.** With `torch.compile` and startup warmup enabled
+> (the default), the backend compiles the segment 1 and segment 2 inference
+> paths before it reports ready — this can take **tens of minutes on a cold
+> cache**, regardless of how you deploy (local, server, Docker, or Modal).
+> `/healthz` responds as soon as the process is up; `/readyz` stays `503` until
+> warmup finishes. For a faster, uncompiled startup while testing, set
+> `FASTVIDEO_ENABLE_STARTUP_WARMUP=0` before starting the backend.
+
 ## Frontend Setup
 
 Install the web dependencies once from the FastVideo checkout:
@@ -162,6 +170,32 @@ BACKEND_HOST=localhost BACKEND_PORT=8009 npm run dev
 ```
 
 Open `http://localhost:5299`.
+
+## Server B200 deployment (SSH)
+
+Deploying on a remote GPU host (for example a B200 box) is a local install run
+over SSH, plus a few server-specific concerns. Two paths:
+
+### Option A: Native (source install)
+
+SSH in, then follow [Install → From source](#method-2-from-source) and
+(recommended) [Building FFmpeg](#optional-building-ffmpeg-for-better-performance),
+then start the backend as in [Quick Start: Local GPU](#quick-start-local-gpu).
+For a remote host, a few things differ from localhost:
+
+- Bind all interfaces: `dreamverse-server --host 0.0.0.0 --port 8009`.
+- Point the frontend/client at the host: `BACKEND_HOST=<b200-host> BACKEND_PORT=8009 npm run dev`.
+- Keep the backend alive across SSH sessions (`tmux` / `systemd` / `nohup`).
+- Expose / firewall port `8009`, or front it with a reverse proxy + auth.
+
+### Option B: Docker (on the server)
+
+SSH in, then follow [Install → Using Docker](#method-3-using-docker) and the run
+steps in [`docker/README.md`](docker/README.md):
+
+```bash
+CEREBRAS_API_KEY="<key>" GROQ_API_KEY="<key>" apps/dreamverse/docker/docker_run.sh
+```
 
 ## Quick Start: Mock Backend (For UI development)
 

--- a/apps/dreamverse/README.md
+++ b/apps/dreamverse/README.md
@@ -2,6 +2,8 @@
 
 Dreamverse is the FastVideo realtime video generation & editing platform. It lives in this monorepo under `apps/dreamverse/`.
 
+**Deploy on:** [local GPU](#quick-start-local-gpu) · [self-hosted B200 (SSH)](#server-b200-deployment-ssh) · [Docker](docker/README.md) · [Modal](scripts/modal/README.md)
+
 ## Install Dreamverse
 
 You can install Dreamverse using one of the methods below.


### PR DESCRIPTION
## Summary

Prep for the Dreamverse release by making the deployment story discoverable from both the repo root and the app README.

**`apps/dreamverse/README.md`**
- New top-level **Deployment** overview table — Local GPU (native) / Server B200 (SSH) / Docker / Modal — each linking to its guide.
- New **Server B200 deployment (SSH)** section with two options:
  - **Native** (source install): `ssh` → `uv pip install -e ".[dreamverse]"` → native FFmpeg → export keys → `dreamverse-server` (+ frontend).
  - **Docker**: `docker_build.sh` → `docker_run.sh`.
- Adds a first-boot warmup caveat (`torch.compile` + startup warmup can take tens of minutes on a cold cache; `/readyz` stays `503` until it finishes).

**`README.md`** (root)
- New **Dreamverse — Realtime Video Generation & Editing** highlight section (links to the app, live demo, blog, and the deployment guide).
- New Key Features bullet for Dreamverse.

All commands mirror the existing `scripts/launch`, `docker/`, and `install_native_ffmpeg.sh` flows — no new tooling introduced.

## Notes for reviewers

A few choices called out so contributors can refine:
- The native Server B200 option serves the UI via `npm run dev` (dev server), matching the existing local quick start. A production server may prefer a built/static UI or the Docker UI image.
- The section does not cover exposing port `8009` publicly (firewall / reverse proxy / auth) — worth adding for internet-facing servers.
- Process supervision is mentioned generically (`tmux` / `systemd` / `nohup`); no `systemd` unit sample yet.

## Test evidence

- Docs-only change. `pre-commit run --files README.md apps/dreamverse/README.md` → codespell + PyMarkdown **Passed**.
- Deploy commands cross-checked against the scripts they reference (`docker_run.sh` requires `CEREBRAS_API_KEY`/`GROQ_API_KEY`, maps host `8009`, mounts the HF cache + outputs; `install_native_ffmpeg.sh` emits `ffmpeg-env.sh`).