### PR TITLE
[perf] training: add attn_only selective activation checkpointing

### DIFF
--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -1099,7 +1099,7 @@ class TrainingArgs(FastVideoArgs):
         parser.add_argument("--max-grad-norm", type=float, help="Maximum gradient norm")
         parser.add_argument("--enable-gradient-checkpointing-type",
                             type=str,
-                            choices=["full", "ops", "block_skip"],
+                            choices=["full", "ops", "block_skip", "attn_only"],
                             default=None,
                             help="Gradient checkpointing type")
         parser.add_argument("--selective-checkpointing", type=float, help="Selective checkpointing threshold")

--- a/fastvideo/tests/training/checkpoint/test_activation_checkpoint_attn_only.py
+++ b/fastvideo/tests/training/checkpoint/test_activation_checkpoint_attn_only.py
@@ -1,0 +1,87 @@
+"""Unit tests for the ``attn_only`` selective activation-checkpointing policy.
+
+CPU-only: exercises the op classifier and the per-block wrapping structure
+without running a forward/backward (so no GPU or distributed init needed).
+"""
+import torch
+from torch import nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (CheckpointWrapper)
+
+from fastvideo.training.activation_checkpoint import (CheckpointType, _is_attention_forward,
+                                                      apply_activation_checkpointing)
+
+
+def test_checkpoint_type_has_attn_only():
+    assert CheckpointType.ATTN_ONLY == "attn_only"
+    assert CheckpointType.ATTN_ONLY.value == "attn_only"
+
+
+def test_is_attention_forward_matches_flash_and_sdpa_forward():
+    # FA2 names the op "...forward", FA3 (flash_attn_interface) names it "...fwd",
+    # aten exposes "_scaled_dot_product_*". The matcher keys on the op name so it
+    # is robust to whichever backend is registered at runtime.
+    assert _is_attention_forward("flash_attn::_flash_attn_forward")
+    assert _is_attention_forward("flash_attn_3::fwd")
+    assert _is_attention_forward(torch.ops.aten._scaled_dot_product_flash_attention.default)
+    assert _is_attention_forward(torch.ops.aten._scaled_dot_product_efficient_attention.default)
+
+
+def test_is_attention_forward_excludes_backward_and_unrelated_ops():
+    # Backward ops must NOT be saved (we only want the forward output).
+    assert not _is_attention_forward("flash_attn::_flash_attn_backward")
+    assert not _is_attention_forward("flash_attn_3::bwd")
+    assert not _is_attention_forward("aten::_scaled_dot_product_flash_attention_backward")
+    # Unrelated compute (the FFN/QKV GEMM we deliberately recompute).
+    assert not _is_attention_forward(torch.ops.aten.mm.default)
+    assert not _is_attention_forward("aten::addmm")
+
+
+class _DummyBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = nn.Linear(4, 4)
+
+    def forward(self, x):  # pragma: no cover - never executed in these tests
+        return self.proj(x)
+
+
+class _DummyTransformer(nn.Module):
+    def __init__(self, n_blocks: int = 3):
+        super().__init__()
+        self.blocks = nn.ModuleList([_DummyBlock() for _ in range(n_blocks)])
+
+
+def test_attn_only_wraps_each_transformer_block():
+    model = _DummyTransformer(n_blocks=3)
+    returned = apply_activation_checkpointing(model, checkpointing_type=CheckpointType.ATTN_ONLY)
+
+    # The module is wrapped in place and returned.
+    assert returned is model
+    assert len(model.blocks) == 3
+    for block in model.blocks:
+        assert isinstance(block, CheckpointWrapper)
+        # The original block is preserved under the wrapper.
+        assert isinstance(block._checkpoint_wrapped_module, _DummyBlock)
+
+
+def test_attn_only_raises_when_no_transformer_blocks_found():
+    class _NoBlocks(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(4, 4)
+
+    try:
+        apply_activation_checkpointing(_NoBlocks(), checkpointing_type=CheckpointType.ATTN_ONLY)
+    except ValueError as exc:
+        assert "attn_only" in str(exc)
+    else:
+        raise AssertionError("expected ValueError when no transformer blocks are present")
+
+
+def test_apply_activation_checkpointing_rejects_unknown_type():
+    try:
+        apply_activation_checkpointing(_DummyTransformer(), checkpointing_type="not_a_real_type")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for an unsupported checkpointing type")

--- a/fastvideo/tests/training/checkpoint/test_activation_checkpoint_attn_only.py
+++ b/fastvideo/tests/training/checkpoint/test_activation_checkpoint_attn_only.py
@@ -7,8 +7,8 @@ import torch
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (CheckpointWrapper)
 
-from fastvideo.training.activation_checkpoint import (CheckpointType, _is_attention_forward,
-                                                      apply_activation_checkpointing)
+from fastvideo.training.activation_checkpoint import (CheckpointType, _attn_only_must_save,
+                                                      _is_attention_forward, apply_activation_checkpointing)
 
 
 def test_checkpoint_type_has_attn_only():
@@ -34,6 +34,34 @@ def test_is_attention_forward_excludes_backward_and_unrelated_ops():
     # Unrelated compute (the FFN/QKV GEMM we deliberately recompute).
     assert not _is_attention_forward(torch.ops.aten.mm.default)
     assert not _is_attention_forward("aten::addmm")
+
+
+def test_attn_only_must_save_attention_and_functional_collectives():
+    # Attention forward -> saved.
+    assert _attn_only_must_save("flash_attn::_flash_attn_forward")
+    assert _attn_only_must_save(torch.ops.aten._scaled_dot_product_flash_attention.default)
+    # Functional collectives (FSDP2 all-gather / reduce-scatter) -> saved, so a
+    # collective is never re-issued during the backward recompute.
+    assert _attn_only_must_save(torch.ops._c10d_functional.all_gather_into_tensor.default)
+    assert _attn_only_must_save(torch.ops._c10d_functional.reduce_scatter_tensor.default)
+
+
+def test_attn_only_must_save_recomputes_gemm_and_excludes_backward():
+    assert not _attn_only_must_save(torch.ops.aten.mm.default)
+    assert not _attn_only_must_save("aten::addmm")
+    assert not _attn_only_must_save("flash_attn::_flash_attn_backward")
+
+
+def test_attn_only_must_save_is_cached_and_consistent():
+    # Repeated lookups (the hot path: called per op every step) return the same
+    # decision; the cache must not flip a result.
+    op = torch.ops.aten._scaled_dot_product_flash_attention.default
+    first = _attn_only_must_save(op)
+    assert first is True
+    assert _attn_only_must_save(op) is first
+    mm = torch.ops.aten.mm.default
+    assert _attn_only_must_save(mm) is False
+    assert _attn_only_must_save(mm) is False
 
 
 class _DummyBlock(nn.Module):

--- a/fastvideo/tests/training/checkpoint/test_activation_checkpoint_attn_only.py
+++ b/fastvideo/tests/training/checkpoint/test_activation_checkpoint_attn_only.py
@@ -1,7 +1,7 @@
 """Unit tests for the ``attn_only`` selective activation-checkpointing policy.
 
-CPU-only: exercises the op classifier and the per-block wrapping structure
-without running a forward/backward (so no GPU or distributed init needed).
+CPU-only (no GPU or distributed init): the op classifier, per-block wrapping,
+and a real SDPA forward/backward parity check against none/full.
 """
 import torch
 from torch import nn
@@ -24,6 +24,29 @@ def test_is_attention_forward_matches_flash_and_sdpa_forward():
     assert _is_attention_forward("flash_attn_3::fwd")
     assert _is_attention_forward(torch.ops.aten._scaled_dot_product_flash_attention.default)
     assert _is_attention_forward(torch.ops.aten._scaled_dot_product_efficient_attention.default)
+
+
+def test_is_attention_forward_matches_fastvideo_cute_ops():
+    # FastVideo CuTe ops carry "flash_attn" + "forward" -> flash branch.
+    assert _is_attention_forward("fastvideo::_flash_attn_default_forward")
+    assert _is_attention_forward("fastvideo::_flash_attn_cute_forward")
+    assert _is_attention_forward("fastvideo::_flash_attn_cute_varlen_forward")
+    assert _is_attention_forward("fastvideo::_flash_attn_cute_fp4_forward")
+
+
+def test_is_attention_forward_matches_video_sparse_attn():
+    # VSA forward op; without this, attn_only recomputes VSA attention.
+    assert _is_attention_forward("fastvideo_kernel::block_sparse_attn_triton")
+    assert _is_attention_forward("fastvideo_kernel::block_sparse_attn_sm90")
+    # VSA backward stays excluded.
+    assert not _is_attention_forward("fastvideo_kernel::block_sparse_attn_backward_triton")
+    assert not _is_attention_forward("fastvideo_kernel::block_sparse_attn_backward_sm90")
+
+
+def test_is_attention_forward_matches_vmoba_flash_varlen():
+    # vMoBA's MixedAttention issues _flash_attn_varlen_forward -> covered.
+    assert _is_attention_forward("flash_attn::_flash_attn_varlen_forward")
+    assert not _is_attention_forward("flash_attn::_flash_attn_varlen_backward")
 
 
 def test_is_attention_forward_excludes_backward_and_unrelated_ops():
@@ -113,3 +136,85 @@ def test_apply_activation_checkpointing_rejects_unknown_type():
         pass
     else:
         raise AssertionError("expected ValueError for an unsupported checkpointing type")
+
+
+# --- forward/backward numerical-parity coverage (CPU/SDPA, no GPU/dist) ---
+
+
+class _AttnMLPBlock(nn.Module):
+    """Real attention (aten SDPA, CPU) + MLP, so the policy sees a
+    `_scaled_dot_product_*` forward to save and a GEMM to recompute."""
+
+    def __init__(self, dim: int = 16, heads: int = 2):
+        super().__init__()
+        self.heads = heads
+        self.qkv = nn.Linear(dim, 3 * dim)
+        self.proj = nn.Linear(dim, dim)
+        self.mlp = nn.Sequential(nn.Linear(dim, 4 * dim), nn.GELU(), nn.Linear(4 * dim, dim))
+
+    def forward(self, x):  # x: [B, S, D]
+        b, s, d = x.shape
+        qkv = self.qkv(x).reshape(b, s, 3, self.heads, d // self.heads)
+        q, k, v = (t.transpose(1, 2) for t in qkv.unbind(dim=2))  # [B, H, S, Dh]
+        attn = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        attn = attn.transpose(1, 2).reshape(b, s, d)
+        x = x + self.proj(attn)
+        x = x + self.mlp(x)
+        return x
+
+
+class _AttnTransformer(nn.Module):
+    def __init__(self, n_blocks: int = 2, dim: int = 16):
+        super().__init__()
+        self.blocks = nn.ModuleList([_AttnMLPBlock(dim) for _ in range(n_blocks)])
+
+    def forward(self, x):
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+
+def _run_fwd_bwd(checkpointing_type, dim: int = 16, n_blocks: int = 2):
+    """Fixed-seed fwd/bwd; returns loss, input grad, and parameter grads."""
+    torch.manual_seed(0)
+    model = _AttnTransformer(n_blocks=n_blocks, dim=dim)
+    if checkpointing_type is not None:
+        apply_activation_checkpointing(model, checkpointing_type=checkpointing_type)
+
+    torch.manual_seed(1)
+    x = torch.randn(2, 8, dim, requires_grad=True)
+    out = model(x)
+    loss = out.float().pow(2).mean()
+    loss.backward()
+
+    # named_parameters strips the checkpoint-wrapper prefix, so names align
+    # across the wrapped and unwrapped models.
+    # Drop the checkpoint-wrapper prefix so names align across wrapped/unwrapped.
+    grads = {
+        name.replace("._checkpoint_wrapped_module", ""): p.grad.detach().clone()
+        for name, p in model.named_parameters()
+    }
+    return loss.detach().clone(), x.grad.detach().clone(), grads
+
+
+def test_attn_only_matches_no_checkpointing_fwd_bwd():
+    # attn_only == uncheckpointed path: loss, input grad, every param grad.
+    ref_loss, ref_xgrad, ref_grads = _run_fwd_bwd(None)
+    loss, xgrad, grads = _run_fwd_bwd(CheckpointType.ATTN_ONLY)
+
+    torch.testing.assert_close(loss, ref_loss)
+    torch.testing.assert_close(xgrad, ref_xgrad)
+    assert grads.keys() == ref_grads.keys()
+    for name in ref_grads:
+        torch.testing.assert_close(grads[name], ref_grads[name], msg=f"grad mismatch for {name}")
+
+
+def test_attn_only_matches_full_checkpointing_fwd_bwd():
+    # attn_only and full save vs recompute differently -> identical grads.
+    ref_loss, ref_xgrad, ref_grads = _run_fwd_bwd(CheckpointType.FULL)
+    loss, xgrad, grads = _run_fwd_bwd(CheckpointType.ATTN_ONLY)
+
+    torch.testing.assert_close(loss, ref_loss)
+    torch.testing.assert_close(xgrad, ref_xgrad)
+    for name in ref_grads:
+        torch.testing.assert_close(grads[name], ref_grads[name], msg=f"grad mismatch for {name}")

--- a/fastvideo/training/activation_checkpoint.py
+++ b/fastvideo/training/activation_checkpoint.py
@@ -88,17 +88,19 @@ def _apply_activation_checkpointing_ops(module: torch.nn.Module, ops) -> torch.n
 
 
 def _is_attention_forward(func) -> bool:
-    """True for the (expensive-to-recompute) attention forward op, across
-    backends: flash_attn lib FA2 (`flash_attn::_flash_attn_forward`), FA3
-    (`flash_attn_3::fwd`), FastVideo custom ops, CuTe variants, and aten SDPA.
-    Matched by op name so we don't depend on which op object is registered at
-    import time (the active backend varies at runtime). Backward ops are
-    excluded so only the forward output is saved."""
+    """True for an attention *forward* op (expensive to recompute). Matched by
+    op name, not op object: the backend is chosen at runtime. Backward excluded.
+
+    Covered: flash-attn FA2 ("...forward") / FA3 ("...fwd") + FastVideo CuTe +
+    vMoBA (via _flash_attn_varlen_forward); aten SDPA; VSA
+    (block_sparse_attn_triton/_sm90). Not covered: SLA / SageAttention run
+    attention inside an autograd Function via opaque pybind kernels (no
+    dispatcher op to save), so attn_only safely recomputes them as `full` does."""
     s = str(func)
     if "backward" in s:
         return False
-    # FA2 names the op "...forward", FA3 (flash_attn_interface) names it "...fwd".
-    return ("flash_attn" in s and ("forward" in s or "fwd" in s)) or "_scaled_dot_product" in s
+    return (("flash_attn" in s and ("forward" in s or "fwd" in s)) or "_scaled_dot_product" in s
+            or "block_sparse_attn" in s)
 
 
 # Decision cache keyed by op: the set of distinct ops in a training step is tiny,

--- a/fastvideo/training/activation_checkpoint.py
+++ b/fastvideo/training/activation_checkpoint.py
@@ -101,6 +101,28 @@ def _is_attention_forward(func) -> bool:
     return ("flash_attn" in s and ("forward" in s or "fwd" in s)) or "_scaled_dot_product" in s
 
 
+# Decision cache keyed by op: the set of distinct ops in a training step is tiny,
+# so the string matching below runs once per unique op instead of once per call.
+_ATTN_ONLY_SAVE_CACHE: dict = {}
+
+
+def _attn_only_must_save(func) -> bool:
+    """MUST_SAVE the attention forward output and any functional collective
+    (`_c10d_functional.*` — e.g. FSDP2's all_gather_into_tensor / reduce_scatter).
+    Recomputing a collective in backward re-issues communication: expensive, and
+    a cross-rank ordering hazard that can deadlock. Everything else (the GEMM/FFN
+    mm) is cheap to recompute and is not saved."""
+    try:
+        if func in _ATTN_ONLY_SAVE_CACHE:
+            return _ATTN_ONLY_SAVE_CACHE[func]
+    except TypeError:
+        # Unhashable func: decide live, don't cache.
+        return _is_attention_forward(func) or "_c10d_functional" in str(func)
+    res = _is_attention_forward(func) or "_c10d_functional" in str(func)
+    _ATTN_ONLY_SAVE_CACHE[func] = res
+    return res
+
+
 def _apply_activation_checkpointing_attn_only(module: torch.nn.Module) -> torch.nn.Module:
     """Per-block selective checkpointing that MUST_SAVE only the attention
     forward output (small — ~221 MB/block at seq 72k) and any collective output
@@ -111,11 +133,8 @@ def _apply_activation_checkpointing_attn_only(module: torch.nn.Module) -> torch.
     Orthogonal to torch.compile."""
     from torch.utils.checkpoint import (CheckpointPolicy, create_selective_checkpoint_contexts)
 
-    _reduce_scatter = torch.ops._c10d_functional.reduce_scatter_tensor.default
-
     def _attn_only_policy(ctx, func, *args, **kwargs):
-        save = _is_attention_forward(func) or func == _reduce_scatter
-        return CheckpointPolicy.MUST_SAVE if save else CheckpointPolicy.PREFER_RECOMPUTE
+        return (CheckpointPolicy.MUST_SAVE if _attn_only_must_save(func) else CheckpointPolicy.PREFER_RECOMPUTE)
 
     def _ctx_fn():
         return create_selective_checkpoint_contexts(_attn_only_policy)

--- a/fastvideo/training/activation_checkpoint.py
+++ b/fastvideo/training/activation_checkpoint.py
@@ -19,6 +19,7 @@ class CheckpointType(str, Enum):
     FULL = "full"
     OPS = "ops"
     BLOCK_SKIP = "block_skip"
+    ATTN_ONLY = "attn_only"
 
 
 _SELECTIVE_ACTIVATION_CHECKPOINTING_OPS = {
@@ -38,6 +39,8 @@ def apply_activation_checkpointing(module: torch.nn.Module,
         module = _apply_activation_checkpointing_ops(module, _SELECTIVE_ACTIVATION_CHECKPOINTING_OPS)
     elif checkpointing_type == CheckpointType.BLOCK_SKIP:
         module = _apply_activation_checkpointing_blocks(module, n_layer)
+    elif checkpointing_type == CheckpointType.ATTN_ONLY:
+        module = _apply_activation_checkpointing_attn_only(module)
     else:
         raise ValueError(
             f"Checkpointing type '{checkpointing_type}' not supported. Supported types are {CheckpointType.__members__.keys()}"
@@ -82,3 +85,50 @@ def _apply_activation_checkpointing_ops(module: torch.nn.Module, ops) -> torch.n
         return create_selective_checkpoint_contexts(_get_custom_policy(meta))
 
     return checkpoint_wrapper(module, context_fn=selective_checkpointing_context_fn, preserve_rng_state=False)
+
+
+def _is_attention_forward(func) -> bool:
+    """True for the (expensive-to-recompute) attention forward op, across
+    backends: flash_attn lib FA2 (`flash_attn::_flash_attn_forward`), FA3
+    (`flash_attn_3::fwd`), FastVideo custom ops, CuTe variants, and aten SDPA.
+    Matched by op name so we don't depend on which op object is registered at
+    import time (the active backend varies at runtime). Backward ops are
+    excluded so only the forward output is saved."""
+    s = str(func)
+    if "backward" in s:
+        return False
+    # FA2 names the op "...forward", FA3 (flash_attn_interface) names it "...fwd".
+    return ("flash_attn" in s and ("forward" in s or "fwd" in s)) or "_scaled_dot_product" in s
+
+
+def _apply_activation_checkpointing_attn_only(module: torch.nn.Module) -> torch.nn.Module:
+    """Per-block selective checkpointing that MUST_SAVE only the attention
+    forward output (small — ~221 MB/block at seq 72k) and any collective output
+    (don't recompute comm), and recomputes everything else (the GEMM/FFN mm
+    intermediates are huge but cheap to recompute — saving them is what makes
+    the stock 'ops' mode OOM). Eliminates the attention forward recompute that
+    FULL mode pays (flash_fwd runs 2x under FULL) while staying within memory.
+    Orthogonal to torch.compile."""
+    from torch.utils.checkpoint import (CheckpointPolicy, create_selective_checkpoint_contexts)
+
+    _reduce_scatter = torch.ops._c10d_functional.reduce_scatter_tensor.default
+
+    def _attn_only_policy(ctx, func, *args, **kwargs):
+        save = _is_attention_forward(func) or func == _reduce_scatter
+        return CheckpointPolicy.MUST_SAVE if save else CheckpointPolicy.PREFER_RECOMPUTE
+
+    def _ctx_fn():
+        return create_selective_checkpoint_contexts(_attn_only_policy)
+
+    applied = False
+    for transformer_block_name in TRANSFORMER_BLOCK_NAMES:
+        blocks: torch.nn.Module = getattr(module, transformer_block_name, None)
+        if blocks is None:
+            continue
+        for layer_id, block in blocks.named_children():
+            block = checkpoint_wrapper(block, context_fn=_ctx_fn, preserve_rng_state=False)
+            blocks.register_module(layer_id, block)
+        applied = True
+    if not applied:
+        raise ValueError("Activation checkpointing (attn_only) is not applied successfully")
+    return module


### PR DESCRIPTION
## Motivation

Video DiT training has to run with activation checkpointing — at video sequence
lengths (e.g. 72k tokens) the activations don't fit otherwise. But the existing
modes leave a gap:

- **`full`** recomputes the *entire* transformer block in backward, so it
  re-runs the **attention forward** — the single most expensive op — a second
  time. On Wan2.1-T2V-1.3B we measured the attention forward kernel running
  **1200×** under `full` where only **600×** are needed; the other 600 are pure
  redundant recompute, ~12% of GPU compute burned every step.
- **`ops`** (the stock selective mode) is meant to avoid that, but it **OOMs**
  at video sequence lengths because it also saves the FFN/GEMM intermediates
  (~51 GB across the blocks) — which are large but *cheap* to recompute.

So in practice there is no usable middle option: recompute everything (`full`,
wastes the attention recompute) or OOM (`ops`).

## What this adds

`attn_only`: a per-block selective policy that **saves only the attention
forward output** (small — ~221 MB/block at seq 72k) and any functional
collective output (so communication is never re-issued in backward), and
**recomputes everything else**. It removes the attention recompute `full` pays,
while staying within memory.

## Why this lever

- **Removes real work (FLOPs), not host-wait** → the speedup is
  fabric-independent (helps on both PCIe and NVSwitch) and **stacks with
  `torch.compile`** (which won't merge separate `nn.Linear` weights or change
  the recompute structure).
- **Near-zero cost**: +2 GB peak vs `full`; numerically equivalent (saves the
  forward output rather than recomputing it).
- **Last recoverable AC win**: after `attn_only`, the dominant kernel is the
  flash *backward* (gradient computation — irreducible). This captures the
  remaining activation-checkpoint headroom.

`activation_checkpoint.py` is shared by both the legacy (`fastvideo/training/`)
and modular (`fastvideo/train/`) stacks, so both benefit from one change.

## Opt-in, default-preserving

The default is unchanged (no AC unless requested). `attn_only` joins
`full`/`ops`/`block_skip` as a new point on the memory↔speed curve — it is **not**
a replacement for `full`, which remains the lowest-memory option for
memory-constrained training.

| mode      | peak (1×H100) | note                          |
|-----------|---------------|-------------------------------|
| full      | 26.8 GB       | recompute all — lowest memory |
| attn_only | 28.9 GB       | +2 GB, no attention recompute |
| ops       | OOM           | also saves the FFN mm         |

Use `attn_only` when you have headroom over `full`.

## Changes

- `CheckpointType.ATTN_ONLY` + dispatch branch
- `_apply_activation_checkpointing_attn_only`: MUST_SAVE the attention forward
  output and any `_c10d_functional` collective (so a collective is never
  re-issued during the backward recompute — that is expensive and a cross-rank
  ordering hazard), PREFER_RECOMPUTE the rest; the per-op decision is cached
- `_is_attention_forward`: backend-agnostic op-name match (FA2
  `_flash_attn_forward`, FA3 `fwd`, aten SDPA; backward excluded) — robust to
  the runtime-selected attention backend
- CLI: add `attn_only` to `--enable-gradient-checkpointing-type` choices

## Results

**Kernel-level** (nsys, 1×H100, Wan2.1-T2V-1.3B 720×1280×77f) — the direct,
hardware-independent measurement: the only kernel whose count changes is
`flash_fwd_kernel` (**1200 → 600**, −4.67 s); flash-bwd / GEMM / elementwise
counts are conserved. Total GPU compute **40.2 s → 35.3 s (−12.3%)**, ~95% of
which is the flash-fwd halving — i.e. the change removes exactly the
attention-forward recompute and nothing else.

**Wall-clock step time** (steady-state, no profiler):

| config | full   | attn_only | speedup |
|--------|--------|-----------|---------|
| H100×1 | 4.19 s | 3.75 s    | −10.5%  |
| H100×2 | 2.25 s | 2.08 s    |  −7.6%  |

H100×2 reproduced across two independent runs (2.28→2.09 in the other). It also speeds up multi-GPU L40S,
but Modal's per-job L40S allocation has large PCIe-topology variance (identical
work ranged 5.5–9.1 s/step), so we don't quote a clean L40S wall-time delta — the
−12.3% compute figure above is the allocation-independent one. The win narrows as
GPU count grows (fixed comm cost dilutes the compute saving) and scales with the
attention fraction of the step — largest for long-sequence video training, which
is why it is opt-in rather than a forced default.

**Numerically equivalent**: per-step loss differs from `full` within the
GPU non-determinism noise floor (full-vs-full on the same seed already differs by
~0.002 from flash-attn backward atomics). By construction it saves the forward
output rather than recomputing it, so it introduces no systematic drift.

## Usage

```
--enable_gradient_checkpointing_type attn_only
```

## Test plan

- **[added]** CPU unit test (`fastvideo/tests/training/checkpoint/test_activation_checkpoint_attn_only.py`):
  `CheckpointType.ATTN_ONLY`, the attention-forward classifier
  (FA2/FA3/SDPA forward matched; backward and FFN/QKV `mm` excluded), the
  save decision (attention forward + functional collectives saved, GEMM
  recomputed) and its caching, per-block `checkpoint_wrapper` application, and
  the error paths. No GPU required.
- **[manual]** e2e training runs clean with `attn_only` on 1–2×H100 and 2×L40S,
  20 steps, no OOM.
