### PR TITLE
[bugfix]: dreamverse modal bypasses ENTRYPOINT — set ffmpeg env + key check

### DIFF
--- a/apps/dreamverse/scripts/modal/modal_app.py
+++ b/apps/dreamverse/scripts/modal/modal_app.py
@@ -61,7 +61,13 @@ dreamverse_state = modal.Volume.from_name("dreamverse-state", create_if_missing=
 )
 @modal.web_server(8009, startup_timeout=4800)
 def serve():
-    missing = [k for k in _REQUIRED_SECRET_KEYS if not os.environ.get(k)]
+    # ``or ""`` collapses ``None`` (unset) into an empty string, ``.strip()``
+    # collapses whitespace-only values (e.g. ``"   "``) — both should be
+    # treated as missing.
+    missing = [
+        k for k in _REQUIRED_SECRET_KEYS
+        if not (os.environ.get(k) or "").strip()
+    ]
     if missing:
         raise RuntimeError(
             "dreamverse-api-keys secret is missing required entries: "

--- a/apps/dreamverse/scripts/modal/modal_app.py
+++ b/apps/dreamverse/scripts/modal/modal_app.py
@@ -14,6 +14,12 @@ if not IMAGE:
         "dreamverse-ui-cuda12.9.1-sha-* tag if serving the static UI."
     )
 
+# ``@modal.web_server`` invokes ``serve()`` directly and bypasses the image
+# ENTRYPOINT (``docker/docker_entrypoint.sh``).  That entrypoint normally
+# ``:?``-validates these secret entries and ``source``-s ``ffmpeg-env.sh``;
+# neither runs on Modal, so we replicate both here.
+_REQUIRED_SECRET_KEYS: tuple[str, ...] = ("CEREBRAS_API_KEY", "GROQ_API_KEY")
+
 image = modal.Image.from_registry(IMAGE)
 image = image.env({
     "DREAMVERSE_IMAGE": IMAGE,
@@ -24,6 +30,12 @@ image = image.env({
     "ENABLE_TORCH_COMPILE": "1",
     "DREAMVERSE_MAX_AUTOTUNE": os.environ.get("DREAMVERSE_MAX_AUTOTUNE", "1"),
     "STREAM_MODE": "av_fmp4",
+    # Native ffmpeg is built into ``/opt/ffmpeg-native`` by the Dockerfile but
+    # is not on the image's ``PATH``.  Without these, ``av_streaming``'s
+    # ``shutil.which("ffmpeg")`` returns ``None`` and ``av_fmp4`` muxing has
+    # no encoder.  ``ffmpeg-env.sh`` would normally set them.
+    "FASTVIDEO_FFMPEG_BIN": "/opt/ffmpeg-native/bin/ffmpeg",
+    "FASTVIDEO_VIDEO_CODEC": "libx264",
 })
 
 app = modal.App("dreamverse-b200")
@@ -49,4 +61,11 @@ dreamverse_state = modal.Volume.from_name("dreamverse-state", create_if_missing=
 )
 @modal.web_server(8009, startup_timeout=4800)
 def serve():
+    missing = [k for k in _REQUIRED_SECRET_KEYS if not os.environ.get(k)]
+    if missing:
+        raise RuntimeError(
+            "dreamverse-api-keys secret is missing required entries: "
+            f"{', '.join(missing)}. Add them with `modal secret create "
+            "dreamverse-api-keys ... --force` and redeploy "
+            "(see apps/dreamverse/scripts/modal/README.md).")
     subprocess.Popen(["dreamverse-server", "--host", "0.0.0.0", "--port", "8009"])


### PR DESCRIPTION
## Summary

Modal's `@modal.web_server` decorator invokes `serve()` directly (`Popen` the `dreamverse-server`) and bypasses the image's ENTRYPOINT (`apps/dreamverse/docker/docker_entrypoint.sh`). The bypassed entrypoint normally does two things that **silently no-op on Modal**:

1. `:?`-validates `CEREBRAS_API_KEY` and `GROQ_API_KEY` (fails the container fast if either is missing from the mounted secret).
2. Sources `ffmpeg-env.sh`, which exports `FASTVIDEO_FFMPEG_BIN=/opt/ffmpeg-native/bin/ffmpeg`.

## Symptoms observed

Deploying the post-#1394 UI image (`dreamverse-ui-cuda12.9.1-sha-2c13793`) on Modal:

- **No ffmpeg, video silently broken.** `/opt/ffmpeg-native/bin` is not on the container `PATH` (`apps/dreamverse/docker/Dockerfile:24`). With `FASTVIDEO_FFMPEG_BIN` unset, `av_streaming.py:28`'s `shutil.which("ffmpeg")` returns `None` and `av_fmp4` muxing has no encoder.
- **Missing keys surface at first request, not boot.** A `dreamverse-api-keys` secret with placeholder values lets the container come up fine; prompt rewriting then fails on the first user request instead of at boot.

## Fix

Both changes in `apps/dreamverse/scripts/modal/modal_app.py`:

1. Set `FASTVIDEO_FFMPEG_BIN=/opt/ffmpeg-native/bin/ffmpeg` and `FASTVIDEO_VIDEO_CODEC=libx264` in `image.env` so `av_streaming` finds the native ffmpeg the Dockerfile builds.
2. Add a fail-fast guard in `serve()` that checks the required secret entries before launching the server, mirroring the entrypoint's `:?` behavior.

A comment block above the env dict documents why these are needed (entrypoint bypass), so the next reader doesn't lose the context.

## Test evidence

- `pre-commit run --files apps/dreamverse/scripts/modal/modal_app.py` and `python -c "import ast; ast.parse(open(...))"` pass.
- The ffmpeg gap was empirically discovered while bringing up the dreamverse Modal deploy with the post-#1394 image; setting `FASTVIDEO_FFMPEG_BIN` in `image.env` was the workaround that made `av_streaming`'s `shutil.which` resolve to the right binary during that session.
- The key fail-fast is mechanical (re-raises `RuntimeError` when `os.environ.get(k)` is empty for either required key); the message names the missing key(s) and points at the README so the operator knows exactly what to fix.