### PR TITLE
[bugfix] matrixgame2 causal denoise: store KV-cache end indices as Python int

### DIFF
--- a/fastvideo/pipelines/stages/matrixgame2_denoising.py
+++ b/fastvideo/pipelines/stages/matrixgame2_denoising.py
@@ -278,10 +278,8 @@ class MatrixGame2CausalDenoisingStage(DenoisingStage):
                 torch.zeros([batch_size, kv_cache_size, num_attention_heads, attention_head_dim],
                             dtype=dtype,
                             device=device),
-                "global_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
-                "local_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
+                "global_end_index": 0,
+                "local_end_index": 0,
             })
 
         return kv_cache
@@ -302,10 +300,8 @@ class MatrixGame2CausalDenoisingStage(DenoisingStage):
                 torch.zeros([batch_size, kv_cache_size, action_heads, keyboard_head_dim], dtype=dtype, device=device),
                 "v":
                 torch.zeros([batch_size, kv_cache_size, action_heads, keyboard_head_dim], dtype=dtype, device=device),
-                "global_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
-                "local_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
+                "global_end_index": 0,
+                "local_end_index": 0,
             })
             kv_cache_mouse.append({
                 "k":
@@ -316,10 +312,8 @@ class MatrixGame2CausalDenoisingStage(DenoisingStage):
                 torch.zeros([batch_size * self.frame_seq_length, kv_cache_size, action_heads, mouse_head_dim],
                             dtype=dtype,
                             device=device),
-                "global_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
-                "local_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
+                "global_end_index": 0,
+                "local_end_index": 0,
             })
 
         return kv_cache_mouse, kv_cache_keyboard


### PR DESCRIPTION
## Summary

matrixgame2 causal inference stored the KV-cache end indices
(`global_end_index` / `local_end_index`) as GPU tensors. The consumers in
`causal_model.py` and `action_module.py` then call `int(tensor.item())` on
every access — each `.item()` is a GPU→CPU sync that serializes the
autoregressive denoise loop.

Both consumers already handle a plain Python `int` (their
`isinstance(..., torch.Tensor)` check falls through to the int path), so this
just initializes the indices as ints in `_initialize_kv_cache` /
`_initialize_action_kv_cache`.

## How it was found (nsys-ai)

On an H100 matrixgame2 trace, `host_sync_parent_ranges` attributed
**10,244 `aten::item` syncs** to the denoising stage (~264 ms), and
`cpu_gpu_pipeline` showed ~29.7k GPU starvation events from host-blocking
between dispatches.

## Result

Denoise-stage `.item()` syncs: **10,244 → 644 (−94%)**. Output unchanged — the
consumer sites already accepted plain ints.
