### PR TITLE
[feat]: decouple Dreamverse fMP4 streaming from generation

### DIFF
--- a/apps/dreamverse/dreamverse/gpu_pool.py
+++ b/apps/dreamverse/dreamverse/gpu_pool.py
@@ -5,6 +5,7 @@ import asyncio
 import multiprocessing as mp
 import os
 import subprocess
+import threading
 import time
 import traceback
 from dataclasses import dataclass
@@ -35,6 +36,7 @@ from dreamverse.worker_ipc import (
     LeaveAck,
     MediaChunk,
     MediaComplete,
+    MediaError,
     MediaInit,
     ReloadAck,
     ReloadModelPayload,
@@ -46,6 +48,8 @@ from dreamverse.worker_ipc import (
     WorkerError,
     WorkerEvent,
 )
+
+ACTIVE_STREAM_JOIN_TIMEOUT_SECONDS = 15.0
 
 
 def _parse_requested_gpu_limit() -> int | None:
@@ -163,10 +167,98 @@ def gpu_worker_process(
     from dreamverse.video_generation import VideoGenerationWorker
 
     worker = VideoGenerationWorker(gpu_id)
+    # One active fMP4 stream per worker keeps binary media chunks ordered by segment.
+    active_stream_thread: threading.Thread | None = None
+    active_stream_segment_idx: int | None = None
 
     def event_loop(first_cmd: Command = None):
         """Blocking event loop for LTX2; dispatches user commands."""
         print(f"[GPU {gpu_id}] Entering event loop")
+
+        def wait_for_active_stream() -> None:
+            """Join the active fMP4 segment stream before leave, shutdown, or the next stream."""
+            nonlocal active_stream_thread
+            nonlocal active_stream_segment_idx
+            if active_stream_thread is None:
+                return
+            if active_stream_thread.is_alive():
+                print(f"[GPU {gpu_id}] Waiting for AV stream "
+                      f"segment {active_stream_segment_idx} before continuing")
+            active_stream_thread.join(timeout=ACTIVE_STREAM_JOIN_TIMEOUT_SECONDS)
+            if active_stream_thread.is_alive():
+                raise RuntimeError(f"Timed out waiting for AV stream segment "
+                                   f"{active_stream_segment_idx} after "
+                                   f"{ACTIVE_STREAM_JOIN_TIMEOUT_SECONDS:.0f}s")
+            active_stream_thread = None
+            active_stream_segment_idx = None
+
+        def start_stream_thread(
+            *,
+            step_result,
+            user_id: str,
+            segment_idx: int,
+            stream_id: str,
+            head_trim_frames: int,
+            head_trim_audio_frames: int,
+        ) -> None:
+            """Start fMP4 encoding for one segment and publish media events to the controller."""
+            nonlocal active_stream_thread
+            nonlocal active_stream_segment_idx
+            wait_for_active_stream()
+            stream_timings = dict(step_result.timings)
+
+            def _publish(event: StreamEvent) -> None:
+                response_queue.put(_stream_event_to_worker_event(event, user_id, segment_idx))
+
+            def _run_stream() -> None:
+                try:
+                    av_ok, av_error = stream_fmp4(
+                        frames=step_result.frames,
+                        audio=step_result.audio,
+                        audio_sample_rate=step_result.audio_sample_rate,
+                        stream_id=stream_id,
+                        timings=stream_timings,
+                        head_trim_frames=head_trim_frames,
+                        head_trim_audio_frames=head_trim_audio_frames,
+                        shared_buffer=None,
+                        shared_buffer_bytes=0,
+                        publish=_publish,
+                        log_prefix=f"[GPU {gpu_id}]",
+                    )
+                    if not av_ok:
+                        response_queue.put(
+                            MediaError(
+                                user_id=user_id,
+                                segment_idx=segment_idx,
+                                stream_id=stream_id,
+                                message=av_error or "worker av_fmp4 stream failed",
+                            ))
+                        return
+                    print(f"[GPU {gpu_id}] AV streamed segment {segment_idx}: "
+                          f"encode_total={stream_timings.get('av_encode_stream_ms', 0):.0f}ms "
+                          f"wav_write={stream_timings.get('av_wav_write_ms', 0):.1f}ms "
+                          f"spawn={stream_timings.get('av_ffmpeg_spawn_ms', 0):.1f}ms "
+                          f"first_chunk={stream_timings.get('av_first_chunk_ms', 0):.0f}ms "
+                          f"chunk_interval_med={stream_timings.get('av_chunk_interval_ms_median', 0):.1f}ms "
+                          f"chunk_interval_p95={stream_timings.get('av_chunk_interval_ms_p95', 0):.1f}ms "
+                          f"publish_med={stream_timings.get('av_chunk_publish_ms_median', 0):.2f}ms "
+                          f"read_med={stream_timings.get('av_chunk_read_ms_median', 0):.1f}ms")
+                except Exception as exc:
+                    response_queue.put(
+                        MediaError(
+                            user_id=user_id,
+                            segment_idx=segment_idx,
+                            stream_id=stream_id,
+                            message=str(exc),
+                        ))
+
+            active_stream_thread = threading.Thread(
+                target=_run_stream,
+                name=f"dreamverse-av-stream-gpu{gpu_id}-seg{segment_idx}",
+                daemon=False,
+            )
+            active_stream_segment_idx = segment_idx
+            active_stream_thread.start()
 
         def handle_command(cmd: Command):
             if cmd.type == CommandType.USER_JOIN:
@@ -200,40 +292,21 @@ def gpu_worker_process(
                           f"audio_shape={audio_shape}, "
                           f"audio_sample_rate={step_result.audio_sample_rate}")
                     stream_id = generate_stream_id(segment_idx)
-
-                    def _publish(event: StreamEvent) -> None:
-                        response_queue.put(_stream_event_to_worker_event(event, cmd.user_id, segment_idx))
-
-                    av_ok, av_error = stream_fmp4(
-                        frames=step_result.frames,
-                        audio=step_result.audio,
-                        audio_sample_rate=step_result.audio_sample_rate,
+                    start_stream_thread(
+                        step_result=step_result,
+                        user_id=cmd.user_id,
+                        segment_idx=segment_idx,
                         stream_id=stream_id,
-                        timings=step_result.timings,
                         head_trim_frames=head_trim_frames,
                         head_trim_audio_frames=head_trim_audio_frames,
-                        shared_buffer=shared_stream_buffer,
-                        shared_buffer_bytes=shared_stream_buffer_bytes,
-                        publish=_publish,
-                        log_prefix=f"[GPU {gpu_id}]",
                     )
-                    if not av_ok:
-                        raise RuntimeError(av_error or "worker av_fmp4 stream failed")
-                    print(f"[GPU {gpu_id}] AV streamed segment {segment_idx}: "
-                          f"encode_total={step_result.timings.get('av_encode_stream_ms', 0):.0f}ms "
-                          f"wav_write={step_result.timings.get('av_wav_write_ms', 0):.1f}ms "
-                          f"spawn={step_result.timings.get('av_ffmpeg_spawn_ms', 0):.1f}ms "
-                          f"first_chunk={step_result.timings.get('av_first_chunk_ms', 0):.0f}ms "
-                          f"chunk_interval_med={step_result.timings.get('av_chunk_interval_ms_median', 0):.1f}ms "
-                          f"chunk_interval_p95={step_result.timings.get('av_chunk_interval_ms_p95', 0):.1f}ms "
-                          f"publish_med={step_result.timings.get('av_chunk_publish_ms_median', 0):.2f}ms "
-                          f"read_med={step_result.timings.get('av_chunk_read_ms_median', 0):.1f}ms")
-                    step_result.timings["ipc_put_start_ns"] = time.time_ns()
+                    step_timings = dict(step_result.timings)
+                    step_timings["ipc_put_start_ns"] = time.time_ns()
                     response_queue.put(
                         StepComplete(
                             user_id=cmd.user_id,
                             segment_idx=segment_idx,
-                            timings=step_result.timings,
+                            timings=step_timings,
                         ))
                 except Exception as e:
                     print(f"[GPU {gpu_id}] Step error: {e}")
@@ -245,8 +318,17 @@ def gpu_worker_process(
 
             elif cmd.type == CommandType.USER_LEAVE:
                 print(f"[GPU {gpu_id}] User {cmd.user_id[:8]} left")
-                worker.clear_conditioning()
-                response_queue.put(LeaveAck(user_id=cmd.user_id))
+                try:
+                    wait_for_active_stream()
+                    worker.clear_conditioning()
+                    response_queue.put(LeaveAck(user_id=cmd.user_id))
+                except Exception as e:
+                    print(f"[GPU {gpu_id}] Leave error: {e}")
+                    response_queue.put(WorkerError(
+                        user_id=cmd.user_id,
+                        message=str(e),
+                    ))
+                    return False
 
             elif cmd.type == CommandType.SHUTDOWN:
                 return False  # Signal to exit
@@ -286,6 +368,7 @@ def gpu_worker_process(
 
         if first_cmd is not None:
             if first_cmd.type == CommandType.SHUTDOWN:
+                wait_for_active_stream()
                 worker.shutdown()
                 response_queue.put(ShutdownAck())
                 return
@@ -300,6 +383,7 @@ def gpu_worker_process(
 
             if cmd.type == CommandType.SHUTDOWN:
                 print(f"[GPU {gpu_id}] Event loop shutting down")
+                wait_for_active_stream()
                 worker.shutdown()
                 response_queue.put(ShutdownAck())
                 return
@@ -600,7 +684,7 @@ class GPUSlot:
                     continue
 
                 # AV streaming events → route to the user's stream queue.
-                if isinstance(event, (MediaInit, MediaChunk, MediaComplete)):
+                if isinstance(event, (MediaInit, MediaChunk, MediaComplete, MediaError)):
                     stream_queue = self._stream_queues.get(event.user_id)
                     if stream_queue is not None:
                         await stream_queue.put(event)

--- a/apps/dreamverse/dreamverse/session/controller.py
+++ b/apps/dreamverse/dreamverse/session/controller.py
@@ -1408,7 +1408,7 @@ class SessionController:
                                 "stream_id": stream_id,
                                 "chunks": relayed_chunks,
                             })
-                            total_segments_hint = segment_total_hints.get(
+                            total_segments_hint = segment_total_hints.pop(
                                 event.segment_idx,
                                 max(event.segment_idx, len(curated_prompts)),
                             )

--- a/apps/dreamverse/dreamverse/session/controller.py
+++ b/apps/dreamverse/dreamverse/session/controller.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING
 from fastapi import WebSocket, WebSocketDisconnect
 from dreamverse.gpu_pool import GPUSlot
 from dreamverse.session_init_image import cleanup_session_init_image, persist_session_init_image
-from dreamverse.worker_ipc import MediaChunk, MediaComplete, MediaInit
+from dreamverse.worker_ipc import MediaChunk, MediaComplete, MediaError, MediaInit
 
 from dreamverse.config import (
     DEFAULT_MODEL_ID,
@@ -155,6 +155,8 @@ class SessionController:
         websocket_reader_task: asyncio.Task | None = None
         prompt_worker_task: asyncio.Task | None = None
         rewrite_seed_prompts_task: asyncio.Task | None = None
+        # Drains worker fMP4 events while the main loop can request the next segment.
+        media_relay_task: asyncio.Task | None = None
         session_init_image = None
 
         async def session_timeout():
@@ -288,9 +290,16 @@ class SessionController:
             locked_segment_prompts: list[str] = []
             seed_prompt_memory: list[str] = list(curated_prompts)
             generated_segment_count = 0
+            # fMP4 relay state:
+            # - stream_* counters and stream_complete_pending gate stream completion.
+            # - segment_total_hints supports ltx2_segment_complete payloads.
+            stream_generated_segment_count = 0
+            media_completed_segment_count = 0
             generation_cap_blocked = False
             auto_extension_blocked_segment_idx: int | None = None
             prompt_sources_drained_logged = False
+            stream_complete_pending = False
+            segment_total_hints: dict[int, int] = {}
             generation_paused = bool(initial_rollout_prompt and not single_clip_mode and len(curated_prompts) == 0)
             pending_seed_reset = False
             pending_seed_reset_reason = ""
@@ -435,9 +444,13 @@ class SessionController:
                 nonlocal pending_reset_conditioning
                 nonlocal force_curated_restart_segment
                 nonlocal generated_segment_count
+                nonlocal stream_generated_segment_count
+                nonlocal media_completed_segment_count
                 nonlocal generation_cap_blocked
                 nonlocal auto_extension_blocked_segment_idx
                 nonlocal prompt_sources_drained_logged
+                nonlocal stream_complete_pending
+                nonlocal segment_total_hints
                 nonlocal pending_simple_prompt_submission
                 nonlocal single_clip_waiting_for_request
                 nonlocal rollout_waiting_for_rewrite
@@ -527,9 +540,13 @@ class SessionController:
                 pending_reset_conditioning = True
                 force_curated_restart_segment = False
                 generated_segment_count = 0
+                stream_generated_segment_count = 0
+                media_completed_segment_count = 0
                 generation_cap_blocked = False
                 auto_extension_blocked_segment_idx = None
                 prompt_sources_drained_logged = False
+                stream_complete_pending = False
+                segment_total_hints.clear()
                 pending_simple_prompt_submission = None
                 single_clip_waiting_for_request = False
                 rollout_waiting_for_rewrite = False
@@ -1313,6 +1330,118 @@ class SessionController:
 
             av_event_queue = slot.register_stream_queue(client_id)
 
+            async def maybe_send_stream_complete() -> None:
+                """Send 'stream-complete' only after every generated segment has completed fMP4 media."""
+                nonlocal project_stream_started
+                nonlocal stream_complete_pending
+                if not project_stream_started or not stream_complete_pending:
+                    return
+                if (stream_generated_segment_count > 0
+                        and media_completed_segment_count < stream_generated_segment_count):
+                    return
+                project_stream_started = False
+                stream_complete_pending = False
+                await ws_send_json({"type": "ltx2_stream_complete"})
+                await log_event("ws_stream_complete")
+
+            async def media_relay_loop() -> None:
+                """Relay fMP4 media from this slot's per-user queue to the browser.
+
+                Generation waits for StepComplete and can then request the next
+                segment. This task independently forwards media events for
+                already-generated segments, and closes the browser stream only
+                after media completion catches up with generated segments.
+                """
+                nonlocal media_completed_segment_count
+                current_media_segment_idx: int | None = None
+                media_chunks_relayed = 0
+                media_bytes_relayed = 0
+                while not stop_event.is_set():
+                    try:
+                        event = await asyncio.wait_for(av_event_queue.get(), timeout=0.1)
+                    except asyncio.TimeoutError:
+                        continue
+
+                    match event:
+                        case MediaInit(mime=mime, stream_id=stream_id):
+                            current_media_segment_idx = event.segment_idx
+                            media_chunks_relayed = 0
+                            media_bytes_relayed = 0
+                            await ws_send_json({
+                                "type": "media_init",
+                                "segment_idx": event.segment_idx,
+                                "mime": mime,
+                                "stream_id": stream_id,
+                                "mode": "av_fmp4",
+                            })
+                        case MediaChunk(
+                            chunk=chunk_bytes,
+                            chunk_offset=chunk_offset,
+                            chunk_length=chunk_length,
+                            uses_shared_buffer=uses_shared,
+                        ):
+                            if (uses_shared and chunk_offset is not None and chunk_length is not None
+                                    and slot.shared_stream_buffer is not None):
+                                start = chunk_offset
+                                end = start + chunk_length
+                                chunk = bytes(slot.shared_stream_buffer[start:end])
+                            else:
+                                chunk = chunk_bytes or b""
+                            if chunk:
+                                if current_media_segment_idx != event.segment_idx:
+                                    current_media_segment_idx = event.segment_idx
+                                    media_chunks_relayed = 0
+                                    media_bytes_relayed = 0
+                                media_chunks_relayed += 1
+                                media_bytes_relayed += len(chunk)
+                                await ws_send_bytes(chunk)
+                        case MediaComplete(stream_id=stream_id, chunks=n):
+                            media_completed_segment_count += 1
+                            if current_media_segment_idx != event.segment_idx:
+                                current_media_segment_idx = event.segment_idx
+                                media_chunks_relayed = 0
+                                media_bytes_relayed = 0
+                            relayed_chunks = n if n is not None else media_chunks_relayed
+                            await ws_send_json({
+                                "type": "media_segment_complete",
+                                "segment_idx": event.segment_idx,
+                                "stream_id": stream_id,
+                                "chunks": relayed_chunks,
+                            })
+                            total_segments_hint = segment_total_hints.get(
+                                event.segment_idx,
+                                max(event.segment_idx, len(curated_prompts)),
+                            )
+                            await ws_send_json({
+                                "type": "ltx2_segment_complete",
+                                "segment_idx": event.segment_idx,
+                                "total_segments": total_segments_hint,
+                            })
+                            await log_event(
+                                "segment_complete",
+                                {
+                                    "segment_idx": event.segment_idx,
+                                    "data_size_bytes": media_bytes_relayed,
+                                },
+                            )
+                            print(f"[GPU {gpu_id}] Segment {event.segment_idx}: "
+                                  f"relayed av chunks={media_chunks_relayed}, "
+                                  f"bytes={media_bytes_relayed / (1024 * 1024):.1f}MB")
+                            await maybe_send_stream_complete()
+                        case MediaError(stream_id=stream_id, message=message):
+                            await ws_send_json({
+                                "type": "error",
+                                "message": f"AV streaming failed for segment {event.segment_idx}: {message}",
+                                "segment_idx": event.segment_idx,
+                                "stream_id": stream_id,
+                            })
+                            stop_event.set()
+                        case _:
+                            print(f"[GPU {gpu_id}] Unknown AV event: "
+                                  f"{type(event).__name__}")
+
+            media_relay_task = asyncio.create_task(media_relay_loop())
+
             while not stop_event.is_set():
                 if pending_project_end:
                     await enter_project_idle()
@@ -1320,6 +1449,13 @@ class SessionController:
                     continue
 
                 if not project_active:
+                    await asyncio.sleep(0.05)
+                    continue
+
+                if (pending_seed_reset and project_stream_started
+                        and media_completed_segment_count < stream_generated_segment_count):
+                    stream_complete_pending = True
+                    await maybe_send_stream_complete()
                     await asyncio.sleep(0.05)
                     continue
 
@@ -1337,6 +1473,10 @@ class SessionController:
                     single_clip_waiting_for_request = False
                     dropped_raw = drain_queue_nowait(raw_prompt_queue)
                     dropped_ready = drain_queue_nowait(ready_prompt_queue)
+                    stream_generated_segment_count = 0
+                    media_completed_segment_count = 0
+                    stream_complete_pending = False
+                    segment_total_hints.clear()
 
                     loop_iteration += 1
                     project_stream_started = True
@@ -1399,9 +1539,8 @@ class SessionController:
                         f"generated_segments={generated_segment_count}); "
                         "waiting for rollout rewrite",
                     )
-                    project_stream_started = False
-                    await ws_send_json({"type": "ltx2_stream_complete"})
-                    await log_event("ws_stream_complete")
+                    stream_complete_pending = True
+                    await maybe_send_stream_complete()
 
                 if generation_cap_blocked:
                     await asyncio.sleep(0.05)
@@ -1612,86 +1751,23 @@ class SessionController:
 
                 t_start = time.perf_counter()
                 timings: dict = {}
-                av_chunks_relayed = 0
-                av_bytes_relayed = 0
-                av_streamed = False
+                segment_total_hints[segment_idx] = total_segments_hint
 
                 step_reset_conditioning = pending_reset_conditioning
                 pending_reset_conditioning = False
                 step_image_path = (str(session_init_image.file_path)
                                    if segment_idx == 1 and session_init_image is not None else None)
-                step_task = asyncio.create_task(
-                    slot.user_step(
+                segment_generation_active = True
+                try:
+                    timings = await slot.user_step(
                         client_id,
                         prompt=prompt,
                         segment_idx=segment_idx,
                         image_path=step_image_path,
                         reset_conditioning=step_reset_conditioning,
-                    ))
-                segment_generation_active = True
-                try:
-                    while not stop_event.is_set() and (not step_task.done() or not av_event_queue.empty()):
-                        try:
-                            event = await asyncio.wait_for(av_event_queue.get(), timeout=0.05)
-                        except asyncio.TimeoutError:
-                            continue
-
-                        if event.segment_idx != segment_idx:
-                            print(f"[GPU {gpu_id}] Ignoring out-of-order AV event: "
-                                  f"event_seg={event.segment_idx}, current_seg={segment_idx}, "
-                                  f"kind={type(event).__name__}")
-                            continue
-
-                        match event:
-                            case MediaInit(mime=mime, stream_id=stream_id):
-                                av_streamed = True
-                                await ws_send_json({
-                                    "type": "media_init",
-                                    "segment_idx": segment_idx,
-                                    "mime": mime,
-                                    "stream_id": stream_id,
-                                    "mode": "av_fmp4",
-                                })
-                            case MediaChunk(
-                                chunk=chunk_bytes,
-                                chunk_offset=chunk_offset,
-                                chunk_length=chunk_length,
-                                uses_shared_buffer=uses_shared,
-                            ):
-                                if (uses_shared and chunk_offset is not None and chunk_length is not None
-                                        and slot.shared_stream_buffer is not None):
-                                    start = chunk_offset
-                                    end = start + chunk_length
-                                    # Copy out of shared buffer for websocket send.
-                                    chunk = bytes(slot.shared_stream_buffer[start:end])
-                                else:
-                                    chunk = chunk_bytes or b""
-                                if chunk:
-                                    av_chunks_relayed += 1
-                                    av_bytes_relayed += len(chunk)
-                                    await ws_send_bytes(chunk)
-                            case MediaComplete(stream_id=stream_id, chunks=n):
-                                await ws_send_json({
-                                    "type": "media_segment_complete",
-                                    "segment_idx": segment_idx,
-                                    "stream_id": stream_id,
-                                    "chunks": n if n is not None else av_chunks_relayed,
-                                })
-                            case _:
-                                print(f"[GPU {gpu_id}] Unknown AV event: "
-                                      f"{type(event).__name__}")
-
-                    if not step_task.done():
-                        step_task.cancel()
-                    else:
-                        timings = await step_task
+                    )
                 finally:
                     segment_generation_active = False
-                    if not step_task.done():
-                        try:
-                            await step_task
-                        except asyncio.CancelledError:
-                            pass
 
                 if stop_event.is_set():
                     break
@@ -1715,51 +1791,28 @@ class SessionController:
                       f"overhead={overhead_vs_worker_ms:.0f}ms, "
                       f"ipc_queue={ipc_queue_str}")
 
-                if not av_streamed:
-                    raise RuntimeError(f"Segment {segment_idx} AV stream did not initialize "
-                                       "(no media_init event)")
+                segment_latency_ms = {
+                    "total": round(main_user_step_ms, 2),
+                    "worker_e2e": round(worker_e2e_ms, 2),
+                    "main_user_step": round(main_user_step_ms, 2),
+                    "overhead": round(overhead_vs_worker_ms, 2),
+                }
                 generated_segment_count += 1
+                stream_generated_segment_count += 1
 
-                print(f"[GPU {gpu_id}] Segment {segment_idx}: "
-                      f"relayed av chunks={av_chunks_relayed}, "
-                      f"bytes={av_bytes_relayed / (1024 * 1024):.1f}MB")
                 _main_print(
                     "INFO",
                     f"Segments generated for client {client_id[:8]}: "
                     f"{generated_segment_count}",
                 )
-                await log_event(
-                    "segment_complete",
-                    {
-                        "segment_idx": segment_idx,
-                        "latency_ms": {
-                            "total": round(main_user_step_ms, 2),
-                            "worker_e2e": round(worker_e2e_ms, 2),
-                            "main_user_step": round(main_user_step_ms, 2),
-                            "overhead": round(overhead_vs_worker_ms, 2),
-                        },
-                        "data_size_bytes": av_bytes_relayed,
-                    },
-                )
                 await ws_send_json({
                     "type": "step_complete",
-                    "latency_ms": {
-                        "total": round(main_user_step_ms, 2),
-                        "worker_e2e": round(worker_e2e_ms, 2),
-                        "main_user_step": round(main_user_step_ms, 2),
-                        "overhead": round(overhead_vs_worker_ms, 2),
-                    },
-                })
-                await ws_send_json({
-                    "type": "ltx2_segment_complete",
-                    "segment_idx": segment_idx,
-                    "total_segments": total_segments_hint,
+                    "latency_ms": segment_latency_ms,
                 })
                 if single_clip_mode and not single_clip_waiting_for_request:
                     single_clip_waiting_for_request = True
-                    project_stream_started = False
-                    await ws_send_json({"type": "ltx2_stream_complete"})
-                    await log_event("ws_stream_complete")
+                    stream_complete_pending = True
+                    await maybe_send_stream_complete()
                     _main_print(
                         "INFO",
                         f"Single-clip session idle for client {client_id[:8]} "
@@ -1792,6 +1845,7 @@ class SessionController:
             await cancel_task(websocket_reader_task)
             await cancel_task(prompt_worker_task)
             await cancel_task(rewrite_seed_prompts_task)
+            await cancel_task(media_relay_task)
 
             if slot is not None and client_id:
                 slot.unregister_stream_queue(client_id)

--- a/apps/dreamverse/dreamverse/tests/test_session_logging.py
+++ b/apps/dreamverse/dreamverse/tests/test_session_logging.py
@@ -112,6 +112,8 @@ class _FakeSlot:
             "reset_conditioning": reset_conditioning,
         })
         queue = self._stream_queues[client_id]
+        if self._step_delay_s > 0:
+            await asyncio.sleep(self._step_delay_s)
         await queue.put(MediaInit(
             user_id=client_id,
             segment_idx=segment_idx,
@@ -132,8 +134,6 @@ class _FakeSlot:
             stream_id=f"stream-{segment_idx}",
             chunks=1,
         ))
-        if self._step_delay_s > 0:
-            await asyncio.sleep(self._step_delay_s)
         return {"e2e_latency_ms": 10.0}
 
 
@@ -423,14 +423,6 @@ def test_websocket_flow_emits_required_session_events():
             for event in fake_logger.events
             if event["event"] == "segment_complete"
         )
-        latency = segment_complete.get("latency_ms")
-        assert isinstance(latency, dict)
-        assert set(latency.keys()) == {
-            "total",
-            "worker_e2e",
-            "main_user_step",
-            "overhead",
-        }
         assert isinstance(segment_complete.get("data_size_bytes"), int)
         assert segment_complete["data_size_bytes"] > 0
     finally:

--- a/apps/dreamverse/dreamverse/tests/test_session_logging.py
+++ b/apps/dreamverse/dreamverse/tests/test_session_logging.py
@@ -22,7 +22,7 @@ import dreamverse.main as server_main  # noqa: E402
 import dreamverse.runtime as runtime  # noqa: E402
 from dreamverse.config import PROMPT_TIMEOUT_MS  # noqa: E402
 from dreamverse.session_logger import SessionEventLogger  # noqa: E402
-from dreamverse.worker_ipc import MediaChunk, MediaComplete, MediaInit  # noqa: E402
+from dreamverse.worker_ipc import MediaChunk, MediaComplete, MediaError, MediaInit  # noqa: E402
 from dreamverse.session import controller as session_controller  # noqa: E402
 from dreamverse.utils import PROMPT_EXTENSION_FAILURE_USER_MESSAGE  # noqa: E402
 
@@ -79,11 +79,21 @@ class _FakeWebSocket:
 
 
 class _FakeSlot:
-    def __init__(self, step_delay_s: float = 0.0):
+    def __init__(
+        self,
+        step_delay_s: float = 0.0,
+        media_delay_s: float = 0.0,
+        async_media: bool = False,
+        media_error: bool = False,
+    ):
         self.shared_stream_buffer = None
         self._stream_queues: dict[str, asyncio.Queue] = {}
         self.calls: list[dict[str, object]] = []
         self._step_delay_s = max(0.0, float(step_delay_s))
+        self._media_delay_s = max(0.0, float(media_delay_s))
+        self._async_media = async_media
+        self._media_error = media_error
+        self.media_tasks: list[asyncio.Task] = []
 
     async def join_user(self, client_id: str, model_id: str) -> None:
         del client_id, model_id
@@ -95,6 +105,42 @@ class _FakeSlot:
 
     def unregister_stream_queue(self, client_id: str) -> None:
         self._stream_queues.pop(client_id, None)
+
+    async def _emit_media_events(self, client_id: str, segment_idx: int) -> None:
+        if self._media_delay_s > 0:
+            await asyncio.sleep(self._media_delay_s)
+        queue = self._stream_queues.get(client_id)
+        if queue is None:
+            return
+        stream_id = f"stream-{segment_idx}"
+        if self._media_error:
+            await queue.put(MediaError(
+                user_id=client_id,
+                segment_idx=segment_idx,
+                stream_id=stream_id,
+                message="fake media failure",
+            ))
+            return
+        await queue.put(MediaInit(
+            user_id=client_id,
+            segment_idx=segment_idx,
+            stream_id=stream_id,
+            mime='video/mp4; codecs="avc1.640028,mp4a.40.2"',
+            uses_shared_buffer=False,
+        ))
+        await queue.put(MediaChunk(
+            user_id=client_id,
+            segment_idx=segment_idx,
+            stream_id=stream_id,
+            chunk=b"abc123",
+            uses_shared_buffer=False,
+        ))
+        await queue.put(MediaComplete(
+            user_id=client_id,
+            segment_idx=segment_idx,
+            stream_id=stream_id,
+            chunks=1,
+        ))
 
     async def user_step(
         self,
@@ -111,35 +157,33 @@ class _FakeSlot:
             "image_path": image_path,
             "reset_conditioning": reset_conditioning,
         })
-        queue = self._stream_queues[client_id]
+        if client_id not in self._stream_queues:
+            raise KeyError(client_id)
         if self._step_delay_s > 0:
             await asyncio.sleep(self._step_delay_s)
-        await queue.put(MediaInit(
-            user_id=client_id,
-            segment_idx=segment_idx,
-            stream_id=f"stream-{segment_idx}",
-            mime='video/mp4; codecs="avc1.640028,mp4a.40.2"',
-            uses_shared_buffer=False,
-        ))
-        await queue.put(MediaChunk(
-            user_id=client_id,
-            segment_idx=segment_idx,
-            stream_id=f"stream-{segment_idx}",
-            chunk=b"abc123",
-            uses_shared_buffer=False,
-        ))
-        await queue.put(MediaComplete(
-            user_id=client_id,
-            segment_idx=segment_idx,
-            stream_id=f"stream-{segment_idx}",
-            chunks=1,
-        ))
+        if self._async_media:
+            self.media_tasks.append(asyncio.create_task(self._emit_media_events(client_id, segment_idx)))
+            await asyncio.sleep(0)
+        else:
+            await self._emit_media_events(client_id, segment_idx)
         return {"e2e_latency_ms": 10.0}
 
 
 class _FakeGPUPool:
-    def __init__(self, step_delay_s: float = 0.0):
-        self._slot = _FakeSlot(step_delay_s=step_delay_s)
+    def __init__(
+        self,
+        step_delay_s: float = 0.0,
+        media_delay_s: float = 0.0,
+        async_media: bool = False,
+        media_error: bool = False,
+    ):
+        self._slot = _FakeSlot(
+            step_delay_s=step_delay_s,
+            media_delay_s=media_delay_s,
+            async_media=async_media,
+            media_error=media_error,
+        )
+        self.release_calls: list[str] = []
 
     def get_status(self) -> dict[str, int]:
         return {
@@ -153,7 +197,7 @@ class _FakeGPUPool:
         return 0, self._slot
 
     async def release(self, client_id: str) -> None:
-        del client_id
+        self.release_calls.append(client_id)
 
 
 def _make_png_data_url() -> str:
@@ -532,6 +576,115 @@ def test_simple_generate_reuses_session_and_resets_conditioning():
             }
             for payload in step_complete_events
         )
+    finally:
+        runtime.gpu_pool = old_gpu_pool
+        runtime.prompt_enhancer = old_prompt_enhancer
+        runtime.session_event_logger = old_session_logger
+        runtime.prompt_safety_filter = old_prompt_safety_filter
+
+
+def test_stream_complete_waits_for_async_media_tail():
+    old_gpu_pool = runtime.gpu_pool
+    old_prompt_enhancer = runtime.prompt_enhancer
+    old_session_logger = runtime.session_event_logger
+    old_prompt_safety_filter = runtime.prompt_safety_filter
+    try:
+        fake_logger = _FakeSessionLogger()
+        fake_pool = _FakeGPUPool(
+            media_delay_s=0.05,
+            async_media=True,
+        )
+        runtime.gpu_pool = fake_pool
+        runtime.prompt_enhancer = _FakePromptEnhancer()
+        runtime.session_event_logger = fake_logger
+        runtime.prompt_safety_filter = None
+
+        ws = _FakeWebSocket(
+            [
+                (
+                    0.0,
+                    {
+                        "type": "session_init_v2",
+                        "curated_prompts": ["segment one prompt"],
+                        "single_clip_mode": True,
+                        "enhancement_enabled": False,
+                        "auto_extension_enabled": False,
+                        "loop_generation_enabled": False,
+                    },
+                ),
+                (0.25, {"type": "leave"}),
+            ]
+        )
+
+        asyncio.run(server_main.websocket_endpoint(ws))
+
+        message_types = [payload["type"] for payload in ws.sent_json]
+        step_complete_idx = message_types.index("step_complete")
+        media_init_idx = message_types.index("media_init")
+        media_segment_complete_idx = message_types.index("media_segment_complete")
+        stream_complete_idx = message_types.index("ltx2_stream_complete")
+
+        assert step_complete_idx < media_init_idx
+        assert media_init_idx < media_segment_complete_idx
+        assert media_segment_complete_idx < stream_complete_idx
+        assert ws.sent_bytes == [b"abc123"]
+        assert "ws_stream_complete" in [
+            event["event"] for event in fake_logger.events
+        ]
+    finally:
+        runtime.gpu_pool = old_gpu_pool
+        runtime.prompt_enhancer = old_prompt_enhancer
+        runtime.session_event_logger = old_session_logger
+        runtime.prompt_safety_filter = old_prompt_safety_filter
+
+
+def test_media_error_stops_session_and_releases_gpu_slot():
+    old_gpu_pool = runtime.gpu_pool
+    old_prompt_enhancer = runtime.prompt_enhancer
+    old_session_logger = runtime.session_event_logger
+    old_prompt_safety_filter = runtime.prompt_safety_filter
+    try:
+        fake_logger = _FakeSessionLogger()
+        fake_pool = _FakeGPUPool(
+            async_media=True,
+            media_error=True,
+        )
+        runtime.gpu_pool = fake_pool
+        runtime.prompt_enhancer = _FakePromptEnhancer()
+        runtime.session_event_logger = fake_logger
+        runtime.prompt_safety_filter = None
+
+        ws = _FakeWebSocket(
+            [
+                (
+                    0.0,
+                    {
+                        "type": "session_init_v2",
+                        "curated_prompts": [
+                            "segment one prompt",
+                            "segment two prompt",
+                        ],
+                        "enhancement_enabled": False,
+                        "auto_extension_enabled": False,
+                        "loop_generation_enabled": False,
+                    },
+                ),
+                (0.25, {"type": "leave"}),
+            ]
+        )
+
+        asyncio.run(server_main.websocket_endpoint(ws))
+
+        error_messages = [
+            payload
+            for payload in ws.sent_json
+            if payload.get("type") == "error"
+        ]
+        assert error_messages
+        assert error_messages[0]["segment_idx"] == 1
+        assert "AV streaming failed for segment 1" in error_messages[0]["message"]
+        assert [call["segment_idx"] for call in fake_pool._slot.calls] == [1]
+        assert len(fake_pool.release_calls) == 1
     finally:
         runtime.gpu_pool = old_gpu_pool
         runtime.prompt_enhancer = old_prompt_enhancer

--- a/apps/dreamverse/dreamverse/worker_ipc.py
+++ b/apps/dreamverse/dreamverse/worker_ipc.py
@@ -98,6 +98,15 @@ class MediaComplete:
     chunks: int
 
 
+@dataclass(frozen=True)
+class MediaError:
+    """Post-generation fMP4 failure routed through the segment media path."""
+    user_id: str
+    segment_idx: int
+    stream_id: str
+    message: str
+
+
 # ---- System events (no user_id) --------------------------------------------
 
 
@@ -121,6 +130,7 @@ WorkerEvent = (StepComplete
                | MediaInit
                | MediaChunk
                | MediaComplete
+               | MediaError
                | InitAck
                | ShutdownAck)
 


### PR DESCRIPTION
## Summary

- move Dreamverse fMP4 packaging out of the synchronous USER_STEP path into one serial worker-side background stream thread
- add MediaError for post-generation fMP4 failures and route media events through a SessionController media relay task
- keep ltx2_segment_complete and ltx2_stream_complete tied to media completion while StepComplete remains the generation/continuation-state boundary
- update session logging expectations for the split generation/media lifecycle

## Tests

- git diff --cached --check
- /home/hal-jundas/codes/FastVideo/.venv/bin/python -m py_compile apps/dreamverse/dreamverse/session/controller.py apps/dreamverse/dreamverse/tests/test_session_logging.py
- /home/hal-jundas/codes/FastVideo/.venv/bin/python -m pytest apps/dreamverse/dreamverse/tests/test_session_logging.py::test_websocket_flow_emits_required_session_events -q *(blocked during collection: Triton reports `RuntimeError: 0 active drivers ([]). There should only be one.`)*