### PR TITLE
[feat] Optional cache-dit step caching for the Wan DiT

### DIFF
--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -95,6 +95,13 @@ surfaces:
       moba_config: "Derived runtime config loaded from moba_config_path."
       model_paths: "Runtime bookkeeping."
       model_loaded: "Runtime bookkeeping."
+      use_cachedit: "Opt-in cache-dit step-caching toggle (Wan DiT); runtime plumbing, not part of the typed API yet."
+      cachedit_fn_compute_blocks: "cache-dit leading-block count; runtime plumbing for use_cachedit."
+      cachedit_bn_compute_blocks: "cache-dit trailing-block count; runtime plumbing for use_cachedit."
+      cachedit_residual_threshold: "cache-dit residual-diff skip threshold; runtime plumbing for use_cachedit."
+      cachedit_max_warmup_steps: "cache-dit warmup-step count; runtime plumbing for use_cachedit."
+      cachedit_taylorseer: "cache-dit TaylorSeer calibrator toggle; runtime plumbing for use_cachedit."
+      cachedit_taylorseer_order: "cache-dit TaylorSeer expansion order; runtime plumbing for use_cachedit."
 
   pipeline_config_base:
     moved:

--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -101,6 +101,13 @@ surfaces:
       moba_config: "Derived runtime config loaded from moba_config_path."
       model_paths: "Runtime bookkeeping."
       model_loaded: "Runtime bookkeeping."
+      use_cachedit: "Opt-in cache-dit step-caching toggle (Wan DiT); runtime plumbing, not part of the typed API yet."
+      cachedit_fn_compute_blocks: "cache-dit leading-block count; runtime plumbing for use_cachedit."
+      cachedit_bn_compute_blocks: "cache-dit trailing-block count; runtime plumbing for use_cachedit."
+      cachedit_residual_threshold: "cache-dit residual-diff skip threshold; runtime plumbing for use_cachedit."
+      cachedit_max_warmup_steps: "cache-dit warmup-step count; runtime plumbing for use_cachedit."
+      cachedit_taylorseer: "cache-dit TaylorSeer calibrator toggle; runtime plumbing for use_cachedit."
+      cachedit_taylorseer_order: "cache-dit TaylorSeer expansion order; runtime plumbing for use_cachedit."
 
   pipeline_config_base:
     moved:

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -132,6 +132,28 @@ class FastVideoArgs:
     vae_cpu_offload: bool = True
     pin_cpu_memory: bool = True
 
+    # Step caching via cache-dit (https://github.com/vipshop/cache-dit).
+    # LOSSY: skips DiT blocks on steps whose features barely change, so the
+    # output is NOT bit-identical (SSIM<1.0). Opt-in, default OFF, Wan DiT
+    # only for now. When on, the first ``cachedit_fn_compute_blocks`` blocks
+    # always run and produce an L1 "stable" residual; if its relative change
+    # from the previous step is below ``cachedit_residual_threshold`` the
+    # middle blocks are skipped and a cached residual reused; the last
+    # ``cachedit_bn_compute_blocks`` blocks always run to refine. No caching
+    # during the first ``cachedit_max_warmup_steps`` steps. ``cachedit_
+    # taylorseer`` swaps the constant-residual reuse for a Taylor-expansion
+    # extrapolation of the residual (higher fidelity at the same skip rate).
+    # Requires ``pip install cache-dit`` and is incompatible with DiT
+    # offloading (see DenoisingStage — caching skips blocks, offload assumes
+    # every block runs each step).
+    use_cachedit: bool = False
+    cachedit_fn_compute_blocks: int = 8
+    cachedit_bn_compute_blocks: int = 0
+    cachedit_residual_threshold: float = 0.08
+    cachedit_max_warmup_steps: int = 8
+    cachedit_taylorseer: bool = False
+    cachedit_taylorseer_order: int = 1
+
     # Compilation
     # ``enable_torch_compile`` covers the DiT path (transformer,
     # transformer_2, and the LTX-2 stage-2 transformer_refine).
@@ -589,6 +611,47 @@ class FastVideoArgs:
             "--disable-autocast",
             action=StoreBoolean,
             help="Disable autocast for denoising loop and vae decoding in pipeline sampling",
+        )
+
+        # cache-dit step caching (lossy; Wan DiT). Requires `pip install
+        # cache-dit` and is incompatible with DiT offloading.
+        parser.add_argument(
+            "--use-cachedit",
+            action=StoreBoolean,
+            help="Enable cache-dit step caching for the Wan DiT (lossy; skips DiT blocks on steps whose features "
+            "barely change). Requires `pip install cache-dit`; incompatible with DiT offloading.",
+        )
+        parser.add_argument(
+            "--cachedit-fn-compute-blocks",
+            type=int,
+            help="cache-dit: number of leading DiT blocks always computed (default 8).",
+        )
+        parser.add_argument(
+            "--cachedit-bn-compute-blocks",
+            type=int,
+            help="cache-dit: number of trailing DiT blocks always computed to refine (default 0).",
+        )
+        parser.add_argument(
+            "--cachedit-residual-threshold",
+            type=float,
+            help="cache-dit: relative L1 residual-diff threshold below which middle blocks are skipped (default 0.08; "
+            "higher = faster, lower quality).",
+        )
+        parser.add_argument(
+            "--cachedit-max-warmup-steps",
+            type=int,
+            help="cache-dit: number of initial steps that always compute every block (default 8).",
+        )
+        parser.add_argument(
+            "--cachedit-taylorseer",
+            action=StoreBoolean,
+            help="cache-dit: use a TaylorSeer calibrator (extrapolates the cached residual instead of holding it "
+            "constant — higher fidelity at the same skip rate).",
+        )
+        parser.add_argument(
+            "--cachedit-taylorseer-order",
+            type=int,
+            help="cache-dit: TaylorSeer expansion order / number of derivatives (default 1; 2 = quadratic).",
         )
 
         # VSA parameters

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -159,6 +159,28 @@ class FastVideoArgs:
     vae_parallel_encode: bool = False
     vae_parallel_decode_strategy: str | None = None
 
+    # Step caching via cache-dit (https://github.com/vipshop/cache-dit).
+    # LOSSY: skips DiT blocks on steps whose features barely change, so the
+    # output is NOT bit-identical (SSIM<1.0). Opt-in, default OFF, Wan DiT
+    # only for now. When on, the first ``cachedit_fn_compute_blocks`` blocks
+    # always run and produce an L1 "stable" residual; if its relative change
+    # from the previous step is below ``cachedit_residual_threshold`` the
+    # middle blocks are skipped and a cached residual reused; the last
+    # ``cachedit_bn_compute_blocks`` blocks always run to refine. No caching
+    # during the first ``cachedit_max_warmup_steps`` steps. ``cachedit_
+    # taylorseer`` swaps the constant-residual reuse for a Taylor-expansion
+    # extrapolation of the residual (higher fidelity at the same skip rate).
+    # Requires ``pip install cache-dit`` and is incompatible with DiT
+    # offloading (see DenoisingStage — caching skips blocks, offload assumes
+    # every block runs each step).
+    use_cachedit: bool = False
+    cachedit_fn_compute_blocks: int = 8
+    cachedit_bn_compute_blocks: int = 0
+    cachedit_residual_threshold: float = 0.08
+    cachedit_max_warmup_steps: int = 8
+    cachedit_taylorseer: bool = False
+    cachedit_taylorseer_order: int = 1
+
     # Compilation
     # ``enable_torch_compile`` covers the DiT path (transformer,
     # transformer_2, and the LTX-2 stage-2 transformer_refine).
@@ -709,6 +731,47 @@ class FastVideoArgs:
             "--disable-autocast",
             action=StoreBoolean,
             help="Disable autocast for denoising loop and vae decoding in pipeline sampling",
+        )
+
+        # cache-dit step caching (lossy; Wan DiT). Requires `pip install
+        # cache-dit` and is incompatible with DiT offloading.
+        parser.add_argument(
+            "--use-cachedit",
+            action=StoreBoolean,
+            help="Enable cache-dit step caching for the Wan DiT (lossy; skips DiT blocks on steps whose features "
+            "barely change). Requires `pip install cache-dit`; incompatible with DiT offloading.",
+        )
+        parser.add_argument(
+            "--cachedit-fn-compute-blocks",
+            type=int,
+            help="cache-dit: number of leading DiT blocks always computed (default 8).",
+        )
+        parser.add_argument(
+            "--cachedit-bn-compute-blocks",
+            type=int,
+            help="cache-dit: number of trailing DiT blocks always computed to refine (default 0).",
+        )
+        parser.add_argument(
+            "--cachedit-residual-threshold",
+            type=float,
+            help="cache-dit: relative L1 residual-diff threshold below which middle blocks are skipped (default 0.08; "
+            "higher = faster, lower quality).",
+        )
+        parser.add_argument(
+            "--cachedit-max-warmup-steps",
+            type=int,
+            help="cache-dit: number of initial steps that always compute every block (default 8).",
+        )
+        parser.add_argument(
+            "--cachedit-taylorseer",
+            action=StoreBoolean,
+            help="cache-dit: use a TaylorSeer calibrator (extrapolates the cached residual instead of holding it "
+            "constant — higher fidelity at the same skip rate).",
+        )
+        parser.add_argument(
+            "--cachedit-taylorseer-order",
+            type=int,
+            help="cache-dit: TaylorSeer expansion order / number of derivatives (default 1; 2 = quadratic).",
         )
 
         # VSA parameters

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -67,6 +67,51 @@ class DenoisingStage(PipelineStage):
                                           AttentionBackendEnum.TORCH_SDPA, AttentionBackendEnum.SAGE_ATTN_THREE)  # hack
         )
 
+    def _enable_or_refresh_cachedit(self, model, fastvideo_args, num_inference_steps) -> None:
+        """Wire ``model`` into cache-dit via a transformer-only BlockAdapter on
+        first use, then refresh the cache context each generation. cache-dit is
+        lazy-imported so it stays an optional dependency.
+
+        Wan runs cond + uncond as separate forwards (``enable_separate_cfg=True``),
+        cond first (``cfg_compute_first=False``). ``num_inference_steps`` lets
+        cache-dit auto-refresh at the generation boundary; we also call
+        ``refresh_context`` explicitly per generation so cache state never leaks
+        across prompts (the bare-transformer path has no pipeline call to reset
+        it otherwise).
+        """
+        import cache_dit
+        from cache_dit import (BlockAdapter, DBCacheConfig, ForwardPattern, TaylorSeerCalibratorConfig)
+
+        cache_config = DBCacheConfig(
+            Fn_compute_blocks=fastvideo_args.cachedit_fn_compute_blocks,
+            Bn_compute_blocks=fastvideo_args.cachedit_bn_compute_blocks,
+            residual_diff_threshold=fastvideo_args.cachedit_residual_threshold,
+            max_warmup_steps=fastvideo_args.cachedit_max_warmup_steps,
+            enable_separate_cfg=True,
+            cfg_compute_first=False,
+            num_inference_steps=num_inference_steps,
+        )
+        calibrator_config = None
+        if fastvideo_args.cachedit_taylorseer:
+            calibrator_config = TaylorSeerCalibratorConfig(taylorseer_order=fastvideo_args.cachedit_taylorseer_order)
+
+        if not getattr(model, "_cachedit_enabled", False):
+            adapter = BlockAdapter(
+                transformer=model,
+                blocks=model.blocks,
+                forward_pattern=ForwardPattern.Pattern_2,
+                has_separate_cfg=True,
+                check_forward_pattern=False,
+            )
+            cache_dit.enable_cache(adapter, cache_config=cache_config, calibrator_config=calibrator_config)
+            model._cachedit_enabled = True
+            logger.info("cache-dit enabled: Fn=%d Bn=%d threshold=%s warmup=%d taylorseer=%s",
+                        fastvideo_args.cachedit_fn_compute_blocks, fastvideo_args.cachedit_bn_compute_blocks,
+                        fastvideo_args.cachedit_residual_threshold, fastvideo_args.cachedit_max_warmup_steps,
+                        fastvideo_args.cachedit_taylorseer)
+        else:
+            cache_dit.refresh_context(model, num_inference_steps=num_inference_steps)
+
     def forward(
         self,
         batch: ForwardBatch,
@@ -272,6 +317,24 @@ class DenoisingStage(PipelineStage):
         _cfg_gate_fresh_uncond = 0
         _cfg_gate_reused_delta = 0
         _cfg_gate_invalidations = 0
+
+        # cache-dit step caching skips DiT blocks, which is incompatible with
+        # layerwise / CPU offload: the offload hook prefetches each block's
+        # params on the prior block's forward and releases them on its own,
+        # assuming every block runs exactly once per step. A skipped block
+        # leaves its params prefetched-but-never-released, desyncing the chain.
+        if fastvideo_args.use_cachedit and (fastvideo_args.dit_layerwise_offload or fastvideo_args.dit_cpu_offload):
+            raise ValueError("use_cachedit is incompatible with DiT offloading: caching skips "
+                             "blocks, but the layerwise/CPU offload hook assumes every block "
+                             "runs each step. Set dit_layerwise_offload=False and "
+                             "dit_cpu_offload=False (the model must fit in GPU memory).")
+        # Enable cache-dit on the transformer(s) once, then refresh the cache
+        # context each generation so state never leaks across prompts.
+        if fastvideo_args.use_cachedit:
+            for _tf in (self.transformer, self.transformer_2):
+                _model = getattr(_tf, "module", _tf)
+                if _model is not None and hasattr(_model, "blocks"):
+                    self._enable_or_refresh_cachedit(_model, fastvideo_args, num_inference_steps)
 
         # Run denoising loop
         with self.progress_bar(total=num_inference_steps) as progress_bar:

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -79,8 +79,12 @@ class DenoisingStage(PipelineStage):
         across prompts (the bare-transformer path has no pipeline call to reset
         it otherwise).
         """
-        import cache_dit
-        from cache_dit import (BlockAdapter, DBCacheConfig, ForwardPattern, TaylorSeerCalibratorConfig)
+        try:
+            import cache_dit
+            from cache_dit import (BlockAdapter, DBCacheConfig, ForwardPattern, TaylorSeerCalibratorConfig)
+        except ImportError as e:
+            raise ImportError("use_cachedit requires the cache-dit package, which is not installed. Install it with "
+                              "`pip install \"fastvideo[cache]\"` (or `pip install cache-dit`).") from e
 
         cache_config = DBCacheConfig(
             Fn_compute_blocks=fastvideo_args.cachedit_fn_compute_blocks,
@@ -328,6 +332,14 @@ class DenoisingStage(PipelineStage):
                              "blocks, but the layerwise/CPU offload hook assumes every block "
                              "runs each step. Set dit_layerwise_offload=False and "
                              "dit_cpu_offload=False (the model must fit in GPU memory).")
+        # cache-dit skips blocks via data-dependent control flow (a per-step
+        # residual-diff decision), which torch.compile cannot trace without
+        # graph breaks/recompiles. Disallow the combination for now (eager
+        # only); compile support is a follow-up.
+        if fastvideo_args.use_cachedit and fastvideo_args.enable_torch_compile:
+            raise ValueError("use_cachedit is currently incompatible with enable_torch_compile: cache-dit "
+                             "introduces data-dependent control flow that torch.compile cannot trace cleanly. "
+                             "Set enable_torch_compile=False (eager); compile support is a follow-up.")
         # Enable cache-dit on the transformer(s) once, then refresh the cache
         # context each generation so state never leaks across prompts.
         if fastvideo_args.use_cachedit:

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -88,8 +88,12 @@ class DenoisingStage(PipelineStage):
         across prompts (the bare-transformer path has no pipeline call to reset
         it otherwise).
         """
-        import cache_dit
-        from cache_dit import (BlockAdapter, DBCacheConfig, ForwardPattern, TaylorSeerCalibratorConfig)
+        try:
+            import cache_dit
+            from cache_dit import (BlockAdapter, DBCacheConfig, ForwardPattern, TaylorSeerCalibratorConfig)
+        except ImportError as e:
+            raise ImportError("use_cachedit requires the cache-dit package, which is not installed. Install it with "
+                              "`pip install \"fastvideo[cache]\"` (or `pip install cache-dit`).") from e
 
         cache_config = DBCacheConfig(
             Fn_compute_blocks=fastvideo_args.cachedit_fn_compute_blocks,
@@ -422,6 +426,14 @@ class DenoisingStage(PipelineStage):
                              "blocks, but the layerwise/CPU offload hook assumes every block "
                              "runs each step. Set dit_layerwise_offload=False and "
                              "dit_cpu_offload=False (the model must fit in GPU memory).")
+        # cache-dit skips blocks via data-dependent control flow (a per-step
+        # residual-diff decision), which torch.compile cannot trace without
+        # graph breaks/recompiles. Disallow the combination for now (eager
+        # only); compile support is a follow-up.
+        if fastvideo_args.use_cachedit and fastvideo_args.enable_torch_compile:
+            raise ValueError("use_cachedit is currently incompatible with enable_torch_compile: cache-dit "
+                             "introduces data-dependent control flow that torch.compile cannot trace cleanly. "
+                             "Set enable_torch_compile=False (eager); compile support is a follow-up.")
         # Enable cache-dit on the transformer(s) once, then refresh the cache
         # context each generation so state never leaks across prompts.
         if fastvideo_args.use_cachedit:

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -76,6 +76,51 @@ class DenoisingStage(PipelineStage):
             requested=component_attention_backend(self.transformer),
         )
 
+    def _enable_or_refresh_cachedit(self, model, fastvideo_args, num_inference_steps) -> None:
+        """Wire ``model`` into cache-dit via a transformer-only BlockAdapter on
+        first use, then refresh the cache context each generation. cache-dit is
+        lazy-imported so it stays an optional dependency.
+
+        Wan runs cond + uncond as separate forwards (``enable_separate_cfg=True``),
+        cond first (``cfg_compute_first=False``). ``num_inference_steps`` lets
+        cache-dit auto-refresh at the generation boundary; we also call
+        ``refresh_context`` explicitly per generation so cache state never leaks
+        across prompts (the bare-transformer path has no pipeline call to reset
+        it otherwise).
+        """
+        import cache_dit
+        from cache_dit import (BlockAdapter, DBCacheConfig, ForwardPattern, TaylorSeerCalibratorConfig)
+
+        cache_config = DBCacheConfig(
+            Fn_compute_blocks=fastvideo_args.cachedit_fn_compute_blocks,
+            Bn_compute_blocks=fastvideo_args.cachedit_bn_compute_blocks,
+            residual_diff_threshold=fastvideo_args.cachedit_residual_threshold,
+            max_warmup_steps=fastvideo_args.cachedit_max_warmup_steps,
+            enable_separate_cfg=True,
+            cfg_compute_first=False,
+            num_inference_steps=num_inference_steps,
+        )
+        calibrator_config = None
+        if fastvideo_args.cachedit_taylorseer:
+            calibrator_config = TaylorSeerCalibratorConfig(taylorseer_order=fastvideo_args.cachedit_taylorseer_order)
+
+        if not getattr(model, "_cachedit_enabled", False):
+            adapter = BlockAdapter(
+                transformer=model,
+                blocks=model.blocks,
+                forward_pattern=ForwardPattern.Pattern_2,
+                has_separate_cfg=True,
+                check_forward_pattern=False,
+            )
+            cache_dit.enable_cache(adapter, cache_config=cache_config, calibrator_config=calibrator_config)
+            model._cachedit_enabled = True
+            logger.info("cache-dit enabled: Fn=%d Bn=%d threshold=%s warmup=%d taylorseer=%s",
+                        fastvideo_args.cachedit_fn_compute_blocks, fastvideo_args.cachedit_bn_compute_blocks,
+                        fastvideo_args.cachedit_residual_threshold, fastvideo_args.cachedit_max_warmup_steps,
+                        fastvideo_args.cachedit_taylorseer)
+        else:
+            cache_dit.refresh_context(model, num_inference_steps=num_inference_steps)
+
     def forward(
         self,
         batch: ForwardBatch,
@@ -366,6 +411,24 @@ class DenoisingStage(PipelineStage):
         _cfg_gate_fresh_uncond = 0
         _cfg_gate_reused_delta = 0
         _cfg_gate_invalidations = 0
+
+        # cache-dit step caching skips DiT blocks, which is incompatible with
+        # layerwise / CPU offload: the offload hook prefetches each block's
+        # params on the prior block's forward and releases them on its own,
+        # assuming every block runs exactly once per step. A skipped block
+        # leaves its params prefetched-but-never-released, desyncing the chain.
+        if fastvideo_args.use_cachedit and (fastvideo_args.dit_layerwise_offload or fastvideo_args.dit_cpu_offload):
+            raise ValueError("use_cachedit is incompatible with DiT offloading: caching skips "
+                             "blocks, but the layerwise/CPU offload hook assumes every block "
+                             "runs each step. Set dit_layerwise_offload=False and "
+                             "dit_cpu_offload=False (the model must fit in GPU memory).")
+        # Enable cache-dit on the transformer(s) once, then refresh the cache
+        # context each generation so state never leaks across prompts.
+        if fastvideo_args.use_cachedit:
+            for _tf in (self.transformer, self.transformer_2):
+                _model = getattr(_tf, "module", _tf)
+                if _model is not None and hasattr(_model, "blocks"):
+                    self._enable_or_refresh_cachedit(_model, fastvideo_args, num_inference_steps)
 
         # Run denoising loop
         with self.progress_bar(total=num_inference_steps) as progress_bar:

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -429,11 +429,16 @@ class DenoisingStage(PipelineStage):
         # cache-dit skips blocks via data-dependent control flow (a per-step
         # residual-diff decision), which torch.compile cannot trace without
         # graph breaks/recompiles. Disallow the combination for now (eager
-        # only); compile support is a follow-up.
-        if fastvideo_args.use_cachedit and fastvideo_args.enable_torch_compile:
-            raise ValueError("use_cachedit is currently incompatible with enable_torch_compile: cache-dit "
+        # only); compile support is a follow-up. ``inference_torch_compile``
+        # (regional fullgraph compile of each DiT block) is even stricter —
+        # the loader compiles the blocks with fullgraph=True before this stage
+        # ever runs, so the skip decision cannot graph-break out.
+        if fastvideo_args.use_cachedit and (fastvideo_args.enable_torch_compile
+                                            or fastvideo_args.inference_torch_compile):
+            _flag = ("enable_torch_compile" if fastvideo_args.enable_torch_compile else "inference_torch_compile")
+            raise ValueError(f"use_cachedit is currently incompatible with {_flag}: cache-dit "
                              "introduces data-dependent control flow that torch.compile cannot trace cleanly. "
-                             "Set enable_torch_compile=False (eager); compile support is a follow-up.")
+                             f"Set {_flag}=False (eager); compile support is a follow-up.")
         # Enable cache-dit on the transformer(s) once, then refresh the cache
         # context each generation so state never leaks across prompts.
         if fastvideo_args.use_cachedit:

--- a/fastvideo/tests/modal/_cachedit_ab_inner.py
+++ b/fastvideo/tests/modal/_cachedit_ab_inner.py
@@ -130,8 +130,11 @@ def _compute_ssim_main(args) -> int:
         try:
             from torchvision.io import read_video
             frames, _, _ = read_video(path, pts_unit="sec", output_format="TCHW")
-            return frames
-        except (ImportError, AttributeError):
+            if frames.shape[0] > 0:
+                return frames
+        except Exception:
+            # torchvision's backend (FFmpeg/PyAV) can raise more than
+            # ImportError/AttributeError; fall back to the PyAV path below.
             pass
         import av
         container = av.open(path)
@@ -146,6 +149,8 @@ def _compute_ssim_main(args) -> int:
     def _ssim(p1, p2):
         f1, f2 = _read_video_frames(p1), _read_video_frames(p2)
         n = min(f1.shape[0], f2.shape[0])
+        if n == 0:
+            raise RuntimeError(f"no decodable frames to compare: {p1} ({f1.shape[0]}) vs {p2} ({f2.shape[0]})")
         f1 = (f1[:n].float() / 255.0).contiguous()
         f2 = (f2[:n].float() / 255.0).contiguous()
         return [pm_ssim(f1[i:i + 1], f2[i:i + 1], data_range=1.0).item() for i in range(n)]
@@ -157,7 +162,8 @@ def _compute_ssim_main(args) -> int:
 
     rows = []
     for b, p in zip(baseline, patched, strict=True):
-        assert b["i"] == p["i"]
+        if b["i"] != p["i"]:
+            raise ValueError(f"baseline/patched prompt index mismatch: {b['i']} != {p['i']}")
         vals = _ssim(b["mp4"], p["mp4"])
         rows.append({
             "i": b["i"],

--- a/fastvideo/tests/modal/_cachedit_ab_inner.py
+++ b/fastvideo/tests/modal/_cachedit_ab_inner.py
@@ -1,0 +1,177 @@
+"""
+Inner-script half of the cache-dit A/B harness.
+
+Runs one denoising pass (caching off or on) over the harness's prompt + seed
+set, records per-prompt walls, and writes a JSON results blob to the path
+given on argv. Invoked by ``cachedit_ab.py`` via ``/opt/venv/bin/python`` so
+FastVideo runs inside the image's venv (Modal's main process Python lacks
+torch).
+
+cache-dit step caching is LOSSY: the patched output is not bit-identical, so
+the SSIM column is a quality measurement (target >= ~0.95), not a 1.0 gate.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("run_pass", "compute_ssim"), default="run_pass")
+    parser.add_argument("--config-json")
+    parser.add_argument("--results-json")
+    parser.add_argument("--baseline-results-json")
+    parser.add_argument("--patched-results-json")
+    parser.add_argument("--ssim-output-json")
+    args = parser.parse_args()
+
+    if args.mode == "compute_ssim":
+        return _compute_ssim_main(args)
+
+    if not args.config_json or not args.results_json:
+        parser.error("--config-json and --results-json are required for mode=run_pass")
+    with open(args.config_json) as f:
+        cfg = json.load(f)
+
+    model_id = cfg["model_id"]
+    num_gpus = cfg["num_gpus"]
+    use_cachedit = cfg["use_cachedit"]
+    fn = cfg.get("cachedit_fn_compute_blocks", 8)
+    bn = cfg.get("cachedit_bn_compute_blocks", 0)
+    threshold = cfg.get("cachedit_residual_threshold", 0.08)
+    warmup = cfg.get("cachedit_max_warmup_steps", 8)
+    taylorseer = cfg.get("cachedit_taylorseer", False)
+    taylorseer_order = cfg.get("cachedit_taylorseer_order", 1)
+    enable_compile = cfg.get("enable_compile", False)
+    height, width = cfg["height"], cfg["width"]
+    num_frames = cfg["num_frames"]
+    num_inference_steps = cfg["num_inference_steps"]
+    output_dir = cfg["output_dir"]
+    prompts = cfg["prompts"]
+    seed_base = cfg["seed_base"]
+
+    from fastvideo.attention.backends.flash_attn import fa_version
+    print(f"[inner] resolved flash-attn version: FA{fa_version}", flush=True)
+
+    from fastvideo import VideoGenerator
+
+    # cache-dit skips blocks, incompatible with layerwise/CPU offload (the
+    # offload prefetch chain assumes every block runs each step). Disable it on
+    # BOTH passes so the A/B isolates the cache effect. Wan 1.3B fits a single
+    # L40S (48GB) without offload.
+    generator = VideoGenerator.from_pretrained(
+        model_id,
+        num_gpus=num_gpus,
+        use_cachedit=use_cachedit,
+        cachedit_fn_compute_blocks=fn,
+        cachedit_bn_compute_blocks=bn,
+        cachedit_residual_threshold=threshold,
+        cachedit_max_warmup_steps=warmup,
+        cachedit_taylorseer=taylorseer,
+        cachedit_taylorseer_order=taylorseer_order,
+        dit_layerwise_offload=False,
+        dit_cpu_offload=False,
+        enable_torch_compile=enable_compile,
+    )
+    resolved = getattr(generator.fastvideo_args, "use_cachedit", None)
+    if resolved is not use_cachedit:
+        raise RuntimeError(f"use_cachedit did not propagate: requested {use_cachedit}, resolved {resolved}")
+    if use_cachedit:
+        print(f"[inner] cache-dit ON: Fn={fn} Bn={bn} threshold={threshold} warmup={warmup} "
+              f"taylorseer={taylorseer}(order={taylorseer_order})", flush=True)
+    else:
+        print("[inner] caching OFF (baseline)", flush=True)
+
+    os.makedirs(output_dir, exist_ok=True)
+    records = []
+    for i, prompt in enumerate(prompts):
+        prompt_out = os.path.join(output_dir, f"prompt_{i:02d}")
+        t0 = time.perf_counter()
+        generator.generate_video(
+            prompt,
+            output_path=prompt_out,
+            save_video=True,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=num_inference_steps,
+            seed=seed_base + i,
+        )
+        wall = time.perf_counter() - t0
+        # generate_video appends _1, _2, ... rather than overwriting; pick the
+        # mp4 we just wrote by mtime (newest).
+        mp4s = sorted([os.path.join(prompt_out, f) for f in os.listdir(prompt_out) if f.endswith(".mp4")],
+                      key=os.path.getmtime)
+        if not mp4s:
+            raise RuntimeError(f"no .mp4 produced for prompt {i} at {prompt_out}")
+        records.append({"i": i, "wall_s": wall, "mp4": mp4s[-1]})
+        print(f"[inner] [{'cachedit' if use_cachedit else 'baseline'}] prompt {i}: {wall:.3f}s -> {mp4s[-1]}",
+              flush=True)
+
+    with open(args.results_json, "w") as f:
+        json.dump(records, f)
+    print(f"[inner] wrote {len(records)} records to {args.results_json}", flush=True)
+    return 0
+
+
+def _compute_ssim_main(args) -> int:
+    """Pairwise SSIM between baseline and patched output mp4s. Avoids importing
+    fastvideo (its top-level import pulls triton, which needs a CUDA driver);
+    runs on CPU with pytorch_msssim + torchvision/av directly."""
+    if not args.ssim_output_json or not (args.baseline_results_json and args.patched_results_json):
+        raise SystemExit("compute_ssim needs --baseline-results-json, --patched-results-json, --ssim-output-json")
+
+    import torch
+    from pytorch_msssim import ssim as pm_ssim
+
+    def _read_video_frames(path):
+        try:
+            from torchvision.io import read_video
+            frames, _, _ = read_video(path, pts_unit="sec", output_format="TCHW")
+            return frames
+        except (ImportError, AttributeError):
+            pass
+        import av
+        container = av.open(path)
+        frames = []
+        for frame in container.decode(video=0):
+            frames.append(torch.from_numpy(frame.to_ndarray(format="rgb24")).permute(2, 0, 1))
+        container.close()
+        if not frames:
+            raise RuntimeError(f"No video frames decoded from {path}")
+        return torch.stack(frames)
+
+    def _ssim(p1, p2):
+        f1, f2 = _read_video_frames(p1), _read_video_frames(p2)
+        n = min(f1.shape[0], f2.shape[0])
+        f1 = (f1[:n].float() / 255.0).contiguous()
+        f2 = (f2[:n].float() / 255.0).contiguous()
+        return [pm_ssim(f1[i:i + 1], f2[i:i + 1], data_range=1.0).item() for i in range(n)]
+
+    with open(args.baseline_results_json) as f:
+        baseline = json.load(f)
+    with open(args.patched_results_json) as f:
+        patched = json.load(f)
+
+    rows = []
+    for b, p in zip(baseline, patched, strict=True):
+        assert b["i"] == p["i"]
+        vals = _ssim(b["mp4"], p["mp4"])
+        rows.append({
+            "i": b["i"],
+            "baseline_wall_s": b["wall_s"],
+            "patched_wall_s": p["wall_s"],
+            "ssim_mean": float(sum(vals) / len(vals)),
+            "ssim_worst": float(min(vals)),
+        })
+        print(f"[inner]   prompt {b['i']} SSIM mean={rows[-1]['ssim_mean']:.6f} worst={rows[-1]['ssim_worst']:.6f}",
+              flush=True)
+    with open(args.ssim_output_json, "w") as f:
+        json.dump(rows, f)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fastvideo/tests/modal/cachedit_ab.py
+++ b/fastvideo/tests/modal/cachedit_ab.py
@@ -1,0 +1,243 @@
+"""
+A/B harness for ``use_cachedit`` (cache-dit step caching) on the Wan DiT.
+
+Single-container pattern: clone the branch, build once, then run the same N
+seed-pinned prompts twice — once with caching off (baseline) and once with
+``use_cachedit=True`` (optionally + TaylorSeer). Records per-prompt wall +
+pairwise SSIM and prints a delta table.
+
+cache-dit caching is LOSSY: the SSIM column measures the quality cost (target
+>= ~0.95), it is NOT a 1.0 correctness gate. The "win" is the wall delta.
+Sweep ``--threshold`` (and ``--fn`` / ``--bn`` / ``--warmup`` / ``--taylorseer``)
+to trade speed for quality.
+
+Usage (from FastVideo repo root):
+
+    # F8B0 + TaylorSeer, threshold 0.08 (the balanced default), L40S Wan 1.3B
+    modal run fastvideo/tests/modal/cachedit_ab.py --gpu L40S --taylorseer
+
+    # More aggressive (recover more wall): higher threshold
+    modal run fastvideo/tests/modal/cachedit_ab.py --gpu L40S --taylorseer --threshold 0.15
+
+Requires a Modal Secret named ``huggingface-token`` with key ``HF_TOKEN``.
+"""
+import os
+
+import modal
+
+app = modal.App("cachedit-ab")
+
+model_vol = modal.Volume.from_name("hf-model-weights")
+hf_secret = modal.Secret.from_name("huggingface-token")
+image_tag = f"ghcr.io/hao-ai-lab/fastvideo/fastvideo-dev:{os.getenv('IMAGE_VERSION', 'py3.12-latest')}"
+
+# Prebuilt FA3 wheel matching the fastvideo-dev image ABI (Hopper leg only).
+FA3_WHEEL_URL = (
+    "https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.9.4/"
+    "flash_attn_3-3.0.0%2Bcu128torch2.11gite2743ab-cp39-abi3-linux_x86_64.whl")
+
+image = (modal.Image.from_registry(image_tag, add_python="3.12").apt_install(
+    "cmake", "pkg-config", "build-essential", "curl", "libssl-dev", "ffmpeg", "libgl1", "libglib2.0-0",
+).run_commands(
+    "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable",
+    "echo 'source ~/.cargo/env' >> ~/.bashrc",
+).env({"PATH": "/root/.cargo/bin:$PATH"}))
+
+# Same five prompts as the prior Wan A/Bs so deltas compare directly.
+AB_PROMPTS = [
+    "A curious raccoon peers through a vibrant field of yellow sunflowers, its eyes wide with interest. "
+    "The playful yet serene atmosphere is complemented by soft natural light filtering through the petals. "
+    "Mid-shot, warm and cheerful tones.",
+    "A majestic lion strides across the golden savanna, its powerful frame glistening under the warm afternoon "
+    "sun. The tall grass ripples gently in the breeze, enhancing the lion's commanding presence. Low angle, "
+    "steady tracking shot, cinematic.",
+    "A sailing ship cuts through dark stormy waves under a sky of rolling thunderclouds. Sea spray catches the "
+    "lantern light along the hull. Dramatic, painterly tones; medium-wide tracking shot.",
+    "A street vendor in Tokyo flips okonomiyaki on a sizzling iron griddle while neon shop signs reflect in "
+    "rain-slicked pavement. Steam rises around her hands; warm color grade; handheld close-up.",
+    "An astronaut floats slowly past the cupola of a space station, the curve of Earth glowing blue beyond "
+    "the glass. Calm, contemplative pacing; smooth dolly; cinematic.",
+]
+AB_SEED = 42
+
+MODEL_PRESETS = {
+    "wan2_1-t2v-1.3b": {
+        "model_id": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        "height": 720, "width": 1280, "num_frames": 77, "num_inference_steps": 30, "default_num_gpus": 1,
+    },
+    "wan2_2-t2v-14b": {
+        "model_id": "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+        "height": 720, "width": 1280, "num_frames": 49, "num_inference_steps": 30, "default_num_gpus": 2,
+    },
+}
+
+
+def _build_workspace_command(git_repo: str, git_ref: str, install_fa3: bool) -> str:
+    import shlex
+    fa3_step = f'uv pip install --no-cache-dir "{FA3_WHEEL_URL}"' if install_fa3 else 'echo "[fa3] skipped"'
+    return f"""
+set -euxo pipefail
+source $HOME/.local/bin/env
+source $HOME/.cargo/env
+source /opt/venv/bin/activate
+if [ -d /FastVideo/.git ]; then
+  cd /FastVideo && git remote set-url origin {shlex.quote(git_repo)} && git fetch --prune origin
+else
+  git clone {shlex.quote(git_repo)} /FastVideo && cd /FastVideo
+fi
+git checkout {shlex.quote(git_ref)}
+git submodule update --init --recursive
+{fa3_step}
+uv pip install -e ".[test]"
+uv pip install cache-dit
+cd fastvideo-kernel && ./build.sh && cd ..
+export HF_HOME=/root/data/.cache
+hf auth login --token "$HF_TOKEN"
+"""
+
+
+def _run_pass(*, use_cachedit: bool, model_id: str, num_gpus: int, preset: dict, output_dir: str,
+              enable_compile: bool, num_prompts, fn: int, bn: int, threshold: float, warmup: int,
+              taylorseer: bool, taylorseer_order: int) -> list[dict]:
+    import json
+    import subprocess
+    import tempfile
+
+    selected = list(AB_PROMPTS) if num_prompts is None else list(AB_PROMPTS)[:num_prompts]
+    config = {
+        "model_id": model_id, "num_gpus": num_gpus, "use_cachedit": use_cachedit,
+        "cachedit_fn_compute_blocks": fn, "cachedit_bn_compute_blocks": bn,
+        "cachedit_residual_threshold": threshold, "cachedit_max_warmup_steps": warmup,
+        "cachedit_taylorseer": taylorseer, "cachedit_taylorseer_order": taylorseer_order,
+        "enable_compile": enable_compile, "height": preset["height"], "width": preset["width"],
+        "num_frames": preset["num_frames"], "num_inference_steps": preset["num_inference_steps"],
+        "output_dir": output_dir, "prompts": selected, "seed_base": AB_SEED,
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(config, f)
+        config_path = f.name
+    results_path = config_path.replace(".json", ".results.json")
+    inner = "/FastVideo/fastvideo/tests/modal/_cachedit_ab_inner.py"
+    cmd = (f"source /opt/venv/bin/activate && exec python {inner} "
+           f"--config-json {config_path} --results-json {results_path}")
+    subprocess.run(["/bin/bash", "-lc", cmd], check=True)
+    with open(results_path) as f:
+        return json.load(f)
+
+
+def _pairwise_ssim(baseline: list[dict], patched: list[dict]) -> list[dict]:
+    import json
+    import subprocess
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".baseline.json", delete=False) as f:
+        json.dump(baseline, f)
+        bpath = f.name
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".patched.json", delete=False) as f:
+        json.dump(patched, f)
+        ppath = f.name
+    spath = bpath.replace(".baseline.json", ".ssim.json")
+    inner = "/FastVideo/fastvideo/tests/modal/_cachedit_ab_inner.py"
+    cmd = (f"source /opt/venv/bin/activate && exec python {inner} --mode compute_ssim "
+           f"--baseline-results-json {bpath} --patched-results-json {ppath} --ssim-output-json {spath}")
+    subprocess.run(["/bin/bash", "-lc", cmd], check=True)
+    with open(spath) as f:
+        return json.load(f)
+
+
+def _print_table(rows: list[dict], label: str) -> None:
+    print(f"\n=== cache-dit A/B results ({label}) ===")
+    print("NOTE: cache-dit is lossy — SSIM is a quality cost (target >= ~0.95), not a 1.0 gate.")
+    print(f"{'prompt':>6} {'baseline_wall_s':>16} {'patched_wall_s':>16} {'delta_pct':>10} {'ssim_mean':>10} "
+          f"{'ssim_worst':>11}")
+    base_sum = patched_sum = 0.0
+    means, worsts = [], []
+    for r in rows:
+        delta = (r["patched_wall_s"] - r["baseline_wall_s"]) / r["baseline_wall_s"] * 100.0
+        print(f"{r['i']:>6} {r['baseline_wall_s']:>16.3f} {r['patched_wall_s']:>16.3f} {delta:>9.2f}% "
+              f"{r['ssim_mean']:>10.6f} {r['ssim_worst']:>11.6f}")
+        base_sum += r["baseline_wall_s"]
+        patched_sum += r["patched_wall_s"]
+        means.append(r["ssim_mean"])
+        worsts.append(r["ssim_worst"])
+    print(f"\nbaseline total: {base_sum:.3f}s")
+    print(f"cachedit total: {patched_sum:.3f}s")
+    print(f"wall delta:     {(patched_sum - base_sum) / base_sum * 100.0:+.2f}%   (negative = faster)")
+    print(f"SSIM mean-of-means:  {sum(means) / len(means):.6f}")
+    print(f"SSIM worst-of-worst: {min(worsts):.6f}")
+
+
+@app.function(image=image, timeout=10800, volumes={"/root/data": model_vol}, secrets=[hf_secret], gpu="L40S:1")
+def run_ab(*, git_repo: str, git_ref: str, model_preset: str, num_gpus: int, install_fa3: bool = False,
+           enable_compile: bool = False, num_prompts: int = 0, fn: int = 8, bn: int = 0, threshold: float = 0.08,
+           warmup: int = 8, taylorseer: bool = False, taylorseer_order: int = 1):
+    import subprocess
+
+    if model_preset not in MODEL_PRESETS:
+        raise ValueError(f"unknown model_preset: {model_preset}")
+    if "HF_TOKEN" not in os.environ:
+        raise RuntimeError("HF_TOKEN not set — Modal Secret 'huggingface-token' missing the HF_TOKEN key.")
+    preset = MODEL_PRESETS[model_preset]
+
+    result = subprocess.run(["/bin/bash", "-lc", _build_workspace_command(git_repo, git_ref, install_fa3)],
+                            env=os.environ.copy(), capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr)
+        raise RuntimeError(f"workspace setup failed (rc={result.returncode})")
+    os.chdir("/FastVideo")
+
+    common = dict(model_id=preset["model_id"], num_gpus=num_gpus, preset=preset, enable_compile=enable_compile,
+                  num_prompts=(num_prompts if num_prompts > 0 else None), fn=fn, bn=bn, threshold=threshold,
+                  warmup=warmup, taylorseer=taylorseer, taylorseer_order=taylorseer_order)
+
+    ts_tag = f"-ts{taylorseer_order}" if taylorseer else ""
+    cfg_tag = f"cachedit{ts_tag}_f{fn}b{bn}t{str(threshold).replace('.', 'p')}w{warmup}"
+    baseline_dir = f"/root/data/cachedit_out/{model_preset}/baseline"
+    patched_dir = f"/root/data/cachedit_out/{model_preset}/{cfg_tag}"
+    label = f"{model_preset} | Fn={fn} Bn={bn} threshold={threshold} warmup={warmup} taylorseer={taylorseer}"
+
+    print(f"\n--- baseline pass (caching off) on {model_preset} ---")
+    baseline = _run_pass(use_cachedit=False, output_dir=baseline_dir, **common)
+    print(f"\n--- cache-dit pass ({label}) ---")
+    patched = _run_pass(use_cachedit=True, output_dir=patched_dir, **common)
+
+    rows = _pairwise_ssim(baseline, patched)
+    _print_table(rows, label)
+    return rows
+
+
+@app.local_entrypoint()
+def main(gpu: str = "L40S", model: str = "wan2_1-t2v-1.3b", num_gpus: int = 0, git_repo: str = "",
+         git_ref: str = "perf/wan-cachedit", enable_compile: bool = False, num_prompts: int = 0, fn: int = 8,
+         bn: int = 0, threshold: float = 0.08, warmup: int = 8, taylorseer: bool = False, taylorseer_order: int = 1):
+    """Drive the cache-dit A/B from your laptop. ``--taylorseer`` enables the
+    TaylorSeer calibrator. Sweep ``--threshold`` (higher = more aggressive /
+    faster / lower quality). ``git_repo`` defaults to the ``fork`` remote."""
+    import subprocess
+
+    if model not in MODEL_PRESETS:
+        raise ValueError(f"unknown model: {model}; choose from {list(MODEL_PRESETS)}")
+    if num_gpus == 0:
+        num_gpus = MODEL_PRESETS[model]["default_num_gpus"]
+    if not git_repo:
+        for remote in ("fork", "origin"):
+            try:
+                git_repo = subprocess.check_output(["git", "config", "--get", f"remote.{remote}.url"],
+                                                   text=True, stderr=subprocess.DEVNULL).strip()
+                break
+            except subprocess.CalledProcessError:
+                continue
+        if not git_repo:
+            raise RuntimeError("Could not resolve git_repo. Pass --git-repo or configure a 'fork'/'origin' remote.")
+
+    install_fa3 = gpu.upper().startswith("H100") or gpu.upper().startswith("H200")
+    print(f"GPU: {gpu}:{num_gpus}  model: {model}  ref: {git_ref}  install_fa3: {install_fa3}  "
+          f"compile: {enable_compile}  prompts: {num_prompts or 'all'}  "
+          f"cache-dit: Fn={fn} Bn={bn} threshold={threshold} warmup={warmup} "
+          f"taylorseer={taylorseer}(o{taylorseer_order})  repo: {git_repo}")
+
+    run_ab.with_options(gpu=f"{gpu}:{num_gpus}").remote(
+        git_repo=git_repo, git_ref=git_ref, model_preset=model, num_gpus=num_gpus, install_fa3=install_fa3,
+        enable_compile=enable_compile, num_prompts=num_prompts, fn=fn, bn=bn, threshold=threshold, warmup=warmup,
+        taylorseer=taylorseer, taylorseer_order=taylorseer_order)

--- a/fastvideo/tests/modal/cachedit_ab.py
+++ b/fastvideo/tests/modal/cachedit_ab.py
@@ -88,8 +88,7 @@ fi
 git checkout {shlex.quote(git_ref)}
 git submodule update --init --recursive
 {fa3_step}
-uv pip install -e ".[test]"
-uv pip install cache-dit
+uv pip install -e ".[test,cache]"
 cd fastvideo-kernel && ./build.sh && cd ..
 export HF_HOME=/root/data/.cache
 hf auth login --token "$HF_TOKEN"
@@ -120,9 +119,16 @@ def _run_pass(*, use_cachedit: bool, model_id: str, num_gpus: int, preset: dict,
     inner = "/FastVideo/fastvideo/tests/modal/_cachedit_ab_inner.py"
     cmd = (f"source /opt/venv/bin/activate && exec python {inner} "
            f"--config-json {config_path} --results-json {results_path}")
-    subprocess.run(["/bin/bash", "-lc", cmd], check=True)
-    with open(results_path) as f:
-        return json.load(f)
+    try:
+        subprocess.run(["/bin/bash", "-lc", cmd], check=True)
+        with open(results_path) as f:
+            return json.load(f)
+    finally:
+        for p in (config_path, results_path):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
 
 
 def _pairwise_ssim(baseline: list[dict], patched: list[dict]) -> list[dict]:
@@ -140,9 +146,16 @@ def _pairwise_ssim(baseline: list[dict], patched: list[dict]) -> list[dict]:
     inner = "/FastVideo/fastvideo/tests/modal/_cachedit_ab_inner.py"
     cmd = (f"source /opt/venv/bin/activate && exec python {inner} --mode compute_ssim "
            f"--baseline-results-json {bpath} --patched-results-json {ppath} --ssim-output-json {spath}")
-    subprocess.run(["/bin/bash", "-lc", cmd], check=True)
-    with open(spath) as f:
-        return json.load(f)
+    try:
+        subprocess.run(["/bin/bash", "-lc", cmd], check=True)
+        with open(spath) as f:
+            return json.load(f)
+    finally:
+        for p in (bpath, ppath, spath):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
 
 
 def _print_table(rows: list[dict], label: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,11 @@ test = [
     "plotly",
 ]
 
+# Optional step-caching backend. Enables FastVideoArgs.use_cachedit (lossy
+# DBCache / TaylorSeer acceleration for the Wan DiT). Not a runtime dep —
+# only imported when use_cachedit is set. Install: uv pip install "fastvideo[cache]"
+cache = ["cache-dit"]
+
 # Eval extras. See fastvideo/eval/README.md for which install path
 # covers which metrics. detectron2 (vbench color/object_class/etc.) is
 # CUDA-version-pinned and not cleanly pip-installable — install it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,11 @@ test = [
     "plotly",
 ]
 
+# Optional step-caching backend. Enables FastVideoArgs.use_cachedit (lossy
+# DBCache / TaylorSeer acceleration for the Wan DiT). Not a runtime dep —
+# only imported when use_cachedit is set. Install: uv pip install "fastvideo[cache]"
+cache = ["cache-dit"]
+
 # Eval extras. See fastvideo/eval/README.md for which install path
 # covers which metrics. detectron2 (vbench color/object_class/etc.) is
 # CUDA-version-pinned and not cleanly pip-installable — install it


### PR DESCRIPTION
### Optional step caching for the Wan DiT via cache-dit

**What & why.** Adds opt-in, default-off step caching for Wan inference using the [cache-dit](https://github.com/vipshop/cache-dit) library. Diffusion runs the DiT once per denoising step, and adjacent steps produce nearly-identical features — cache-dit's DBCache skips the middle DiT blocks on steps whose leading-block residual barely changes and reuses a cached result. An optional **TaylorSeer** calibrator extrapolates that residual (Taylor expansion) instead of holding it constant, giving higher fidelity at the same skip rate. Lossy (SSIM < 1.0), so default-off and gated behind `--use-cachedit`.

**How.** cache-dit attaches through a transformer-only `BlockAdapter` (no diffusers pipeline needed). `DenoisingStage._enable_or_refresh_cachedit()` enables the cache once per transformer and refreshes the cache context each generation (`num_inference_steps` + `refresh_context`) so state never leaks across prompts. Wan's separate cond/uncond forwards are handled via `enable_separate_cfg=True` / `cfg_compute_first=False`.

**Results** — Wan2.1-T2V-1.3B, 1×L40S, 720×1280 / 77f / 30 steps, 5 prompts, eager. Two operating points via `--cachedit-residual-threshold` (both F8B0 + TaylorSeer):

| Preset | threshold | wall | SSIM mean / worst |
|---|---|---|---|
| Quality (default) | 0.08 | −18% | 0.957 / 0.941 |
| Performance | 0.15 | **−32%** | 0.943 / 0.920 |

TaylorSeer is the key to the aggressive preset: spot-checked frames including a high-detail space-station cupola are visually clean at **both** thresholds. Without TaylorSeer (plain DBCache constant-residual reuse), the same −32% operating point shows undersolved-noise artifacts on that high-detail content — extrapolating the residual is what keeps the aggressive setting clean.

**Caveats.**
- Incompatible with DiT offloading — caching skips blocks, the offload hook assumes every block runs each step; guarded with a clear error (set `--dit-cpu-offload False --dit-layerwise-offload False`).
- Eager only; the `torch.compile` path is rejected with a clear error (caching adds data-dependent control flow). Follow-up.
- Wan DiT only for now.
- cache-dit is added as an **optional** `[cache]` extra, lazy-imported — not a runtime dependency. (Flagging the new optional dependency explicitly for maintainer visibility.)

**Test evidence.** Modal A/B harness `fastvideo/tests/modal/cachedit_ab.py` (baseline vs cached, per-prompt wall + SSIM) — produced the numbers above. Reproduce: `modal run fastvideo/tests/modal/cachedit_ab.py --gpu L40S --taylorseer` (quality) or `--taylorseer --threshold 0.15` (performance).

