### PR TITLE
[bugfix] tests: include ltx2_3_base in expected LTX2 preset set (#1427)

### DIFF
--- a/fastvideo/tests/api/test_presets.py
+++ b/fastvideo/tests/api/test_presets.py
@@ -334,7 +334,7 @@ class TestLtx2Presets:
         import fastvideo.registry  # noqa: F401
         presets = get_presets_for_family("ltx2")
         names = {p.name for p in presets}
-        assert names == {"ltx2_base", "ltx2_distilled", "ltx2_two_stage"}
+        assert names == {"ltx2_base", "ltx2_3_base", "ltx2_distilled", "ltx2_two_stage"}
 
     def test_ltx2_base_lookup(self) -> None:
         import fastvideo.registry  # noqa: F401


### PR DESCRIPTION
## Problem

`fastvideo/tests/api/test_presets.py::TestLtx2Presets::test_ltx2_presets_registered` fails on a clean `main`:

```
>       assert names == {"ltx2_base", "ltx2_distilled", "ltx2_two_stage"}
E       AssertionError
E         Extra items in the left set:
E         'ltx2_3_base'
```

#1397 (LTX-2.3 transformer support) registered a fourth preset `ltx2_3_base` (`fastvideo/pipelines/basic/ltx2/presets.py`) and made it the LTX2 **default** (`fastvideo/registry.py`), but the test still hard-codes the previous three-preset set. Because this lives in the shared unit-test job (`run_unit_test` → `pytest ./fastvideo/tests/api/ ...`), it red-lights CI for every open PR, not just the one that surfaced it.

## Fix

Add `ltx2_3_base` to the expected set so it matches the presets actually registered for the `ltx2` family:

```python
assert names == {"ltx2_base", "ltx2_3_base", "ltx2_distilled", "ltx2_two_stage"}
```

Verified these are exactly the four `PresetSpec`s with `model_family="ltx2"` registered in `fastvideo/pipelines/basic/ltx2/presets.py`.

## Test evidence

Test-only change to a single assertion set; the `run_unit_test` CI job (which covers `fastvideo/tests/api/`) is the validation surface and will exercise it on this PR.

Fixes #1427