### PR TITLE
[chore]: unpin runtime deps in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,16 @@ classifiers = [
 
 dependencies = [
     # Core Libraries
-    "scipy==1.14.1",
-    "six==1.16.0",
-    "h5py==3.12.1",
+    "scipy>=1.14.1",
+    "six>=1.16.0",
+    "h5py>=3.12.1",
     "requests>=2.32.2",
 
     # Machine Learning & Transformers
-    "transformers==4.57.3",
+    "transformers>=4.57.3",
     "tokenizers>=0.20.1",
-    "sentencepiece==0.2.0",
-    "timm==1.0.11",
+    "sentencepiece>=0.2.0",
+    "timm>=1.0.11",
     "peft>=0.15.0",
     "diffusers>=0.33.1",
     "torch==2.11.0",
@@ -35,21 +35,21 @@ dependencies = [
     "accelerate==1.0.1",
 
     # Computer Vision & Image Processing
-    "opencv-python==4.10.0.84",
+    "opencv-python>=4.10.0.84",
     "pillow>=10.3.0",
-    "imageio==2.36.0",
-    "imageio-ffmpeg==0.5.1",
+    "imageio>=2.36.0",
+    "imageio-ffmpeg>=0.5.1",
     "einops",
 
     # Experiment Tracking & Logging
     "wandb>=0.21.0",
     "loguru",
-    "test-tube==0.7.5",
+    "test-tube>=0.7.5",
     
     # Miscellaneous Utilities
     "tqdm",
     "pytest",
-    "PyYAML==6.0.1",
+    "PyYAML>=6.0.1",
     "protobuf>=5.28.3",
     "gradio==5.32.0",
     "moviepy>=2.0.0",
@@ -73,17 +73,17 @@ dependencies = [
     # Training Dependencies
     "torchdata",
     "pyarrow",
-    "datasets==4.0.0",
+    "datasets>=4.0.0",
     "av",
 
     # Preprocessing Dependencies
     "torchcodec",
     "ray>=2.49.1",
-    "ftfy==6.3.1",
+    "ftfy>=6.3.1",
 
     # Job Runner
-    "fastapi==0.129.0",
-    "uvicorn==0.41.0"
+    "fastapi>=0.129.0",
+    "uvicorn>=0.41.0"
 ]
 
 [tool.uv]
@@ -130,7 +130,7 @@ lint = [
 
 test = [
     "av",
-    "pytorch-msssim==1.0.0",
+    "pytorch-msssim>=1.0.0",
     "pytest",
     "pandas",
     "plotly",
@@ -170,7 +170,7 @@ streaming = [
 ]
 
 dreamverse = [
-    "uvicorn[standard]==0.41.0",
+    "uvicorn[standard]>=0.41.0",
     "cerebras-cloud-sdk",
     "flash-attn-cute @ git+https://github.com/XOR-op/flash-attention.git@fa4-compile#subdirectory=flash_attn/cute",
     "flashinfer-python",

--- a/pyproject_other.toml
+++ b/pyproject_other.toml
@@ -15,16 +15,16 @@ classifiers = [
 
 dependencies = [
     # Core Libraries
-    "scipy==1.14.1",
-    "six==1.16.0",
-    "h5py==3.12.1",
+    "scipy>=1.14.1",
+    "six>=1.16.0",
+    "h5py>=3.12.1",
     "requests>=2.32.2",
 
     # Machine Learning & Transformers
-    "transformers==4.57.3",
+    "transformers>=4.57.3",
     "tokenizers>=0.20.1",
-    "sentencepiece==0.2.0",
-    "timm==1.0.11",
+    "sentencepiece>=0.2.0",
+    "timm>=1.0.11",
     "peft>=0.15.0",
     "diffusers>=0.33.1",
     "torch==2.11.0",
@@ -34,21 +34,21 @@ dependencies = [
     "accelerate==1.0.1",
 
     # Computer Vision & Image Processing
-    "opencv-python==4.10.0.84",
+    "opencv-python>=4.10.0.84",
     "pillow>=10.3.0",
-    "imageio==2.36.0",
-    "imageio-ffmpeg==0.5.1",
+    "imageio>=2.36.0",
+    "imageio-ffmpeg>=0.5.1",
     "einops",
 
     # Experiment Tracking & Logging
     "wandb>=0.21.0",
     "loguru",
-    "test-tube==0.7.5",
+    "test-tube>=0.7.5",
 
     # Miscellaneous Utilities
     "tqdm",
     "pytest",
-    "PyYAML==6.0.1",
+    "PyYAML>=6.0.1",
     "protobuf>=5.28.3",
     "gradio==5.32.0",
     "moviepy>=2.0.0",
@@ -71,7 +71,7 @@ dependencies = [
     # Training Dependencies
     "torchdata",
     "pyarrow",
-    "datasets==4.0.0",
+    "datasets>=4.0.0",
     "av",
 
     # Preprocessing Dependencies
@@ -93,7 +93,7 @@ lint = [
 
 test = [
     "av",
-    "pytorch-msssim==1.0.0",
+    "pytorch-msssim>=1.0.0",
     "pytest",
 ]
 


### PR DESCRIPTION
## Summary

Loosens hard `==X.Y.Z` pins to `>=X.Y.Z` floors for runtime dependencies whose versions don't materially affect kernel ABI or lint reproducibility. The previously-pinned version becomes the known-good floor, so existing installs still resolve to the same versions while new installs can pick up bug-fix and minor releases.

Mirrored across both `pyproject.toml` (16 packages) and `pyproject_other.toml` (the 13-package subset it declares). No lockfile committed.

## Unpinned

`pyproject.toml` (16): transformers, scipy, six, h5py, sentencepiece, timm, opencv-python, imageio, imageio-ffmpeg, test-tube, PyYAML, ftfy, datasets, fastapi, uvicorn (+ uvicorn[standard] in dreamverse extra), pytorch-msssim.

`pyproject_other.toml` (13): the overlapping subset — transformers, scipy, six, h5py, sentencepiece, timm, opencv-python, imageio, imageio-ffmpeg, test-tube, PyYAML, datasets, pytorch-msssim. (No ftfy/fastapi/uvicorn in this variant.)

All `==X.Y.Z` → `>=X.Y.Z`.

## Kept pinned (intentional, both files)

| Package | Pin | Why |
|---|---|---|
| `torch` | `==2.11.0` | CUDA arch + flash-attn ABI + `fastvideo-kernel` ABI all tied to this |
| `accelerate` | `==1.0.1` | training behavior (mixed-precision, FSDP) sensitive to release |
| `gradio` | `==5.32.0` | UI/API frequently breaks across minor releases |
| `fastvideo-kernel` | `==0.2.6` | internal kernel ABI; bumps must be coordinated with torch + CUDA |
| `pre-commit` | `==4.0.1` | lint reproducibility across contributors |

## Notes

- `transformers` unpinned per request, to let CI exercise compatibility with newer releases.
- Conservative otherwise: kernel-coupled, training-sensitive, and UI-fragile pins stay.
