### PR TITLE
[bugfix]: unblock PyPI publish (flash-attn-cute direct dep)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ torchaudio = [
   { index = "pytorch-cu128", marker = "sys_platform == 'linux'" },
 ]
 imagebind = { git = "https://github.com/facebookresearch/ImageBind.git", rev = "53680b02d7e37b19b124fa37bae4b6c98c38f5be" }
+flash-attn-cute = { git = "https://github.com/XOR-op/flash-attention.git", branch = "fa4-compile", subdirectory = "flash_attn/cute" }
 
 [[tool.uv.index]]
 name = "pytorch-cpu"
@@ -175,7 +176,10 @@ streaming = [
 dreamverse = [
     "uvicorn[standard]>=0.41.0",
     "cerebras-cloud-sdk",
-    "flash-attn-cute @ git+https://github.com/XOR-op/flash-attention.git@fa4-compile#subdirectory=flash_attn/cute",
+    # PyPI forbids direct URL deps in published metadata; pin the fork via
+    # [tool.uv.sources] above (same pattern as imagebind) so the wheel stays
+    # publishable while uv workspace installs still get the fork.
+    "flash-attn-cute",
     "flashinfer-python",
     "openai>=1.40",
 ]


### PR DESCRIPTION
## Problem

The `v0.2.0` PyPI publish ([failing run](https://github.com/hao-ai-lab/FastVideo/actions/runs/26980426527)) failed at upload with:

```
400 Can't have direct dependency: flash-attn-cute @
git+https://github.com/XOR-op/flash-attention.git@fa4-compile#subdirectory=flash_attn/cute ; extra == "dreamverse"
```

PyPI forbids PEP 508 direct URL/VCS references (`pkg @ git+https://…`) in uploaded
package metadata. The `dreamverse` extra pinned `flash-attn-cute` to a git fork
inline, so the generated `Requires-Dist` carried a `git+https://…` URL and PyPI
rejected the upload.

## Fix

Mirror the pattern already used for `imagebind`:

- Reference `flash-attn-cute` by **plain name** in the `dreamverse` extra.
- Pin the fork (`XOR-op/flash-attention`, branch `fa4-compile`, subdir
  `flash_attn/cute`) in `[tool.uv.sources]`.

The published wheel now carries a plain `Requires-Dist: flash-attn-cute; extra == "dreamverse"`,
while `uv` workspace installs of `apps/dreamverse` still resolve the fork via the
source override. (`fa4-compile` is a branch in the fork, so the source uses `branch =`.)

## Verification

Rendered the wheel metadata via setuptools (`prepare_metadata_for_build_wheel`):

- Direct-reference (`@ git+…`) entries in `Requires-Dist`: **0** (was 1)
- `Requires-Dist: flash-attn-cute; extra == "dreamverse"` ✅
- `Requires-Dist: imagebind; extra == "eval-audio"` ✅ (unchanged)

A full scan of `pyproject.toml` confirms this was the **only** direct reference in
the metadata — all other deps/extras are plain names.

> pre-commit was not run locally (jj-only checkout, no colocated `.git`); the CI
> pre-commit job will validate. The change is TOML-only.

## Releasing 0.2.0 after merge

`0.2.0` is not on PyPI yet (the upload was rejected before anything landed), so the
version is still free to publish. This fix keeps the version at `0.2.0`, so the
`on: push` version-change check will **skip** the publish job — trigger it manually:

```
gh workflow run publish-fastvideo.yml --repo hao-ai-lab/FastVideo --ref main
```

(or bump to `0.2.1` to let the push auto-publish).
