### PR TITLE
[bugfix]: build fastvideo-kernel on GPU-less Docker runners

### DIFF
--- a/docker/Dockerfile.python3.10
+++ b/docker/Dockerfile.python3.10
@@ -55,12 +55,14 @@ RUN source $HOME/.local/bin/env && \
     echo 'source /opt/venv/bin/activate' >> /root/.bashrc && \
     echo 'if [ -n "$ZSH_VERSION" ] && [ -f ~/.zshrc ]; then . ~/.zshrc; elif [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.profile
 
-# Install FastVideo Unified Kernel
+# Install FastVideo Unified Kernel.
+# This build machine has no GPU, so target Hopper (sm_90a) explicitly instead
+# of probing a live device for the arch (matches the released kernel wheel).
 RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
     cd fastvideo-kernel && \
     git submodule update --init --recursive && \
-    ./build.sh
+    TORCH_CUDA_ARCH_LIST=9.0a ./build.sh
 
 
 EXPOSE 22

--- a/docker/Dockerfile.python3.11
+++ b/docker/Dockerfile.python3.11
@@ -55,12 +55,14 @@ RUN source $HOME/.local/bin/env && \
     echo 'source /opt/venv/bin/activate' >> /root/.bashrc && \
     echo 'if [ -n "$ZSH_VERSION" ] && [ -f ~/.zshrc ]; then . ~/.zshrc; elif [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.profile
 
-# Install FastVideo Unified Kernel
+# Install FastVideo Unified Kernel.
+# This build machine has no GPU, so target Hopper (sm_90a) explicitly instead
+# of probing a live device for the arch (matches the released kernel wheel).
 RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
     cd fastvideo-kernel && \
     git submodule update --init --recursive && \
-    ./build.sh
+    TORCH_CUDA_ARCH_LIST=9.0a ./build.sh
 
 
 EXPOSE 22

--- a/docker/Dockerfile.python3.12
+++ b/docker/Dockerfile.python3.12
@@ -55,11 +55,13 @@ RUN source $HOME/.local/bin/env && \
     echo 'source /opt/venv/bin/activate' >> /root/.bashrc && \
     echo 'if [ -n "$ZSH_VERSION" ] && [ -f ~/.zshrc ]; then . ~/.zshrc; elif [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.profile
 
-# Install FastVideo Unified Kernel
+# Install FastVideo Unified Kernel.
+# This build machine has no GPU, so target Hopper (sm_90a) explicitly instead
+# of probing a live device for the arch (matches the released kernel wheel).
 RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
     cd fastvideo-kernel && \
     git submodule update --init --recursive && \
-    ./build.sh
+    TORCH_CUDA_ARCH_LIST=9.0a ./build.sh
 
 EXPOSE 22

--- a/docker/Dockerfile.python3.12.cuda12.9.1
+++ b/docker/Dockerfile.python3.12.cuda12.9.1
@@ -55,12 +55,14 @@ RUN source $HOME/.local/bin/env && \
     echo 'source /opt/venv/bin/activate' >> /root/.bashrc && \
     echo 'if [ -n "$ZSH_VERSION" ] && [ -f ~/.zshrc ]; then . ~/.zshrc; elif [ -f ~/.bashrc ]; then . ~/.bashrc; fi' > /root/.profile
 
-# Install FastVideo Unified Kernel
+# Install FastVideo Unified Kernel.
+# This build machine has no GPU, so target Hopper (sm_90a) explicitly instead
+# of probing a live device for the arch (matches the released kernel wheel).
 RUN source $HOME/.local/bin/env && \
     source /opt/venv/bin/activate && \
     cd fastvideo-kernel && \
     git submodule update --init --recursive && \
-    ./build.sh
+    TORCH_CUDA_ARCH_LIST=9.0a ./build.sh
 
 
 EXPOSE 22

--- a/fastvideo-kernel/build.sh
+++ b/fastvideo-kernel/build.sh
@@ -78,16 +78,26 @@ print(f'{mj}.{mn}')"
 }
 
 if [ "${GPU_BACKEND}" = "CUDA" ]; then
-    detected_cc="$(detect_with_torch)" || {
-        echo "ERROR: torch-based CUDA arch detection failed in uv environment." >&2
-        echo "       Ensure torch is installed and CUDA is available in the uv-selected Python." >&2
-        exit 1
-    }
-
-    cc_major="${detected_cc%%.*}"
-    cc_minor="${detected_cc##*.}"
+    # Compute capability drives the arch/TK defaults below. Prefer an explicit
+    # TORCH_CUDA_ARCH_LIST (works on GPU-less build machines such as CI/Docker);
+    # only probe a live GPU via torch when no arch was provided.
+    if [ -n "${TORCH_CUDA_ARCH_LIST:-}" ]; then
+        echo "Using TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST} (skipping torch GPU probe)"
+        first_arch="${TORCH_CUDA_ARCH_LIST%%[;, ]*}"   # first entry, e.g. 9.0a
+        first_arch="${first_arch%[af]}"                # strip trailing a/f suffix
+        cc_major="${first_arch%%.*}"
+        cc_minor="${first_arch##*.}"
+    else
+        detected_cc="$(detect_with_torch)" || {
+            echo "ERROR: torch-based CUDA arch detection failed and TORCH_CUDA_ARCH_LIST is unset." >&2
+            echo "       Set TORCH_CUDA_ARCH_LIST (e.g. 9.0a) for GPU-less builds, or build where CUDA is available." >&2
+            exit 1
+        }
+        cc_major="${detected_cc%%.*}"
+        cc_minor="${detected_cc##*.}"
+        echo "Detected compute capability via torch: ${detected_cc}"
+    fi
     cmake_arch="${cc_major}${cc_minor}"
-    echo "Detected compute capability via torch: ${detected_cc} (sm_${cmake_arch})"
 
     # Respect explicit overrides.
     if [ -z "${TORCH_CUDA_ARCH_LIST:-}" ]; then


### PR DESCRIPTION
## Problem

The **Build and Push Docker Images** workflow ([failing run](https://github.com/hao-ai-lab/FastVideo/actions/runs/27030808598)) fails for all CUDA variants (py3.10/3.11/3.12) at the `fastvideo-kernel` build step:

```
#17 RuntimeError: torch.cuda.is_available() is false
#17 ERROR: torch-based CUDA arch detection failed in uv environment.
Dockerfile.python3.10:59  RUN ... cd fastvideo-kernel && ... ./build.sh
```

## Root cause

`fastvideo-kernel/build.sh` probed a **live GPU** via `torch.cuda.is_available()` /
`get_device_capability()` to choose the CUDA arch, and hard-`exit 1`'d when none was
found — *before* its own `TORCH_CUDA_ARCH_LIST` override was ever consulted. GitHub
Actions Docker builders have no GPU, so the kernel build aborts.

It passed as recently as 05-27 only because the kernel layer was served from the GHA
build cache (`cache-from: type=gha`); the recent `pyproject.toml` churn (0.2.0 release
+ dep unpinning) invalidated that layer and forced a fresh, GPU-less rebuild that
exposed the latent requirement.

## Fix

- **`build.sh`**: when `TORCH_CUDA_ARCH_LIST` is set, skip the torch GPU probe and
  derive the arch/TK defaults from it; only fall back to torch detection when no arch
  is provided (preserves local-GPU auto-detect). This makes the script's documented
  override contract actually work on GPU-less machines.
- **CUDA Dockerfiles** (`python3.10`, `python3.11`, `python3.12`,
  `python3.12.cuda12.9.1`): set `TORCH_CUDA_ARCH_LIST=9.0a` on the build invocation so
  they cross-compile for Hopper without a device — the **same recipe
  `publish-kernel.yml` already uses** for the released kernel wheel.

The ROCm Dockerfile is unaffected (`--rocm` ⇒ `GPU_BACKEND=ROCM`, which bypasses the
CUDA arch block entirely).

## Verification

Ran the real `build.sh` on a GPU-less env (stubbed `uv`/`git` to skip the heavy
compile):

- `TORCH_CUDA_ARCH_LIST=9.0a` →
  `Using TORCH_CUDA_ARCH_LIST=9.0a (skipping torch GPU probe)` and
  `CMAKE_ARGS: -DCMAKE_CUDA_ARCHITECTURES=90a -DFASTVIDEO_KERNEL_BUILD_TK=ON -DGPU_BACKEND=CUDA`
  — matches the `publish-kernel.yml` recipe. ✅
- Unset arch → still probes torch and auto-detects the local GPU. ✅

## Notes

- All images target **Hopper (sm_90a)**, consistent with the published
  `fastvideo-kernel` wheel. If multi-arch dev images are wanted later, that's a
  separate enhancement (set a broader `TORCH_CUDA_ARCH_LIST` / pass it as a build arg).
- Re-run via **workflow_dispatch** (the workflow is manual-only), ticking the
  py3.10/3.11/3.12 inputs.
- Did not run pre-commit locally (jj-only checkout, no `.git`); CI will validate.
