### PR TITLE
[misc] add .agents/reviewers scaffold (scoped PR-review agents)

### DIFF
--- a/.agents/reviewers/README.md
+++ b/.agents/reviewers/README.md
@@ -1,0 +1,86 @@
+# PR Reviewers
+
+Repo-specific automatic PR reviewers for FastVideo. Each reviewer is a scoped
+agent definition (role + checklist + references) tailored to a concrete slice
+of the codebase. A dispatcher routes an incoming PR to one or more reviewers
+based on the changed paths and labels.
+
+> Status: **Draft / Skeleton.** None of these reviewers have been exercised on
+> real PRs yet. Treat their output as a first pass, not a replacement for human
+> review. See [STATUS.md](../STATUS.md) for the trust-level ladder.
+
+## Layout
+
+```
+.agents/reviewers/
+├── README.md              ← this file
+├── ROUTING.md             ← label/path → reviewer routing table
+├── index.jsonl            ← machine-readable reviewer index
+├── dispatcher/
+│   └── DISPATCHER.md      ← instructions for the orchestrator
+├── shared/
+│   ├── pr-context.md      ← how to fetch PR diff/files/labels via gh
+│   ├── review-output.md   ← required output format + severity levels
+│   └── repo-conventions.md ← conventions every reviewer should know
+├── model/                 ← model / pipeline / config reviewer
+│   ├── REVIEWER.md
+│   ├── checklist.md
+│   └── references.md
+├── kernel/                ← fastvideo-kernel + attention backend reviewer
+│   ├── REVIEWER.md
+│   ├── checklist.md
+│   └── references.md
+├── training/              ← training / distillation / dataset reviewer
+│   ├── REVIEWER.md
+│   ├── checklist.md
+│   └── references.md
+└── general/               ← inference serving / CI / docs / fallback
+    ├── REVIEWER.md
+    ├── checklist.md
+    └── references.md
+```
+
+## Reviewers at a glance
+
+| Reviewer | Covers | Primary labels | Primary paths |
+|----------|--------|----------------|---------------|
+| [model](model/REVIEWER.md) | New models, DiT/VAE/encoder edits, pipeline wiring, arch configs, SSIM coverage | `scope: model`, `type: new-model` | `fastvideo/models/`, `fastvideo/layers/`, `fastvideo/configs/models/`, `fastvideo/pipelines/basic/`, `fastvideo/tests/ssim/` |
+| [kernel](kernel/REVIEWER.md) | CUDA/C++/Triton kernels, attention backend fusions, kernel↔layer wiring | `scope: kernel`, `scope: attention` | `fastvideo-kernel/`, `csrc/`, `fastvideo/attention/` |
+| [training](training/REVIEWER.md) | Training methods, distillation, datasets, SP/TP/FSDP wiring, checkpointing | `scope: training`, `scope: data`, `scope: distributed` | `fastvideo/train/`, `fastvideo/training/`, `fastvideo/dataset/`, `fastvideo/distributed/`, `examples/train*/`, `examples/distill/` |
+| [general](general/REVIEWER.md) | Inference serving, public API, CLI, CI, docs, UI, dependencies, fallback | `scope: inference`, `scope: infra`, `scope: docs`, `scope: ui`, `type: ci`, `type: docs`, `type: misc` | `fastvideo/entrypoints/`, `fastvideo/api/`, `fastvideo/worker/`, `.github/`, `docs/`, `ui/`, `pyproject.toml` |
+
+Full rules live in [ROUTING.md](ROUTING.md). When a PR matches multiple
+reviewers (common — a new model PR often hits model + training + general), the
+dispatcher fans out and each reviewer reports independently.
+
+## Invocation
+
+Today, invocation is manual. The intended entry points are:
+
+1. **Human invokes reviewer directly.** Paste the contents of a `REVIEWER.md`
+   into a Claude Code prompt along with PR number / diff.
+2. **Dispatcher-driven.** Run the dispatcher (see `dispatcher/DISPATCHER.md`)
+   with a PR number; it fetches context, picks reviewers, and runs each.
+3. **Future: CI hook.** A GitHub Action can call the dispatcher on
+   `pull_request` events. Not wired up yet.
+
+## How to add a new reviewer
+
+1. Create `.agents/reviewers/<name>/` with `REVIEWER.md`, `checklist.md`,
+   `references.md`.
+2. Add its triggers to [ROUTING.md](ROUTING.md).
+3. Register it in [index.jsonl](index.jsonl).
+4. Update the table above.
+
+## Conventions
+
+- All reviewers use the **common output format** in
+  [shared/review-output.md](shared/review-output.md) so their output is
+  composable.
+- All reviewers **MUST cite file paths with line numbers** (`file:line`) when
+  flagging issues, so the user can jump straight to the location.
+- Severity levels: **BLOCKER** → **MAJOR** → **MINOR** → **NIT**. Defined in
+  [shared/review-output.md](shared/review-output.md).
+- Reviewers must **not** block on style issues — `pre-commit` handles that.
+  Focus on things humans care about: correctness, design, test coverage,
+  regressions, perf, GPU-memory, API stability.

--- a/.agents/reviewers/ROUTING.md
+++ b/.agents/reviewers/ROUTING.md
@@ -1,0 +1,97 @@
+# Reviewer Routing
+
+How the dispatcher decides which reviewer(s) to run for a PR. The table below
+mirrors the authoritative label-to-path map in `.github/mergify.yml` — when
+mergify changes, keep this in sync.
+
+## Routing rules
+
+A PR activates a reviewer if **any** of its matchers fire. Multiple reviewers
+can (and usually do) activate for a single PR.
+
+### `model` reviewer
+**Activates when any of:**
+- PR has label `scope: model` or `type: new-model`
+- PR title starts with `[new-model]`
+- Changed paths match any of:
+  - `fastvideo/models/**`
+  - `fastvideo/layers/**`
+  - `fastvideo/configs/models/**`
+  - `fastvideo/pipelines/basic/**`  *(per-model pipeline wiring)*
+  - `fastvideo/registry.py`
+  - `fastvideo/tests/ssim/**`
+  - `fastvideo/tests/encoders/**`
+  - `fastvideo/tests/transformers/**`
+  - `examples/inference/basic/**`
+
+### `kernel` reviewer
+**Activates when any of:**
+- PR has label `scope: kernel` or `scope: attention`
+- PR title starts with `[kernel]` or mentions `triton` / `cuda` / `fused`
+- Changed paths match any of:
+  - `fastvideo-kernel/**`
+  - `csrc/**`
+  - `fastvideo/attention/**`
+  - `fastvideo-kernel/benchmarks/**`
+  - `fastvideo-kernel/tests/**`
+
+### `training` reviewer
+**Activates when any of:**
+- PR has label `scope: training`, `scope: data`, or `scope: distributed`
+- Changed paths match any of:
+  - `fastvideo/train/**`
+  - `fastvideo/training/**`
+  - `fastvideo/distillation/**`
+  - `fastvideo/dataset/**`
+  - `fastvideo/distributed/**`
+  - `fastvideo/pipelines/preprocess/**`
+  - `examples/train/**`
+  - `examples/training/**`
+  - `examples/distill/**`
+  - `examples/preprocessing/**`
+  - `scripts/distill/**`
+  - `scripts/finetune/**`
+  - `scripts/preprocess/**`
+  - `fastvideo/tests/training/**`
+
+### `general` reviewer
+**Activates when any of:**
+- **Always activates as a fallback** if no other reviewer matched.
+- Additionally activates on its own when any of:
+  - PR has label `scope: inference`, `scope: infra`, `scope: docs`, `scope: ui`, `type: ci`, `type: docs`, `type: misc`, `type: refactor`
+  - Changed paths match any of:
+    - `fastvideo/entrypoints/**`
+    - `fastvideo/api/**`
+    - `fastvideo/worker/**`
+    - `fastvideo/pipelines/stages/**`
+    - `fastvideo/pipelines/samplers/**`
+    - `fastvideo/tests/modal/**`
+    - `.github/**`
+    - `.buildkite/**`
+    - `.agents/**`
+    - `docker/**`
+    - `docs/**`
+    - `ui/**`
+    - `pyproject.toml`
+    - `mkdocs.yml`
+    - `comfyui/**`
+
+## Edge cases
+
+- **Multi-scope PRs** (e.g. #1087 "Nvtx tracer" touches 6 scopes): run every
+  matched reviewer in parallel. Consolidation happens in the dispatcher's
+  summary step.
+- **`needs-rebase` PRs**: the dispatcher should refuse to review — the diff is
+  stale and comments would land on moving code. Emit a single note and exit.
+- **Draft PRs**: review if the author explicitly asks (via `gh pr comment`) or
+  if the dispatcher is invoked with `--include-drafts`. Otherwise skip.
+- **CI-only PRs** (`type: ci`): route to `general` only, even if they touch
+  `fastvideo/tests/` (which would normally hit `scope: infra`).
+- **Revert PRs**: skip automated review and flag for human — diffs are often
+  mechanical and review focus should be "why are we reverting".
+
+## Source of truth
+
+The label → path map is defined in
+[`.github/mergify.yml`](../../.github/mergify.yml). If you add a new scope
+label there, update this file too. Consider writing a test that diffs the two.

--- a/.agents/reviewers/dispatcher/DISPATCHER.md
+++ b/.agents/reviewers/dispatcher/DISPATCHER.md
@@ -1,0 +1,161 @@
+---
+name: pr-review-dispatcher
+description: Route a PR to the correct scoped reviewer(s) and consolidate their output into one report
+---
+
+# PR Review Dispatcher
+
+Top-level orchestrator for the automatic PR reviewer system. Given a PR
+number, it fetches context, selects one or more scoped reviewers, runs them,
+and emits a consolidated report.
+
+## Prerequisites
+
+- `gh` CLI authenticated against `hao-ai-lab/FastVideo`.
+- Working directory is the repo root.
+- Repo-conventions doc read once per session: [`../shared/repo-conventions.md`](../shared/repo-conventions.md).
+
+## Inputs
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `pr` | Yes | PR number (e.g. `1245`). |
+| `include_drafts` | No | If true, review draft PRs. Default false. |
+| `force_reviewers` | No | Comma-separated reviewer names to force (skip routing). |
+| `skip_reviewers` | No | Comma-separated reviewer names to exclude. |
+
+## Steps
+
+### 1. Gate checks
+
+- If the PR has label `needs-rebase`, emit:
+
+    > **Dispatcher:** PR #`<N>` is marked `needs-rebase`. Skipping review — the
+    > diff is stale. Re-invoke after rebase.
+
+  and exit.
+- If the PR is a draft and `include_drafts` is false, emit a one-line note and exit.
+- If required CI check `pre-commit` failed, note it at the top of the report
+  but continue (human will fix style; reviewer focuses on substance).
+- If required CI checks `fastcheck-passed` / `full-suite-passed` are FAILURE
+  (common on merged PRs being audited), **scan the PR body** for explicit
+  acknowledgment phrases before flagging:
+  - "expected to fail", "first run will fail"
+  - "no reference video yet", "references will be seeded"
+  - "blocked on #NNNN"
+
+  If the body acknowledges the failure with a reason, record it as context
+  ("PR body acknowledges expected CI failure: `<quote>`") and do **not** flag
+  it in the consolidated report as a process concern. If the body does not
+  acknowledge it, treat as a MAJOR anomaly in the general reviewer's scope.
+  See `../shared/repo-conventions.md` → "Expected failure" workflow.
+- Flag whether the PR is **open** or **merged** at the top of the report so
+  reviewers calibrate severity (see `../shared/review-output.md` → Pre-merge
+  vs post-merge semantics).
+
+### 2. Fetch context
+
+Follow [`../shared/pr-context.md`](../shared/pr-context.md). Fetch **once** and
+pass the bundle to each reviewer (avoid re-hitting the GitHub API).
+
+Record:
+- `metadata` (number, title, author, labels, base, draft)
+- `body` (PR description)
+- `files` (list of path + additions + deletions)
+- `diff` (unified diff — may be truncated for huge PRs)
+- `checks` (pre-commit / fastcheck / full-suite status)
+- `existing_review_comments`
+
+### 3. Route
+
+Apply the rules in [`../ROUTING.md`](../ROUTING.md). Produce a set of
+activated reviewers. If no reviewer matches by path/label, always fall back
+to `general`.
+
+Minimum fan-out: 1 (general). Typical fan-out: 1–3. Max: 4 (all reviewers).
+
+Examples:
+
+| PR | Signal | Reviewers |
+|----|--------|-----------|
+| #1245 `[perf] fused RoPE Triton kernel + FP32LayerNorm` | `scope: kernel`, `scope: model` | `kernel`, `model` |
+| #1244 `[feat] LongCat self-forcing training scaffold` | `scope: training` | `training` |
+| #1236 `[new-model] Port Z-Image T2I` | `type: new-model`, `scope: model` | `model`, `general` *(touches examples/docs)* |
+| #1230 `[CI] detect-changes + conditional Docker rebuild` | `type: ci`, `scope: infra` | `general` |
+| #1225 `Attn-QAT Video Diffusion Code` | 9 scopes | `model`, `kernel`, `training`, `general` |
+
+### 4. Run each reviewer
+
+For each activated reviewer:
+
+1. Load its `REVIEWER.md`, `checklist.md`, `references.md`.
+2. Pass the shared PR context + the reviewer-scoped file list (narrow the diff
+   to paths the reviewer owns — see `../shared/pr-context.md` "Scope reduction").
+3. Produce output in the format defined by
+   [`../shared/review-output.md`](../shared/review-output.md).
+
+Run reviewers **in parallel** where the harness supports it (each reviewer is
+an independent Agent call). They do not share state.
+
+### 5. Consolidate
+
+Produce a single top-level report with this structure:
+
+```markdown
+# PR #<N> Review — consolidated
+
+**Title**: <title>
+**Author**: <author>
+**Reviewers run**: <list>
+**Verdict (aggregate)**: <APPROVE if all reviewers approved, else REQUEST_CHANGES>
+**Blocker count**: <N>  |  Major: <N>  |  Minor: <N>  |  Nit: <N>
+
+---
+
+## <reviewer-1> report
+<verbatim output>
+
+---
+
+## <reviewer-2> report
+<verbatim output>
+
+...
+
+## Unified action list
+<Top blockers + majors, de-duplicated across reviewers, sorted by severity.>
+
+## Untouched scopes
+<Any scope that no reviewer covered. Dispatcher flags so a human can decide
+whether to run that reviewer manually or treat as out of scope.>
+```
+
+### 6. Post (optional)
+
+Posting the report as a PR comment is **not** part of the default flow. Do
+not post automatically — this is a skeleton and output fidelity hasn't been
+validated. If a human decides to post, they can run:
+
+```bash
+gh pr comment "$PR" --body-file <report>.md
+```
+
+## Output
+
+- A single markdown report (console or file).
+- Optional: a structured JSON sidecar with per-reviewer verdicts + finding
+  counts. Not implemented yet.
+
+## References
+
+- [Routing](../ROUTING.md)
+- [PR context](../shared/pr-context.md)
+- [Review output format](../shared/review-output.md)
+- [Repo conventions](../shared/repo-conventions.md)
+- [`.github/mergify.yml`](../../../.github/mergify.yml) — authoritative label/path map
+
+## Status
+
+**Draft.** The dispatcher has not been tested end-to-end on a real PR.
+Next steps: run against a recent merged PR (e.g. #1245) and compare the
+consolidated report against the human review that actually landed.

--- a/.agents/reviewers/general/REVIEWER.md
+++ b/.agents/reviewers/general/REVIEWER.md
@@ -1,0 +1,128 @@
+---
+name: general-reviewer
+description: Review PRs for inference serving, public API, CI, docs, UI, dependencies; fallback reviewer
+---
+
+# General Reviewer
+
+## Role
+
+You are the **fallback reviewer** and the owner of everything that doesn't
+fit the scoped reviewers: inference serving, public API, CLI, CI, docs, UI,
+dependencies. You also re-check **cross-cutting risks** on any PR (public API
+stability, backward compat, license/secret leaks).
+
+Read these once before reviewing:
+- [`../shared/pr-context.md`](../shared/pr-context.md)
+- [`../shared/review-output.md`](../shared/review-output.md)
+- [`../shared/repo-conventions.md`](../shared/repo-conventions.md)
+- [`./checklist.md`](./checklist.md)
+- [`./references.md`](./references.md)
+
+## Scope
+
+**You own:**
+- `fastvideo/entrypoints/**` — CLI + dispatch.
+- `fastvideo/api/**` — public Python API, OpenAI-compatible serving,
+  sampling params.
+- `fastvideo/worker/**` — worker subprocess entry.
+- `fastvideo/pipelines/stages/**` + `fastvideo/pipelines/samplers/**` — shared pipeline stages (cross-model).
+- `.github/**` — GitHub Actions workflows.
+- `.buildkite/**` — Buildkite CI.
+- `docker/**` — container configuration.
+- `docs/**` — MkDocs source.
+- `ui/**` — Job Runner UI.
+- `comfyui/**` — ComfyUI integration.
+- `pyproject.toml`, `mkdocs.yml`, top-level config.
+- **Fallback**: any path no other reviewer owns.
+
+**Not your scope:**
+- Model / pipeline / arch config code → model reviewer.
+- Kernel / attention backend code → kernel reviewer.
+- Training code → training reviewer.
+
+## What to focus on
+
+### Public API (`fastvideo/api/`, `fastvideo/entrypoints/`)
+
+- **Backward compat**: any rename, removal, or default change in a
+  user-facing class (e.g. `VideoGenerator`, `SamplingParams`, `ServeConfig`)
+  needs either a deprecation shim or a migration note in the PR body.
+- **CLI flags** in `fastvideo/entrypoints/cli_args.py` (or wherever) changing
+  name / default → flag.
+- **OpenAI-compatible serving**: recent work (#1218, #1220, #1226, #1234,
+  #1237, #1238, #1239) overhauled this — behavior should match OpenAI's API
+  where it claims to. Any divergence without justification is **MAJOR**.
+
+### Pipeline stages (`fastvideo/pipelines/stages/`)
+
+These are shared across models. Changes here affect multiple pipelines.
+
+- Ask for cross-model testing evidence (SSIM on at least 2 pipelines).
+- New stages should be reusable (accept generic inputs, not model-specific
+  dicts).
+
+### CI (`.github/workflows/`, `.buildkite/`)
+
+- **Secrets**: grep for `${{ secrets.` — any new secret reference should
+  come with a note in the PR body about how it was provisioned.
+- **`pull_request_target`** is dangerous (gives write access to untrusted
+  code). It's already used for Full Suite triggers (#1213) — verify any new
+  usage is gated on contributor association or label.
+- **Permissions**: each workflow should declare minimal `permissions:` block.
+  Flag `permissions: write-all` or implicit full perms.
+- **Concurrency**: long-running workflows should have a `concurrency:` block
+  to cancel superseded runs.
+- **Caching**: actions should pin SHAs, not version tags (pattern followed in
+  this repo — check new actions use the same).
+
+### Docs (`docs/`)
+
+- MkDocs source. Any new page must be added to `mkdocs.yml` nav or it won't
+  render.
+- Check that example commands still work (match current CLI / API).
+- Internal links should be relative, not absolute GitHub URLs.
+
+### UI (`ui/`)
+
+- Job Runner UI is recent (#1172, #1189). Security-sensitive: verify auth /
+  ACL, CSRF, and that the UI doesn't expose unescaped HTML from run metadata.
+
+### Dependencies (`pyproject.toml`)
+
+- New deps: verify license is compatible (MIT / BSD / Apache-2.0 are OK; GPL
+  / AGPL need explicit discussion).
+- Version pin: prefer `>=x.y,<x.(y+1)` over `>=x.y` for fast-moving deps.
+- Removed deps: make sure nothing still imports them.
+
+### Cross-cutting risks (ALWAYS check, even outside scope)
+
+- **Secret leak**: grep the full diff for `API_KEY`, `SECRET`, `TOKEN`,
+  `PRIVATE_KEY`, `.env`, `credentials.json`. The repo does not commit these.
+- **Large binary check-in**: any `.pth`, `.bin`, `.mp4`, `.tar`, `.zip`, or
+  `.safetensors` > 100KB committed directly. Video assets should go to
+  `assets/videos/` **only if tiny** or live on HF.
+- **License header**: new source files should have the project's license
+  preamble if the convention is present in neighbors (grep for an existing
+  file in the same directory).
+- **`.gitignore`**: new tooling that writes cache/output files should add
+  patterns here.
+
+## Common anti-patterns
+
+- **Workflow file missing `permissions:` block** — defaults to write-all on
+  older Actions setups.
+- **CLI flag renamed without a deprecation path.**
+- **Docs example uses a flag that no longer exists** (check the current
+  entrypoint).
+- **`pyproject.toml` bump without a reason in the PR body.**
+- **Debug script committed to repo root** (`debug_*.py`, `compare_*.py`,
+  `dump_*.py`). Several appeared in the open-PR sweep — flag to move to a
+  local `scratch/` or remove.
+
+## Produce output
+
+Use the template in [`../shared/review-output.md`](../shared/review-output.md).
+As the fallback reviewer, be explicit about which parts of the PR you **did
+not** review (other reviewers cover them), so the user knows coverage is
+partitioned.

--- a/.agents/reviewers/general/checklist.md
+++ b/.agents/reviewers/general/checklist.md
@@ -1,0 +1,73 @@
+# General reviewer checklist
+
+## Public API
+
+- [ ] User-facing renames / removals have a deprecation shim or migration note.
+- [ ] New CLI flags documented in `docs/` or the PR body.
+- [ ] OpenAI-compatible serving behavior matches OpenAI spec (or divergence
+      is justified).
+- [ ] `SamplingParams` / `ServeConfig` / `VideoGenerator` defaults unchanged
+      unless called out.
+
+## Pipeline stages (shared)
+
+- [ ] Cross-model test evidence provided when `pipelines/stages/` is edited
+      (at least 2 pipelines).
+- [ ] New stages are reusable — accept generic inputs, not model-specific
+      dicts.
+
+## CI
+
+- [ ] No secret hard-coded in workflow yaml.
+- [ ] `pull_request_target` usage is gated (if newly used).
+- [ ] Minimal `permissions:` block declared.
+- [ ] `concurrency:` block declared for long workflows.
+- [ ] Action versions pinned to SHA (match repo convention).
+
+## Docs
+
+- [ ] New pages added to `mkdocs.yml` nav.
+- [ ] Example commands match current CLI / API.
+- [ ] Internal links are relative.
+
+## UI
+
+- [ ] Auth / ACL preserved.
+- [ ] No unescaped HTML from run metadata.
+
+## Dependencies
+
+- [ ] License compatible (MIT / BSD / Apache-2.0 OK).
+- [ ] Version pins consistent with the rest of the file.
+- [ ] Removed deps no longer imported anywhere.
+
+## Cross-cutting (check on every PR)
+
+- [ ] No secret strings in diff.
+- [ ] No large binaries committed directly.
+- [ ] License header on new source files (if neighbors have one).
+- [ ] Debug / scratch scripts not committed to repo root.
+- [ ] `.gitignore` updated for any new generated-file pattern.
+
+## PR template compliance
+
+- [ ] Title matches the mergify regex (from
+      `.github/mergify.yml:merge_protections.success_conditions`):
+
+      ```
+      (?i)^\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model)\]
+      ```
+
+      Common misses: `[test]`, `[tests]`, `[wip]`, `[draft]` — none are valid.
+- [ ] Description is not the template placeholder.
+- [ ] Test Plan + Test Results sections populated (even for non-code PRs —
+      "N/A because docs-only" is acceptable).
+
+## Merge-protection anomalies (always check on a merged PR)
+
+- [ ] If the PR is already merged, confirm the required checks
+      (`pre-commit`, `fastcheck-passed`, `full-suite-passed`) were SUCCESS at
+      merge, or that the PR body explicitly acknowledges an expected failure
+      (see `../shared/repo-conventions.md` → "Expected failure" workflow).
+- [ ] Title matched the mergify regex at merge time. If not, the `/merge`
+      queue should have rejected it — note the anomaly.

--- a/.agents/reviewers/general/references.md
+++ b/.agents/reviewers/general/references.md
@@ -1,0 +1,72 @@
+# General reviewer — references
+
+## Public API / serving
+
+- `fastvideo/api/` — public Python API, sampling params, serving config.
+- `fastvideo/entrypoints/` — CLI entry points and dispatch.
+- `fastvideo/worker/` — worker subprocess.
+
+Recent API work (the `[feat] [N/n] Improve API` series):
+- #1218 (1/n) initial files for new public API.
+- #1220 (2/n) `video_generator` support.
+- #1226 (3/n) CLI extension.
+- #1234 (4/n) sampling param refactor + presets.
+- #1235 misc API cleanup.
+- #1237 (5/n) `ServeConfig.default_request` into OpenAI serving.
+- #1238 (5.5/n) streaming server config surface + serve dispatch.
+- #1239 (6/n) LTX-2 public preset + gpu_pool translation.
+
+## Pipeline stages
+
+- `fastvideo/pipelines/stages/` — cross-model stages (text_encoding,
+  denoising, decode, etc).
+- `fastvideo/pipelines/samplers/` — sampler implementations.
+
+## CI
+
+- `.github/workflows/ci-precommit.yml`
+- `.github/workflows/ci-aggregate-status.yml`
+- `.github/workflows/ci-slash-commands.yml`
+- `.github/workflows/ci-trigger-full-suite.yml`
+- `.github/workflows/community-*.yml` (issue labeling, stale, welcome).
+- `.github/workflows/publish-*.yml` (release publishing).
+- `.github/mergify.yml` — auto-labeling + merge protections.
+- `.buildkite/` — Buildkite pipeline.
+
+Recent CI work (Eigensystem / Jinzhe Pan, heavy churn Mar–Apr 2026):
+- #1186, #1187 — CI infrastructure cleanup + workflow reorganization (1/2, 2/2).
+- #1200 — Replace Merge Queue with auto-merge.
+- #1202 — Fork PR checkout fix.
+- #1210, #1211, #1212 — test retry + reference-video handling.
+- #1213 — `pull_request_target` for Full Suite.
+- #1214 — direct test retry.
+- #1215 — update instead of rebase for auto sync.
+- #1216 — mergify upgrade.
+
+## Docs
+
+- `docs/` — MkDocs source.
+- `docs/contributing/pull_requests.md` — PR flow + `/test <scope>` commands.
+- `docs/contributing/ci_architecture.md` — the CI model.
+- `docs/contributing/overview.md`.
+- `docs/contributing/coding_agents.md` — how agents should contribute.
+- `docs/design/overview.md` — architecture.
+- `mkdocs.yml` — nav.
+
+## UI
+
+- `ui/` — Job Runner UI (recently re-landed in #1189 after revert in #1188).
+
+## Misc
+
+- `pyproject.toml` — deps + build config.
+- `mkdocs.yml` — docs build.
+- `AGENTS.md` / `CLAUDE.md` — agent / style guide.
+- `.github/PULL_REQUEST_TEMPLATE.md` — PR template.
+- `.github/mergify.yml` — label auto-application + merge protections.
+
+## Related
+
+- `.agents/skills/` — agent skills (scanning one can quickly show whether a
+  task should be a skill or a reviewer).
+- `.agents/workflows/` — SOPs.

--- a/.agents/reviewers/index.jsonl
+++ b/.agents/reviewers/index.jsonl
@@ -1,0 +1,4 @@
+{"name": "model", "description": "Review PRs that add or modify models, DiTs, VAEs, encoders, pipelines, arch configs", "path": "model/REVIEWER.md", "status": "draft", "trust": "low"}
+{"name": "kernel", "description": "Review PRs that add or modify CUDA/C++/Triton kernels and attention backends", "path": "kernel/REVIEWER.md", "status": "draft", "trust": "low"}
+{"name": "training", "description": "Review PRs that add or modify training methods, distillation, datasets, or distributed training", "path": "training/REVIEWER.md", "status": "draft", "trust": "low"}
+{"name": "general", "description": "Review PRs for inference serving, public API, CI, docs, UI, dependencies; fallback reviewer", "path": "general/REVIEWER.md", "status": "draft", "trust": "low"}

--- a/.agents/reviewers/kernel/REVIEWER.md
+++ b/.agents/reviewers/kernel/REVIEWER.md
@@ -1,0 +1,123 @@
+---
+name: kernel-reviewer
+description: Review PRs that add or modify CUDA/C++/Triton kernels or the attention backend layer
+---
+
+# Kernel Reviewer
+
+## Role
+
+You are reviewing a PR that touches `fastvideo-kernel/`, `csrc/`, or
+`fastvideo/attention/`. Your job is to catch **correctness**, **numerical**,
+**build**, and **perf-regression** issues in low-level code — the things that
+will hit users as wrong outputs, OOMs, or silent slowdowns.
+
+Read these once before reviewing:
+- [`../shared/pr-context.md`](../shared/pr-context.md) — how to fetch PR context
+- [`../shared/review-output.md`](../shared/review-output.md) — required output format
+- [`../shared/repo-conventions.md`](../shared/repo-conventions.md) — shared conventions
+- [`./checklist.md`](./checklist.md) — per-item checklist
+- [`./references.md`](./references.md) — key files to consult
+
+## Scope
+
+**You own:**
+- `fastvideo-kernel/**` — the separate kernel package, including
+  - `fastvideo-kernel/csrc/**` (CUDA / C++ source)
+  - `fastvideo-kernel/include/**` (headers)
+  - `fastvideo-kernel/python/fastvideo_kernel/**` (Python bindings, Triton kernels)
+  - `fastvideo-kernel/tests/**` (correctness tests)
+  - `fastvideo-kernel/benchmarks/**` (perf benchmarks)
+  - `fastvideo-kernel/CMakeLists.txt`, `build.sh`, `pyproject.toml`
+- `csrc/**` (if the repo still has a top-level one).
+- `fastvideo/attention/**` — attention backend dispatch and wrappers.
+
+**Often in the grey zone:** layers that call kernels —
+`fastvideo/layers/rotary_embedding.py`, `fastvideo/layers/layernorm.py`. Own
+the kernel-wiring changes (the call site); defer model-parity review to the
+model reviewer.
+
+**Not your scope:**
+- `fastvideo/models/**` model architecture changes → model reviewer.
+- `fastvideo/train/**` / training scripts → training reviewer.
+
+## What to focus on
+
+### Correctness
+
+- **Reference implementation**: every new kernel needs a test in
+  `fastvideo-kernel/tests/` that compares against a reference (typically
+  PyTorch eager or an existing kernel). If missing, **BLOCKER**.
+- **Tolerance**: check the `atol` / `rtol` in the test. For BF16, `atol=1e-2`
+  is common; FP16 tighter; FP32 tighter still. Flag suspiciously loose
+  tolerances (e.g. `atol=1e-1` on FP32 is a red flag that a kernel bug was
+  papered over).
+- **Shape coverage**: the test matrix should span
+  - head dim `{64, 128, 256}` (typical video DiT head dims),
+  - seqlen (short + long — video latents get very long),
+  - dtype (BF16 + FP16 at minimum; FP32 if supported),
+  - batch size (1 + >1 — batching bugs are common).
+- **Synchronization**: CUDA kernels that use shared memory or warp primitives
+  must have the right `__syncthreads()` / `__syncwarp()`. Grep for them in
+  the diff and confirm they're in the correct block.
+- **Out-of-bounds**: grep for `if (idx <` or `if (offset <` — missing guards
+  often cause silent corruption on the last block.
+- **Atomic contention**: if a kernel uses `atomicAdd`, confirm the expected
+  contention level is acceptable for the target shapes.
+
+### Numerical
+
+- **FP precision**: operations that accumulate (softmax, layernorm, reductions)
+  should use FP32 accumulators. BF16-accumulate reductions are a bug magnet.
+  Flag `fp16` or `bf16` accumulators in reduction loops.
+- **Epsilon placement** in normalization: `x / sqrt(var + eps)` vs
+  `x * rsqrt(var + eps)` differ under autotune — not a bug, but note if the
+  PR changes this.
+
+### Build
+
+- New `.cu` / `.cpp` files are added to `CMakeLists.txt` or the Python
+  `pyproject.toml` build (whichever the kernel uses). If not, `./build.sh`
+  will skip them silently. **BLOCKER** if missing.
+- Check for architecture guards (`__CUDA_ARCH__ >= 800`) when kernel uses
+  sm_80+ instructions (bf16, TMA, async copy).
+- For Triton kernels: `@triton.autotune` configs should be listed; if a kernel
+  claims perf, the autotune config should match the measured shape.
+
+### Perf claims
+
+The PR title or body often claims `2x`, `30% faster`, etc. Hold it to:
+
+- **A benchmark script** under `fastvideo-kernel/benchmarks/`. If missing,
+  **MAJOR** — ask the author to add one following the
+  `bench_flash_attn.py`-style template.
+- **Numbers for the specific GPU they tested on** (A100 / L40S / H100 /
+  B100). Cross-arch claims are suspicious.
+- **Baseline identified**: "2x faster than what?" — if not stated, ask.
+
+### Attention backend layer (`fastvideo/attention/`)
+
+- Any new backend must be registered via `FASTVIDEO_ATTENTION_BACKEND` env var
+  semantics (see `fastvideo/envs.py`).
+- `AttentionBackend` implementations must return the same tensor layout as
+  existing backends (`[B, H, S, D]` or whatever the contract is — confirm in
+  `fastvideo/attention/base.py`).
+- `SDPAImpl.forward()` signature recently had an argument-mismatch bug
+  (#1183). Be suspicious of signature changes.
+
+## Common anti-patterns
+
+- **Benchmark without warmup**: kernel benchmarks should warm up `cudaStreamSynchronize` before timing. If the benchmark loop doesn't, the first-call JIT dominates.
+- **`torch.cuda.synchronize()` inside a timed region** when it's outside in the baseline — apples-to-oranges.
+- **Triton kernel that requires a specific Triton version** without a version pin in `pyproject.toml`.
+- **Missing backward**: if the kernel is used during training (check call
+  sites in `fastvideo/train/`), a forward-only implementation will fail
+  training. Ask for a backward or explicit `no_grad` guard.
+- **`fastvideo-kernel` version bump without a changelog** — the kernel pkg
+  ships separately; unversioned breakage is painful.
+
+## Produce output
+
+Use the template in [`../shared/review-output.md`](../shared/review-output.md).
+For perf PRs, **quote the claim verbatim** from the PR body before asking for
+a benchmark — it makes the ask concrete.

--- a/.agents/reviewers/kernel/checklist.md
+++ b/.agents/reviewers/kernel/checklist.md
@@ -1,0 +1,56 @@
+# Kernel reviewer checklist
+
+## Correctness
+
+- [ ] New/modified kernel has a correctness test in `fastvideo-kernel/tests/`.
+- [ ] Test compares against a reference (PyTorch eager or existing kernel).
+- [ ] Tolerances are appropriate for the dtype (tight enough to catch bugs,
+      loose enough to absorb expected FP drift).
+- [ ] Test matrix covers multiple head dims, seq lengths, dtypes, and at
+      least one batch > 1.
+- [ ] No out-of-bounds access (block-boundary guards in place).
+- [ ] `__syncthreads()` / `__syncwarp()` used where shared memory / warp
+      primitives require it.
+
+## Numerical
+
+- [ ] Reductions (softmax, layernorm, sum) use FP32 accumulators.
+- [ ] No silent dtype downgrade in intermediate tensors.
+- [ ] `eps` placement preserved for layernorm / rmsnorm variants.
+
+## Build
+
+- [ ] New `.cu` / `.cpp` files registered in `CMakeLists.txt` or the Python
+      build config.
+- [ ] `__CUDA_ARCH__` guards present for arch-specific instructions
+      (bf16, TMA, cp.async, wgmma).
+- [ ] `./build.sh` is expected to succeed (author should confirm in PR body).
+- [ ] No reliance on a Triton version not pinned in `fastvideo-kernel/pyproject.toml`.
+
+## Perf claims
+
+- [ ] Title / body claim is quoted verbatim in the review.
+- [ ] Benchmark script exists under `fastvideo-kernel/benchmarks/`.
+- [ ] Benchmark includes warmup and correct sync.
+- [ ] Measured GPU is identified (A100 / L40S / H100 / B100).
+- [ ] Baseline is identified (PyTorch eager? previous kernel? specify.)
+
+## Attention backend (if `fastvideo/attention/` is touched)
+
+- [ ] New backend integrates with `FASTVIDEO_ATTENTION_BACKEND` env var.
+- [ ] Returns the same tensor layout as existing backends.
+- [ ] `SDPAImpl.forward()` signature unchanged, or all call sites updated.
+- [ ] Backend has a fallback path when it's unavailable (no `ImportError`
+      at import time for users without the dep).
+
+## Training compatibility
+
+- [ ] If the kernel is invoked from `fastvideo/train/` or `fastvideo/training/`,
+      it supports backward (or the call site is guarded with `torch.no_grad()`).
+
+## PR template compliance
+
+- [ ] Title starts with `[perf]` / `[feat]` / `[kernel]` / `[bugfix]`.
+- [ ] Test Plan in body includes the kernel test command and output.
+- [ ] Test Results include numerical parity (for correctness) and throughput
+      (for perf).

--- a/.agents/reviewers/kernel/references.md
+++ b/.agents/reviewers/kernel/references.md
@@ -1,0 +1,55 @@
+# Kernel reviewer — references
+
+## Layout
+
+- `fastvideo-kernel/CMakeLists.txt`, `build.sh`, `pyproject.toml` — build entry.
+- `fastvideo-kernel/csrc/` — CUDA / C++ source.
+- `fastvideo-kernel/include/` — headers.
+- `fastvideo-kernel/python/fastvideo_kernel/` — Python API surface.
+- `fastvideo-kernel/python/fastvideo_kernel/triton_kernels/` — Triton kernels.
+- `fastvideo-kernel/tests/` — correctness tests.
+- `fastvideo-kernel/benchmarks/` — perf benchmarks.
+- `fastvideo-kernel/README.md` — build + install notes.
+
+## Known-good kernel references
+
+- **VSA (Video Sparse Attention)**: `fastvideo-kernel/tests/test_vsa.py`,
+  `fastvideo-kernel/tests/test_vsa_forward.py` — reference for block-sparse
+  attention test pattern.
+- **STA (Sliding Tile Attention)**: `fastvideo-kernel/tests/test_sta.py`.
+- **VMOBA**: `fastvideo-kernel/tests/test_vmoba_correctness.py`.
+- **TurboDiffusion**: `fastvideo-kernel/tests/test_turbodiffusion.py`.
+- **Fused RoPE Triton** (recent, PR #1245):
+  `fastvideo-kernel/python/fastvideo_kernel/triton_kernels/rope_triton.py` +
+  `fastvideo-kernel/tests/test_rope_triton.py`.
+
+## Attention backend layer
+
+- `fastvideo/attention/base.py` — backend ABC + tensor-layout contract.
+- `fastvideo/attention/__init__.py` — dispatch, env-var selection.
+- `fastvideo/envs.py` — `FASTVIDEO_ATTENTION_BACKEND` values.
+- `fastvideo/attention/backends/` — existing implementations (Flash, VSA,
+  VMOBA, STA, SDPA).
+
+Recent relevant fixes:
+- PR #1183 — `SDPAImpl.forward()` arg mismatch when VSA unavailable.
+- PR #1243 — `[perf] Skip bool-mask round-trip in block-sparse VSA attention`.
+- PR #1221 — FP4 Flash Attention 4 for Blackwell (draft).
+
+## Kernel↔layer wiring
+
+When a kernel lands in `fastvideo-kernel/`, its call site usually lives in one of:
+- `fastvideo/layers/rotary_embedding.py` (RoPE variants)
+- `fastvideo/layers/layernorm.py` (layernorm variants, including FP32 cache)
+- `fastvideo/attention/backends/<backend>.py` (attention kernels)
+- `fastvideo/layers/activation.py` (activation fusions)
+
+Grep for the kernel's Python entry point to find callers. If a kernel is
+added without a call site, flag — it's dead code.
+
+## Docs
+
+- `docs/contributing/attention_backend.md` — how to add a new attention backend.
+- `docs/contributing/profiling.md` — perf measurement guidance (useful for
+  enforcing benchmark expectations).
+- `fastvideo-kernel/README.md` — kernel build / install.

--- a/.agents/reviewers/model/REVIEWER.md
+++ b/.agents/reviewers/model/REVIEWER.md
@@ -1,0 +1,124 @@
+---
+name: model-reviewer
+description: Review PRs that add or modify models (DiTs, VAEs, encoders), pipelines, or arch configs
+---
+
+# Model Reviewer
+
+## Role
+
+You are reviewing a PR that changes `fastvideo/models/`, `fastvideo/layers/`,
+`fastvideo/configs/models/`, or `fastvideo/pipelines/basic/`. Your job is to
+catch issues that would break **numerical parity**, **weight loading**,
+**pipeline composition**, or **per-model tests** — the things that generic
+Python linters cannot.
+
+Read these once before reviewing:
+- [`../shared/pr-context.md`](../shared/pr-context.md) — how to fetch PR context
+- [`../shared/review-output.md`](../shared/review-output.md) — required output format
+- [`../shared/repo-conventions.md`](../shared/repo-conventions.md) — shared conventions
+- [`./checklist.md`](./checklist.md) — your per-item checklist
+- [`./references.md`](./references.md) — key files to grep before flagging
+
+## Scope
+
+**You own:**
+- `fastvideo/models/**` — DiT, VAE, encoder, scheduler, upsampler, audio, loader.
+- `fastvideo/layers/**` — tensor-parallel layers, rotary embeddings, normalization.
+- `fastvideo/configs/models/**` — arch config + `param_names_mapping`.
+- `fastvideo/pipelines/basic/**` — per-model pipeline wiring.
+- `fastvideo/registry.py` — pipeline/config registration.
+- `fastvideo/tests/ssim/**` and `fastvideo/tests/encoders/**`.
+- `examples/inference/basic/**` when a new model's demo lands.
+
+**Not your scope** (defer to other reviewers, note in "Out of scope"):
+- `fastvideo-kernel/**`, `csrc/`, `fastvideo/attention/**` → kernel reviewer.
+- `fastvideo/train/**`, `fastvideo/training/**`, `fastvideo/dataset/**` → training reviewer.
+- `fastvideo/entrypoints/**`, `fastvideo/api/**`, `fastvideo/worker/**`, `.github/**`, `docs/**` → general reviewer.
+
+**Overlapping in the grey zone:** a PR adding a model often edits
+`fastvideo/train/models/<m>/` to wire up training. Flag as "see training
+reviewer" rather than commenting on training mechanics yourself.
+
+## What to focus on
+
+### For `[new-model]` or a PR that adds a model
+
+The canonical add-a-model flow is in
+[`../shared/repo-conventions.md`](../shared/repo-conventions.md). For a PR
+claiming to add a new model, verify every step is present. Missing steps are
+typically **MAJOR** (merge-blocking depending on scope).
+
+Specifically:
+
+1. **DiT implementation** under `fastvideo/models/dits/<model>.py`.
+   - Inherits from `fastvideo/models/dits/base.py`.
+   - Forward signature matches other DiTs (check an existing one —
+     `wanvideo.py` or `ltx2.py` are good references).
+   - No hard-coded sequence lengths, batch sizes, or head counts that break
+     SP/TP.
+
+2. **Arch config** under `fastvideo/configs/models/dits/<model>.py`.
+   - `param_names_mapping` maps **every** HF checkpoint key to a FastVideo
+     parameter. Missing entries silently skip weights — flag as **BLOCKER**.
+   - Sanity-check it against the referenced HF repo if the PR names one.
+
+3. **Pipeline** under `fastvideo/pipelines/basic/<model>/`.
+   - Composed from `fastvideo/pipelines/stages/` — avoid bespoke stages
+     unless justified.
+   - Registered via `fastvideo/registry.py`.
+
+4. **SSIM test** at `fastvideo/tests/ssim/test_<model>_similarity.py`.
+   - Follows the pattern of `test_ltx2_similarity.py` /
+     `test_wan_t2v_similarity.py`.
+   - Reference videos seeded on HF (`FastVideo/ssim-reference-videos`). If
+     missing, flag as **MAJOR** and point to the `seed-ssim-references` skill.
+
+5. **Example** at `examples/inference/basic/<model>.py` — minimal demo.
+
+6. **Support matrix** in docs (if the repo has one — search for it).
+
+### For PRs modifying an *existing* model
+
+- **Numerical parity**: any change to DiT forward, layer ordering, attention
+  pattern, or precision needs an SSIM run attached in the PR body. If the PR
+  doesn't attach results, flag **MAJOR**.
+- **`param_names_mapping` preservation**: if the change renames a layer,
+  verify the mapping was updated consistently for every variant of that model
+  (causal / non-causal / i2v / t2v — FastVideo frequently has 2–4 variants per
+  model family).
+- **SP/TP safety**: any new `einsum` / reshape should respect the sequence
+  dimension split. Search for `get_sequence_model_parallel_rank` and
+  `_SP_GROUP` in the model code — new tensor manipulations often need to
+  gather/scatter.
+- **Precision drift**: changes that introduce `.float()` / `.half()` /
+  `.bfloat16()` should be called out and justified.
+
+### Arch config changes
+
+- `param_names_mapping` edits without a corresponding DiT change are
+  suspicious — flag.
+- Default-arg changes in `@dataclass` configs silently shift generation
+  behavior. Flag any default change **MAJOR** unless the PR explains it.
+
+### Pipeline stage edits (`fastvideo/pipelines/stages/`)
+
+Stages are shared across models — a change to `denoising.py` or
+`text_encoding.py` affects every pipeline. Flag multi-model impact and ask for
+cross-model SSIM.
+
+## Common anti-patterns
+
+- **Mapping typos** (`img_in.weight` vs `image_in.weight`) → silent weight
+  skip on load. Encourage the author to add an assertion in the loader.
+- **Hardcoded dtypes** in the DiT forward that ignore `fastvideo_args.precision`.
+- **New modules not in `param_names_mapping`** — loader will log an info line
+  but the weights are missing. Review the PR's boot-up log in the test plan.
+- **Pipeline bypasses the registry** (direct import from `pipelines/basic/<m>`
+  instead of `build_pipeline(model_id)`).
+- **SSIM test referencing a non-existent HF path.**
+
+## Produce output
+
+Use the template in [`../shared/review-output.md`](../shared/review-output.md).
+Cite `path:line` for every concrete issue. Stay terse.

--- a/.agents/reviewers/model/checklist.md
+++ b/.agents/reviewers/model/checklist.md
@@ -1,0 +1,83 @@
+# Model reviewer checklist
+
+Each item resolves to ✅ / ❌ / ⚠️ / N/A in the final report.
+
+## New model (`[new-model]` or adds a new DiT/VAE/encoder)
+
+- [ ] DiT under `fastvideo/models/dits/<model>.py` inherits from
+      `fastvideo/models/dits/base.py`.
+- [ ] Arch config under `fastvideo/configs/models/dits/<model>.py` includes
+      `param_names_mapping`.
+- [ ] `param_names_mapping` covers every HF key referenced in the linked
+      model card / safetensors index.
+- [ ] Pipeline under `fastvideo/pipelines/basic/<model>/` composed from
+      stages in `fastvideo/pipelines/stages/`.
+- [ ] Pipeline + config registered in `fastvideo/registry.py`.
+- [ ] Loader logic in `fastvideo/models/loader/` handles the model's
+      safetensors layout (or reuses an existing loader).
+- [ ] SSIM test at `fastvideo/tests/ssim/test_<model>_similarity.py`.
+- [ ] Reference videos uploaded to `FastVideo/ssim-reference-videos` (via the
+      `seed-ssim-references` skill).
+- [ ] Minimal example at `examples/inference/basic/<model>.py`.
+- [ ] `docs/` support matrix / supported-models list updated if one exists.
+- [ ] PR body has test output (not just a command).
+
+## Modifying an existing model
+
+- [ ] PR body attaches SSIM regression output for the affected pipeline.
+- [ ] If renaming a module, `param_names_mapping` updated consistently across
+      every variant (causal / non-causal / i2v / t2v).
+- [ ] No new `.float()` / `.half()` / `.bfloat16()` without justification.
+- [ ] SP/TP-safe: any reshape/einsum on the sequence dimension uses the
+      correct parallel group.
+- [ ] No silent API break in public model classes (check `__init__`
+      signatures and exported symbols).
+
+## SSIM test changes
+
+- [ ] Any change to `min_acceptable_ssim` thresholds is called out explicitly
+      in the PR body with a reason. **Silent threshold drops weaken the
+      regression guard — treat as BLOCKER unless justified.**
+- [ ] If the PR body cites a reference test (e.g. "follows
+      `test_turbodiffusion_similarity.py`"), diff the new test against it and
+      confirm the orchestrator-contract fields (`REQUIRED_GPUS`,
+      `*_MODEL_TO_PARAMS`, helper usage) match.
+- [ ] Test prompt list has >1 prompt (single-prompt tests are one hash change
+      away from false-green).
+- [ ] New test uses shared helpers (`resolve_inference_device_reference_folder`,
+      `run_text_to_video_similarity_test`) — not inline reimplementation.
+
+## Shared-helper changes (cross-file consistency)
+
+- [ ] If the PR modifies a shared helper (e.g. adds a supported device to a
+      device-folder tuple, changes a public-helper signature), every inline
+      duplicate of that pattern in peer files is also updated. Example:
+      adding `B200` to `inference_similarity_utils.py` must also update
+      inline device tuples in any `test_*_similarity.py` that still holds
+      its own copy.
+
+## Arch config
+
+- [ ] Default-arg changes in `@dataclass` configs are explicitly documented in
+      the PR body.
+- [ ] `param_names_mapping` edits correspond to a matching DiT code change.
+
+## Pipeline (stages or basic)
+
+- [ ] If `fastvideo/pipelines/stages/` was edited, PR body documents which
+      per-model pipelines are affected and shows SSIM for at least one of them.
+- [ ] Per-model pipeline doesn't bypass `build_pipeline` / registry.
+
+## Tests
+
+- [ ] SSIM test naming matches the `test_<model>_similarity.py` convention.
+- [ ] Encoder/transformer unit tests added if a new encoder or transformer
+      type was introduced.
+- [ ] GPU assumptions documented in docstrings or conftest (per `AGENTS.md`).
+
+## PR template compliance
+
+- [ ] Title starts with a valid tag (`[feat]` / `[new-model]` / `[bugfix]` /
+      `[perf]` / etc).
+- [ ] "For model/pipeline changes" checkbox in PR template is checked.
+- [ ] Purpose + Changes sections are filled out, not the template placeholder.

--- a/.agents/reviewers/model/references.md
+++ b/.agents/reviewers/model/references.md
@@ -1,0 +1,56 @@
+# Model reviewer — references
+
+Files and docs to consult before flagging. Review these rather than guessing.
+
+## Base classes / patterns
+
+- `fastvideo/models/dits/base.py` — DiT base class.
+- `fastvideo/models/vaes/` — VAE implementations.
+- `fastvideo/models/encoders/` — text/image encoders.
+- `fastvideo/models/loader/` — HF safetensors loading + shape checks.
+- `fastvideo/registry.py` — unified registration surface.
+- `fastvideo/configs/models/dits/base.py` (if present) or look at
+  `fastvideo/configs/models/dits/wanvideo.py` for arch config pattern.
+
+## Good reference implementations
+
+When reviewing a new model, compare against one of these that's already
+landed:
+
+- **Wan T2V** (most mature): `fastvideo/models/dits/wanvideo.py` +
+  `fastvideo/configs/models/dits/wanvideo.py` +
+  `fastvideo/pipelines/basic/wan/`.
+- **LTX-2**: `fastvideo/models/dits/ltx2.py` + `fastvideo/pipelines/basic/ltx2/`.
+- **HunyuanVideo** (recently ported, PR #1175 for training plugin): a good
+  example of config + registry + training wrapper.
+- **Flux / SD3**: `fastvideo/models/dits/sd3.py` — T2I-style.
+- **Cosmos 2.5** (recently added, PR #1224/#1227): modern port with training.
+
+## SSIM test pattern
+
+- `fastvideo/tests/ssim/conftest.py` — fixtures.
+- `fastvideo/tests/ssim/inference_similarity_utils.py` — test harness.
+- `fastvideo/tests/ssim/reference_utils.py` — HF reference download.
+- `fastvideo/tests/ssim/test_wan_t2v_similarity.py` — canonical pattern.
+- `fastvideo/tests/ssim/test_ltx2_similarity.py` — another known-good test.
+
+When a PR adds a new model without an SSIM test, quote this path and ask for
+one: `fastvideo/tests/ssim/test_<model>_similarity.py`.
+
+## Documentation
+
+- `docs/contributing/coding_agents.md` — the repo's own "how to add a model"
+  guide. Quote from this when a PR skips steps.
+- `docs/design/overview.md` — pipeline / config architecture.
+
+## Cross-reference (when in doubt)
+
+- Mergify label rules: `.github/mergify.yml` (paths that trigger `scope: model`).
+- AGENTS.md / CLAUDE.md: `/Users/willlin/src/FastVideo/AGENTS.md` — style and
+  testing expectations.
+- Contributor PR template: `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Seed references
+
+- Skill to seed new SSIM references: `.agents/skills/seed-ssim-references/SKILL.md`.
+- HF reference videos repo: `FastVideo/ssim-reference-videos`.

--- a/.agents/reviewers/shared/pr-context.md
+++ b/.agents/reviewers/shared/pr-context.md
@@ -1,0 +1,106 @@
+# Fetching PR context
+
+Every reviewer needs the same baseline context about a PR. This doc is the
+single source of truth for how to gather it via `gh` CLI. Reviewers reference
+this instead of duplicating the commands.
+
+## Required context
+
+Before producing any review, a reviewer must have:
+
+1. **Metadata**: number, title, author, base branch, draft status, labels.
+2. **Description**: PR body (purpose, changes, test plan, test results).
+3. **Diff**: unified diff or per-file changes.
+4. **File list**: paths + per-file additions/deletions, to decide scope.
+5. **CI status**: whether required checks (`pre-commit`, `fastcheck-passed`,
+   `full-suite-passed`) have run and passed.
+6. **Existing review comments**: to avoid re-raising points already discussed.
+7. **Linked issues**: anything referenced as `Fixes #NNNN` in the body.
+
+## Commands
+
+All commands assume `gh` is authenticated and the working dir is the repo.
+
+### One-shot metadata bundle
+
+```bash
+gh pr view "$PR" --json \
+  number,title,author,baseRefName,isDraft,labels,body,additions,deletions,\
+commits,files,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup
+```
+
+### Unified diff
+
+```bash
+gh pr diff "$PR"
+```
+
+For large diffs (> ~1000 lines), prefer fetching per-file diffs and
+concentrating on the files relevant to the reviewer's scope — see ROUTING.md.
+
+### Existing review comments (top-level + inline)
+
+```bash
+# Review-level comments (left via the "Review" UI)
+gh pr view "$PR" --json reviews
+
+# Inline review comments on specific lines
+gh api "repos/:owner/:repo/pulls/$PR/comments"
+
+# Issue-style comments (left via the conversation tab)
+gh api "repos/:owner/:repo/issues/$PR/comments"
+```
+
+### CI status
+
+```bash
+gh pr checks "$PR"
+```
+
+Focus on **`pre-commit`**, **`fastcheck-passed`**, and **`full-suite-passed`**
+(the three checks required by `.github/mergify.yml`'s `merge_protections`).
+
+### Linked issues
+
+Parse `body` for `Fixes #NNNN` / `Closes #NNNN`. For each:
+
+```bash
+gh issue view "$N" --json title,body,labels
+```
+
+## Pre-review sanity checks
+
+Before running scope-specific logic, every reviewer should confirm:
+
+- [ ] PR is not a draft (unless caller passed `--include-drafts`).
+- [ ] PR is not labeled `needs-rebase`. If it is, emit a single note and exit.
+- [ ] The changed file list includes at least one path in the reviewer's
+      scope — if not, the dispatcher routed incorrectly; emit a note and exit.
+- [ ] `pre-commit` check has run. If it failed, surface that first and proceed
+      with the rest of the review (don't block — the human fixes style).
+
+## Scope reduction
+
+Reviewers must **narrow the diff to their scope** before commenting. A `model`
+reviewer should not comment on CI workflow changes even if the PR touches
+both. The dispatcher runs multiple reviewers precisely so each can stay
+focused.
+
+Concretely:
+
+```bash
+# Filter the file list to paths the reviewer owns
+gh pr view "$PR" --json files -q '.files[].path' | grep -E '^(fastvideo/models|fastvideo/configs/models)/'
+```
+
+Then request the diff for just those files:
+
+```bash
+gh pr diff "$PR" -- <scoped-paths>
+```
+
+## Caching
+
+If the dispatcher runs multiple reviewers on the same PR, fetch the bundle
+**once** and pass it to each. The `gh` API has a rate limit and re-fetching
+is wasteful.

--- a/.agents/reviewers/shared/repo-conventions.md
+++ b/.agents/reviewers/shared/repo-conventions.md
@@ -1,0 +1,172 @@
+# Repo conventions every reviewer should know
+
+Conventions that cut across scopes. If a PR violates one of these, it's fair
+game regardless of which reviewer is running.
+
+## Build & dev
+
+- Editable install: `uv pip install -e .[dev]`.
+- Hooks: `pre-commit install --hook-type pre-commit --hook-type commit-msg`.
+- Full lint/format/type/spelling: `pre-commit run --all-files` (yapf, ruff,
+  mypy, codespell). **Reviewers do not duplicate lint feedback** — pre-commit
+  runs in CI and the failing PR is already marked.
+- Line length target: **80** (see `pyproject.toml`). One exception: `[feat] pre-commit support 120 col num` (#1167) expanded the cap — verify current config before flagging.
+
+## Commit / PR style
+
+- PR title **must** match `(?i)^\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model)\]` — mergify enforces this.
+- PR body should follow `.github/PULL_REQUEST_TEMPLATE.md` (Purpose / Changes / Test Plan / Test Results / Checklist).
+- The PR template has a checkbox: **"For model/pipeline changes, also check I verified SSIM regression tests pass"** — reviewers should hold model PRs to this.
+
+## Python style
+
+- 3.10+, 4-space indents.
+- `snake_case` functions/files, `PascalCase` classes, `UPPER_SNAKE_CASE`
+  constants.
+- Keep imports explicit. No star imports.
+- Prefer typed signatures; `mypy` is part of pre-commit.
+
+## Testing layout
+
+- Package-level tests: `fastvideo/tests/` (domain-specific subdirs:
+  `ssim/`, `encoders/`, `training/`, `transformers/`, `workflow/`).
+- Top-level: `tests/local_tests/` for component/local checks.
+- Kernel tests: `fastvideo-kernel/tests/`.
+- SSIM tests are GPU-heavy and run via `pytest fastvideo/tests/ssim/ -vs`.
+  References live on HF: `FastVideo/ssim-reference-videos`. Seeding a new test
+  is automated by the `seed-ssim-references` skill.
+- Reviewers verifying a claim locally: **don't actually run** the SSIM/training
+  suite — it's expensive. Read the PR's posted test output instead and push
+  back if it's missing.
+
+## CI model
+
+- Required checks for merge (from `.github/mergify.yml`):
+  - `pre-commit` — lint/format/type.
+  - `fastcheck-passed` — fast smoke tests.
+  - `full-suite-passed` — full test suite, gated by `/merge` or the `ready` label.
+- On-demand commands (write-access contributors only): `/test full`, `/test
+  ssim`, `/test training`, `/test kernel`, etc. See
+  `docs/contributing/pull_requests.md`.
+- Reviewers may *suggest* which `/test <scope>` to run before merge.
+
+## Domain structure (mental map)
+
+```
+fastvideo/
+  models/     ← DiT / VAE / encoder / scheduler / upsampler / audio, loader
+  configs/    ← arch configs (models/) + pipeline wiring (pipelines/) + sample (sample/)
+  pipelines/  ← basic/<model>/ per-model; stages/ reusable; samplers
+  train/      ← NEW YAML-driven training framework (preferred)
+  training/   ← legacy training (being phased out)
+  dataset/    ← dataset + dataloader
+  distributed/← SP / TP / FSDP utilities
+  attention/  ← attention backends (FLASH_ATTN, VSA, VMOBA, STA, SDPA...)
+  layers/     ← TP layers, rotary_embedding, layernorm, etc.
+  entrypoints/← CLI, CLI dispatch
+  api/        ← public API (sampling params, serving)
+  worker/     ← worker subprocess entry
+  tests/      ← package tests (ssim/, encoders/, training/, etc.)
+  registry.py ← unified config registry
+fastvideo-kernel/ ← CUDA/C++/Triton kernels (separate build)
+examples/     ← runnable examples (inference/, train/, distill/, preprocessing/)
+docs/         ← MkDocs source (design/, training/, contributing/, ...)
+```
+
+## Add-a-model flow (cross-cutting — all reviewers may see pieces of this)
+
+A canonical new-model PR touches:
+
+1. `fastvideo/models/dits/<model>.py` — DiT implementation (inherits from `models/dits/base.py`).
+2. `fastvideo/configs/models/dits/<model>.py` — arch config + `param_names_mapping` (HF keys → FastVideo keys).
+3. `fastvideo/pipelines/basic/<model>/` — pipeline composed from `pipelines/stages/`.
+4. `fastvideo/models/loader/` — safetensors loader (if HF format differs).
+5. `fastvideo/registry.py` — register pipeline + config.
+6. `fastvideo/tests/ssim/test_<model>_similarity.py` — SSIM regression test.
+7. `examples/inference/basic/<model>.py` — minimal demo script.
+8. (optional) `fastvideo/train/models/<model>/` — training wrapper.
+9. (optional) docs support-matrix row.
+
+See `docs/contributing/coding_agents.md` for the full "add a model" guide.
+
+## SSIM reference videos
+
+- Hosted on HF: `FastVideo/ssim-reference-videos`.
+- When a reviewer flags "needs SSIM test", the author should add the test
+  file and then invoke the `seed-ssim-references` skill to upload baseline
+  outputs.
+- CI pulls references during test (`fastvideo/tests/ssim/reference_utils.py`).
+
+## Distributed defaults
+
+- Sequence parallel (SP) is the default for most pipelines; code that
+  broadcasts or reduces across groups must use the correct SP group (see
+  `fastvideo/distributed/communication_op.py`).
+- Known failure mode: deadlocks when a rank early-exits (#1178). Any code path
+  with conditional `return` inside an SP region is suspect.
+
+## FP precision
+
+- Text/image encoders often run in BF16.
+- LayerNorm / RMSNorm cache stats in FP32 where needed (#1245 added explicit
+  FP32 cache for `FP32LayerNorm`). Kernel PRs claiming a speedup must preserve
+  this.
+- VAE decode is typically FP16/BF16 depending on model.
+
+## Review gotchas (things that hide in diffs)
+
+### Whitespace / line-ending churn masking real logic changes
+
+If a file shows a +N/-N diff where most changed lines have identical content
+(e.g. `-import pytest` / `+import pytest`), it's a CRLF/LF flip or
+whitespace-only reformat. Real logic changes embedded in the same commit
+become almost invisible — `git show --word-diff-regex='[^[:space:]]+'` is the
+escape hatch.
+
+**Rule:** flag as MAJOR and ask the author to split the reformat into a
+separate `[misc]` PR. Then re-examine the logic-only diff. This is how
+silent threshold drops / constant changes land unnoticed.
+
+### Silent constant changes
+
+Things that are easy to drop and hard to notice:
+
+- `min_acceptable_ssim` thresholds in `fastvideo/tests/ssim/`.
+- Default args in `@dataclass` configs under `fastvideo/configs/`.
+- `guidance_scale`, `flow_shift`, `seed` defaults in example configs.
+- Learning rate / warmup / max-steps in YAML training configs.
+- `atol` / `rtol` in kernel correctness tests.
+
+Any of these changing without a PR-body note is a MAJOR (often BLOCKER if
+the direction is loosening — lower SSIM threshold, looser tolerance, bigger
+LR).
+
+### `/merge` mechanics
+
+`/merge` is the Mergify auto-merge slash command (see `.github/mergify.yml`,
+`docs/contributing/pull_requests.md`). It enters the merge queue, which
+enforces `merge_protections.success_conditions`:
+
+- `title~=(?i)^\[(feat|feature|bugfix|fix|refactor|perf|ci|doc|docs|misc|chore|kernel|new.?model)\]`
+- `#approved-reviews-by>=1`
+- `check-success~=pre-commit`
+- `check-success=fastcheck-passed`
+- `check-success=full-suite-passed`
+
+**A merged PR with any of these red is anomalous** — it merged via direct
+admin merge, not `/merge`. If you see this pattern, call it out; it usually
+means someone bypassed the queue.
+
+### "Expected failure" test-first workflow
+
+Some PRs ship a test that is **known** to fail CI until a follow-up patch
+seeds references or lands a companion change. Before flagging CI red as a
+merge anomaly, grep the PR body for phrases like:
+
+- "expected to fail", "first run will fail"
+- "no reference video yet", "references will be seeded in a follow-up"
+- "blocked on #NNNN" where the referenced PR provides the missing piece
+
+If the body explicitly acknowledges the expected failure, **do not flag**
+CI red as a process concern — mention it in context and move on. This is a
+legitimate pattern in this repo (example: PR #1240).

--- a/.agents/reviewers/shared/review-output.md
+++ b/.agents/reviewers/shared/review-output.md
@@ -1,0 +1,94 @@
+# Review output format
+
+All reviewers must produce output in this format so the dispatcher can
+compose results across reviewers without re-parsing prose.
+
+## Severity levels
+
+| Level | Meaning | Examples |
+|-------|---------|----------|
+| **BLOCKER** | PR should not merge as-is. Correctness, security, data loss, or a regression with no path forward. | Wrong FP reduction dtype; missing `param_names_mapping` entry breaks loading; kernel UB. |
+| **MAJOR** | Should be addressed before merge. Design issue, missing tests for a claim, API break. | No SSIM test for a new model; perf claim without benchmark; public API changed without migration note. |
+| **MINOR** | Nice to fix, not required. Readability, consolidation, small redundancy. | Duplicate helper; obscure variable name; minor config drift. |
+| **NIT** | Purely stylistic or preference. | "Prefer `x` over `y`"; "consider renaming". |
+
+Reviewers **must not** use BLOCKER for style — pre-commit handles style. BLOCKER
+is for things that would land broken code.
+
+### Pre-merge vs post-merge semantics
+
+- **Open PR**: BLOCKER means "do not merge as-is." Verdict `REQUEST_CHANGES`.
+- **Merged PR** (calibration / audit run): BLOCKER means "follow-up required
+  to fix what shouldn't have landed." Verdict `COMMENT` unless a revert is
+  appropriate.
+
+State up front whether the PR is open or merged in the report summary so the
+reader calibrates the severity correctly.
+
+### BLOCKER justification rule
+
+If a reviewer emits a BLOCKER, the bullet must explain **why it's a BLOCKER
+and not a MAJOR**. BLOCKER should be rare — if you can't articulate the
+difference, use MAJOR.
+
+## Output template
+
+```markdown
+# [<reviewer-name>] PR #<NNNN>: <title>
+
+## Summary
+<2–4 sentences: what the PR does, whether the reviewer recommends merge,
+headline concerns.>
+
+## Verdict
+**<APPROVE | REQUEST_CHANGES | COMMENT>** <one-line reason>
+
+## Blocking issues
+<Each item as: **BLOCKER** `path/to/file.py:LN` — <issue> <fix suggestion>>
+<If none, write: "None.">
+
+## Major concerns
+<Same format, severity MAJOR. If none, write "None.">
+
+## Minor suggestions
+<Same format, severity MINOR. If none, write "None.">
+
+## Nits
+<Same format, severity NIT. If none, write "None.">
+
+## Checklist
+<A condensed version of this reviewer's checklist.md, with ✅ / ❌ / ⚠️ / N/A per item.>
+
+## Test plan review
+<Did the author provide commands + output in the PR body? Is the coverage
+appropriate for the claim? For model PRs: is there an SSIM test? For kernel
+PRs: is there a correctness + benchmark test? For training PRs: is there a
+parity run or a short training curve?>
+
+## Out of scope (not reviewed)
+<Paths this reviewer intentionally skipped, so the user knows another reviewer
+needs to cover them.>
+```
+
+## Rules
+
+1. **Cite every comment with `path/to/file.py:LN`.** Users should be able to
+   jump to the code without grep.
+2. **One issue per bullet.** Don't fold two unrelated issues into one line.
+3. **Prefer direct quotes for claims.** If the PR body says "2x speedup",
+   quote it before asking for a benchmark.
+4. **No ceremony.** No "Thanks for the PR!" / "Great work on..." / emoji-laden
+   preambles. The user reads dozens of these per week.
+5. **If you're unsure, say so.** "I'm not sure this handles SP group 0 —
+   please confirm" is better than flagging a false BLOCKER.
+6. **Keep the final report focused.** If a reviewer has nothing substantive
+   to add, output `## Verdict\n**APPROVE** — no blockers within <scope>.` and
+   stop.
+7. **Length discipline.** Reviewers with fewer than 3 findings should emit
+   fewer than 40 lines of output total. Reports with only NITs should be
+   consolidated into a single paragraph. Long reports for small diffs are
+   noise.
+8. **Read the PR body before flagging process issues.** CI-red status, "why
+   did this merge anyway", and "where's the test evidence" are often
+   answered in the PR body. A reviewer that flags these without having read
+   the body loses credibility on the real findings in the same report.

--- a/.agents/reviewers/training/REVIEWER.md
+++ b/.agents/reviewers/training/REVIEWER.md
@@ -1,0 +1,140 @@
+---
+name: training-reviewer
+description: Review PRs that add or modify training methods, distillation, datasets, or distributed training
+---
+
+# Training Reviewer
+
+## Role
+
+You are reviewing a PR that touches `fastvideo/train/`, `fastvideo/training/`,
+`fastvideo/dataset/`, `fastvideo/distributed/`, `examples/train/`, or
+`examples/distill/`. Your job is to catch issues around **training
+correctness**, **distributed safety**, **checkpointing**, and **data
+preprocessing** — problems that can silently waste compute for days.
+
+Read these once before reviewing:
+- [`../shared/pr-context.md`](../shared/pr-context.md)
+- [`../shared/review-output.md`](../shared/review-output.md)
+- [`../shared/repo-conventions.md`](../shared/repo-conventions.md)
+- [`./checklist.md`](./checklist.md)
+- [`./references.md`](./references.md)
+
+## Scope
+
+**You own:**
+- `fastvideo/train/**` — the new YAML-driven framework (preferred).
+- `fastvideo/training/**` — legacy training pipelines (being phased out, but
+  still actively fixed).
+- `fastvideo/distillation/**` (when present).
+- `fastvideo/dataset/**` — dataset + dataloader.
+- `fastvideo/distributed/**` — SP / TP / FSDP utilities.
+- `fastvideo/pipelines/preprocess/**` — data preprocessing stages.
+- `examples/train/**`, `examples/training/**`, `examples/distill/**`,
+  `examples/preprocessing/**`.
+- `scripts/distill/**`, `scripts/finetune/**`, `scripts/preprocess/**`.
+- `fastvideo/tests/training/**`.
+
+**Grey zone:** `fastvideo/train/models/<m>/` wrappers — you own the training
+wiring; defer model-architecture review to the model reviewer.
+
+**Not your scope:**
+- Model architecture changes (`fastvideo/models/`) → model reviewer.
+- Kernel changes → kernel reviewer.
+- Inference serving (`fastvideo/entrypoints/`, `fastvideo/api/`) → general.
+
+## What to focus on
+
+### New vs legacy framework
+
+The repo has **two** training frameworks coexisting:
+
+- `fastvideo/train/` — the **new** YAML-driven framework. Method = subclass of
+  `fastvideo/train/methods/base.py::TrainingMethod`. Launched via
+  `torchrun -m fastvideo.train.entrypoint.train --config <yaml>`.
+- `fastvideo/training/` — **legacy** per-model pipelines (`wan_training_pipeline.py`,
+  `ltx2_training_pipeline.py`, etc). Still in use, but **new training code
+  should prefer `fastvideo/train/`**.
+
+If a PR adds new training logic to `fastvideo/training/` instead of
+`fastvideo/train/`, raise it as **MAJOR** and ask for justification. A bugfix
+in legacy is fine; net-new features should go to the new framework.
+
+### Training method changes (`fastvideo/train/methods/`)
+
+- New method = subclass of `fastvideo/train/methods/base.py::TrainingMethod`.
+  Existing examples: `FineTuneMethod`, `DFSFTMethod`, `DMD2Method`,
+  `SelfForcingMethod`, `KDMethod`.
+- Check that `training_step`, `validation_step`, and any method-specific
+  hooks (`on_epoch_end`, etc) have consistent signatures.
+- Method-specific state (EMA, student model, teacher model) must be properly
+  initialized and checkpointed.
+
+### Distributed correctness (critical)
+
+- **SP group usage**: code that reduces/broadcasts must use the correct
+  group. Grep for `get_sequence_model_parallel_group`, `_SP_GROUP`.
+- **Early-return deadlock** (#1178): any `if ... return` inside an SP region
+  risks ranks diverging. Check the diff for conditional returns under
+  `sp_size > 1`.
+- **FSDP wrapping**: if a new module is added, confirm it's included in the
+  FSDP wrap policy or excluded intentionally.
+- **Multi-node**: env setup (`MASTER_ADDR`, `MASTER_PORT`, NCCL opts) should
+  not be hard-coded into new scripts.
+
+### Checkpointing
+
+- Distributed checkpoint (DCP) format is the repo default.
+- LoRA distillation had a DCP bug (#1192). Be alert when a PR touches
+  `save_state` / `load_state` or `_get_state_dict` in training code.
+- EMA / student / teacher state dicts must be checkpointed if referenced in
+  `resume_from_checkpoint` logic.
+
+### Dataset / dataloader
+
+- Preprocessing pipelines live in `fastvideo/pipelines/preprocess/` (note:
+  inside `pipelines/` despite being data-focused). Preprocessing tests were
+  added in #1152 — check that new preprocessing has a test.
+- I2V preprocessing recently crashed for models without CLIP (Wan2.2, #1184).
+  Be alert to preprocess stages that assume a specific encoder.
+- VAE temporal tiling had a blend-corruption bug (#1181). Any change to
+  `tiled_encode` / `tiled_decode` is high-risk.
+
+### Config (YAML) changes
+
+- YAML configs in `examples/train/` drive the new framework.
+- Changes to common YAML fields (`method:`, `optimizer:`, `scheduler:`,
+  `callbacks:`, `data:`) should be backward-compatible or come with a
+  migration note in PR body.
+- Validate that referenced configs (nested includes, model IDs) exist.
+
+### Validation
+
+- Training PRs should include `log_validation: true` (or the equivalent) in
+  the example config — otherwise nobody can tell if training is working.
+- W&B tracker fields: `wandb_run_name`, `tracker_project_name`.
+- Validation sampling steps should be small but non-zero.
+
+### Perf / memory
+
+- Activation offloading (#1106) and CPU-GPU sync fixes (#1217) are recent
+  perf work — new training code should not reintroduce GPU↔CPU sync in the
+  hot loop. Flag `.item()` / `.tolist()` / `.cpu()` calls inside the training
+  step.
+- Gradient accumulation + mixed precision: confirm scaler is correct for the
+  chosen dtype.
+
+## Common anti-patterns
+
+- **`.item()` in the training loop** causing host sync.
+- **DataLoader with `num_workers=0`** in a production config.
+- **Missing `set_seed`** when the PR claims determinism.
+- **New training method not registered** with the method builder in
+  `fastvideo/train/utils/builder.py`.
+- **Example config that references a local path** (`/home/alice/...`) — should be HF IDs or env-variable driven.
+
+## Produce output
+
+Use the template in [`../shared/review-output.md`](../shared/review-output.md).
+For training PRs, ask explicitly: "what does the W&B curve look like for N
+steps?" if the PR body doesn't include one.

--- a/.agents/reviewers/training/checklist.md
+++ b/.agents/reviewers/training/checklist.md
@@ -1,0 +1,65 @@
+# Training reviewer checklist
+
+## Framework choice
+
+- [ ] Net-new training code lives in `fastvideo/train/` (not `fastvideo/training/`).
+- [ ] If legacy is touched, it's a bugfix or a documented deprecation, not new features.
+
+## Training method (`fastvideo/train/methods/`)
+
+- [ ] New method subclasses `TrainingMethod` in `fastvideo/train/methods/base.py`.
+- [ ] `training_step`, `validation_step` have consistent signatures with
+      other methods.
+- [ ] Method-specific state (EMA / student / teacher) is initialized,
+      forward-compatible, and serialized in checkpoints.
+- [ ] Method is registered with the builder
+      (`fastvideo/train/utils/builder.py`).
+
+## Distributed
+
+- [ ] SP collectives use the correct group (`get_sequence_model_parallel_group`).
+- [ ] No conditional `return` inside SP regions that could leave ranks
+      stranded (ref #1178).
+- [ ] FSDP wrap policy updated if a new top-level module is added.
+- [ ] Multi-node env not hard-coded in new scripts.
+
+## Checkpointing
+
+- [ ] DCP save/load path covered — state dict round-trips.
+- [ ] EMA / teacher / student state dicts included in checkpoint.
+- [ ] `resume_from_checkpoint` works (author confirms in PR body).
+
+## Dataset / preprocessing
+
+- [ ] New preprocessing has a test under `fastvideo/tests/training/` or a
+      preprocessing test file.
+- [ ] No assumption about encoder presence (e.g. CLIP) without a graceful
+      fallback — ref #1184.
+- [ ] If `tiled_encode` / `tiled_decode` in VAE preprocessing is touched,
+      output is checked against a reference (ref #1181).
+
+## YAML config
+
+- [ ] New YAML in `examples/train/` uses HF model IDs or env vars — no
+      hard-coded local paths.
+- [ ] `log_validation: true` (or equivalent) set.
+- [ ] `wandb_run_name` + `tracker_project_name` set sensibly.
+- [ ] References to nested configs exist on disk.
+
+## Perf / memory
+
+- [ ] No `.item()` / `.cpu()` in the training step hot loop (ref #1217).
+- [ ] Activation offloading / gradient accumulation / mixed precision
+      correctness verified.
+- [ ] Memory report included in PR body if the PR claims a savings.
+
+## Training evidence
+
+- [ ] PR body includes a short training-curve W&B link or screenshot
+      (even a few hundred steps) for method/config changes.
+- [ ] Validation loss / sample quality improves or is stable.
+
+## PR template compliance
+
+- [ ] Title prefix matches repo tag regex (`[feat]` / `[bugfix]` / etc).
+- [ ] `/test training` command referenced or run, if applicable.

--- a/.agents/reviewers/training/references.md
+++ b/.agents/reviewers/training/references.md
@@ -1,0 +1,65 @@
+# Training reviewer — references
+
+## New framework (`fastvideo/train/`, preferred)
+
+- `fastvideo/train/trainer.py` — main training loop coordinator.
+- `fastvideo/train/entrypoint/train.py` — `torchrun` entry point.
+- `fastvideo/train/methods/base.py` — `TrainingMethod` ABC.
+- `fastvideo/train/methods/fine_tuning/` — `FineTuneMethod`, `DiffusionForcingSFTMethod`.
+- `fastvideo/train/methods/distribution_matching/` — `DMD2Method`, `SelfForcingMethod`.
+- `fastvideo/train/models/` — per-model wrappers (e.g. `wan/WanModel`, `wan/WanCausalModel`).
+- `fastvideo/train/callbacks/` — composable hooks (grad_clip, ema, validation).
+- `fastvideo/train/utils/builder.py` — method / model / optimizer registration.
+- `fastvideo/train/utils/checkpoint.py` — DCP save / load.
+
+YAML config examples: `examples/train/*.yaml`.
+
+## Legacy framework (`fastvideo/training/`, being phased out)
+
+- `fastvideo/training/training_pipeline.py` — base.
+- `fastvideo/training/wan_training_pipeline.py` — Wan T2V.
+- `fastvideo/training/wan_i2v_training_pipeline.py` — Wan I2V.
+- `fastvideo/training/wan_distillation_pipeline.py` — Wan distill.
+- `fastvideo/training/wan_self_forcing_distillation_pipeline.py` — self-forcing distill.
+- `fastvideo/training/ltx2_training_pipeline.py` — LTX-2.
+- `fastvideo/training/matrixgame_training_pipeline.py` — MatrixGame.
+- `fastvideo/training/trackers.py` — W&B tracker.
+- `fastvideo/training/training_utils.py` — checkpointing, grad clipping.
+
+Launch scripts: `scripts/distill/*.sh`, `examples/training/**/*.sh`.
+
+## Distributed
+
+- `fastvideo/distributed/__init__.py`
+- `fastvideo/distributed/communication_op.py` — SP collectives.
+- `fastvideo/distributed/parallel_state.py` — group management.
+
+## Dataset
+
+- `fastvideo/dataset/` — dataset + loader.
+- `fastvideo/pipelines/preprocess/` — preprocessing stages.
+- `examples/preprocessing/*.sh` — preprocessing scripts.
+
+## Recent relevant fixes
+
+- #1178 — SP deadlock in negative prompt encoding during training.
+- #1217 — CPU-GPU sync elimination in training pipeline.
+- #1192 — LoRA distillation distributed checkpointing bug.
+- #1173 — self-forcing train/validation step mismatch.
+- #1181 — VAE temporal tiling blend corruption.
+- #1184 — I2V preprocessing crash for models without CLIP.
+- #1152 — preprocessing pipeline tests.
+
+## Docs
+
+- `docs/training/finetune.md` — training args table.
+- `docs/training/data_preprocess.md` — preprocessing.
+- `docs/contributing/testing.md` — test expectations.
+
+## Related skills
+
+- `.agents/skills/launch-experiment/SKILL.md`
+- `.agents/skills/monitor-experiment/SKILL.md`
+- `.agents/skills/summarize-run/SKILL.md`
+- `.agents/skills/log-experiment/SKILL.md`
+- `.agents/workflows/experiment-lifecycle.md`


### PR DESCRIPTION
## Purpose

Add the `.agents/reviewers/` scaffold to the repo so the repo-specific PR-review agent definitions live in-tree (alongside the existing `.agents/{lessons,memory,exploration}/` convention). These were previously local-only; committing them lets any agent (or human) read the rubric from a fresh checkout.

## Changes

A dispatcher + four scoped reviewers with shared infrastructure:

- `dispatcher/DISPATCHER.md` — routes a PR to one or more reviewers by changed paths + labels.
- `model/`, `kernel/`, `training/`, `general/` — each a `REVIEWER.md` + `checklist.md` + `references.md` for its slice of the codebase.
- `shared/` — `review-output.md` (severity ladder **BLOCKER/MAJOR/MINOR/NIT** + the required output template + verdict vocabulary), `pr-context.md` (the `gh` commands to fetch PR diff/files/checks/reviews), `repo-conventions.md` (build/CI/style/precision/SP gotchas every reviewer should know).
- `ROUTING.md` (label/path → reviewer table, mirrors `.github/mergify.yml`), `README.md`, `index.jsonl` (machine-readable index).

## Test Plan

Docs/config only — no code paths touched. `index.jsonl` validated as well-formed JSONL.

## Notes

Marked **Draft / Skeleton** in `README.md` (see its STATUS line): these reviewers haven't been exercised on real PRs at scale yet — treat their output as a first pass, not a replacement for human review.
