### PR TITLE
[bugfix] EMA in distillation pipeline

### DIFF
--- a/fastvideo/training/distillation_pipeline.py
+++ b/fastvideo/training/distillation_pipeline.py
@@ -371,7 +371,8 @@ class DistillationPipeline(TrainingPipeline):
                                                                    self.transformer.reverse_param_names_mapping)
                     save_file(diffusers_state_dict, weight_path)
 
-                    config_dict = self.transformer.hf_config
+                    # deepcopy so deleting "dtype" doesn't mutate the live model's hf_config
+                    config_dict = copy.deepcopy(self.transformer.hf_config)
                     if "dtype" in config_dict:
                         del config_dict["dtype"]
                     config_path = os.path.join(ema_save_dir, "config.json")
@@ -398,7 +399,8 @@ class DistillationPipeline(TrainingPipeline):
                                                                      self.transformer_2.reverse_param_names_mapping)
                     save_file(diffusers_state_dict_2, weight_path_2)
 
-                    config_dict_2 = self.transformer_2.hf_config
+                    # deepcopy so deleting "dtype" doesn't mutate the live model's hf_config
+                    config_dict_2 = copy.deepcopy(self.transformer_2.hf_config)
                     if "dtype" in config_dict_2:
                         del config_dict_2["dtype"]
                     config_path_2 = os.path.join(ema_2_save_dir, "config.json")

--- a/fastvideo/training/distillation_pipeline.py
+++ b/fastvideo/training/distillation_pipeline.py
@@ -245,7 +245,9 @@ class DistillationPipeline(TrainingPipeline):
 
         self.generator_ema: EMA_FSDP | None = None
         self.generator_ema_2: EMA_FSDP | None = None
-        if (self.training_args.ema_decay is not None) and (self.training_args.ema_decay > 0.0):
+        ema_enabled = (self.training_args.ema_decay is not None) and (self.training_args.ema_decay > 0.0)
+        if ema_enabled and (self.training_args.ema_start_step <= 0):
+            # Only eager-construct from the cold init weights when averaging starts at step 0.
             self.generator_ema = EMA_FSDP(self.transformer, decay=self.training_args.ema_decay)
             logger.info("Initialized generator EMA with decay=%s", self.training_args.ema_decay)
 
@@ -253,6 +255,12 @@ class DistillationPipeline(TrainingPipeline):
             if self.transformer_2 is not None:
                 self.generator_ema_2 = EMA_FSDP(self.transformer_2, decay=self.training_args.ema_decay)
                 logger.info("Initialized generator EMA_2 with decay=%s", self.training_args.ema_decay)
+        elif ema_enabled:
+            # Defer construction to the lazy block in the train loop, which builds the EMA AT
+            # ema_start_step from the already-trained weights. Eager-constructing here would anchor
+            # the shadow to the cold init and leave it base-contaminated (blurry) on short runs.
+            logger.info("Generator EMA deferred: built lazily at ema_start_step=%s from trained weights",
+                        self.training_args.ema_start_step)
         else:
             logger.info("Generator EMA disabled (ema_decay <= 0.0)")
 
@@ -326,22 +334,6 @@ class DistillationPipeline(TrainingPipeline):
                 return model
         return model
 
-    def get_ema_model_copy(self) -> torch.nn.Module | None:
-        """Get a copy of the model with EMA weights applied."""
-        if self.generator_ema is not None:
-            ema_model = copy.deepcopy(self.transformer)
-            self.generator_ema.copy_to_unwrapped(ema_model)
-            return ema_model
-        return None
-
-    def get_ema_2_model_copy(self) -> torch.nn.Module | None:
-        """Get a copy of the transformer_2 model with EMA weights applied."""
-        if self.generator_ema_2 is not None and self.transformer_2 is not None:
-            ema_2_model = copy.deepcopy(self.transformer_2)
-            self.generator_ema_2.copy_to_unwrapped(ema_2_model)
-            return ema_2_model
-        return None
-
     def is_ema_ready(self, current_step: int | None = None):
         """Check if EMA is ready for use (after ema_start_step)."""
         if current_step is None:
@@ -361,68 +353,59 @@ class DistillationPipeline(TrainingPipeline):
         try:
             # Save main transformer EMA
             if self.generator_ema is not None:
-                ema_model = self.get_ema_model_copy()
-                if ema_model is None:
-                    logger.warning("Failed to create EMA model copy")
-                else:
-                    ema_save_dir = os.path.join(output_dir, f"ema_checkpoint-{step}")
-                    os.makedirs(ema_save_dir, exist_ok=True)
+                ema_save_dir = os.path.join(output_dir, f"ema_checkpoint-{step}")
+                os.makedirs(ema_save_dir, exist_ok=True)
 
-                    # save as diffusers format
-                    from safetensors.torch import save_file
+                # save as diffusers format
+                from safetensors.torch import save_file
 
-                    from fastvideo.training.training_utils import (custom_to_hf_state_dict,
-                                                                   gather_state_dict_on_cpu_rank0)
-                    cpu_state = gather_state_dict_on_cpu_rank0(ema_model, device=None)
+                from fastvideo.training.training_utils import (custom_to_hf_state_dict, gather_state_dict_on_cpu_rank0)
+                # Swap EMA weights into the live FSDP module in place (no deepcopy) and gather the
+                # full state dict within the context; weights are restored on exit.
+                with self.generator_ema.apply_to_model(self.transformer):
+                    cpu_state = gather_state_dict_on_cpu_rank0(self.transformer, device=None)
 
-                    if self.global_rank == 0:
-                        weight_path = os.path.join(ema_save_dir, "diffusion_pytorch_model.safetensors")
-                        diffusers_state_dict = custom_to_hf_state_dict(cpu_state, ema_model.reverse_param_names_mapping)
-                        save_file(diffusers_state_dict, weight_path)
+                if self.global_rank == 0:
+                    weight_path = os.path.join(ema_save_dir, "diffusion_pytorch_model.safetensors")
+                    diffusers_state_dict = custom_to_hf_state_dict(cpu_state,
+                                                                   self.transformer.reverse_param_names_mapping)
+                    save_file(diffusers_state_dict, weight_path)
 
-                        config_dict = ema_model.hf_config
-                        if "dtype" in config_dict:
-                            del config_dict["dtype"]
-                        config_path = os.path.join(ema_save_dir, "config.json")
-                        with open(config_path, "w") as f:
-                            json.dump(config_dict, f, indent=4)
+                    config_dict = self.transformer.hf_config
+                    if "dtype" in config_dict:
+                        del config_dict["dtype"]
+                    config_path = os.path.join(ema_save_dir, "config.json")
+                    with open(config_path, "w") as f:
+                        json.dump(config_dict, f, indent=4)
 
-                        logger.info("EMA weights saved to %s", weight_path)
-
-                    del ema_model
+                    logger.info("EMA weights saved to %s", weight_path)
 
             # Save transformer_2 EMA
-            if self.generator_ema_2 is not None:
-                ema_2_model = self.get_ema_2_model_copy()
-                if ema_2_model is None:
-                    logger.warning("Failed to create EMA_2 model copy")
-                else:
-                    ema_2_save_dir = os.path.join(output_dir, f"ema_2_checkpoint-{step}")
-                    os.makedirs(ema_2_save_dir, exist_ok=True)
+            if self.generator_ema_2 is not None and self.transformer_2 is not None:
+                ema_2_save_dir = os.path.join(output_dir, f"ema_2_checkpoint-{step}")
+                os.makedirs(ema_2_save_dir, exist_ok=True)
 
-                    # save as diffusers format
-                    from safetensors.torch import save_file
+                # save as diffusers format
+                from safetensors.torch import save_file
 
-                    from fastvideo.training.training_utils import (custom_to_hf_state_dict,
-                                                                   gather_state_dict_on_cpu_rank0)
-                    cpu_state_2 = gather_state_dict_on_cpu_rank0(ema_2_model, device=None)
+                from fastvideo.training.training_utils import (custom_to_hf_state_dict, gather_state_dict_on_cpu_rank0)
+                with self.generator_ema_2.apply_to_model(self.transformer_2):
+                    cpu_state_2 = gather_state_dict_on_cpu_rank0(self.transformer_2, device=None)
 
-                    if self.global_rank == 0:
-                        weight_path_2 = os.path.join(ema_2_save_dir, "diffusion_pytorch_model.safetensors")
-                        diffusers_state_dict_2 = custom_to_hf_state_dict(cpu_state_2,
-                                                                         ema_2_model.reverse_param_names_mapping)
-                        save_file(diffusers_state_dict_2, weight_path_2)
+                if self.global_rank == 0:
+                    weight_path_2 = os.path.join(ema_2_save_dir, "diffusion_pytorch_model.safetensors")
+                    diffusers_state_dict_2 = custom_to_hf_state_dict(cpu_state_2,
+                                                                     self.transformer_2.reverse_param_names_mapping)
+                    save_file(diffusers_state_dict_2, weight_path_2)
 
-                        config_dict_2 = ema_2_model.hf_config
-                        if "dtype" in config_dict_2:
-                            del config_dict_2["dtype"]
-                        config_path_2 = os.path.join(ema_2_save_dir, "config.json")
-                        with open(config_path_2, "w") as f:
-                            json.dump(config_dict_2, f, indent=4)
+                    config_dict_2 = self.transformer_2.hf_config
+                    if "dtype" in config_dict_2:
+                        del config_dict_2["dtype"]
+                    config_path_2 = os.path.join(ema_2_save_dir, "config.json")
+                    with open(config_path_2, "w") as f:
+                        json.dump(config_dict_2, f, indent=4)
 
-                        logger.info("EMA_2 weights saved to %s", weight_path_2)
-
-                    del ema_2_model
+                    logger.info("EMA_2 weights saved to %s", weight_path_2)
 
         except Exception as e:
             logger.error("Failed to save EMA weights: %s", str(e))


### PR DESCRIPTION
## Purpose

<!-- What does this PR do? Link the related issue if applicable. -->

In `fastvideo/training/distillation_pipeline.py` (used by non–self-forcing DMD pipelines), EMA had two bugs that made `--use_ema True` produce blurry results and never export EMA weights.

**Bug 1 — EMA shadow anchored to the cold init model (with `ema_start_step > 0`).**
The EMA was **eager-constructed in `__init__` from the (untrained) init weights** and updated from step 0. The lazy-construction block in the train loop was dead code.
```python
if (step >= self.training_args.ema_start_step) and (self.generator_ema is None) and (self.training_args.ema_decay > 0):
    self.generator_ema = EMA_FSDP(self.transformer, decay=...)
```
because the eager construct already set `generator_ema` non-`None`. So `ema_start_step` only gated whether EMA is used (`is_ema_ready`), not when the shadow starts accumulating. The shadow therefore averaged in the base/init model.

**Bug 2 — `save_ema_weights` crashes under FSDP (EMA never exported).**
`save_ema_weights` → `get_ema_model_copy()` did `copy.deepcopy(self.transformer)`, which FSDP does not support. Every save raised and was caught:
```
ERROR Failed to save EMA weights: FSDP does not support deepcopy. Please use state dict for serialization
```
As a result no EMA weights were ever written; the exported `generator_inference_transformer/*.safetensors` were the raw (non-EMA) weights.

## Changes

<!-- Describe your changes concisely. What approach did you take? -->

- **Bug 1:** only eager-construct the EMA in `__init__` when `ema_start_step <= 0`; otherwise defer so the existing lazy block builds it at `ema_start_step` from the already-trained weights (the per-step update is already guarded by `if self.generator_ema is not None`, so it correctly does nothing until then). This matches the pattern already used in `self_forcing_distillation_pipeline.py`.
- **Bug 2:** remove `get_ema_model_copy`/`get_ema_2_model_copy`; rewrite `save_ema_weights` to swap EMA weights into the live FSDP module **in place** via `generator_ema.apply_to_model(self.transformer)` and gather with `gather_state_dict_on_cpu_rank0` inside that context (no deepcopy; live weights restored on exit). The gather is collective-safe — all ranks call it; only rank 0 writes the file.


## Test Plan

<!-- How did you verify your changes? Paste exact commands and output. -->

Ran a 4-step DMD distillation on Wan2.1-T2V-1.3B with EMA starting mid-run:

```bash
torchrun --nnodes 1 --nproc_per_node 4 \
  fastvideo/training/wan_distillation_pipeline.py \
  --num_gpus 4 --sp_size 1 --tp_size 1 --hsdp_replicate_dim 4 --hsdp_shard_dim 1 \
  --model_path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
  --pretrained_model_name_or_path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
  --real_score_model_path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
  --fake_score_model_path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
  --data_path <small_parquet_dir> --dataloader_num_workers 2 \
  --output_dir scratch/ema_dryrun_ckpt \
  --max_train_steps 4 --train_batch_size 1 --gradient_accumulation_steps 1 \
  --num_latent_t 20 --num_height 480 --num_width 832 --num_frames 77 \
  --enable_gradient_checkpointing_type full --mixed_precision bf16 \
  --training_state_checkpointing_steps 2 --weight_only_checkpointing_steps 2 \
  --use_ema True --ema_start_step 2 --ema_decay 0.99 \
  --flow_shift 8 --dmd_denoising_steps '1000,757,522' \
  --generator_update_interval 5 --real_score_guidance_scale 2.0
```

## Test Results

- `Generator EMA deferred: built lazily at ema_start_step=2 from trained weights` — deferred init.
- `ema_checkpoint-{2,4}/diffusion_pytorch_model.safetensors` written on disk; run completes 4/4 cleanly.

## Checklist

- [X] I ran `pre-commit run --all-files` and fixed all issues
- [X] I added or updated tests for my changes
- [X] I updated documentation if needed
- [X] I considered GPU memory impact of my changes
