### PR TITLE
[feat]: make VSA tile cache configurable for training

### DIFF
--- a/examples/train/configs/example.yaml
+++ b/examples/train/configs/example.yaml
@@ -129,6 +129,11 @@ training:
   # --- training.vsa [TYPED] -> VSAConfig ---
   vsa:
     sparsity: 0.0                     # default: 0.0 (0.0 = disabled)
+    cache_tile_buf: false             # default: false. Reuse the per-step padded
+                                      # VSA tile buffer across attention layers.
+                                      # Off by default to avoid the activation-
+                                      # checkpointing OOM (#1423); set true on
+                                      # memory-rich setups for the buffer-reuse speedup.
 
   # --- training.model [TYPED] -> ModelTrainingConfig ---
   model:

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -931,6 +931,12 @@ class TrainingArgs(FastVideoArgs):
     # VSA training decay parameters
     VSA_decay_rate: float = 0.01  # decay rate -> 0.02
     VSA_decay_interval_steps: int = 1  # decay interval steps -> 50
+    # Reuse the per-step padded VSA tile buffer across attention layers during
+    # training. Defaults to False: under full activation checkpointing the
+    # cached buffer survives into the backward recompute and inflates peak
+    # memory (see #1423). Enable on memory-rich setups to keep the per-step
+    # buffer-reuse speedup.
+    VSA_cache_tile_buf: bool = False
 
     # LoRA training parameters
     lora_rank: int | None = None
@@ -1171,6 +1177,13 @@ class TrainingArgs(FastVideoArgs):
             type=int,
             default=TrainingArgs.VSA_decay_interval_steps,
             help="VSA decay interval steps")
+        parser.add_argument("--VSA-cache-tile-buf",
+                            action=StoreBoolean,
+                            default=TrainingArgs.VSA_cache_tile_buf,
+                            help="Reuse the per-step padded VSA tile buffer across attention "
+                            "layers during training. Off by default to avoid the activation-"
+                            "checkpointing OOM (#1423); enable on memory-rich setups for the "
+                            "per-step buffer-reuse speedup.")
         parser.add_argument("--lora-training", action=StoreBoolean, help="Whether to use LoRA training")
         parser.add_argument("--lora-rank", type=int, help="LoRA rank")
         parser.add_argument("--lora-alpha", type=int, help="LoRA alpha")

--- a/fastvideo/tests/attention/test_video_sparse_attention_metadata.py
+++ b/fastvideo/tests/attention/test_video_sparse_attention_metadata.py
@@ -6,10 +6,10 @@ from fastvideo.attention.backends.video_sparse_attn import (
 )
 
 
-def _build_metadata(cache_tile_buf: bool):
+def _build_metadata(cache_tile_buf: bool, raw_latent_shape=(4, 4, 4)):
     return VideoSparseAttentionMetadataBuilder().build(
         current_timestep=0,
-        raw_latent_shape=(4, 4, 4),
+        raw_latent_shape=raw_latent_shape,
         patch_size=(1, 1, 1),
         VSA_sparsity=0.5,
         device=torch.device("cpu"),
@@ -36,3 +36,25 @@ def test_vsa_tile_caches_scratch_by_default():
     tiled = impl.tile(x, metadata)
 
     assert metadata.tile_buf is tiled
+
+
+def test_vsa_tile_cached_and_uncached_produce_identical_values():
+    # The cache flag must be a pure performance knob: enabling it (inference /
+    # memory-rich training) and disabling it (#1423 OOM-safe training) must
+    # yield bit-identical tilings. Use a padded shape (dit T=5 -> padded T=8)
+    # so the zero-pad-position scatter is actually exercised.
+    impl = object.__new__(VideoSparseAttentionImpl)
+    md_cached = _build_metadata(cache_tile_buf=True, raw_latent_shape=(5, 4, 4))
+    md_uncached = _build_metadata(cache_tile_buf=False, raw_latent_shape=(5, 4, 4))
+
+    total_seq_length = md_cached.total_seq_length
+    x = torch.randn(2, total_seq_length, 3, 4)
+
+    cached = impl.tile(x, md_cached).clone()
+    uncached = impl.tile(x, md_uncached)
+
+    assert cached.shape == uncached.shape
+    assert torch.equal(cached, uncached)
+    # The cached path stashes the buffer; the uncached path does not.
+    assert md_cached.tile_buf is not None
+    assert md_uncached.tile_buf is None

--- a/fastvideo/train/models/wan/wan.py
+++ b/fastvideo/train/models/wan/wan.py
@@ -401,7 +401,7 @@ class WanModel(ModelBase):
                 patch_size=patch_size,
                 VSA_sparsity=tc.vsa_sparsity,
                 device=self.device,
-                cache_tile_buf=False,
+                cache_tile_buf=tc.vsa_cache_tile_buf,
             )
         elif (envs.FASTVIDEO_ATTENTION_BACKEND == "VMOBA_ATTN"):
             if (not is_vmoba_available() or VideoMobaAttentionMetadataBuilder is None):

--- a/fastvideo/train/utils/config.py
+++ b/fastvideo/train/utils/config.py
@@ -389,6 +389,7 @@ def _build_training_config(
             run_name=str(tr.get("run_name", "") or ""),
         ),
         vsa_sparsity=float(vs.get("sparsity", 0.0) or 0.0),
+        vsa_cache_tile_buf=bool(vs.get("cache_tile_buf", False) or False),
         model=ModelTrainingConfig(
             weighting_scheme=str(m.get("weighting_scheme", "uniform") or "uniform"),
             logit_mean=float(m.get("logit_mean", 0.0) or 0.0),

--- a/fastvideo/train/utils/training_config.py
+++ b/fastvideo/train/utils/training_config.py
@@ -86,6 +86,12 @@ class TrainingConfig:
     checkpoint: CheckpointConfig = field(default_factory=CheckpointConfig)
     tracker: TrackerConfig = field(default_factory=TrackerConfig)
     vsa_sparsity: float = 0.0
+    # Reuse the per-step padded VSA tile buffer across attention layers.
+    # Defaults to False for training: under full activation checkpointing the
+    # cached buffer survives into the backward recompute and inflates peak
+    # memory (see #1423). Enable on memory-rich setups to keep the per-step
+    # buffer-reuse speedup.
+    vsa_cache_tile_buf: bool = False
     model: ModelTrainingConfig = field(default_factory=ModelTrainingConfig)
     pipeline_config: PipelineConfig | None = None
     model_path: str = ""

--- a/fastvideo/training/training_pipeline.py
+++ b/fastvideo/training/training_pipeline.py
@@ -360,7 +360,7 @@ class TrainingPipeline(LoRAPipeline, ABC):
                 patch_size=patch_size,
                 VSA_sparsity=current_vsa_sparsity,
                 device=get_local_torch_device(),
-                cache_tile_buf=False)
+                cache_tile_buf=self.training_args.VSA_cache_tile_buf)
         elif envs.FASTVIDEO_ATTENTION_BACKEND == "VMOBA_ATTN":
             if not vmoba_available:
                 raise ImportError("FASTVIDEO_ATTENTION_BACKEND is set to VMOBA_ATTN, "


### PR DESCRIPTION
## What

Make the VSA per-step tile-buffer cache (`cache_tile_buf`) **configurable for training**, instead of forcing it off.

## Why

#1434 fixed the [#1423](https://github.com/hao-ai-lab/FastVideo/issues/1423) activation-checkpointing OOM by hard-coding `cache_tile_buf=False` at both VSA training build sites. The cached padded buffer was pinned on the per-step `attn_metadata`, so under full activation checkpointing it survived into the backward recompute and inflated peak memory.

But the cache is purely a per-step speed optimization (reuse the padded QKVG tile scratch across VSA layers). On memory-rich setups — FSDP/SP-sharded large clusters, or runs that don't use full activation checkpointing — the OOM doesn't bite, and keeping the cache is a free speedup. Hard-coding `False` takes that off the table.

This exposes it as a config knob, **defaulting to `False`** to preserve #1434's OOM-safe training behavior. Opt in with `True` to keep the buffer-reuse speedup.

## Changes

- **New framework**: `TrainingConfig.vsa_cache_tile_buf` (YAML `training.vsa.cache_tile_buf`), parsed in `config.py`, wired into `WanModel._build_attention_metadata` (`wan.py`). Inherited by cosmos/hunyuan/matrixgame2/wan_causal.
- **Legacy**: `TrainingArgs.VSA_cache_tile_buf` (`--VSA-cache-tile-buf`), wired into `TrainingPipeline._build_attention_metadata` (`training_pipeline.py`). Inherited by distillation + self-forcing.
- **Inference unchanged** — the LTX2 build still omits the kwarg → default `True`.
- **Test**: added a value-equivalence test asserting the cached and non-cached `tile()` paths produce **bit-identical** tilings, on a padded shape (`raw_latent_shape=(5,4,4)` → padded T=8) that actually exercises the zero-pad-position scatter. This pins the property that the flag is a pure performance knob, never a correctness change — and addresses the two MINOR test-depth suggestions from the #1434 review.
- **Docs**: documented `cache_tile_buf` in `examples/train/configs/example.yaml`.

## Stacked on #1434

This is **stacked on #1434** (which introduces the `cache_tile_buf` plumbing — `main` has no such field yet). The net-new change here is one commit; the diff against `main` shows #1434's commit too until it merges. Once #1434 lands, I'll rebase and this collapses to just the configurability commit. Please review/merge #1434 first.

## Test plan

- `ruff` / `yapf` / `codespell` clean on all changed files.
- New equivalence test logic verified standalone (cached == uncached; padding present at `(5,4,4)`).
- Existing `cache_tile_buf` plumbing tests from #1434 still pass (structure unchanged).
