### PR TITLE
[perf] LTX-2.3 distilled i2v: drop max-autotune from compile kwargs

### DIFF
--- a/examples/inference/basic/basic_ltx2_3_distilled_i2v.py
+++ b/examples/inference/basic/basic_ltx2_3_distilled_i2v.py
@@ -18,20 +18,20 @@ What the script does
 --------------------
 1. Loads FastVideo/LTX-2.3-Distilled-Diffusers (8 denoise + 3 refine steps,
    CFG=1, no refine LoRA — the distilled production recipe).
-2. Compiles the DiT, text encoder, and VAE (fullgraph, max-autotune-no-
-   cudagraphs).
-3. Runs 2 warmup calls (untimed) + 2 measured calls. Two warmups are needed
-   even though distilled has no refine LoRA, because Inductor's per-shape
-   autotune for the first call still leaves a few cold guards on call 2;
-   the second warmup settles them. Skipping to a single warmup typically
-   inflates the first measured run by tens of seconds.
+2. Compiles the DiT, text encoder, and VAE (fullgraph, Inductor default
+   mode — autotune adds ~7 min cold-compile here with no measurable
+   e2e gain).
+3. Runs 2 warmup calls (untimed) + 2 measured calls. Two warmups are kept
+   as a safety net — the first call pays cold compile + first-shape guard
+   work, and a second warmup ensures any residual recompiles settle before
+   we measure.
 4. Prints a per-stage breakdown and an average over the measured runs.
 
 Hardware notes
 --------------
 - Single-GPU example; for multi-GPU sequence-parallel see the gradio demo
   under `examples/inference/gradio/local/gradio_local_demo_ltx2_3/`.
-- First-time compile + autotune takes ~10-30 min on H100 / GB200 (cached
+- First-time compile takes ~30-40 min on GB200 (~20 min on H100; cached
   in `$TORCHINDUCTOR_CACHE_DIR` afterwards). Subsequent invocations only
   pay the one-time process load + a few seconds of dynamo trace.
 - On GB200 / Blackwell, run with `env -u LD_LIBRARY_PATH ...` to avoid a
@@ -151,10 +151,13 @@ def main() -> None:
     print(f"i2v image:       {I2V_IMAGE}")
     print(f"Output dir:      {OUTPUT_DIR.resolve()}")
 
+    # mode="default" — Inductor's default schedule matches max-autotune on
+    # this pipeline (denoise/refine/decode all within ~5 ms, n=2) while
+    # saving ~7 min of cold compile on a single GB200.
     torch_compile_kwargs = {
         "backend": "inductor",
         "fullgraph": True,
-        "mode": "max-autotune-no-cudagraphs",
+        "mode": "default",
         "dynamic": False,
     }
 


### PR DESCRIPTION
## Summary

Switch the LTX-2.3 distilled i2v example from `mode="max-autotune-no-cudagraphs"` to Inductor's `mode="default"` for the DiT / text encoder / VAE compiles. On this pipeline autotune adds ~7 minutes to cold compile and gains nothing measurable in steady state.

## Evidence

Measured on a single GB200, fresh inductor cache, otherwise unchanged config (`FastVideo/LTX-2.3-Distilled-Diffusers`, 832×1280, 121 frames @ 24fps, 8 denoise + 3 refine steps, n=2 measured runs):

|                                       | `max-autotune-no-cudagraphs` | `default` | delta  |
|---------------------------------------|--------------|---------|--------|
| cold warmup #1 (compile + 1st gen)    | 2694 s       | 2275 s  | **−419 s (−16%)** |
| warm warmup #2                        | 4.0 s        | 4.0 s   | tied   |
| measured e2e avg                      | 4.29 s       | 4.01 s  | −0.28 s |
| denoise stage                         | 1.481 s      | 1.435 s | tied   |
| refine denoise stage                  | 1.635 s      | 1.630 s | tied   |
| decode stage                          | 0.277 s      | 0.273 s | tied   |

Denoise / refine / decode — the three GPU-bound stages — all match within ~5 ms, so autotune isn't finding faster kernels than the default schedule for this shape set. The e2e delta is driven by `VideoSaveStage` CPU I/O variance (0.486 s vs 0.371 s), not the compute path.

## What changed

- `examples/inference/basic/basic_ltx2_3_distilled_i2v.py`
  - `torch_compile_kwargs["mode"]`: `"max-autotune-no-cudagraphs"` → `"default"` + one-line comment explaining why.
  - Docstring: drop the "max-autotune" reference, update the cold-compile estimate from "~10-30 min on H100 / GB200" to "~30-40 min on GB200 (~20 min on H100)" to reflect what we actually see now.
  - Re-justify the 2-warmup pattern: previously framed as autotune-specific; now framed as a safety net for cold compile + first-shape guard work.

No production code path is touched — this is example-only.

## Test plan

- [x] Run the example with default mode on a clean inductor cache; confirm e2e average matches the autotune run within run-to-run variance.
- [x] Confirm transformer / text_encoder / VAE all log `mode='default'` (`composed_pipeline_base._compile_with_conditions` picks up the kwargs).
- [x] Confirm cold compile is faster (~2275 s vs ~2694 s on GB200).
- [ ] Reproducer for reviewers: `LTX23_I2V_IMAGE=... python examples/inference/basic/basic_ltx2_3_distilled_i2v.py` after `rm -rf $TORCHINDUCTOR_CACHE_DIR`.

## Risk

Low — example-only change, doesn't affect any pipeline or library code. The only user-visible effect is a faster first run and slightly less aggressive autotune (which we showed is unused).