### PR TITLE
[bugfix] Classify new config/sampling fields in schema parity inventory

### DIFF
--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -126,9 +126,18 @@ surfaces:
       text_encoder_configs: "Legacy internal component config object."
       preprocess_text_funcs: "Internal text preprocessing hooks."
       postprocess_text_funcs: "Internal text postprocessing hooks."
+      scheduler_step_in_fp32: "Runtime scheduler precision toggle; not part of the public typed inference API."
 
   pipeline_config_extensions:
     preset_owned:
+      flux2_text_encoder_type:
+        sources:
+          - fastvideo.configs.pipelines.flux_2.Flux2PipelineConfig
+          - fastvideo.configs.pipelines.flux_2.Flux2KleinPipelineConfig
+      text_encoder_out_layers:
+        sources:
+          - fastvideo.configs.pipelines.flux_2.Flux2PipelineConfig
+          - fastvideo.configs.pipelines.flux_2.Flux2KleinPipelineConfig
       conditioning_strategy:
         sources:
           - fastvideo.configs.pipelines.cosmos.CosmosConfig
@@ -492,6 +501,8 @@ surfaces:
       inpaint_mask: request.extensions.stable_audio.inpaint_mask
     internal_only:
       data_type: "Derived from the request shape and not a public input."
+      latents: "Pre-generated diffusion latents supplied by parity/debug harnesses; not a public input."
+      max_sequence_length: "Model-specific text-encoder sequence cap; not part of the public typed inference API."
 
   sampling_param_extensions: {}
 


### PR DESCRIPTION
## Purpose

`Some CI` is currently red on `fastvideo/tests/api/test_schema_parity_inventory.py`. PR #1349 (Flux2 Klein Port) added new fields to `SamplingParam`, `PipelineConfig`,and the Flux2 pipeline configs but did not classify them in `docs/design/inference_schema_parity_inventory.yaml`. (I saw this issue at while doing CI at PR #1245 )
The parity tests assert that every dataclass field is accounted for in the inventory, so the unclassified fields make three tests fail:

- `test_sampling_param_base_fields_are_classified`
- `test_pipeline_config_base_fields_are_classified`
- `test_pipeline_config_extension_fields_are_classified`

This PR only updates the inventory to re-establish parity; no runtime behavior changes.

Fixes # <!-- link the tracking issue if there is one -->

## Changes

Classify the five unclassified fields in `inference_schema_parity_inventory.yaml`:

| Surface | Status bucket | Fields |
|---|---|---|
| `sampling_param_base` | `internal_only` | `latents`, `max_sequence_length` |
| `pipeline_config_base` | `internal_only` | `scheduler_step_in_fp32` |
| `pipeline_config_extensions` | `preset_owned` (sources: Flux2 configs) | `flux2_text_encoder_type`, `text_encoder_out_layers` |

- `latents` / `max_sequence_length` / `scheduler_step_in_fp32` are runtime/debug
  plumbing, so they go under `internal_only` (note-only, not part of the public
  typed inference API).
- `flux2_text_encoder_type` / `text_encoder_out_layers` are model-specific config,
  so they go under `preset_owned` with `sources` pointing to
  `Flux2PipelineConfig` / `Flux2KleinPipelineConfig`, matching the existing
  `text_encoder_class` pattern.
- These are conservative classifications chosen to avoid the typed-schema target
  validation in `test_inventory_targets_exist_in_typed_schema`; maintainers can
  re-bucket to a public status later if any of these should be user-facing.

## Test Plan

```bash
pytest fastvideo/tests/api/test_schema_parity_inventory.py -v
```

Verified that, for every affected surface, the set of dataclass fields exactly
matches the set of inventory-classified fields (the assertion these tests make).

## Test Results

<details>
<summary>Field-set parity (before → after)</summary>

```
sampling_param_base   : missing {latents, max_sequence_length}  -> {}  (75 == 75)
pipeline_config_base  : missing {scheduler_step_in_fp32}        -> {}  (26 == 26)
pipeline_config_exts  : missing {flux2_text_encoder_type,
                                 text_encoder_out_layers}        -> {}  (87 == 87)
fastvideo_args        : already in parity (81 == 81), unchanged
sampling_param_exts   : already in parity ({} == {}), unchanged
```

YAML parses cleanly; `pre-commit run --files docs/design/inference_schema_parity_inventory.yaml` passes (codespell/yaml/format).

</details>

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues
- [x] I added or updated tests for my changes <!-- existing parity tests now pass; they are the regression coverage -->
- [x] I updated documentation if needed <!-- the inventory is the doc being updated -->
- [x] I considered GPU memory impact of my changes <!-- N/A: inventory metadata only -->

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass <!-- N/A: no model/pipeline change -->
- [ ] I updated the support matrix if adding a new model <!-- N/A -->