### PR TITLE
[feat] QAD 5090: Wire the Attn-QAT inference attention backend (8/12)

### DIFF
--- a/fastvideo-kernel/attn_qat_infer/api.py
+++ b/fastvideo-kernel/attn_qat_infer/api.py
@@ -135,13 +135,14 @@ def blockscaled_fp4_attn(qlist: Tuple,
                          is_causal: bool = False, 
                          per_block_mean: bool = True,
                          is_bf16: bool = True,
-                         single_level_p_quant: bool = False
+                         single_level_p_quant: bool = False,
+                         sm_scale: float | None = None
                         ):
-    softmax_scale = (qlist[0].shape[-1] * 2) ** (-0.5)
+    softmax_scale = sm_scale if sm_scale is not None else (qlist[0].shape[-1] * 2) ** (-0.5)
     return fp4attn_cuda.fwd(qlist[0], klist[0], vlist[0], qlist[1], klist[1], vlist[1], delta_s, KL, None, softmax_scale, is_causal, per_block_mean, is_bf16, single_level_p_quant)
 
 
-def sageattn_blackwell(q, k, v, attn_mask = None, is_causal = False, per_block_mean = True, single_level_p_quant = True, **kwargs):
+def sageattn_blackwell(q, k, v, attn_mask = None, is_causal = False, per_block_mean = True, single_level_p_quant = True, sm_scale: float | None = None, **kwargs):
     """
     SageAttention3 Blackwell kernel for FP4 attention.
     
@@ -156,6 +157,8 @@ def sageattn_blackwell(q, k, v, attn_mask = None, is_causal = False, per_block_m
                               (standard per-block FP4 quantization like V, no s_P1).
                               If False (default), use two-level quantization:
                               s_P1 = rowmax(P̃)/(448×6), then s_P2, P̂_2 = φ(P̃/s_P1).
+        sm_scale: Softmax scale to pass through to the CUDA kernel. If None,
+                  defaults to the kernel's 1/sqrt(D) scale.
         **kwargs: Additional arguments (ignored)
     
     Returns:
@@ -180,6 +183,7 @@ def sageattn_blackwell(q, k, v, attn_mask = None, is_causal = False, per_block_m
     is_causal,
     per_block_mean,
     is_bf16,
-    single_level_p_quant
+    single_level_p_quant,
+    sm_scale
     )[0][:, :, :QL, :].contiguous()
     return o_fp4

--- a/fastvideo/configs/models/dits/base.py
+++ b/fastvideo/configs/models/dits/base.py
@@ -24,7 +24,8 @@ class DiTArchConfig(ArchConfig):
                                                  AttentionBackendEnum.TORCH_SDPA,
                                                  AttentionBackendEnum.VIDEO_SPARSE_ATTN,
                                                  AttentionBackendEnum.VMOBA_ATTN, AttentionBackendEnum.SAGE_ATTN_THREE,
-                                                 AttentionBackendEnum.SLA_ATTN, AttentionBackendEnum.SAGE_SLA_ATTN)
+                                                 AttentionBackendEnum.ATTN_QAT_INFER, AttentionBackendEnum.SLA_ATTN,
+                                                 AttentionBackendEnum.SAGE_SLA_ATTN)
 
     hidden_size: int = 0
     num_attention_heads: int = 0

--- a/fastvideo/platforms/cuda.py
+++ b/fastvideo/platforms/cuda.py
@@ -140,6 +140,13 @@ class CudaPlatformBase(Platform):
             except ImportError as e:
                 logger.info(e)
                 logger.info("Sage Attention 3 backend is not installed. Fall back to Flash Attention.")
+        elif selected_backend == AttentionBackendEnum.ATTN_QAT_INFER:
+            from fastvideo.attention.backends.attn_qat_infer import (  # noqa: F401
+                AttnQatInferBackend, is_attn_qat_infer_available)
+            if is_attn_qat_infer_available():
+                logger.info("Using Attn-QAT inference (modified SageAttention3 FP4) backend.")
+                return "fastvideo.attention.backends.attn_qat_infer.AttnQatInferBackend"
+            logger.info("Attn-QAT inference kernel is not built. Fall back to Flash Attention.")
         elif selected_backend == AttentionBackendEnum.VIDEO_SPARSE_ATTN:
             try:
                 from fastvideo_kernel import video_sparse_attn  # noqa: F401

--- a/fastvideo/platforms/interface.py
+++ b/fastvideo/platforms/interface.py
@@ -15,6 +15,7 @@ class AttentionBackendEnum(enum.Enum):
     TORCH_SDPA = enum.auto()
     SAGE_ATTN = enum.auto()
     SAGE_ATTN_THREE = enum.auto()
+    ATTN_QAT_INFER = enum.auto()
     VIDEO_SPARSE_ATTN = enum.auto()
     BSA_ATTN = enum.auto()
     VMOBA_ATTN = enum.auto()


### PR DESCRIPTION
## Purpose

Continues the Attn-QAT upstreaming stack (#1225). Wires in the
`AttnQatInferBackend` that #1358 landed as **deadcode**, now that its modified
SageAttention3 FP4 kernels land in #1455. This makes the 4-bit attention path
selectable end-to-end for Wan-2.1 inference.

## Changes

- `platforms/interface.py`: add `ATTN_QAT_INFER` to `AttentionBackendEnum`. The
  name matches `AttnQatInferBackend.get_name()`, so `backend_name_to_enum()`
  resolves the `FASTVIDEO_ATTENTION_BACKEND=ATTN_QAT_INFER` override.
- `platforms/cuda.py`: dispatch `ATTN_QAT_INFER` → `AttnQatInferBackend`, guarded
  by `is_attn_qat_infer_available()`; falls back to Flash Attention when the
  kernel is not built (non-Blackwell, or before #1455 merges).
- `configs/models/dits/base.py`: add `ATTN_QAT_INFER` to the default
  `_supported_attention_backends` so Wan can select it.

The training-side `ATTN_QAT_TRAIN` backend depends on a separate Triton kernel
and is deferred to the training upstream.

## Test Plan / Test Results

- ✅ `name ↔ enum` closed: `AttnQatInferBackend.get_name() == "ATTN_QAT_INFER"`
  is a valid `AttentionBackendEnum` member.
- ✅ **Dispatch verified on a Blackwell node** (using the #1455-built kernel):
  - kernel present → `get_attn_backend_cls(ATTN_QAT_INFER)` returns
    `fastvideo.attention.backends.attn_qat_infer.AttnQatInferBackend`
  - kernel absent → logs the fallback and returns `FlashAttentionBackend`
- ✅ pre-commit (yapf / ruff / mypy / codespell) passes.

### Notes
- **Depends on #1455** (the kernel). Until that merges, `is_attn_qat_infer_available()`
  returns False on `main`, so this safely no-ops to Flash Attention.
- Full runtime/numeric parity is `sm_120` (RTX 5090)–specific by kernel design.

Part of #1225.
