### PR TITLE
[docs] QAD 5090: Add NVFP4 + Attn-QAT inference example and how-to (9/12)

### DIFF
--- a/docs/inference/optimizations.md
+++ b/docs/inference/optimizations.md
@@ -125,7 +125,7 @@ gen.generate_video(prompt="A raccoon in sunflowers", save_video=True)
 
 ### NVFP4 + Attn-QAT (modified SageAttention3, Blackwell sm_120)
 
-**`ATTN_QAT_INFER`** with **`transformer_quant="NVFP4"`**
+**`ATTN_QAT_INFER`** with **`transformer_quant=nvfp4_qat`**
 
 Runs the DiT fully in 4-bit: NVFP4 linear layers (activations quantized on the
 fly) plus the modified SageAttention3 FP4 attention backend. This is the
@@ -143,10 +143,13 @@ import os
 os.environ["FASTVIDEO_ATTENTION_BACKEND"] = "ATTN_QAT_INFER"
 
 from fastvideo import VideoGenerator
+from fastvideo.layers.quantization import get_quantization_config
 gen = VideoGenerator.from_pretrained(
     "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
     num_gpus=1,
-    transformer_quant="NVFP4",   # or "nvfp4_qat" to match a QAT-distilled checkpoint
+    # Wan-2.1 uses the nvfp4_qat config (NVFP4 is LTX2-specific). Pass an
+    # instance — the bare string is not resolved on the from_pretrained path.
+    transformer_quant=get_quantization_config("nvfp4_qat")(),
     use_fsdp_inference=False,     # FSDP shards invalidate the FP4 tensor pointers
 )
 gen.generate(request={"prompt": "A raccoon in sunflowers", "output": {"save_video": True}})

--- a/docs/inference/optimizations.md
+++ b/docs/inference/optimizations.md
@@ -24,6 +24,7 @@ This page describes the various options for speeding up generation times in Fast
 - Video Sparse Attention: `FASTVIDEO_ATTENTION_BACKEND=VIDEO_SPARSE_ATTN`
 - Sage Attention: `FASTVIDEO_ATTENTION_BACKEND=SAGE_ATTN`
 - Sage Attention 3: `FASTVIDEO_ATTENTION_BACKEND=SAGE_ATTN_THREE`
+- Attn-QAT inference (modified SageAttention3 FP4, sm_120/RTX 5090): `FASTVIDEO_ATTENTION_BACKEND=ATTN_QAT_INFER`
 - Video MoBA Attention: `FASTVIDEO_ATTENTION_BACKEND=VMOBA_ATTN`
 - Sparse Linear Attention: `FASTVIDEO_ATTENTION_BACKEND=SLA_ATTN`
 - SageSLA Attention: `FASTVIDEO_ATTENTION_BACKEND=SAGE_SLA_ATTN`
@@ -121,6 +122,42 @@ gen.generate_video(prompt="A raccoon in sunflowers", save_video=True)
 - `use_fsdp_inference=True` is incompatible with the FP4 path (FSDP shards invalidate tensor pointers)
 - Per-call cosine similarity vs BF16: ~0.99 (slight quantization error accumulates over denoising steps)
 - Only supports `headdim >= 128`
+
+### NVFP4 + Attn-QAT (modified SageAttention3, Blackwell sm_120)
+
+**`ATTN_QAT_INFER`** with **`transformer_quant="NVFP4"`**
+
+Runs the DiT fully in 4-bit: NVFP4 linear layers (activations quantized on the
+fly) plus the modified SageAttention3 FP4 attention backend. This is the
+inference half of the Quantization-Aware Distillation (QAD) recipe and the path
+used for the RTX 5090 release.
+
+The `attn_qat_infer` kernel hard-gates on **sm_120 (consumer Blackwell / RTX
+5090)**; on other GPUs the backend logs a notice and falls back to Flash
+Attention. See the [Attn-QAT paper](https://arxiv.org/abs/2603.00040).
+
+Enable both halves — attention via the env var, linear via `transformer_quant`:
+
+```python
+import os
+os.environ["FASTVIDEO_ATTENTION_BACKEND"] = "ATTN_QAT_INFER"
+
+from fastvideo import VideoGenerator
+gen = VideoGenerator.from_pretrained(
+    "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+    num_gpus=1,
+    transformer_quant="NVFP4",   # or "nvfp4_qat" to match a QAT-distilled checkpoint
+    use_fsdp_inference=False,     # FSDP shards invalidate the FP4 tensor pointers
+)
+gen.generate(request={"prompt": "A raccoon in sunflowers", "output": {"save_video": True}})
+```
+
+Or run the example script:
+
+```bash
+python examples/inference/optimizations/nvfp4_qat_wan2_1_1_3b.py
+python examples/inference/optimizations/nvfp4_qat_wan2_1_1_3b.py --bf16  # baseline
+```
 
 ### Sliding Tile Attention (Archived)
 

--- a/examples/inference/optimizations/nvfp4_qat_wan2_1_1_3b.py
+++ b/examples/inference/optimizations/nvfp4_qat_wan2_1_1_3b.py
@@ -29,9 +29,10 @@ def main():
                         help="BF16 baseline (no NVFP4 linear, default attention)")
     parser.add_argument("--model", default="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
                         help="Model path or HuggingFace ID")
-    parser.add_argument("--quant-method", default="NVFP4", choices=["NVFP4", "nvfp4_qat"],
-                        help="Linear quantization config. Use nvfp4_qat to match a "
-                             "QAT-distilled checkpoint; NVFP4 for plain FP4 inference.")
+    parser.add_argument("--quant-method", default="nvfp4_qat", choices=["nvfp4_qat", "NVFP4"],
+                        help="Linear quantization config. Wan-2.1 uses nvfp4_qat (matches its "
+                             "to_q/k/v/out + ffn layers); NVFP4 is LTX2-specific and will NOT "
+                             "quantize Wan.")
     parser.add_argument("--compile", action="store_true", help="Enable torch.compile for the DiT")
     parser.add_argument("--num_gpus", type=int, default=1)
     parser.add_argument("--infer_steps", type=int, default=50)
@@ -44,13 +45,16 @@ def main():
 
     # Import after the env var so the platform picks up the selection.
     from fastvideo import VideoGenerator
+    from fastvideo.layers.quantization import get_quantization_config
 
     mode = "bf16" if args.bf16 else f"nvfp4_qat_{args.quant_method}"
     if args.compile:
         mode += "_compile"
     print(f"Mode: {mode.upper()}")
 
-    extra = {} if args.bf16 else {"transformer_quant": args.quant_method}
+    # transformer_quant needs a QuantizationConfig *instance* — the bare string
+    # is not resolved on the from_pretrained kwarg path.
+    extra = {} if args.bf16 else {"transformer_quant": get_quantization_config(args.quant_method)()}
     generator = VideoGenerator.from_pretrained(
         args.model,
         num_gpus=args.num_gpus,

--- a/examples/inference/optimizations/nvfp4_qat_wan2_1_1_3b.py
+++ b/examples/inference/optimizations/nvfp4_qat_wan2_1_1_3b.py
@@ -47,7 +47,7 @@ def main():
     from fastvideo import VideoGenerator
     from fastvideo.layers.quantization import get_quantization_config
 
-    mode = "bf16" if args.bf16 else f"nvfp4_qat_{args.quant_method}"
+    mode = "bf16" if args.bf16 else args.quant_method
     if args.compile:
         mode += "_compile"
     print(f"Mode: {mode.upper()}")

--- a/examples/inference/optimizations/nvfp4_qat_wan2_1_1_3b.py
+++ b/examples/inference/optimizations/nvfp4_qat_wan2_1_1_3b.py
@@ -1,0 +1,91 @@
+"""NVFP4 + Attn-QAT (modified SageAttention3) inference on Blackwell.
+
+Runs Wan2.1-T2V-1.3B fully in 4-bit: NVFP4 linear layers (activations
+quantized on the fly) together with the modified SageAttention3 FP4 attention
+backend (``ATTN_QAT_INFER``). This is the inference half of the
+Quantization-Aware Distillation (QAD) recipe.
+
+Requirements:
+    - RTX 5090 / consumer Blackwell (sm_120a). The attn_qat_infer kernel hard
+      gates on sm_120; on other GPUs it falls back to Flash Attention.
+    - The attn_qat_infer kernel built into fastvideo-kernel (see #1455) and
+      flashinfer for the NVFP4 linear matmuls.
+
+Usage:
+    python nvfp4_qat_wan2_1_1_3b.py                 # NVFP4 linear + Attn-QAT attn
+    python nvfp4_qat_wan2_1_1_3b.py --bf16          # BF16 baseline
+"""
+
+import argparse
+import os
+import time
+
+OUTPUT_PATH = "video_samples"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="NVFP4 + Attn-QAT video generation")
+    parser.add_argument("--bf16", action="store_true",
+                        help="BF16 baseline (no NVFP4 linear, default attention)")
+    parser.add_argument("--model", default="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+                        help="Model path or HuggingFace ID")
+    parser.add_argument("--quant-method", default="NVFP4", choices=["NVFP4", "nvfp4_qat"],
+                        help="Linear quantization config. Use nvfp4_qat to match a "
+                             "QAT-distilled checkpoint; NVFP4 for plain FP4 inference.")
+    parser.add_argument("--compile", action="store_true", help="Enable torch.compile for the DiT")
+    parser.add_argument("--num_gpus", type=int, default=1)
+    parser.add_argument("--infer_steps", type=int, default=50)
+    args = parser.parse_args()
+
+    # The attention backend is selected via env var before the engine starts.
+    # ATTN_QAT_INFER -> AttnQatInferBackend (modified SageAttention3 FP4).
+    if not args.bf16:
+        os.environ["FASTVIDEO_ATTENTION_BACKEND"] = "ATTN_QAT_INFER"
+
+    # Import after the env var so the platform picks up the selection.
+    from fastvideo import VideoGenerator
+
+    mode = "bf16" if args.bf16 else f"nvfp4_qat_{args.quant_method}"
+    if args.compile:
+        mode += "_compile"
+    print(f"Mode: {mode.upper()}")
+
+    extra = {} if args.bf16 else {"transformer_quant": args.quant_method}
+    generator = VideoGenerator.from_pretrained(
+        args.model,
+        num_gpus=args.num_gpus,
+        use_fsdp_inference=args.bf16,
+        dit_cpu_offload=False,
+        vae_cpu_offload=True,
+        text_encoder_cpu_offload=True,
+        enable_torch_compile=args.compile,
+        **extra,
+    )
+
+    prompt = (
+        "A curious raccoon peers through a vibrant field of yellow sunflowers, its eyes "
+        "wide with interest. The playful yet serene atmosphere is complemented by soft "
+        "natural light filtering through the petals. Mid-shot, warm and cheerful tones."
+    )
+
+    n_warmup = 2 if args.compile else 1
+    for _ in range(n_warmup):
+        generator.generate(request={"prompt": prompt, "sampling": {"num_inference_steps": 2},
+                                    "output": {"save_video": False}})
+
+    os.makedirs(OUTPUT_PATH, exist_ok=True)
+    start = time.time()
+    generator.generate(request={
+        "prompt": prompt,
+        "sampling": {"num_inference_steps": args.infer_steps},
+        "output": {"save_video": True, "output_path": os.path.join(OUTPUT_PATH, f"raccoon_{mode}.mp4")},
+    })
+    elapsed = time.time() - start
+    print(f"[{mode.upper()}] {args.infer_steps} steps in {elapsed:.2f}s "
+          f"({args.infer_steps / elapsed:.2f} it/s)")
+
+    generator.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

Continues the Attn-QAT upstreaming stack (#1225). Adds a runnable example and
how-to for the **inference half of the QAD recipe**: NVFP4 linear layers plus
the modified SageAttention3 FP4 attention backend (`ATTN_QAT_INFER`, wired in by
#1457). This is the RTX 5090 inference path from the release.

## Changes

- `examples/inference/optimizations/nvfp4_qat_wan2_1_1_3b.py`: Wan2.1-T2V-1.3B
  4-bit inference — `transformer_quant="NVFP4"` for the linear layers and
  `FASTVIDEO_ATTENTION_BACKEND=ATTN_QAT_INFER` for attention. Includes a
  `--bf16` baseline and a `--quant-method nvfp4_qat` option to match a
  QAT-distilled checkpoint.
- `docs/inference/optimizations.md`: list the `ATTN_QAT_INFER` backend and add a
  "NVFP4 + Attn-QAT" section.

## Test Plan / Test Results

- ✅ Example parses (`py_compile`); pre-commit (codespell / PyMarkdown) passes.
- ✅ API surface validated: `transformer_quant="NVFP4"` resolves to a
  `quant_config` on `dit_config` (`_apply_transformer_quant`), and
  `ATTN_QAT_INFER` is a selectable backend (per #1457) that falls back to Flash
  when the kernel is absent.
- ⏳ **Draft** — a full end-to-end generation has **not** been run: the
  `attn_qat_infer` kernel is sm_120-only (RTX 5090) and this PR also depends on
  the still-unmerged #1455 (kernel). Needs a run on a 5090 to confirm output
  quality / timings before marking ready.

### Open question
- `AttnQatInferImpl.forward` passes `sm_scale=` but the kernel signature does not
  accept it, so softmax scale falls back to the kernel default. For Wan
  (`scale = d**-0.5`) this is likely a no-op, but should be confirmed on a 5090;
  a fix would belong in the kernel (#1455).

Depends on #1455 and #1457. Part of #1225.
