### PR TITLE
[kernel] QAD 5090: Add Attn-QAT training Triton kernels (11/12)

### DIFF
--- a/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/attn_qat_train.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/attn_qat_train.py
@@ -1,0 +1,1119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from https://github.com/triton-lang/triton/blob/main/python/tutorials/06-fused-attention.py
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+from .quant_utils import fake_quantize_q, fake_quantize_kv, fake_quantize
+# from attn_qat_infer.api import triton_group_mean
+
+
+def is_cuda():
+    return triton.runtime.driver.active.get_current_target().backend == "cuda"
+
+
+def supports_host_descriptor():
+    return is_cuda() and torch.cuda.get_device_capability()[0] >= 9
+
+
+def is_blackwell():
+    return is_cuda() and torch.cuda.get_device_capability()[0] == 10
+
+
+def is_hopper():
+    return is_cuda() and torch.cuda.get_device_capability()[0] == 9
+
+
+@triton.jit
+def _mul_alpha(acc, alpha, BM: tl.constexpr, BN: tl.constexpr):
+    acc0, acc1 = acc.reshape([BM, 2, BN // 2]).permute(0, 2, 1).split()
+    acc0 = acc0 * alpha[:, None]
+    acc1 = acc1 * alpha[:, None]
+    acc = tl.join(acc0, acc1).permute(0, 2, 1).reshape([BM, BN])
+    return acc
+
+
+@triton.jit
+def _attn_fwd_inner(acc, high_prec_acc, l_i, m_i, q, q_valid,
+                    desc_k, desc_v,
+                    offset_y, dtype: tl.constexpr, start_m, qk_scale,
+                    BLOCK_M: tl.constexpr, HEAD_DIM: tl.constexpr, BLOCK_N: tl.constexpr,
+                    STAGE: tl.constexpr, offs_m: tl.constexpr, offs_n: tl.constexpr,
+                    N_CTX: tl.constexpr, warp_specialize: tl.constexpr, IS_HOPPER: tl.constexpr,
+                    IS_QAT: tl.constexpr,
+                    fake_quant_P: tl.constexpr = True,
+                    two_level_quant_P: tl.constexpr = False,
+                    use_global_sf_P: tl.constexpr = True):
+    # range of values handled by this stage (kv blocks)
+    if STAGE == 1:
+        lo, hi = 0, start_m * BLOCK_M
+    elif STAGE == 2:
+        lo, hi = start_m * BLOCK_M, (start_m + 1) * BLOCK_M
+        lo = tl.multiple_of(lo, BLOCK_M)
+    # causal = False
+    else:
+        lo, hi = 0, N_CTX
+    offsetk_y = offset_y + lo  # offset from the start of the current batch-head combination
+    if dtype == tl.float8e5:
+        offsetv_y = offset_y * HEAD_DIM + lo
+    else:
+        offsetv_y = offset_y + lo
+    # loop over k, v and update accumulator
+    for start_n in tl.range(lo, hi, BLOCK_N, warp_specialize=warp_specialize):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+        kv_valid = (start_n + offs_n) < N_CTX
+        # -- compute qk ----
+        k = desc_k.load([offsetk_y, 0])
+        k = tl.where(kv_valid[:, None], k, 0.0)
+        qk = tl.dot(q, tl.trans(k))
+        if STAGE == 2:
+            mask = offs_m[:, None] >= (start_n + offs_n[None, :])
+            qk = qk * qk_scale + tl.where(mask & kv_valid[None, :], 0, -1.0e6)
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            qk -= m_ij[:, None]
+        else:
+            qk = tl.where(kv_valid[None, :], qk, -1.0e6)
+            m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+            qk = qk * qk_scale - m_ij[:, None]
+        p = tl.math.exp2(qk)
+        if IS_QAT:  
+            p, high_prec_p = fake_quantize(
+                src_tensor=p,
+                valid_src_mask=tl.full(shape=p.shape, value=1.0, dtype=p.dtype) == 1.0,
+                BLOCK_SIZE_OUT_DIM=BLOCK_M,
+                BLOCK_SIZE_QUANT_DIM=BLOCK_N,
+                dst_dtype=dtype,
+                two_level_quant_P=two_level_quant_P,
+                use_global_sf=use_global_sf_P
+            )
+            l_ij = tl.sum(high_prec_p, 1)
+        else:
+            l_ij = tl.sum(p, 1)
+        # -- compute correction factor
+        alpha = tl.math.exp2(m_i - m_ij)
+        # -- update output accumulator --
+        if not IS_HOPPER and warp_specialize and BLOCK_M == 128 and HEAD_DIM == 128:
+            BM: tl.constexpr = acc.shape[0]
+            BN: tl.constexpr = acc.shape[1]
+            acc = _mul_alpha(acc, alpha, BM, BN)
+            if IS_QAT:
+                high_prec_acc = _mul_alpha(high_prec_acc, alpha, BM, BN)
+        else:
+            acc = acc * alpha[:, None]
+            if IS_QAT:
+                high_prec_acc = high_prec_acc * alpha[:, None]
+        # prepare p and v for the dot
+        if dtype == tl.float8e5:
+            v = desc_v.load([0, offsetv_y]).T
+        else:
+            v = desc_v.load([offsetv_y, 0])
+            v = tl.where(kv_valid[:, None], v, 0.0)
+        p = p.to(dtype)
+        # note that this non transposed v for FP8 is only supported on Blackwell
+        acc = tl.dot(p, v.to(dtype), acc)
+        if IS_QAT:
+            high_prec_acc = tl.dot(high_prec_p, v, high_prec_acc)
+        # update m_i and l_i
+        # place this at the end of the loop to reduce register pressure
+        l_i = l_i * alpha + l_ij
+        m_i = m_ij
+        offsetk_y += BLOCK_N
+        offsetv_y += BLOCK_N
+    if IS_QAT:
+        return acc, high_prec_acc, l_i, m_i
+    else:
+        return acc, acc, l_i, m_i
+
+
+def _host_descriptor_pre_hook(nargs):
+    BLOCK_M = nargs["BLOCK_M"]
+    BLOCK_N = nargs["BLOCK_N"]
+    HEAD_DIM = nargs["HEAD_DIM"]
+    if not isinstance(nargs["desc_q"], TensorDescriptor):
+        return
+    nargs["desc_q"].block_shape = [BLOCK_M, HEAD_DIM]
+    if nargs["FP8_OUTPUT"]:
+        nargs["desc_v"].block_shape = [HEAD_DIM, BLOCK_N]
+    else:
+        nargs["desc_v"].block_shape = [BLOCK_N, HEAD_DIM]
+    nargs["desc_k"].block_shape = [BLOCK_N, HEAD_DIM]
+    nargs["desc_o"].block_shape = [1, BLOCK_M, HEAD_DIM]
+    if "desc_high_prec_o" in nargs and isinstance(nargs["desc_high_prec_o"], TensorDescriptor):
+        nargs["desc_high_prec_o"].block_shape = [1, BLOCK_M, HEAD_DIM]
+
+
+NUM_STAGES_OPTIONS = [2, 3, 4]
+
+configs = [
+    triton.Config({'BLOCK_M': BM, 'BLOCK_N': BN}, num_stages=s, num_warps=w, pre_hook=_host_descriptor_pre_hook)
+    for BM in [64, 128]
+    for BN in [32, 64, 128]
+    for s in NUM_STAGES_OPTIONS
+    for w in [4, 8]
+]
+if "PYTEST_VERSION" in os.environ:
+    # Use a single config in testing for reproducibility
+    configs = [
+        triton.Config(dict(BLOCK_M=128, BLOCK_N=64), num_stages=2, num_warps=4, pre_hook=_host_descriptor_pre_hook),
+    ]
+
+
+def keep(conf):
+    BLOCK_M = conf.kwargs["BLOCK_M"]
+    BLOCK_N = conf.kwargs["BLOCK_N"]
+    return not (is_cuda() and torch.cuda.get_device_capability()[0] == 9 and BLOCK_M * BLOCK_N < 128 * 128
+                and conf.num_warps == 8)
+
+
+def prune_invalid_configs(configs, named_args, **kwargs):
+    N_CTX_Q = kwargs["N_CTX_Q"]
+    N_CTX_KV = kwargs["N_CTX_KV"]
+    return [
+        conf for conf in configs
+        if conf.kwargs.get("BLOCK_M", 0) <= N_CTX_Q
+        and conf.kwargs.get("BLOCK_N", 0) <= N_CTX_KV
+        and conf.kwargs.get("BLOCK_N", 0) % conf.kwargs.get("BLOCK_M", 0) == 0
+    ]
+
+
+@triton.jit
+def _maybe_make_tensor_desc(desc_or_ptr, shape, strides, block_shape):
+    if isinstance(desc_or_ptr, tl.tensor_descriptor):
+        return desc_or_ptr
+    else:
+        return tl.make_tensor_descriptor(desc_or_ptr, shape, strides, block_shape)
+
+
+# @triton.autotune(configs=list(filter(keep, configs)), key=["N_CTX_Q", "N_CTX_KV", "HEAD_DIM", "FP8_OUTPUT", "warp_specialize"],
+#                  prune_configs_by={'early_config_prune': prune_invalid_configs}, cache_results=True)
+@triton.jit
+def _attn_fwd(sm_scale, M,
+              Z, H, desc_q, desc_k, desc_v, desc_o, desc_high_prec_o, N_CTX_Q, N_CTX_KV,
+              HEAD_DIM: tl.constexpr,
+              BLOCK_M: tl.constexpr,
+              BLOCK_N: tl.constexpr,
+              FP8_OUTPUT: tl.constexpr,
+              STAGE: tl.constexpr,
+              warp_specialize: tl.constexpr,
+              IS_HOPPER: tl.constexpr,
+              IS_QAT: tl.constexpr,
+              fake_quant_P: tl.constexpr = True,
+              two_level_quant_P: tl.constexpr = False,
+              use_global_sf_P: tl.constexpr = True,
+              ):
+    dtype = tl.float8e5 if FP8_OUTPUT else tl.bfloat16
+    tl.static_assert(BLOCK_N <= HEAD_DIM)
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H  # since it's Z then H in the shape
+    off_h = off_hz % H
+
+    y_dim_q = Z * H * N_CTX_Q
+    y_dim_kv = Z * H * N_CTX_KV
+    desc_q = _maybe_make_tensor_desc(desc_q, shape=[y_dim_q, HEAD_DIM], strides=[HEAD_DIM, 1],
+                                     block_shape=[BLOCK_M, HEAD_DIM])
+    if FP8_OUTPUT:
+        desc_v = _maybe_make_tensor_desc(desc_v, shape=[HEAD_DIM, y_dim_kv], strides=[N_CTX_KV, 1],
+                                         block_shape=[HEAD_DIM, BLOCK_N])
+    else:
+        desc_v = _maybe_make_tensor_desc(desc_v, shape=[y_dim_kv, HEAD_DIM], strides=[HEAD_DIM, 1],
+                                         block_shape=[BLOCK_N, HEAD_DIM])
+    desc_k = _maybe_make_tensor_desc(desc_k, shape=[y_dim_kv, HEAD_DIM], strides=[HEAD_DIM, 1],
+                                     block_shape=[BLOCK_N, HEAD_DIM])
+    desc_o = _maybe_make_tensor_desc(
+        desc_o, shape=[Z * H, N_CTX_Q, HEAD_DIM],
+        strides=[N_CTX_Q * HEAD_DIM, HEAD_DIM, 1],
+        block_shape=[1, BLOCK_M, HEAD_DIM]
+    )
+    if IS_QAT:
+        desc_high_prec_o = _maybe_make_tensor_desc(
+            desc_high_prec_o, shape=[Z * H, N_CTX_Q, HEAD_DIM],
+            strides=[N_CTX_Q * HEAD_DIM, HEAD_DIM, 1],
+            block_shape=[1, BLOCK_M, HEAD_DIM]
+        )
+
+    offset_y_q = off_z * (N_CTX_Q * H) + off_h * N_CTX_Q  # offset for query tensor
+    offset_y_kv = off_z * (N_CTX_KV * H) + off_h * N_CTX_KV  # offset for key/value tensors
+    qo_offset_y = offset_y_q + start_m * BLOCK_M
+    # initialize offsets
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)  # for kv blocks
+    q_valid = offs_m < N_CTX_Q
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+    if IS_QAT:
+        high_prec_acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+    else:
+        # dummy value
+        high_prec_acc = acc
+    # load scales
+    qk_scale = sm_scale
+    qk_scale *= 1.44269504  # 1/log(2)
+    # load q: it will stay in SRAM throughout
+    q = desc_q.load([qo_offset_y, 0])  # load from start of q block and start of the entire head dimension
+    q = tl.where(q_valid[:, None], q, 0.0)
+    # stage 1: off-band
+    # For causal = True, STAGE = 3 and _attn_fwd_inner gets 1 as its STAGE
+    # For causal = False, STAGE = 1, and _attn_fwd_inner gets 3 as its STAGE
+    if STAGE & 1:
+        acc, high_prec_acc, l_i, m_i = _attn_fwd_inner(
+            acc, high_prec_acc, l_i, m_i, q, q_valid,
+            desc_k, desc_v,
+            offset_y_kv, dtype, start_m, qk_scale,
+            BLOCK_M, HEAD_DIM, BLOCK_N,
+            4 - STAGE, offs_m, offs_n, N_CTX_KV,
+            warp_specialize, IS_HOPPER, IS_QAT, fake_quant_P, two_level_quant_P, use_global_sf_P
+        )
+    # stage 2: on-band
+    if STAGE & 2:
+        acc, high_prec_acc, l_i, m_i = _attn_fwd_inner(
+            acc, high_prec_acc, l_i, m_i, q, q_valid,
+            desc_k, desc_v,
+            offset_y_kv, dtype, start_m, qk_scale,
+            BLOCK_M, HEAD_DIM, BLOCK_N,
+            2, offs_m, offs_n, N_CTX_KV,
+            warp_specialize, IS_HOPPER, IS_QAT, fake_quant_P, two_level_quant_P, use_global_sf_P
+        )
+    # epilogue
+    m_i += tl.math.log2(l_i)
+    acc = acc / l_i[:, None]
+    if IS_QAT:
+        high_prec_acc = high_prec_acc / l_i[:, None]
+    m_ptrs = M + off_hz * N_CTX_Q + offs_m
+    tl.store(m_ptrs, m_i, mask=q_valid)
+    desc_o.store([off_hz, start_m * BLOCK_M, 0], acc[None, :, :])
+    if IS_QAT:
+        desc_high_prec_o.store([off_hz, start_m * BLOCK_M, 0], high_prec_acc[None, :, :])
+
+
+@triton.jit
+def _attn_bwd_preprocess(O, DO,
+                         Delta,
+                         Z, H, N_CTX,
+                         BLOCK_M: tl.constexpr, HEAD_DIM: tl.constexpr
+                         ):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_hz = tl.program_id(1)
+    off_n = tl.arange(0, HEAD_DIM)
+    valid = off_m < N_CTX
+    # load
+    o = tl.load(O + off_hz * HEAD_DIM * N_CTX + off_m[:, None] * HEAD_DIM + off_n[None, :], mask=valid[:, None])
+    do = tl.load(DO + off_hz * HEAD_DIM * N_CTX + off_m[:, None] * HEAD_DIM + off_n[None, :], mask=valid[:, None]).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(Delta + off_hz * N_CTX + off_m, delta, mask=valid)
+
+
+# The main inner-loop logic for computing dK and dV.
+@triton.jit
+def _attn_bwd_dkdv(dk, dv,
+                   Q, k, v, qk_scale,
+                   DO,
+                   M, D, Q_MEAN,
+                   # shared by Q/K/V/DO.
+                   stride_tok, stride_d,
+                   H, N_CTX, BLOCK_M1: tl.constexpr,
+                   BLOCK_N1: tl.constexpr,
+                   HEAD_DIM: tl.constexpr,
+                   # Filled in by the wrapper.
+                   start_n, start_m, num_steps,
+                   MASK: tl.constexpr,
+                   IS_QAT: tl.constexpr,
+                   two_level_quant_P: tl.constexpr = False,
+                   fake_quant_P: tl.constexpr = True,
+                   SMOOTH_Q: tl.constexpr = False,
+                   use_global_sf_P: tl.constexpr = True,
+                   warp_specialize: tl.constexpr = False):
+    offs_m = start_m + tl.arange(0, BLOCK_M1)
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+    offs_k = tl.arange(0, HEAD_DIM)
+    q_ptrs = Q + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+    do_ptrs = DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+    if SMOOTH_Q:
+        q_m_ptrs = Q_MEAN + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+    # BLOCK_N1 must be a multiple of BLOCK_M1, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
+    curr_m = start_m
+    step_m = BLOCK_M1
+    for blk_idx in range(num_steps):
+        offs_m = curr_m + tl.arange(0, BLOCK_M1)
+        q_valid = offs_m < N_CTX
+        q = tl.load(q_ptrs, mask=q_valid[:, None])
+        if SMOOTH_Q:
+            q_m = tl.load(q_m_ptrs, mask=q_valid[:, None])
+        # Load m before computing qk to reduce pipeline stall.
+        m = tl.load(M + offs_m, mask=q_valid)
+        qk = tl.dot(q, tl.trans(k))
+        qk = qk * qk_scale
+        # Autoregressive masking - apply BEFORE exp2 to match forward pass behavior
+        if MASK:
+            mask = (offs_m[:, None] >= offs_n[None, :])
+            qk = tl.where(mask, qk, -1.0e6)
+        p = tl.math.exp2(qk - m[:, None])
+        do = tl.load(do_ptrs, mask=q_valid[:, None])
+        # Compute dV.
+        p_quant = p
+        if IS_QAT and fake_quant_P:
+            p_quant, _ = fake_quantize(
+                src_tensor=p,
+                valid_src_mask=tl.full(shape=p.shape, value=1.0, dtype=p.dtype) == 1.0,
+                BLOCK_SIZE_OUT_DIM=BLOCK_M1,
+                BLOCK_SIZE_QUANT_DIM=BLOCK_N1,
+                dst_dtype=p.dtype,
+                two_level_quant_P=two_level_quant_P,
+                use_global_sf=use_global_sf_P
+            )
+        dv += tl.dot(tl.trans(p_quant.to(tl.bfloat16)), do)
+        # D (= delta) is pre-divided by ds_scale.
+        Di = tl.load(D + offs_m, mask=q_valid)
+        # Compute dP and dS.
+        dp = tl.dot(do, tl.trans(v))
+        ds = p * (dp - Di[:, None])
+        ds = ds.to(tl.bfloat16)
+        dk += tl.dot(tl.trans(ds), q)
+        if SMOOTH_Q:
+            dk += tl.sum(ds, axis=1, keep_dims=True) * q_m
+        # Increment pointers.
+        curr_m += step_m
+        q_ptrs += step_m * stride_tok
+        do_ptrs += step_m * stride_tok
+        if SMOOTH_Q:
+            q_m_ptrs += step_m * stride_tok
+    return dk, dv
+
+
+# The main inner-loop logic for computing dQ
+@triton.jit
+def _attn_bwd_dq(dq, q, K, V,
+                 do, m, D, qk_scale,
+                 # shared by Q/K/V/DO.
+                 stride_tok, stride_d,
+                 H, N_CTX,
+                 K_MEAN,
+                 BLOCK_M2: tl.constexpr,
+                 BLOCK_N2: tl.constexpr,
+                 HEAD_DIM: tl.constexpr,
+                 # Filled in by the wrapper.
+                 start_m, start_n, num_steps,
+                 MASK: tl.constexpr,
+                 SMOOTH_K: tl.constexpr,
+                 warp_specialize: tl.constexpr = False):
+    offs_m = start_m + tl.arange(0, BLOCK_M2)
+    offs_n = start_n + tl.arange(0, BLOCK_N2)
+    offs_k = tl.arange(0, HEAD_DIM)
+    k_ptrs = K + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+    v_ptrs = V + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+    q_valid = offs_m < N_CTX
+    # D (= delta) is pre-divided by ds_scale.
+    Di = tl.load(D + offs_m, mask=q_valid)
+    # BLOCK_M2 must be a multiple of BLOCK_N2, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_M2 % BLOCK_N2 == 0)
+    curr_n = start_n
+    step_n = BLOCK_N2
+
+    if SMOOTH_K:
+        k_m = tl.load(K_MEAN + offs_k)
+
+    for blk_idx in range(num_steps):
+        # bounds checking for kv block (dynamic)
+        offs_n = curr_n + tl.arange(0, BLOCK_N2)
+        kv_valid = offs_n < N_CTX
+        k = tl.load(k_ptrs, mask=kv_valid[:, None])
+        v = tl.load(v_ptrs, mask=kv_valid[:, None])
+
+        qk = tl.dot(q, tl.trans(k))
+        qk = qk * qk_scale
+        # Autoregressive masking - apply BEFORE exp2 to match forward pass behavior
+        if MASK:
+            mask = (offs_m[:, None] >= offs_n[None, :])
+            qk = tl.where(mask, qk, -1.0e6)
+        p = tl.math.exp2(qk - m)
+        # Compute dP and dS.
+        dp = tl.dot(do, tl.trans(v))
+        ds = p * (dp - Di[:, None])
+        # Compute dQ.
+        # NOTE: We need to de-scale dq in the end, because k was pre-scaled.
+        dq += tl.dot(ds.to(tl.bfloat16), k)
+
+        if SMOOTH_K:
+            dq += tl.sum(ds, axis=1, keep_dims=True) * k_m[None, :]
+        # Increment pointers.
+        curr_n += step_n
+        k_ptrs += step_n * stride_tok
+        v_ptrs += step_n * stride_tok
+    return dq
+
+
+@triton.jit
+def _compute_cross_attn_pointer_offsets(bhid, H, N_CTX_Q, stride_z_q, stride_z_kv, stride_h_q, stride_h_kv):
+    """Helper function to compute pointer offsets for cross-attention backward kernels."""
+    off_chz = (bhid * N_CTX_Q).to(tl.int64)
+    adj_q = (stride_h_q * (bhid % H) + stride_z_q * (bhid // H))
+    adj_kv = (stride_h_kv * (bhid % H) + stride_z_kv * (bhid // H))
+    return off_chz, adj_q, adj_kv
+
+
+@triton.jit
+def _attn_bwd_dq_cross(Q, K, V, sm_scale,
+                       DO, DQ,
+                       M, D,
+                       stride_z_q, stride_z_kv, stride_h_q,
+                       stride_h_kv, stride_tok_q, stride_tok_kv, stride_d_q, stride_d_kv,
+                       H, N_CTX_Q, N_CTX_KV,
+                       K_MEAN,
+                       BLOCK_M2: tl.constexpr,
+                       BLOCK_N2: tl.constexpr,
+                       HEAD_DIM: tl.constexpr,
+                       SMOOTH_K: tl.constexpr,
+                       warp_specialize: tl.constexpr = False):
+    # Apply scale AFTER dot product for better precision
+    RCP_LN2: tl.constexpr = 1.4426950408889634  # = 1.0 / ln(2)
+    qk_scale = sm_scale * RCP_LN2
+
+    bhid = tl.program_id(2)
+    off_chz, adj_q, adj_kv = _compute_cross_attn_pointer_offsets(bhid, H, N_CTX_Q, stride_z_q, stride_z_kv, stride_h_q, stride_h_kv)
+
+    Q += adj_q
+    K += adj_kv
+    V += adj_kv
+    DO += adj_q
+    DQ += adj_q
+    M += off_chz
+    D += off_chz
+
+    pid = tl.program_id(0)
+    start_m = pid * BLOCK_M2
+    offs_m = start_m + tl.arange(0, BLOCK_M2)
+    offs_k = tl.arange(0, HEAD_DIM)
+
+    q_valid = offs_m < N_CTX_Q
+    q = tl.load(Q + offs_m[:, None] * stride_tok_q + offs_k[None, :] * stride_d_q, mask=q_valid[:, None])
+    dq = tl.zeros([BLOCK_M2, HEAD_DIM], dtype=tl.float32)
+    do = tl.load(DO + offs_m[:, None] * stride_tok_q + offs_k[None, :] * stride_d_q, mask=q_valid[:, None])
+    m = tl.load(M + offs_m, mask=q_valid)[:, None]
+
+    Di = tl.load(D + offs_m, mask=q_valid)
+    num_steps = (N_CTX_KV + BLOCK_N2 - 1) // BLOCK_N2
+    if SMOOTH_K:
+        k_m = tl.load(K_MEAN + offs_k)
+    for step in range(num_steps):
+        start_n = step * BLOCK_N2
+        offs_n = start_n + tl.arange(0, BLOCK_N2)
+        kv_valid = offs_n < N_CTX_KV
+
+        k = tl.load(K + offs_n[:, None] * stride_tok_kv + offs_k[None, :] * stride_d_kv, mask=kv_valid[:, None])
+        v = tl.load(V + offs_n[:, None] * stride_tok_kv + offs_k[None, :] * stride_d_kv, mask=kv_valid[:, None])
+
+        qk = tl.dot(q, tl.trans(k))
+        qk = qk * qk_scale
+        p = tl.math.exp2(qk - m)
+
+        dp = tl.dot(do, tl.trans(v))
+        ds = p * (dp - Di[:, None])
+        ds = ds.to(tl.bfloat16)
+        dq += tl.dot(ds, k)
+
+        if SMOOTH_K:
+            dq += tl.sum(ds, axis=1, keep_dims=True) * k_m[None, :]
+
+    # NOTE: dq is scaled by sm_scale since K is not pre-scaled
+    dq *= sm_scale
+    dq_ptrs = DQ + offs_m[:, None] * stride_tok_q + offs_k[None, :] * stride_d_q
+    tl.store(dq_ptrs, dq, mask=q_valid[:, None])
+
+
+@triton.jit
+def _attn_bwd_dkdv_cross(Q, K, V, sm_scale,
+                         DO, DK, DV,
+                         M, D, Q_MEAN,
+                         stride_z_q, stride_z_kv, stride_h_q, stride_h_kv, 
+                         stride_tok_q, stride_tok_kv, stride_d_q, stride_d_kv,
+                         H, N_CTX_Q, N_CTX_KV,
+                         BLOCK_M1: tl.constexpr,
+                         BLOCK_N1: tl.constexpr,
+                         HEAD_DIM: tl.constexpr,
+                         IS_QAT: tl.constexpr,
+                         two_level_quant_P: tl.constexpr = False,
+                         fake_quant_P: tl.constexpr = True,
+                         SMOOTH_Q: tl.constexpr = False,
+                         use_global_sf_P: tl.constexpr = True,
+                         warp_specialize: tl.constexpr = False
+                         ):
+    # Apply scale AFTER dot product for better precision
+    RCP_LN2: tl.constexpr = 1.4426950408889634  # = 1.0 / ln(2)
+    qk_scale = sm_scale * RCP_LN2
+
+    bhid = tl.program_id(2)
+    off_chz, adj_q, adj_kv = _compute_cross_attn_pointer_offsets(bhid, H, N_CTX_Q, stride_z_q, stride_z_kv, stride_h_q, stride_h_kv)
+
+    Q += adj_q
+    K += adj_kv
+    V += adj_kv
+    DO += adj_q
+    DK += adj_kv
+    DV += adj_kv
+    M += off_chz
+    D += off_chz
+
+    if SMOOTH_Q:
+        Q_MEAN += adj_q
+
+    pid = tl.program_id(0)
+    start_n = pid * BLOCK_N1
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+    offs_k = tl.arange(0, HEAD_DIM)
+
+    dk = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
+    dv = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
+
+    kv_valid = offs_n < N_CTX_KV
+    k_block = tl.load(K + offs_n[:, None] * stride_tok_kv + offs_k[None, :] * stride_d_kv, mask=kv_valid[:, None])
+    v_block = tl.load(V + offs_n[:, None] * stride_tok_kv + offs_k[None, :] * stride_d_kv, mask=kv_valid[:, None])
+
+    num_q_steps = (N_CTX_Q + BLOCK_M1 - 1) // BLOCK_M1
+    for step in range(num_q_steps):
+        start_m = step * BLOCK_M1
+        offs_m = start_m + tl.arange(0, BLOCK_M1)
+        q_valid = offs_m < N_CTX_Q
+
+        q = tl.load(Q + offs_m[:, None] * stride_tok_q + offs_k[None, :] * stride_d_q, mask=q_valid[:, None])
+        do = tl.load(DO + offs_m[:, None] * stride_tok_q + offs_k[None, :] * stride_d_q, mask=q_valid[:, None])
+        m = tl.load(M + offs_m, mask=q_valid)
+
+        qk = tl.dot(q, tl.trans(k_block))
+        # Apply scale AFTER dot product (matches forward pass, better precision)
+        qk = qk * qk_scale
+        p = tl.math.exp2(qk - m[:, None])
+        p_quant = p
+        if IS_QAT and fake_quant_P:
+            p_quant, _ = fake_quantize(
+                src_tensor=p,
+                valid_src_mask=tl.full(shape=p.shape, value=1.0, dtype=p.dtype) == 1.0,
+                BLOCK_SIZE_OUT_DIM=BLOCK_M1,
+                BLOCK_SIZE_QUANT_DIM=BLOCK_N1,
+                dst_dtype=p.dtype,
+                two_level_quant_P=two_level_quant_P,
+                use_global_sf=use_global_sf_P
+            )
+        dv += tl.dot(tl.trans(p_quant.to(tl.bfloat16)), do)
+
+        dp = tl.dot(do, tl.trans(v_block))
+        Di = tl.load(D + offs_m, mask=q_valid)
+        ds = p * (dp - Di[:, None])
+        ds = ds.to(tl.bfloat16)
+        dk += tl.dot(tl.trans(ds), q)
+
+        if SMOOTH_Q:
+            q_m = tl.load(Q_MEAN + offs_m[:, None] * stride_tok_q + offs_k[None, :] * stride_d_q, mask=q_valid[:, None])
+            dk += tl.sum(ds, axis=1, keep_dims=True) * q_m
+
+    dv_ptrs = DV + offs_n[:, None] * stride_tok_kv + offs_k[None, :] * stride_d_kv
+    tl.store(dv_ptrs, dv, mask=kv_valid[:, None])
+
+    dk *= sm_scale
+    dk_ptrs = DK + offs_n[:, None] * stride_tok_kv + offs_k[None, :] * stride_d_kv
+    tl.store(dk_ptrs, dk, mask=kv_valid[:, None])
+
+
+@triton.jit
+def _attn_bwd(Q, K, V, sm_scale,
+              DO,
+              DQ, DK, DV,
+              M, D, Q_MEAN,
+              # shared by Q/K/V/DO.
+              stride_z, stride_h, stride_tok, stride_d,
+              H, N_CTX,
+              K_MEAN,
+              BLOCK_M1: tl.constexpr,
+              BLOCK_N1: tl.constexpr,
+              BLOCK_M2: tl.constexpr,
+              BLOCK_N2: tl.constexpr,
+              BLK_SLICE_FACTOR: tl.constexpr,
+              HEAD_DIM: tl.constexpr,
+              CAUSAL: tl.constexpr,
+              IS_QAT: tl.constexpr,
+              SMOOTH_K: tl.constexpr,
+              two_level_quant_P: tl.constexpr = False,
+              fake_quant_P: tl.constexpr = True,
+              SMOOTH_Q: tl.constexpr = False,
+              use_global_sf_P: tl.constexpr = True,
+              warp_specialize: tl.constexpr = False):
+
+    bhid = tl.program_id(2)
+    off_chz = (bhid * N_CTX).to(tl.int64)
+    adj = (stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)
+    pid = tl.program_id(0)
+
+    # offset pointers for batch/head
+    Q += adj
+    K += adj
+    V += adj
+    DO += adj
+    DQ += adj
+    DK += adj
+    DV += adj
+    M += off_chz
+    D += off_chz
+
+    if SMOOTH_Q:
+        Q_MEAN += adj
+
+    # load scales
+    offs_k = tl.arange(0, HEAD_DIM)
+
+    start_n = pid * BLOCK_N1
+    start_m = start_n
+
+    MASK_BLOCK_M1: tl.constexpr = BLOCK_M1 // BLK_SLICE_FACTOR
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+    kv_valid = offs_n < N_CTX
+
+    dv = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
+    dk = tl.zeros([BLOCK_N1, HEAD_DIM], dtype=tl.float32)
+
+    # load K and V: they stay in SRAM throughout the inner loop.
+    k = tl.load(K + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d, mask=kv_valid[:, None])
+    v = tl.load(V + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d, mask=kv_valid[:, None])
+
+    # qk_scale is expressed in base-2 domain because we use exp2/log2.
+    # Two equivalent ways to form qk_scale:
+    # - **Post-scale (default)**: qk = dot(q, k^T) * (sm_scale / ln2)
+    # - **Pre-scale (Flash-aligned)**: k is pre-multiplied by (sm_scale / ln2) and qk_scale = 1
+    RCP_LN2: tl.constexpr = 1.4426950408889634  # = 1.0 / ln(2)
+    qk_scale = sm_scale * RCP_LN2
+
+    # For causal attention, process diagonal block with masking, then rest without
+    # For non-causal attention, process all blocks without masking
+    if CAUSAL:
+        num_steps = BLOCK_N1 // MASK_BLOCK_M1
+
+        dk, dv = _attn_bwd_dkdv(
+            dk, dv,
+            Q, k, v, qk_scale,
+            DO,
+            M, D, Q_MEAN,
+            stride_tok, stride_d,
+            H, N_CTX,
+            MASK_BLOCK_M1, BLOCK_N1, HEAD_DIM,
+            start_n, start_m, num_steps,
+            MASK=True,
+            IS_QAT=IS_QAT,
+            two_level_quant_P=two_level_quant_P,
+            fake_quant_P=fake_quant_P,
+            SMOOTH_Q=SMOOTH_Q,
+            use_global_sf_P=use_global_sf_P,
+            warp_specialize=warp_specialize
+        )
+
+        start_m += num_steps * MASK_BLOCK_M1
+        num_steps = (N_CTX - start_m + BLOCK_M1 - 1) // BLOCK_M1
+    else:
+        # For non-causal, start from 0 and process all Q blocks
+        start_m = 0
+        num_steps = (N_CTX + BLOCK_M1 - 1) // BLOCK_M1
+
+    # Compute dK and dV for non-masked blocks.
+    dk, dv = _attn_bwd_dkdv(
+        dk, dv,
+        Q, k, v, qk_scale,
+        DO,
+        M, D, Q_MEAN,
+        stride_tok, stride_d,
+        H, N_CTX,
+        BLOCK_M1, BLOCK_N1, HEAD_DIM,
+        start_n, start_m, num_steps,
+        MASK=False,
+        IS_QAT=IS_QAT,
+        two_level_quant_P=two_level_quant_P,
+        fake_quant_P=fake_quant_P,
+        SMOOTH_Q=SMOOTH_Q,
+        use_global_sf_P=use_global_sf_P,
+        warp_specialize=warp_specialize
+    )
+
+    dv_ptrs = DV + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+    tl.store(dv_ptrs, dv, mask=kv_valid[:, None])
+
+    # Write back dK.
+    dk *= sm_scale
+    dk_ptrs = DK + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+    tl.store(dk_ptrs, dk, mask=kv_valid[:, None])
+
+    # THIS BLOCK DOES DQ:
+    start_m = pid * BLOCK_M2
+    end_n = start_m + BLOCK_M2
+
+    MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
+    offs_m = start_m + tl.arange(0, BLOCK_M2)
+    q_valid = offs_m < N_CTX
+
+    q = tl.load(Q + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d, mask=q_valid[:, None])
+
+    dq = tl.zeros([BLOCK_M2, HEAD_DIM], dtype=tl.float32)
+    do = tl.load(DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d, mask=q_valid[:, None])
+
+    m = tl.load(M + offs_m, mask=q_valid)[:, None]
+
+    # Compute dQ for masked (diagonal) blocks.
+    # NOTE: This code scans each row of QK^T backward (from right to left,
+    # but inside each call to _attn_bwd_dq, from left to right), but that's
+    # not due to anything important.  I just wanted to reuse the loop
+    # structure for dK & dV above as much as possible.
+    if CAUSAL:
+        num_steps = BLOCK_M2 // MASK_BLOCK_N2
+        dq = _attn_bwd_dq(
+            dq, q, K, V,
+            do, m, D, qk_scale,
+            stride_tok, stride_d,
+            H, N_CTX,
+            K_MEAN,
+            BLOCK_M2, MASK_BLOCK_N2, HEAD_DIM,
+            start_m, end_n - num_steps * MASK_BLOCK_N2, num_steps,
+            MASK=True,
+            SMOOTH_K=SMOOTH_K,
+            warp_specialize=warp_specialize,
+        )
+        end_n -= num_steps * MASK_BLOCK_N2
+        # stage 2: process KV blocks from 0 to end_n (before diagonal), ceiling division to include remainder
+        num_steps = (end_n + BLOCK_N2 - 1) // BLOCK_N2
+        start_n = 0
+    else:
+        # For non-causal, process all KV blocks from 0 to N_CTX (ceiling division to include remainder)
+        num_steps = (N_CTX + BLOCK_N2 - 1) // BLOCK_N2
+        start_n = 0
+    # stage 2
+    dq = _attn_bwd_dq(
+        dq, q, K, V,
+        do, m, D, qk_scale,
+        stride_tok, stride_d,
+        H, N_CTX,
+        K_MEAN,
+        BLOCK_M2, BLOCK_N2, HEAD_DIM,
+        start_m, start_n, num_steps,
+        MASK=False,
+        SMOOTH_K=SMOOTH_K,
+        warp_specialize=warp_specialize,
+    )
+    # Write back dQ.
+    # NOTE: dq is scaled by sm_scale since K is not pre-scaled (unlike original which used LN2)
+    dq_ptrs = DQ + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+    dq *= sm_scale
+    tl.store(dq_ptrs, dq, mask=q_valid[:, None])
+
+
+class _attention(torch.autograd.Function):
+
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        causal,
+        sm_scale,
+        use_qat_qkv_backward=True,
+        smooth_k=True,
+        warp_specialize=True,
+        IS_QAT=True,
+        two_level_quant_P=True,
+        fake_quant_P=True,
+        use_high_prec_o=False,
+        smooth_q=False,
+        use_global_sf_P=True,
+        use_global_sf_QKV=True,
+    ):
+        # shape constraints
+        HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]
+        # when v is in float8_e5m2 it is transposed.
+        HEAD_DIM_V = v.shape[-1]
+        assert HEAD_DIM_Q == HEAD_DIM_K and HEAD_DIM_K == HEAD_DIM_V
+        assert HEAD_DIM_K in {16, 32, 64, 128, 256}
+
+        # Support different sequence lengths for q and k/v (needed for cross attention)
+        N_CTX_Q = q.shape[2]  # Query sequence length
+        N_CTX_KV = k.shape[2]  # Key/Value sequence length (may differ from query)
+        assert k.shape[2] == v.shape[2], "k and v must have the same sequence length"
+
+        # smoothing k from SageAttn
+        ctx.k_mean = None
+        if smooth_k:
+            k_mean = k.mean(dim=(0, 1, 2), keepdim=True)
+            k = k - k_mean
+            ctx.k_mean = k_mean.view(-1)
+        
+        q_orig, k_orig, v_orig = None, None, None
+        if not use_qat_qkv_backward:
+            q_orig, k_orig, v_orig = q, k, v
+        ctx.q_orig, ctx.k_orig, ctx.v_orig = q_orig, k_orig, v_orig
+
+        o = torch.empty_like(q)
+        if IS_QAT:
+            high_prec_o = torch.empty_like(q)
+        else:
+            # Initialize to a dummy value
+            high_prec_o = o
+        stage = 3 if causal else 1
+        extra_kern_args = {}
+
+        M = torch.empty((q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32)  # (Z, H, N_CTX_Q)
+        # Use device_descriptor for Hopper + warpspec.
+        if supports_host_descriptor() and not (is_hopper() and warp_specialize):
+            # Note that on Hopper we cannot perform a FP8 dot with a non-transposed second tensor
+            y_dim_q = q.shape[0] * q.shape[1] * q.shape[2]
+            y_dim_kv = k.shape[0] * k.shape[1] * k.shape[2]
+
+            dummy_block = [1, 1]
+            # (Z, H, N_CTX_Q, HEAD_DIM_K) -> (Z*H*N_CTX_Q, HEAD_DIM_K)
+            desc_q = TensorDescriptor(q, shape=[y_dim_q, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            if q.dtype == torch.float8_e5m2:
+                desc_v = TensorDescriptor(
+                    v, shape=[HEAD_DIM_K, y_dim_kv], strides=[k.shape[2], 1],
+                    block_shape=dummy_block
+                )
+            else:
+                desc_v = TensorDescriptor(
+                    v, shape=[y_dim_kv, HEAD_DIM_K], strides=[HEAD_DIM_K, 1],
+                    block_shape=dummy_block
+                )
+            desc_k = TensorDescriptor(k, shape=[y_dim_kv, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            # Use 3D descriptor for output to handle N_CTX_Q boundaries correctly
+            dummy_block3d = [1, 1, 1]
+            ZH = q.shape[0] * q.shape[1]
+            desc_o = TensorDescriptor(
+                o, shape=[ZH, N_CTX_Q, HEAD_DIM_K],
+                strides=[N_CTX_Q * HEAD_DIM_K, HEAD_DIM_K, 1],
+                block_shape=dummy_block3d
+            )
+            if IS_QAT:
+                desc_high_prec_o = TensorDescriptor(
+                    high_prec_o, shape=[ZH, N_CTX_Q, HEAD_DIM_K],
+                    strides=[N_CTX_Q * HEAD_DIM_K, HEAD_DIM_K, 1],
+                    block_shape=dummy_block3d
+                )
+            else:
+                desc_high_prec_o = desc_o  # Use regular output descriptor when not in QAT mode
+        else:
+            desc_q = q
+            desc_v = v
+            desc_k = k
+            desc_o = o
+            if IS_QAT:
+                desc_high_prec_o = high_prec_o
+            else:
+                desc_high_prec_o = o  # Use regular output when not in QAT mode
+
+        def alloc_fn(size: int, align: int, _):
+            return torch.empty(size, dtype=torch.int8, device="cuda")
+
+        triton.set_allocator(alloc_fn)
+
+        def grid(META):
+            # (ceil(N_CTX / BLOCK_M), Z * H, 1)
+            return (triton.cdiv(q.shape[2], META["BLOCK_M"]), q.shape[0] * q.shape[1], 1)
+
+        ctx.grid = grid
+        if is_blackwell() and warp_specialize:
+            if HEAD_DIM_K == 128 and q.dtype == torch.float16:
+                extra_kern_args["maxnreg"] = 168
+            else:
+                extra_kern_args["maxnreg"] = 80
+
+        BLOCK_M, BLOCK_N = 32, 32
+        if IS_QAT:
+            fake_q = torch.empty_like(q)
+            fake_k = torch.empty_like(k)
+            fake_v = torch.empty_like(v)
+
+            # override desc_q, desc_k, desc_v with fake_q, fake_k, fake_v
+            if supports_host_descriptor() and not (is_hopper() and warp_specialize):
+                # (Z, H, N_CTX_Q, HEAD_DIM_K) -> (Z*H*N_CTX_Q, HEAD_DIM_K)
+                desc_q = TensorDescriptor(fake_q, shape=[y_dim_q, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+                desc_k = TensorDescriptor(fake_k, shape=[y_dim_kv, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+                desc_v = TensorDescriptor(fake_v, shape=[y_dim_kv, HEAD_DIM_K], strides=[HEAD_DIM_K, 1], block_shape=dummy_block)
+            else:
+                desc_q = fake_q
+                desc_k = fake_k
+                desc_v = fake_v
+
+            H = q.shape[1]
+            grid_1 = (triton.cdiv(q.shape[2], BLOCK_M), q.shape[0] * q.shape[1], 1)
+            grid_2 = (triton.cdiv(k.shape[2], BLOCK_N), q.shape[0] * q.shape[1], 1)
+
+            fake_quantize_q[grid_1](
+                q, fake_q,
+                q.stride(0), q.stride(1),
+                q.stride(2), q.stride(3),
+                fake_q.stride(0), fake_q.stride(1),
+                fake_q.stride(2), fake_q.stride(3),
+                H, N_CTX_Q,
+                BLOCK_M=BLOCK_M, HEAD_DIM=HEAD_DIM_K,
+                use_global_sf=use_global_sf_QKV,
+            )
+            fake_quantize_kv[grid_2](
+                k, v, fake_k, fake_v,
+                k.stride(0), k.stride(1),
+                k.stride(2), k.stride(3),
+                fake_k.stride(0), fake_k.stride(1),
+                fake_k.stride(2), fake_k.stride(3),
+                H, N_CTX_KV,
+                BLOCK_N=BLOCK_N, HEAD_DIM=HEAD_DIM_K, 
+                use_global_sf=use_global_sf_QKV,
+            )
+
+        # Apply pre-hook to set block shapes on tensor descriptors
+        _host_descriptor_pre_hook({
+            "BLOCK_M": BLOCK_M,
+            "BLOCK_N": BLOCK_N,
+            "HEAD_DIM": HEAD_DIM_K,
+            "desc_q": desc_q,
+            "desc_k": desc_k,
+            "desc_v": desc_v,
+            "desc_o": desc_o,
+            "desc_high_prec_o": desc_high_prec_o,
+            "FP8_OUTPUT": q.dtype == torch.float8_e5m2,
+        })
+
+        _attn_fwd[grid](
+            sm_scale, M,
+            q.shape[0], q.shape[1],
+            desc_q, desc_k, desc_v, desc_o, desc_high_prec_o,
+            N_CTX_Q=N_CTX_Q,
+            N_CTX_KV=N_CTX_KV,
+            HEAD_DIM=HEAD_DIM_K,
+            BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+            FP8_OUTPUT=q.dtype == torch.float8_e5m2,
+            STAGE=stage,
+            warp_specialize=warp_specialize,
+            IS_HOPPER=is_hopper(),
+            IS_QAT=IS_QAT,
+            fake_quant_P=fake_quant_P,
+            two_level_quant_P=two_level_quant_P,
+            use_global_sf_P=use_global_sf_P,
+            num_warps=4,
+            num_stages=2,
+            **extra_kern_args
+        )
+        o_for_bwd = high_prec_o if IS_QAT and use_high_prec_o else o
+
+        if IS_QAT:
+            q = fake_q
+            k = fake_k
+            v = fake_v
+
+        ctx.save_for_backward(q, k, v, o_for_bwd, M)
+        ctx.sm_scale = sm_scale
+        ctx.HEAD_DIM = HEAD_DIM_K
+        ctx.causal = causal
+        ctx.IS_QAT = IS_QAT
+        ctx.use_qat_qkv_backward = use_qat_qkv_backward
+        ctx.smooth_k = smooth_k
+        ctx.two_level_quant_P = two_level_quant_P
+        ctx.fake_quant_P = fake_quant_P
+        ctx.smooth_q = smooth_q
+        ctx.use_global_sf_P = use_global_sf_P
+        ctx.warp_specialize = warp_specialize
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        q, k, v, o_for_bwd, M = ctx.saved_tensors
+        do = do.contiguous()
+        assert do.is_contiguous()
+        dq = torch.empty_like(q)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        BATCH, N_HEAD, N_CTX_Q = q.shape[:3]
+        N_CTX_KV = k.shape[2]
+        assert k.shape[2] == v.shape[2], "k and v must have the same sequence length"
+        PRE_BLOCK = 128
+        NUM_STAGES = 3
+        NUM_WARPS = 4
+        BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 32, 32, 32, 32
+        if not ctx.use_qat_qkv_backward:
+            q = ctx.q_orig
+            k = ctx.k_orig
+            v = ctx.v_orig
+        BLK_SLICE_FACTOR = 1 if ctx.IS_QAT else 2  # must be 1 for QAT
+        # NOTE: K is NOT pre-scaled here - scaling is applied AFTER qk dot product in kernels
+        # This improves precision by avoiding rounding errors in K before the dot product
+        arg_k = k
+        pre_grid = ((N_CTX_Q + PRE_BLOCK - 1) // PRE_BLOCK, BATCH * N_HEAD)
+        delta = torch.empty_like(M)
+        _attn_bwd_preprocess[pre_grid](
+            o_for_bwd, do,
+            delta,
+            BATCH, N_HEAD, N_CTX_Q,
+            BLOCK_M=PRE_BLOCK, HEAD_DIM=ctx.HEAD_DIM
+        )
+
+        q_m = None
+        if ctx.smooth_q:
+            # _, q_m = triton_group_mean(q)
+            q_m = q_m.repeat_interleave(q.shape[2] // q_m.shape[2], dim=2)  # B,H,L,D
+
+        if N_CTX_Q == N_CTX_KV:
+            # Use existing kernel for self-attention (same sequence lengths)
+            grid = ((N_CTX_KV + BLOCK_N1 - 1) // BLOCK_N1, 1, BATCH * N_HEAD)
+            _attn_bwd[grid](
+                q, arg_k, v, ctx.sm_scale, do, dq, dk, dv,
+                M, delta, q_m,
+                q.stride(0), q.stride(1), q.stride(2), q.stride(3),
+                N_HEAD, N_CTX_KV,
+                ctx.k_mean,
+                BLOCK_M1=BLOCK_M1, BLOCK_N1=BLOCK_N1,
+                BLOCK_M2=BLOCK_M2, BLOCK_N2=BLOCK_N2,
+                BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,
+                HEAD_DIM=ctx.HEAD_DIM,
+                CAUSAL=ctx.causal,
+                IS_QAT=ctx.IS_QAT,
+                SMOOTH_K=ctx.smooth_k,
+                two_level_quant_P=ctx.two_level_quant_P,
+            fake_quant_P=ctx.fake_quant_P,
+            SMOOTH_Q=ctx.smooth_q,
+            use_global_sf_P=ctx.use_global_sf_P,
+            warp_specialize=ctx.warp_specialize,
+                num_warps=NUM_WARPS,
+                num_stages=NUM_STAGES
+            )
+        else:
+            # Use separate kernels for cross-attention (different sequence lengths)
+            grid_dq = ((N_CTX_Q + BLOCK_M2 - 1) // BLOCK_M2, 1, BATCH * N_HEAD)
+            _attn_bwd_dq_cross[grid_dq](
+                q, arg_k, v, ctx.sm_scale, do, dq, M, delta,
+                q.stride(0), k.stride(0), q.stride(1), k.stride(1), q.stride(2), k.stride(2), q.stride(3), k.stride(3),
+                N_HEAD, N_CTX_Q, N_CTX_KV,
+                ctx.k_mean,
+                BLOCK_M2=BLOCK_M2, BLOCK_N2=BLOCK_N2,
+                HEAD_DIM=ctx.HEAD_DIM,
+                SMOOTH_K=ctx.smooth_k,
+                warp_specialize=ctx.warp_specialize,
+                num_warps=NUM_WARPS,
+                num_stages=NUM_STAGES,
+            )
+            grid_dkdv = ((N_CTX_KV + BLOCK_N1 - 1) // BLOCK_N1, 1, BATCH * N_HEAD)
+            _attn_bwd_dkdv_cross[grid_dkdv](
+                q, arg_k, v, ctx.sm_scale, do, dk, dv, M, delta, q_m,
+                q.stride(0), k.stride(0), q.stride(1), k.stride(1), q.stride(2), k.stride(2), q.stride(3), k.stride(3),
+                N_HEAD, N_CTX_Q, N_CTX_KV,
+                BLOCK_M1=BLOCK_M1, BLOCK_N1=BLOCK_N1,
+                HEAD_DIM=ctx.HEAD_DIM,
+                IS_QAT=ctx.IS_QAT,
+                two_level_quant_P=ctx.two_level_quant_P,
+                fake_quant_P=ctx.fake_quant_P,
+                SMOOTH_Q=ctx.smooth_q,
+                use_global_sf_P=ctx.use_global_sf_P,
+                warp_specialize=ctx.warp_specialize,
+                num_warps=NUM_WARPS,
+                num_stages=NUM_STAGES,
+            )
+
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
+
+
+attention = _attention.apply

--- a/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/fused_attention.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/fused_attention.py
@@ -1,0 +1,55 @@
+"""Compatibility shim for the legacy non-QAT Triton attention import path.
+
+Historically callers imported
+``fastvideo_kernel.triton_kernels.fused_attention`` directly. The shared
+implementation now lives in ``attn_qat_train.py`` and is parameterized by the
+``IS_QAT`` flag. This module preserves the original public API for tests and
+downstream users while always dispatching to the non-QAT configuration.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from .attn_qat_train import attention as _attention
+
+
+def attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    causal: bool,
+    sm_scale: float,
+    warp_specialize: bool = True,
+) -> torch.Tensor:
+    """Run the shared Triton attention kernel in non-QAT mode."""
+    use_qat_qkv_backward = True
+    smooth_k = False
+    is_qat = False
+    two_level_quant_p = False
+    fake_quant_p = False
+    use_high_prec_o = False
+    smooth_q = False
+    use_global_sf_p = False
+    use_global_sf_qkv = False
+
+    return _attention(
+        q,
+        k,
+        v,
+        causal,
+        sm_scale,
+        use_qat_qkv_backward,
+        smooth_k,
+        warp_specialize,
+        is_qat,
+        two_level_quant_p,
+        fake_quant_p,
+        use_high_prec_o,
+        smooth_q,
+        use_global_sf_p,
+        use_global_sf_qkv,
+    )
+
+
+__all__ = ["attention"]

--- a/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/nvfp4_utils.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/nvfp4_utils.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# Adapted from https://github.com/triton-lang/triton/blob/main/python/triton_kernels/triton_kernels/numerics_details/mxfp_details/_upcast_from_mxfp.py
+# and https://github.com/triton-lang/triton/blob/main/python/triton_kernels/triton_kernels/numerics_details/mxfp_details/_downcast_to_mxfp.py
+
+import triton
+import triton.language as tl
+from triton.language.target_info import cuda_capability_geq
+
+MXFP_BLOCK_SIZE = tl.constexpr(16)
+
+@triton.jit
+def _compute_quant_and_scale(
+    src_tensor,
+    valid_src_mask,
+    mx_tensor_dtype: tl.constexpr = tl.uint8,
+    use_global_sf=True,
+    two_level_quant_P=False,
+):
+    BLOCK_SIZE_OUT_DIM: tl.constexpr = src_tensor.shape[0]
+    BLOCK_SIZE_QUANT_DIM: tl.constexpr = src_tensor.shape[1]
+    BLOCK_SIZE_QUANT_MX_SCALE: tl.constexpr = src_tensor.shape[1] // MXFP_BLOCK_SIZE
+    is_fp4: tl.constexpr = mx_tensor_dtype == tl.uint8
+
+    tl.static_assert(
+        is_fp4
+        or mx_tensor_dtype == tl.float8e4nv
+        or mx_tensor_dtype == tl.float8e5,
+        "mx_tensor_dtype must be uint8, float8e4nv, or float8e5",
+    )
+
+    # Explicit cast to fp32 since most ops are not supported on bfloat16. We avoid needless conversions to and from bf16
+    f32_tensor = src_tensor.to(tl.float32)
+    abs_tensor = tl.abs(f32_tensor)
+    abs_tensor = tl.where(valid_src_mask, abs_tensor, -1.0)  # Don't consider padding tensors in scale computation
+    
+    if two_level_quant_P:
+        # row max from SageAttn3 paper
+        global_max_val = tl.max(f32_tensor, axis=1, keep_dims=True)  # (BLOCK_SIZE_OUT_DIM, 1)
+        global_max_val = tl.maximum(global_max_val, 1e-8)
+        s_enc = ((6 * 448) / global_max_val).reshape([BLOCK_SIZE_OUT_DIM, 1, 1])
+        s_dec = (1 / s_enc)
+
+    abs_tensor = tl.reshape(abs_tensor, [BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_MX_SCALE, MXFP_BLOCK_SIZE])
+
+    if use_global_sf and not two_level_quant_P:
+        global_max_val = tl.max(abs_tensor)
+        # Avoid division by zero: if all values are padding (max is 0), use a default scale
+        global_max_val = tl.maximum(global_max_val, 1e-8)
+        s_enc = (6 * 448) / global_max_val
+        s_dec = (1 / s_enc)
+    elif not two_level_quant_P and not use_global_sf:
+        s_dec = 1.0
+        s_enc = 1.0
+    
+    max_val = tl.max(abs_tensor, axis=2, keep_dims=True)  # (BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_MX_SCALE, 1)  # per block maxima
+    s_dec_b = max_val / 6  # (BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_MX_SCALE, 1)
+    s_dec_b_e4m3 = (s_dec_b * s_enc).to(tl.float8e4nv)  # (BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_MX_SCALE, 1)
+    s_enc_b = 1 / (s_dec_b_e4m3.to(tl.float32) * s_dec)  # (BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_MX_SCALE, 1)
+
+    f32_tensor = tl.reshape(f32_tensor, [BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_MX_SCALE, MXFP_BLOCK_SIZE])
+    quant_tensor = f32_tensor * s_enc_b
+
+    # Reshape the tensors after scaling
+    quant_tensor = quant_tensor.reshape([BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_DIM])
+    # Set the invalid portions of the tensor to 0. This will ensure that any padding tensors are 0 in the mx format.
+    quant_tensor = tl.where(valid_src_mask, quant_tensor, 0.0)
+    dequant_scale = s_dec_b_e4m3.reshape([BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_MX_SCALE])
+
+    if is_fp4 and cuda_capability_geq(10, 0):
+        # Convert scaled values to two f32 lanes and use PTX cvt to e2m1x2 with two f32 operands.
+        pairs = tl.reshape(quant_tensor, [BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_DIM // 2, 2])
+        lo_f, hi_f = tl.split(pairs)
+        lo_f32 = lo_f.to(tl.float32)
+        hi_f32 = hi_f.to(tl.float32)
+
+        # Inline PTX: cvt.rn.satfinite.e2m1x2.f32 takes two f32 sources and produces one .b8 packed e2m1x2.
+        out_tensor = tl.inline_asm_elementwise(
+            """
+            {
+                .reg .b8 r;
+                cvt.rn.satfinite.e2m1x2.f32 r, $1, $2;
+                mov.b32 $0, {r, r, r, r};
+            }
+            """,
+            constraints="=r,f,f",
+            args=[hi_f32, lo_f32],
+            dtype=tl.uint8,
+            is_pure=True,
+            pack=1,
+        )
+    elif is_fp4:
+        quant_tensor = quant_tensor.to(tl.uint32, bitcast=True)
+        signs = quant_tensor & 0x80000000
+        exponents = (quant_tensor >> 23) & 0xFF
+        mantissas_orig = (quant_tensor & 0x7FFFFF)
+
+        # For RTNE: 0.25 < x < 0.75 maps to 0.5 (denormal); exactly 0.25 maps to 0.0
+        E8_BIAS = 127
+        E2_BIAS = 1
+        # Move implicit bit 1 at the beginning to mantissa for denormals
+        is_subnormal = exponents < E8_BIAS
+        adjusted_exponents = tl.core.sub(E8_BIAS, exponents + 1, sanitize_overflow=False)
+        mantissas_pre = (0x400000 | (mantissas_orig >> 1))
+        mantissas = tl.where(is_subnormal, mantissas_pre >> adjusted_exponents, mantissas_orig)
+
+        # For normal numbers, we change the bias from 127 to 1, and for subnormals, we keep exponent as 0.
+        exponents = tl.maximum(exponents, E8_BIAS - E2_BIAS) - (E8_BIAS - E2_BIAS)
+
+        # Combine sign, exponent, and mantissa, while saturating
+        # Round to nearest, ties to even (RTNE): use guard/sticky and LSB to decide increment
+        m2bits = mantissas >> 21
+        lsb_keep = (m2bits >> 1) & 0x1
+        guard = m2bits & 0x1
+        IS_SRC_FP32: tl.constexpr = src_tensor.dtype == tl.float32
+        if IS_SRC_FP32:
+            bit0_dropped = (mantissas_orig & 0x1) != 0
+            mask = (1 << tl.minimum(adjusted_exponents, 31)) - 1
+            dropped_post = (mantissas_pre & mask) != 0
+            sticky = is_subnormal & (bit0_dropped | dropped_post)
+            sticky |= ((mantissas & 0x1FFFFF) != 0).to(tl.uint32)
+        else:
+            sticky = ((mantissas & 0x1FFFFF) != 0).to(tl.uint32)
+        round_inc = guard & (sticky | lsb_keep)
+        e2m1_tmp = tl.minimum((((exponents << 2) | m2bits) + round_inc) >> 1, 0x7)
+        e2m1_value = ((signs >> 28) | e2m1_tmp).to(tl.uint8)
+
+        e2m1_value = tl.reshape(e2m1_value, [BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_DIM // 2, 2])
+        evens, odds = tl.split(e2m1_value)
+        out_tensor = evens | (odds << 4)
+    else:
+        out_tensor = quant_tensor.to(mx_tensor_dtype)
+
+    return out_tensor, dequant_scale, s_dec
+
+@triton.jit
+def _compute_dequant(
+    mx_tensor,
+    scale,
+    s_dec,
+    BLOCK_SIZE_OUT_DIM: tl.constexpr,
+    BLOCK_SIZE_QUANT_DIM: tl.constexpr,
+    dst_dtype: tl.constexpr,
+):
+    tl.static_assert(BLOCK_SIZE_QUANT_DIM % MXFP_BLOCK_SIZE == 0, f"Block size along quantization block must be a multiple of {MXFP_BLOCK_SIZE=}")
+    # uint8 signifies two fp4 e2m1 values packed into a single byte
+    mx_tensor_dtype: tl.constexpr = mx_tensor.dtype
+    tl.static_assert(dst_dtype == tl.float16 or dst_dtype == tl.bfloat16 or dst_dtype == tl.float32)
+    tl.static_assert(
+        mx_tensor_dtype == tl.uint8
+        or ((mx_tensor_dtype == tl.float8e4nv or mx_tensor_dtype == tl.float8e5) or mx_tensor_dtype == dst_dtype),
+        "mx_tensor_ptr must be uint8 or float8 or dst_dtype")
+    tl.static_assert(scale.dtype == tl.float8e4nv, "scale must be float8e4nv")
+
+    # Determine if we are dealing with fp8 types.
+    is_fp4: tl.constexpr = mx_tensor_dtype == tl.uint8
+    BLOCK_SIZE_QUANT_MX_SCALE: tl.constexpr = BLOCK_SIZE_QUANT_DIM // MXFP_BLOCK_SIZE
+
+    # Upcast the scale to the destination type.
+    if dst_dtype == tl.bfloat16:
+        dst_scale = scale.to(tl.bfloat16)
+    else:
+        dst_scale = scale.to(tl.float32)
+        if dst_dtype == tl.float16:
+            dst_scale = dst_scale.to(tl.float16)
+
+    # Now upcast the tensor.
+    intermediate_dtype: tl.constexpr = tl.bfloat16 if dst_dtype == tl.float32 else dst_dtype
+    if cuda_capability_geq(10, 0):
+        assert is_fp4
+        packed_u32 = tl.inline_asm_elementwise(
+            asm="""
+            {
+            .reg .b8 in_8;
+            .reg .f16x2 out;
+            cvt.u8.u32 in_8, $1;
+            cvt.rn.f16x2.e2m1x2 out, in_8;
+            mov.b32 $0, out;
+            }
+            """,
+            constraints="=r,r",
+            args=[mx_tensor],  # tl.uint8 passed in as a 32-bit reg with value in low 8 bits
+            dtype=tl.uint32,
+            is_pure=True,
+            pack=1,
+        )
+        lo_u16 = (packed_u32 & 0xFFFF).to(tl.uint16)
+        hi_u16 = (packed_u32 >> 16).to(tl.uint16)
+        lo_f16 = lo_u16.to(tl.float16, bitcast=True)
+        hi_f16 = hi_u16.to(tl.float16, bitcast=True)
+
+        if intermediate_dtype == tl.float16:
+            x0, x1 = lo_f16, hi_f16
+        else:
+            x0 = lo_f16.to(intermediate_dtype)
+            x1 = hi_f16.to(intermediate_dtype)
+
+        dst_tensor = tl.interleave(x0, x1)
+
+    else:
+        assert is_fp4
+        dst_bias: tl.constexpr = 127 if intermediate_dtype == tl.bfloat16 else 15  # exponent bias
+        dst_0p5: tl.constexpr = 16128 if intermediate_dtype == tl.bfloat16 else 0x3800
+        dst_m_bits: tl.constexpr = 7 if intermediate_dtype == tl.bfloat16 else 10  # mantissa bits
+        # e2m1
+        em0 = mx_tensor & 0x07
+        em1 = mx_tensor & 0x70
+        x0 = (em0.to(tl.uint16) << (dst_m_bits - 1)) | ((mx_tensor & 0x08).to(tl.uint16) << 12)
+        x1 = (em1.to(tl.uint16) << (dst_m_bits - 5)) | ((mx_tensor & 0x80).to(tl.uint16) << 8)
+        # Three cases:
+        # 1) x is normal and non-zero: Correct bias
+        x0 = tl.where((em0 & 0x06) != 0, x0 + ((dst_bias - 1) << dst_m_bits), x0)
+        x1 = tl.where((em1 & 0x60) != 0, x1 + ((dst_bias - 1) << dst_m_bits), x1)
+        # 2) x is subnormal (x == 0bs001 where s is the sign): Map to +-0.5 in the dst type
+        x0 = tl.where(em0 == 0x01, dst_0p5 | (x0 & 0x8000), x0)
+        x1 = tl.where(em1 == 0x10, dst_0p5 | (x1 & 0x8000), x1)
+        # 3) x is zero, do nothing
+        dst_tensor = tl.interleave(x0, x1).to(intermediate_dtype, bitcast=True)
+
+    dst_tensor = dst_tensor.to(dst_dtype)
+
+    # Reshape for proper broadcasting: the scale was stored with a 16‐sized “inner” grouping.
+    dst_tensor = dst_tensor.reshape([BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_MX_SCALE, MXFP_BLOCK_SIZE])
+    dst_scale = dst_scale.reshape([BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_MX_SCALE, 1])
+    scale = scale.reshape(dst_scale.shape)
+
+    out_tensor = dst_tensor * dst_scale * s_dec  # NVFP4 has the additional global scale factor
+    if dst_dtype == tl.float32:
+        max_fin = 3.4028234663852886e+38
+    elif dst_dtype == tl.bfloat16:
+        max_fin = 3.3895313892515355e+38
+    else:
+        tl.static_assert(dst_dtype == tl.float16)
+        max_fin = 65504
+    out_tensor = tl.clamp(out_tensor, min=-max_fin, max=max_fin)
+    out_tensor = out_tensor.reshape([BLOCK_SIZE_OUT_DIM, BLOCK_SIZE_QUANT_DIM])
+    out_tensor = out_tensor.to(dst_dtype)
+    return out_tensor

--- a/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/quant_utils.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/quant_utils.py
@@ -1,0 +1,80 @@
+import triton
+import triton.language as tl
+
+from .nvfp4_utils import _compute_quant_and_scale, _compute_dequant
+
+@triton.jit
+def fake_quantize(src_tensor, valid_src_mask, BLOCK_SIZE_OUT_DIM: tl.constexpr,
+                    BLOCK_SIZE_QUANT_DIM: tl.constexpr,
+                    dst_dtype: tl.constexpr,
+                    mx_tensor_dtype: tl.constexpr = tl.uint8,
+                    use_global_sf: tl.constexpr = True,
+                    two_level_quant_P: tl.constexpr = False):
+    high_prec_src_tensor = src_tensor
+    src_tensor, src_scale, src_s_dec = _compute_quant_and_scale(src_tensor=src_tensor,
+                                                                valid_src_mask=valid_src_mask,
+                                                                mx_tensor_dtype=mx_tensor_dtype,
+                                                                use_global_sf=use_global_sf,
+                                                                two_level_quant_P=two_level_quant_P)
+    src_tensor = _compute_dequant(mx_tensor=src_tensor, 
+                                  scale=src_scale, 
+                                  s_dec=src_s_dec, 
+                                  BLOCK_SIZE_OUT_DIM=BLOCK_SIZE_OUT_DIM, 
+                                  BLOCK_SIZE_QUANT_DIM=BLOCK_SIZE_QUANT_DIM, 
+                                  dst_dtype=dst_dtype)
+    return src_tensor, high_prec_src_tensor.to(src_tensor.dtype)
+
+@triton.jit
+def fake_quantize_q(Q, fake_Q, stride_z_q, stride_h_q, 
+                    stride_tok_q, stride_d_q,
+                    fake_stride_z_q, fake_stride_h_q,
+                    fake_stride_tok_q, fake_stride_d_q,
+                    H, N_CTX_Q,
+                    BLOCK_M: tl.constexpr,
+                    HEAD_DIM: tl.constexpr,
+                    use_global_sf: tl.constexpr = True):
+    bhid = tl.program_id(1)
+    adj_q = (stride_h_q * (bhid % H) + stride_z_q * (bhid // H))
+    fake_adj_q = (fake_stride_h_q * (bhid % H) + fake_stride_z_q * (bhid // H))
+    Q += adj_q
+    fake_Q += fake_adj_q
+
+    pid = tl.program_id(0)
+    start_m = pid * BLOCK_M
+    offs_m = start_m + tl.arange(0, BLOCK_M)
+    offs_k = tl.arange(0, HEAD_DIM)
+
+    q_valid = offs_m < N_CTX_Q
+    q = tl.load(Q + offs_m[:, None] * stride_tok_q + offs_k[None, :] * stride_d_q, mask=q_valid[:, None], other=0.0)
+    q, _ = fake_quantize(src_tensor=q, valid_src_mask=q_valid[:, None], BLOCK_SIZE_OUT_DIM=BLOCK_M, BLOCK_SIZE_QUANT_DIM=HEAD_DIM, dst_dtype=q.dtype, use_global_sf=use_global_sf)
+    tl.store(fake_Q + offs_m[:, None] * fake_stride_tok_q + offs_k[None, :] * fake_stride_d_q, q, mask=q_valid[:, None])
+
+@triton.jit
+def fake_quantize_kv(K, V, fake_K, fake_V, stride_z_kv, stride_h_kv, 
+                    stride_tok_kv, stride_d_kv,
+                    fake_stride_z_kv, fake_stride_h_kv,
+                    fake_stride_tok_kv, fake_stride_d_kv,
+                    H, N_CTX_KV,
+                    BLOCK_N: tl.constexpr,
+                    HEAD_DIM: tl.constexpr,
+                    use_global_sf: tl.constexpr = True):
+    bhid = tl.program_id(1)
+    adj_kv = (stride_h_kv * (bhid % H) + stride_z_kv * (bhid // H))
+    fake_adj_kv = (fake_stride_h_kv * (bhid % H) + fake_stride_z_kv * (bhid // H))
+    K += adj_kv
+    V += adj_kv
+    fake_K += fake_adj_kv
+    fake_V += fake_adj_kv
+
+    pid = tl.program_id(0)
+    start_n = pid * BLOCK_N
+    offs_n = start_n + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, HEAD_DIM)
+    
+    kv_valid = offs_n < N_CTX_KV
+    k_block = tl.load(K + offs_n[:, None] * stride_tok_kv + offs_k[None, :] * stride_d_kv, mask=kv_valid[:, None], other=0.0)
+    v_block = tl.load(V + offs_n[:, None] * stride_tok_kv + offs_k[None, :] * stride_d_kv, mask=kv_valid[:, None], other=0.0)
+    k, _ = fake_quantize(src_tensor=k_block, valid_src_mask=kv_valid[:, None], BLOCK_SIZE_OUT_DIM=BLOCK_N, BLOCK_SIZE_QUANT_DIM=HEAD_DIM, dst_dtype=k_block.dtype, use_global_sf=use_global_sf)
+    v, _ = fake_quantize(src_tensor=v_block, valid_src_mask=kv_valid[:, None], BLOCK_SIZE_OUT_DIM=BLOCK_N, BLOCK_SIZE_QUANT_DIM=HEAD_DIM, dst_dtype=v_block.dtype, use_global_sf=use_global_sf)
+    tl.store(fake_K + offs_n[:, None] * fake_stride_tok_kv + offs_k[None, :] * fake_stride_d_kv, k, mask=kv_valid[:, None])
+    tl.store(fake_V + offs_n[:, None] * fake_stride_tok_kv + offs_k[None, :] * fake_stride_d_kv, v, mask=kv_valid[:, None])

--- a/fastvideo-kernel/tests/test_attn_qat_train.py
+++ b/fastvideo-kernel/tests/test_attn_qat_train.py
@@ -1,0 +1,1503 @@
+#!/usr/bin/env python3
+"""
+Simple test for attn_qat_train.
+Tests forward and backward passes with and without QAT enabled.
+"""
+
+import torch
+from fastvideo_kernel.triton_kernels.attn_qat_train import _attention
+from fastvideo_kernel.triton_kernels.fused_attention import attention as fused_attention
+from math import sqrt
+
+attention = _attention.apply
+DEVICE = torch.device("cuda")
+
+
+def attn_qat_train_wrapper(q_BLHD, k_BLHD, v_BLHD, is_causal=False, sm_scale=None):
+    """
+    Wrapper function that mimics attn_qat_train from the backend wrapper.
+    Converts from BLHD format to BHLD format, calls attention, then converts back.
+    
+    Args:
+        q_BLHD: Query tensor in (B, L, H, D) format
+        k_BLHD: Key tensor in (B, L, H, D) format
+        v_BLHD: Value tensor in (B, L, H, D) format
+        is_causal: Whether to apply causal masking
+        sm_scale: Scale factor for attention scores (if None, uses 1.0 / sqrt(D))
+    
+    Returns:
+        Output tensor in (B, L, H, D) format
+    """
+    if sm_scale is None:
+        sm_scale = 1.0 / sqrt(q_BLHD.shape[-1])
+    
+    # Convert from BLHD to BHLD format
+    q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+    k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+    v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+    
+    # Call attention with BHLD format
+    o_BHLD = attention(q_BHLD, k_BHLD, v_BHLD, is_causal, sm_scale)
+    
+    # Convert back from BHLD to BLHD format
+    return o_BHLD.permute(0, 2, 1, 3).contiguous()
+
+
+def fused_attn_wrapper(q_BLHD, k_BLHD, v_BLHD, is_causal=False, sm_scale=None, warp_specialize=True):
+    """
+    Wrapper function for fused_attention from fused_attention.py.
+    Converts from BLHD format to BHLD format, calls attention, then converts back.
+    
+    Args:
+        q_BLHD: Query tensor in (B, L, H, D) format
+        k_BLHD: Key tensor in (B, L, H, D) format
+        v_BLHD: Value tensor in (B, L, H, D) format
+        is_causal: Whether to apply causal masking
+        sm_scale: Scale factor for attention scores (if None, uses 1.0 / sqrt(D))
+        warp_specialize: Whether to use warp specialization (default: True)
+    
+    Returns:
+        Output tensor in (B, L, H, D) format
+    """
+    if sm_scale is None:
+        sm_scale = 1.0 / sqrt(q_BLHD.shape[-1])
+    
+    # Convert from BLHD to BHLD format
+    q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+    k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+    v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+    
+    # Call fused attention with BHLD format
+    # Note: fused_attention expects inputs in BHLD format and only supports same sequence lengths
+    o_BHLD = fused_attention(q_BHLD, k_BHLD, v_BHLD, is_causal, sm_scale, warp_specialize)
+    
+    # Convert back from BHLD to BLHD format
+    return o_BHLD.permute(0, 2, 1, 3).contiguous()
+
+
+def cosine_similarity(tensor1, tensor2):
+    """
+    Compute cosine similarity between two tensors.
+    
+    Args:
+        tensor1: First tensor
+        tensor2: Second tensor (same shape as tensor1)
+    
+    Returns:
+        Cosine similarity value (scalar)
+    """
+    # Flatten tensors for computation
+    t1_flat = tensor1.flatten().float()
+    t2_flat = tensor2.flatten().float()
+    
+    # Compute cosine similarity: (A · B) / (||A|| * ||B||)
+    dot_product = torch.dot(t1_flat, t2_flat)
+    norm1 = torch.norm(t1_flat)
+    norm2 = torch.norm(t2_flat)
+    
+    # Avoid division by zero
+    if norm1 == 0 or norm2 == 0:
+        return 0.0
+    
+    cos_sim = dot_product / (norm1 * norm2)
+    return cos_sim.item()
+
+
+def naive_attention(q, k, v, causal, sm_scale):
+    """
+    Naive PyTorch implementation of attention for comparison.
+    
+    Args:
+        q: Query tensor of shape (Z, H, N_CTX_Q, HEAD_DIM)
+        k: Key tensor of shape (Z, H, N_CTX_KV, HEAD_DIM)
+        v: Value tensor of shape (Z, H, N_CTX_KV, HEAD_DIM)
+        causal: Whether to apply causal masking (only meaningful when N_CTX_Q == N_CTX_KV)
+        sm_scale: Scale factor for attention scores
+    
+    Returns:
+        Output tensor of shape (Z, H, N_CTX_Q, HEAD_DIM)
+    """
+    # Compute attention scores: QK^T
+    scores = torch.matmul(q, k.transpose(-2, -1)) * sm_scale
+    
+    # Apply causal mask if needed
+    # Note: Causal masking is only meaningful when Q and KV have the same sequence length
+    if causal:
+        N_CTX_Q = q.shape[-2]
+        N_CTX_KV = k.shape[-2]
+        if N_CTX_Q == N_CTX_KV:
+            # Standard causal masking: query i can only attend to keys 0 to i
+            mask = torch.tril(torch.ones(N_CTX_Q, N_CTX_KV, device=scores.device, dtype=scores.dtype))
+            scores = scores.masked_fill(mask == 0, float("-inf"))
+        else:
+            # For different sequence lengths, causal masking doesn't apply in the same way
+            # In cross-attention, typically no causal masking is applied
+            pass
+    
+    # Apply softmax
+    attn_weights = torch.softmax(scores, dim=-1)
+    
+    # Apply attention weights to values
+    out = torch.matmul(attn_weights, v)
+    
+    return out
+
+def test_qat_attention_forward():
+    """Test forward pass with QAT enabled vs disabled."""
+    torch.manual_seed(42)
+    
+    # Test parameters
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16  
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = False
+    
+    # Create input tensors in BLHD format (B, L, H, D) = (Z, N_CTX, H, HEAD_DIM)
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    
+    # Test with QAT (using wrapper that does permute/contiguous)
+    out_qat_BLHD = attn_qat_train_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Convert to BHLD for naive attention comparison
+    q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+    k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+    v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+    out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+    out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    # Check that outputs have correct shape
+    assert out_qat_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_naive_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    
+    # Check that outputs are finite
+    assert torch.isfinite(out_qat_BLHD).all()
+    assert torch.isfinite(out_naive_BLHD).all()
+    
+    # Compare QAT and naive outputs
+    max_diff = (out_qat_BLHD - out_naive_BLHD).abs().max()
+    mean_diff = (out_qat_BLHD - out_naive_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_qat_BLHD, out_naive_BLHD)
+    print(f"  QAT vs Naive Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM} - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # QAT output should be reasonably close to naive (within tolerance due to quantization)
+    # Using a reasonable tolerance for float16 and quantization effects
+    # assert max_diff < 1.0, f"QAT and naive outputs should be reasonably close, got max_diff={max_diff.item():.6f}"
+    
+    print("✓ Forward pass test passed.")
+
+
+def test_qat_attention_backward():
+    """Test backward pass with QAT enabled."""
+    torch.manual_seed(42)
+    
+    # Test parameters
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = True
+    
+    # Create input tensors in BLHD format for QAT
+    q_qat_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    k_qat_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    v_qat_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    
+    # Create input tensors for naive (same values, convert to BHLD)
+    q_naive_BHLD = q_qat_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    k_naive_BHLD = k_qat_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    v_naive_BHLD = v_qat_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    
+    # Forward pass with QAT (using wrapper)
+    out_qat_BLHD = attn_qat_train_wrapper(q_qat_BLHD, k_qat_BLHD, v_qat_BLHD, causal, sm_scale)
+    
+    # Forward pass with naive
+    out_naive_BHLD = naive_attention(q_naive_BHLD, k_naive_BHLD, v_naive_BHLD, causal, sm_scale)
+    out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    # Create dummy gradient (same for both, in BLHD format)
+    # Ensure gradient is contiguous as required by the backward function
+    dout = torch.randn_like(out_qat_BLHD).contiguous()
+    
+    # Backward pass for QAT
+    out_qat_BLHD.backward(dout)
+    
+    # Backward pass for naive
+    out_naive_BLHD.backward(dout)
+    
+    # Check that gradients are computed
+    assert q_qat_BLHD.grad is not None
+    assert k_qat_BLHD.grad is not None
+    assert v_qat_BLHD.grad is not None
+    assert q_naive_BHLD.grad is not None
+    assert k_naive_BHLD.grad is not None
+    assert v_naive_BHLD.grad is not None
+    
+    # Check that gradients have correct shape
+    assert q_qat_BLHD.grad.shape == q_qat_BLHD.shape
+    assert k_qat_BLHD.grad.shape == k_qat_BLHD.shape
+    assert v_qat_BLHD.grad.shape == v_qat_BLHD.shape
+    
+    # Check that gradients are finite
+    assert torch.isfinite(q_qat_BLHD.grad).all()
+    assert torch.isfinite(k_qat_BLHD.grad).all()
+    assert torch.isfinite(v_qat_BLHD.grad).all()
+    
+    # Convert naive gradients to BLHD format for comparison
+    q_naive_grad_BLHD = q_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    k_naive_grad_BLHD = k_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    v_naive_grad_BLHD = v_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    
+    # Compare gradients with naive
+    dq_diff = (q_qat_BLHD.grad - q_naive_grad_BLHD).abs()
+    dk_diff = (k_qat_BLHD.grad - k_naive_grad_BLHD).abs()
+    dv_diff = (v_qat_BLHD.grad - v_naive_grad_BLHD).abs()
+    
+    dq_cos_sim = cosine_similarity(q_qat_BLHD.grad, q_naive_grad_BLHD)
+    dk_cos_sim = cosine_similarity(k_qat_BLHD.grad, k_naive_grad_BLHD)
+    dv_cos_sim = cosine_similarity(v_qat_BLHD.grad, v_naive_grad_BLHD)
+    
+    print(f"  dQ - Max diff: {dq_diff.max().item():.6f}, Mean diff: {dq_diff.mean().item():.6f}, Cosine sim: {dq_cos_sim:.6f}")
+    print(f"  dK - Max diff: {dk_diff.max().item():.6f}, Mean diff: {dk_diff.mean().item():.6f}, Cosine sim: {dk_cos_sim:.6f}")
+    print(f"  dV - Max diff: {dv_diff.max().item():.6f}, Mean diff: {dv_diff.mean().item():.6f}, Cosine sim: {dv_cos_sim:.6f}")
+    
+    # Gradients should be reasonably close (within tolerance due to quantization)
+    # assert dq_diff.max() < 2.0, f"dQ gradients should be reasonably close, got max_diff={dq_diff.max().item():.6f}"
+    # assert dk_diff.max() < 2.0, f"dK gradients should be reasonably close, got max_diff={dk_diff.max().item():.6f}"
+    # assert dv_diff.max() < 2.0, f"dV gradients should be reasonably close, got max_diff={dv_diff.max().item():.6f}"
+    
+    print("✓ Backward pass test passed.")
+
+
+def test_qat_attention_different_shapes():
+    """Test QAT attention with different input shapes."""
+    torch.manual_seed(42)
+    
+    test_configs = [
+        (2, 4, 128, 64),  # Medium
+        (1, 8, 256, 128), # Large head dim
+    ]
+    
+    dtype = torch.bfloat16
+    causal = True
+    
+    for Z, H, N_CTX, HEAD_DIM in test_configs:
+        # Create input tensors in BLHD format
+        q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+        k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+        v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+        
+        sm_scale = 1.0 / sqrt(HEAD_DIM)
+        out_qat_BLHD = attn_qat_train_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+        
+        # Convert to BHLD for naive attention
+        q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+        k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+        v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+        out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+        out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+        
+        assert out_qat_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+        assert out_naive_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+        assert torch.isfinite(out_qat_BLHD).all()
+        assert torch.isfinite(out_naive_BLHD).all()
+        
+        # Compare outputs
+        max_diff = (out_qat_BLHD - out_naive_BLHD).abs().max()
+        mean_diff = (out_qat_BLHD - out_naive_BLHD).abs().mean()
+        cos_sim = cosine_similarity(out_qat_BLHD, out_naive_BLHD)
+        print(f"  (Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM}) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+        
+        # Outputs should be reasonably close
+        # assert max_diff < 1.0, f"QAT and naive outputs should be reasonably close for shape (Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM}), got max_diff={max_diff.item():.6f}"
+        
+        print(f"✓ Shape test passed for (Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM})")
+
+
+def test_qat_attention_non_causal():
+    """Test QAT attention with non-causal masking."""
+    torch.manual_seed(42)
+    
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = False
+    
+    # Create input tensors in BLHD format
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    
+    out_qat_BLHD = attn_qat_train_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Convert to BHLD for naive attention
+    q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+    k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+    v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+    out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+    out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    assert out_qat_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_naive_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert torch.isfinite(out_qat_BLHD).all()
+    assert torch.isfinite(out_naive_BLHD).all()
+    
+    # Compare outputs
+    max_diff = (out_qat_BLHD - out_naive_BLHD).abs().max()
+    mean_diff = (out_qat_BLHD - out_naive_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_qat_BLHD, out_naive_BLHD)
+    print(f"  QAT vs Naive (non-causal) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # Outputs should be reasonably close
+    # assert max_diff < 1.0, f"QAT and naive outputs should be reasonably close for non-causal, got max_diff={max_diff.item():.6f}"
+    
+    print("✓ Non-causal test passed.")
+
+
+def test_qat_attention_causal():
+    """Test QAT attention with causal masking."""
+    torch.manual_seed(42)
+    
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = True
+    
+    # Create input tensors in BLHD format
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    
+    out_qat_BLHD = attn_qat_train_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Convert to BHLD for naive attention
+    q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+    k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+    v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+    out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+    out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    assert out_qat_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_naive_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert torch.isfinite(out_qat_BLHD).all()
+    assert torch.isfinite(out_naive_BLHD).all()
+    
+    # Compare outputs
+    max_diff = (out_qat_BLHD - out_naive_BLHD).abs().max()
+    mean_diff = (out_qat_BLHD - out_naive_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_qat_BLHD, out_naive_BLHD)
+    print(f"  QAT vs Naive (causal) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # Outputs should be reasonably close
+    # assert max_diff < 1.0, f"QAT and naive outputs should be reasonably close for causal, got max_diff={max_diff.item():.6f}"
+    
+    print("✓ Causal test passed.")
+
+
+def test_qat_attention_causal_backward():
+    """Test backward pass of QAT attention with causal masking vs naive."""
+    torch.manual_seed(42)
+    
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = True
+    
+    # Create input tensors in BLHD format for QAT
+    q_qat_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    k_qat_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    v_qat_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    
+    # Create input tensors for naive (same values, convert to BHLD)
+    q_naive_BHLD = q_qat_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    k_naive_BHLD = k_qat_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    v_naive_BHLD = v_qat_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    
+    # Forward pass with QAT
+    out_qat_BLHD = attn_qat_train_wrapper(q_qat_BLHD, k_qat_BLHD, v_qat_BLHD, causal, sm_scale)
+    
+    # Forward pass with naive
+    out_naive_BHLD = naive_attention(q_naive_BHLD, k_naive_BHLD, v_naive_BHLD, causal, sm_scale)
+    out_naive_BHLD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    # Create dummy gradient
+    dout = torch.randn_like(out_qat_BLHD).contiguous()
+    
+    # Backward pass for QAT
+    out_qat_BLHD.backward(dout)
+    
+    # Backward pass for naive
+    out_naive_BHLD.backward(dout)
+    
+    # Check that gradients are computed
+    assert q_qat_BLHD.grad is not None
+    assert k_qat_BLHD.grad is not None
+    assert v_qat_BLHD.grad is not None
+    
+    # Convert naive gradients to BLHD format for comparison
+    q_naive_grad_BLHD = q_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    k_naive_grad_BLHD = k_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    v_naive_grad_BLHD = v_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    
+    # Compare gradients
+    dq_diff = (q_qat_BLHD.grad - q_naive_grad_BLHD).abs()
+    dk_diff = (k_qat_BLHD.grad - k_naive_grad_BLHD).abs()
+    dv_diff = (v_qat_BLHD.grad - v_naive_grad_BLHD).abs()
+    
+    dq_cos_sim = cosine_similarity(q_qat_BLHD.grad, q_naive_grad_BLHD)
+    dk_cos_sim = cosine_similarity(k_qat_BLHD.grad, k_naive_grad_BLHD)
+    dv_cos_sim = cosine_similarity(v_qat_BLHD.grad, v_naive_grad_BLHD)
+    
+    print(f"  dQ - Max diff: {dq_diff.max().item():.6f}, Mean diff: {dq_diff.mean().item():.6f}, Cosine sim: {dq_cos_sim:.6f}")
+    print(f"  dK - Max diff: {dk_diff.max().item():.6f}, Mean diff: {dk_diff.mean().item():.6f}, Cosine sim: {dk_cos_sim:.6f}")
+    print(f"  dV - Max diff: {dv_diff.max().item():.6f}, Mean diff: {dv_diff.mean().item():.6f}, Cosine sim: {dv_cos_sim:.6f}")
+    
+    print("✓ Causal backward test passed.")
+
+
+def test_qat_attention_different_seq_lengths():
+    """Test QAT attention with different sequence lengths for Q and KV (cross-attention)."""
+    torch.manual_seed(42)
+    
+    test_configs = [
+        (2, 4, 64, 128, 64, False),   # Q shorter than KV, non-causal
+        (2, 4, 128, 64, 64, False),   # Q longer than KV, non-causal
+        (1, 8, 256, 128, 64, False), # Q longer than KV, larger dimensions
+    ]
+    
+    dtype = torch.bfloat16
+    
+    for Z, H, N_CTX_Q, N_CTX_KV, HEAD_DIM, causal in test_configs:
+        sm_scale = 1.0 / sqrt(HEAD_DIM)
+        
+        # Create input tensors in BLHD format with different sequence lengths
+        q_BLHD = torch.randn((Z, N_CTX_Q, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+        k_BLHD = torch.randn((Z, N_CTX_KV, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+        v_BLHD = torch.randn((Z, N_CTX_KV, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+        
+        # Test with QAT (using wrapper that does permute/contiguous)
+        out_qat_BLHD = attn_qat_train_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+        
+        # Convert to BHLD for naive attention comparison
+        q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+        k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+        v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+        out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+        out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+        
+        # Check that outputs have correct shape (should match Q sequence length)
+        assert out_qat_BLHD.shape == (Z, N_CTX_Q, H, HEAD_DIM)
+        assert out_naive_BLHD.shape == (Z, N_CTX_Q, H, HEAD_DIM)
+        
+        # Check that outputs are finite
+        assert torch.isfinite(out_qat_BLHD).all()
+        assert torch.isfinite(out_naive_BLHD).all()
+        
+        # Compare QAT and naive outputs
+        max_diff = (out_qat_BLHD - out_naive_BLHD).abs().max()
+        mean_diff = (out_qat_BLHD - out_naive_BLHD).abs().mean()
+        cos_sim = cosine_similarity(out_qat_BLHD, out_naive_BLHD)
+        print(f"  (N_CTX_Q={N_CTX_Q}, N_CTX_KV={N_CTX_KV}, causal={causal}) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+        
+        # Outputs should be reasonably close
+        # assert max_diff < 1.0, f"QAT and naive outputs should be reasonably close for (N_CTX_Q={N_CTX_Q}, N_CTX_KV={N_CTX_KV}), got max_diff={max_diff.item():.6f}"
+        
+        print(f"✓ Different sequence lengths test passed for (N_CTX_Q={N_CTX_Q}, N_CTX_KV={N_CTX_KV})")
+
+
+def test_qat_attention_different_seq_lengths_backward():
+    """Test backward pass of QAT attention with different sequence lengths for Q and KV (cross-attention)."""
+    torch.manual_seed(42)
+    
+    test_configs = [
+        (2, 4, 64, 128, 64, False),   # Q shorter than KV, non-causal
+        (2, 4, 128, 64, 64, False),   # Q longer than KV, non-causal
+    ]
+    
+    dtype = torch.bfloat16
+    
+    for Z, H, N_CTX_Q, N_CTX_KV, HEAD_DIM, causal in test_configs:
+        sm_scale = 1.0 / sqrt(HEAD_DIM)
+        
+        # Create input tensors in BLHD format with different sequence lengths
+        q_qat_BLHD = torch.randn((Z, N_CTX_Q, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+        k_qat_BLHD = torch.randn((Z, N_CTX_KV, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+        v_qat_BLHD = torch.randn((Z, N_CTX_KV, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+        
+        # Create input tensors for naive (same values, convert to BHLD)
+        q_naive_BHLD = q_qat_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+        k_naive_BHLD = k_qat_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+        v_naive_BHLD = v_qat_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+        
+        # Forward pass with QAT
+        out_qat_BLHD = attn_qat_train_wrapper(q_qat_BLHD, k_qat_BLHD, v_qat_BLHD, causal, sm_scale)
+        
+        # Forward pass with naive
+        out_naive_BHLD = naive_attention(q_naive_BHLD, k_naive_BHLD, v_naive_BHLD, causal, sm_scale)
+        out_naive_BHLD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+        
+        # Create dummy gradient
+        dout = torch.randn_like(out_qat_BLHD).contiguous()
+        
+        # Backward pass for QAT
+        out_qat_BLHD.backward(dout)
+        
+        # Backward pass for naive
+        out_naive_BHLD.backward(dout)
+        
+        # Check that gradients are computed
+        assert q_qat_BLHD.grad is not None
+        assert k_qat_BLHD.grad is not None
+        assert v_qat_BLHD.grad is not None
+        assert q_naive_BHLD.grad is not None
+        assert k_naive_BHLD.grad is not None
+        assert v_naive_BHLD.grad is not None
+        
+        # Check that gradients have correct shape
+        assert q_qat_BLHD.grad.shape == q_qat_BLHD.shape
+        assert k_qat_BLHD.grad.shape == k_qat_BLHD.shape
+        assert v_qat_BLHD.grad.shape == v_qat_BLHD.shape
+        
+        # Check that gradients are finite
+        assert torch.isfinite(q_qat_BLHD.grad).all()
+        assert torch.isfinite(k_qat_BLHD.grad).all()
+        assert torch.isfinite(v_qat_BLHD.grad).all()
+        
+        # Convert naive gradients to BLHD format for comparison
+        q_naive_grad_BLHD = q_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+        k_naive_grad_BLHD = k_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+        v_naive_grad_BLHD = v_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+        
+        # Compare gradients
+        dq_diff = (q_qat_BLHD.grad - q_naive_grad_BLHD).abs()
+        dk_diff = (k_qat_BLHD.grad - k_naive_grad_BLHD).abs()
+        dv_diff = (v_qat_BLHD.grad - v_naive_grad_BLHD).abs()
+        
+        dq_cos_sim = cosine_similarity(q_qat_BLHD.grad, q_naive_grad_BLHD)
+        dk_cos_sim = cosine_similarity(k_qat_BLHD.grad, k_naive_grad_BLHD)
+        dv_cos_sim = cosine_similarity(v_qat_BLHD.grad, v_naive_grad_BLHD)
+        
+        print(f"  (N_CTX_Q={N_CTX_Q}, N_CTX_KV={N_CTX_KV}) - dQ: Max diff: {dq_diff.max().item():.6f}, Mean diff: {dq_diff.mean().item():.6f}, Cosine sim: {dq_cos_sim:.6f}")
+        print(f"  (N_CTX_Q={N_CTX_Q}, N_CTX_KV={N_CTX_KV}) - dK: Max diff: {dk_diff.max().item():.6f}, Mean diff: {dk_diff.mean().item():.6f}, Cosine sim: {dk_cos_sim:.6f}")
+        print(f"  (N_CTX_Q={N_CTX_Q}, N_CTX_KV={N_CTX_KV}) - dV: Max diff: {dv_diff.max().item():.6f}, Mean diff: {dv_diff.mean().item():.6f}, Cosine sim: {dv_cos_sim:.6f}")
+        
+        # Gradients should be reasonably close (within tolerance due to quantization)
+        # assert dq_diff.max() < 2.0, f"dQ gradients should be reasonably close, got max_diff={dq_diff.max().item():.6f}"
+        # assert dk_diff.max() < 2.0, f"dK gradients should be reasonably close, got max_diff={dk_diff.max().item():.6f}"
+        # assert dv_diff.max() < 2.0, f"dV gradients should be reasonably close, got max_diff={dv_diff.max().item():.6f}"
+        
+        print(f"✓ Cross-attention backward test passed for (N_CTX_Q={N_CTX_Q}, N_CTX_KV={N_CTX_KV})")
+
+
+def test_fused_attention_forward():
+    """Test forward pass of fused attention vs naive PyTorch implementation."""
+    torch.manual_seed(42)
+    
+    # Test parameters
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16  # fused_attention uses float16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = False
+    
+    # Create input tensors in BLHD format (B, L, H, D) = (Z, N_CTX, H, HEAD_DIM)
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    
+    # Test with fused attention (using wrapper that does permute/contiguous)
+    out_fused_BLHD = fused_attn_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Convert to BHLD for naive attention comparison
+    q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+    k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+    v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+    out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+    out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    # Check that outputs have correct shape
+    assert out_fused_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_naive_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    
+    # Check that outputs are finite
+    assert torch.isfinite(out_fused_BLHD).all()
+    assert torch.isfinite(out_naive_BLHD).all()
+    
+    # Compare fused and naive outputs
+    max_diff = (out_fused_BLHD - out_naive_BLHD).abs().max()
+    mean_diff = (out_fused_BLHD - out_naive_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_fused_BLHD, out_naive_BLHD)
+    print(f"  Fused vs Naive - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # Fused attention should be reasonably close to naive (within tolerance for float16)
+    # assert max_diff < 1e-1, f"Fused and naive outputs should be reasonably close, got max_diff={max_diff.item():.6f}"
+    
+    print("✓ Fused attention forward pass test passed.")
+
+
+def test_fused_attention_backward():
+    """Test backward pass of fused attention vs naive PyTorch implementation."""
+    torch.manual_seed(42)
+    
+    # Test parameters
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = True
+    
+    # Create input tensors in BLHD format for fused attention
+    q_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    k_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    v_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    
+    # Create input tensors for naive (same values, convert to BHLD)
+    q_naive_BHLD = q_fused_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    k_naive_BHLD = k_fused_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    v_naive_BHLD = v_fused_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    
+    # Forward pass with fused attention (using wrapper)
+    out_fused_BLHD = fused_attn_wrapper(q_fused_BLHD, k_fused_BLHD, v_fused_BLHD, causal, sm_scale)
+    
+    # Forward pass with naive
+    out_naive_BHLD = naive_attention(q_naive_BHLD, k_naive_BHLD, v_naive_BHLD, causal, sm_scale)
+    out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    # Create dummy gradient (same for both, in BLHD format)
+    dout = torch.randn_like(out_fused_BLHD).contiguous()
+    
+    # Backward pass for fused attention
+    out_fused_BLHD.backward(dout)
+    
+    # Backward pass for naive
+    out_naive_BLHD.backward(dout)
+    
+    # Check that gradients are computed
+    assert q_fused_BLHD.grad is not None
+    assert k_fused_BLHD.grad is not None
+    assert v_fused_BLHD.grad is not None
+    assert q_naive_BHLD.grad is not None
+    assert k_naive_BHLD.grad is not None
+    assert v_naive_BHLD.grad is not None
+    
+    # Check that gradients have correct shape
+    assert q_fused_BLHD.grad.shape == q_fused_BLHD.shape
+    assert k_fused_BLHD.grad.shape == k_fused_BLHD.shape
+    assert v_fused_BLHD.grad.shape == v_fused_BLHD.shape
+    
+    # Check that gradients are finite
+    assert torch.isfinite(q_fused_BLHD.grad).all()
+    assert torch.isfinite(k_fused_BLHD.grad).all()
+    assert torch.isfinite(v_fused_BLHD.grad).all()
+    
+    # Convert naive gradients to BLHD format for comparison
+    q_naive_grad_BLHD = q_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    k_naive_grad_BLHD = k_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    v_naive_grad_BLHD = v_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    
+    # Compare gradients with naive
+    dq_diff = (q_fused_BLHD.grad - q_naive_grad_BLHD).abs()
+    dk_diff = (k_fused_BLHD.grad - k_naive_grad_BLHD).abs()
+    dv_diff = (v_fused_BLHD.grad - v_naive_grad_BLHD).abs()
+    
+    dq_cos_sim = cosine_similarity(q_fused_BLHD.grad, q_naive_grad_BLHD)
+    dk_cos_sim = cosine_similarity(k_fused_BLHD.grad, k_naive_grad_BLHD)
+    dv_cos_sim = cosine_similarity(v_fused_BLHD.grad, v_naive_grad_BLHD)
+    
+    print(f"  dQ - Max diff: {dq_diff.max().item():.6f}, Mean diff: {dq_diff.mean().item():.6f}, Cosine sim: {dq_cos_sim:.6f}")
+    print(f"  dK - Max diff: {dk_diff.max().item():.6f}, Mean diff: {dk_diff.mean().item():.6f}, Cosine sim: {dk_cos_sim:.6f}")
+    print(f"  dV - Max diff: {dv_diff.max().item():.6f}, Mean diff: {dv_diff.mean().item():.6f}, Cosine sim: {dv_cos_sim:.6f}")
+    
+    # Gradients should be reasonably close (within tolerance for float16)
+    # assert dq_diff.max() < 1e-1, f"dQ gradients should be reasonably close, got max_diff={dq_diff.max().item():.6f}"
+    # assert dk_diff.max() < 1e-1, f"dK gradients should be reasonably close, got max_diff={dk_diff.max().item():.6f}"
+    # assert dv_diff.max() < 1e-1, f"dV gradients should be reasonably close, got max_diff={dv_diff.max().item():.6f}"
+    
+    print("✓ Fused attention backward pass test passed.")
+
+
+def test_fused_attention_different_shapes():
+    """Test fused attention with different input shapes."""
+    torch.manual_seed(42)
+    
+    test_configs = [
+        (1, 2, 64, 32),   # Small
+        (2, 4, 128, 64),  # Medium
+        (1, 8, 256, 128), # Large head dim
+    ]
+    
+    dtype = torch.bfloat16
+    causal = True
+    
+    for Z, H, N_CTX, HEAD_DIM in test_configs:
+        # Create input tensors in BLHD format
+        q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+        k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+        v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+        
+        sm_scale = 1.0 / sqrt(HEAD_DIM)
+        out_fused_BLHD = fused_attn_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+        
+        # Convert to BHLD for naive attention
+        q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+        k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+        v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+        out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+        out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+        
+        assert out_fused_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+        assert out_naive_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+        assert torch.isfinite(out_fused_BLHD).all()
+        assert torch.isfinite(out_naive_BLHD).all()
+        
+        # Compare outputs
+        max_diff = (out_fused_BLHD - out_naive_BLHD).abs().max()
+        mean_diff = (out_fused_BLHD - out_naive_BLHD).abs().mean()
+        cos_sim = cosine_similarity(out_fused_BLHD, out_naive_BLHD)
+        print(f"  (Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM}) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+        
+        # Outputs should be reasonably close
+        # assert max_diff < 1e-1, f"Fused and naive outputs should be reasonably close for shape (Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM}), got max_diff={max_diff.item():.6f}"
+        
+        print(f"✓ Fused attention shape test passed for (Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM})")
+
+
+def test_fused_attention_non_causal():
+    """Test fused attention with non-causal masking."""
+    torch.manual_seed(42)
+    
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = False
+    
+    # Create input tensors in BLHD format
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    
+    out_fused_BLHD = fused_attn_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Convert to BHLD for naive attention
+    q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+    k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+    v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+    out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+    out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    assert out_fused_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_naive_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert torch.isfinite(out_fused_BLHD).all()
+    assert torch.isfinite(out_naive_BLHD).all()
+    
+    # Compare outputs
+    max_diff = (out_fused_BLHD - out_naive_BLHD).abs().max()
+    mean_diff = (out_fused_BLHD - out_naive_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_fused_BLHD, out_naive_BLHD)
+    print(f"  Fused vs Naive (non-causal) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # Outputs should be reasonably close
+    # assert max_diff < 1e-1, f"Fused and naive outputs should be reasonably close for non-causal, got max_diff={max_diff.item():.6f}"
+    
+    print("✓ Fused attention non-causal test passed.")
+
+
+def test_fused_attention_causal():
+    """Test fused attention with causal masking."""
+    torch.manual_seed(42)
+    
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = True
+    
+    # Create input tensors in BLHD format
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    
+    out_fused_BLHD = fused_attn_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Convert to BHLD for naive attention
+    q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+    k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+    v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+    out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+    out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    assert out_fused_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_naive_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert torch.isfinite(out_fused_BLHD).all()
+    assert torch.isfinite(out_naive_BLHD).all()
+    
+    # Compare outputs
+    max_diff = (out_fused_BLHD - out_naive_BLHD).abs().max()
+    mean_diff = (out_fused_BLHD - out_naive_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_fused_BLHD, out_naive_BLHD)
+    print(f"  Fused vs Naive (causal) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # Outputs should be reasonably close
+    # assert max_diff < 1e-1, f"Fused and naive outputs should be reasonably close for causal, got max_diff={max_diff.item():.6f}"
+    
+    print("✓ Fused attention causal test passed.")
+
+
+def test_fused_attention_causal_backward():
+    """Test backward pass of fused attention with causal masking vs naive."""
+    torch.manual_seed(42)
+    
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = True
+    
+    # Create input tensors in BLHD format for fused attention
+    q_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    k_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    v_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    
+    # Create input tensors for naive (same values, convert to BHLD)
+    q_naive_BHLD = q_fused_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    k_naive_BHLD = k_fused_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    v_naive_BHLD = v_fused_BLHD.clone().permute(0, 2, 1, 3).contiguous().detach().requires_grad_(True)
+    
+    # Forward pass with fused attention
+    out_fused_BLHD = fused_attn_wrapper(q_fused_BLHD, k_fused_BLHD, v_fused_BLHD, causal, sm_scale)
+    
+    # Forward pass with naive
+    out_naive_BHLD = naive_attention(q_naive_BHLD, k_naive_BHLD, v_naive_BHLD, causal, sm_scale)
+    out_naive_BHLD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    
+    # Create dummy gradient
+    dout = torch.randn_like(out_fused_BLHD).contiguous()
+    
+    # Backward pass for fused attention
+    out_fused_BLHD.backward(dout)
+    
+    # Backward pass for naive
+    out_naive_BHLD.backward(dout)
+    
+    # Check that gradients are computed
+    assert q_fused_BLHD.grad is not None
+    assert k_fused_BLHD.grad is not None
+    assert v_fused_BLHD.grad is not None
+    
+    # Convert naive gradients to BLHD format for comparison
+    q_naive_grad_BLHD = q_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    k_naive_grad_BLHD = k_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    v_naive_grad_BLHD = v_naive_BHLD.grad.permute(0, 2, 1, 3).contiguous()
+    
+    # Compare gradients
+    dq_diff = (q_fused_BLHD.grad - q_naive_grad_BLHD).abs()
+    dk_diff = (k_fused_BLHD.grad - k_naive_grad_BLHD).abs()
+    dv_diff = (v_fused_BLHD.grad - v_naive_grad_BLHD).abs()
+    
+    dq_cos_sim = cosine_similarity(q_fused_BLHD.grad, q_naive_grad_BLHD)
+    dk_cos_sim = cosine_similarity(k_fused_BLHD.grad, k_naive_grad_BLHD)
+    dv_cos_sim = cosine_similarity(v_fused_BLHD.grad, v_naive_grad_BLHD)
+    
+    print(f"  dQ - Max diff: {dq_diff.max().item():.6f}, Mean diff: {dq_diff.mean().item():.6f}, Cosine sim: {dq_cos_sim:.6f}")
+    print(f"  dK - Max diff: {dk_diff.max().item():.6f}, Mean diff: {dk_diff.mean().item():.6f}, Cosine sim: {dk_cos_sim:.6f}")
+    print(f"  dV - Max diff: {dv_diff.max().item():.6f}, Mean diff: {dv_diff.mean().item():.6f}, Cosine sim: {dv_cos_sim:.6f}")
+    
+    print("✓ Fused attention causal backward test passed.")
+
+
+def test_fused_vs_qat_attention_forward():
+    """Test forward pass comparing fused attention vs QAT attention."""
+    torch.manual_seed(42)
+    
+    # Test parameters
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = False
+    
+    # Create input tensors in BLHD format
+    # Use float16 for both (QAT can handle float16, though it typically uses float16)
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+    
+    # Test with fused attention
+    out_fused_BLHD = fused_attn_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Test with QAT attention (convert to float16 for QAT)
+    q_qat_BLHD = q_BLHD.clone().to(torch.bfloat16)
+    k_qat_BLHD = k_BLHD.clone().to(torch.bfloat16)
+    v_qat_BLHD = v_BLHD.clone().to(torch.bfloat16)
+    out_qat_BLHD = attn_qat_train_wrapper(q_qat_BLHD, k_qat_BLHD, v_qat_BLHD, causal, sm_scale)
+    
+    # Convert QAT output back to float16 for comparison
+    out_qat_BLHD = out_qat_BLHD.to(torch.bfloat16)
+    
+    # Check that outputs have correct shape
+    assert out_fused_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_qat_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    
+    # Check that outputs are finite
+    assert torch.isfinite(out_fused_BLHD).all()
+    assert torch.isfinite(out_qat_BLHD).all()
+    
+    # Compare fused and QAT outputs
+    max_diff = (out_fused_BLHD - out_qat_BLHD).abs().max()
+    mean_diff = (out_fused_BLHD - out_qat_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_fused_BLHD, out_qat_BLHD)
+    print(f"  Fused vs QAT - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # They may differ due to quantization in QAT and different implementations
+    # assert max_diff < 1.0, f"Fused and QAT outputs should be reasonably close, got max_diff={max_diff.item():.6f}"
+    
+    print("✓ Fused vs QAT forward pass test passed.")
+
+
+def test_fused_vs_qat_attention_backward():
+    """Test backward pass comparing fused attention vs QAT attention."""
+    torch.manual_seed(42)
+    
+    # Test parameters
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = True
+    
+    # Create input tensors in BLHD format for fused attention (float16)
+    q_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE, requires_grad=True)
+    k_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE, requires_grad=True)
+    v_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE, requires_grad=True)
+    
+    # Create input tensors for QAT (float16, same values)
+    q_qat_BLHD = q_fused_BLHD.clone().to(torch.bfloat16).detach().requires_grad_(True)
+    k_qat_BLHD = k_fused_BLHD.clone().to(torch.bfloat16).detach().requires_grad_(True)
+    v_qat_BLHD = v_fused_BLHD.clone().to(torch.bfloat16).detach().requires_grad_(True)
+    
+    # Forward pass with fused attention
+    out_fused_BLHD = fused_attn_wrapper(q_fused_BLHD, k_fused_BLHD, v_fused_BLHD, causal, sm_scale)
+    
+    # Forward pass with QAT
+    out_qat_BLHD = attn_qat_train_wrapper(q_qat_BLHD, k_qat_BLHD, v_qat_BLHD, causal, sm_scale)
+    
+    # Create dummy gradient (same for both, in BLHD format)
+    dout = torch.randn_like(out_fused_BLHD).contiguous()
+    dout_qat = dout.to(torch.bfloat16)
+    
+    # Backward pass for fused attention
+    out_fused_BLHD.backward(dout)
+    
+    # Backward pass for QAT
+    out_qat_BLHD.backward(dout_qat)
+    
+    # Check that gradients are computed
+    assert q_fused_BLHD.grad is not None
+    assert k_fused_BLHD.grad is not None
+    assert v_fused_BLHD.grad is not None
+    assert q_qat_BLHD.grad is not None
+    assert k_qat_BLHD.grad is not None
+    assert v_qat_BLHD.grad is not None
+    
+    # Check that gradients have correct shape
+    assert q_fused_BLHD.grad.shape == q_fused_BLHD.shape
+    assert k_fused_BLHD.grad.shape == k_fused_BLHD.shape
+    assert v_fused_BLHD.grad.shape == v_fused_BLHD.shape
+    
+    # Check that gradients are finite
+    assert torch.isfinite(q_fused_BLHD.grad).all()
+    assert torch.isfinite(k_fused_BLHD.grad).all()
+    assert torch.isfinite(v_fused_BLHD.grad).all()
+    
+    # Convert QAT gradients to float16 for comparison
+    q_qat_grad_f16 = q_qat_BLHD.grad.to(torch.bfloat16)
+    k_qat_grad_f16 = k_qat_BLHD.grad.to(torch.bfloat16)
+    v_qat_grad_f16 = v_qat_BLHD.grad.to(torch.bfloat16)
+    
+    # Compare gradients
+    dq_diff = (q_fused_BLHD.grad - q_qat_grad_f16).abs()
+    dk_diff = (k_fused_BLHD.grad - k_qat_grad_f16).abs()
+    dv_diff = (v_fused_BLHD.grad - v_qat_grad_f16).abs()
+    
+    dq_cos_sim = cosine_similarity(q_fused_BLHD.grad, q_qat_grad_f16)
+    dk_cos_sim = cosine_similarity(k_fused_BLHD.grad, k_qat_grad_f16)
+    dv_cos_sim = cosine_similarity(v_fused_BLHD.grad, v_qat_grad_f16)
+    
+    print(f"  dQ - Max diff: {dq_diff.max().item():.6f}, Mean diff: {dq_diff.mean().item():.6f}, Cosine sim: {dq_cos_sim:.6f}")
+    print(f"  dK - Max diff: {dk_diff.max().item():.6f}, Mean diff: {dk_diff.mean().item():.6f}, Cosine sim: {dk_cos_sim:.6f}")
+    print(f"  dV - Max diff: {dv_diff.max().item():.6f}, Mean diff: {dv_diff.mean().item():.6f}, Cosine sim: {dv_cos_sim:.6f}")
+    
+    # Gradients may differ due to quantization in QAT and different implementations
+    # assert dq_diff.max() < 2.0, f"dQ gradients should be reasonably close, got max_diff={dq_diff.max().item():.6f}"
+    # assert dk_diff.max() < 2.0, f"dK gradients should be reasonably close, got max_diff={dk_diff.max().item():.6f}"
+    # assert dv_diff.max() < 2.0, f"dV gradients should be reasonably close, got max_diff={dv_diff.max().item():.6f}"
+    
+    print("✓ Fused vs QAT backward pass test passed.")
+
+
+def test_fused_vs_qat_attention_different_shapes():
+    """Test fused vs QAT attention with different input shapes."""
+    torch.manual_seed(42)
+    
+    test_configs = [
+        (2, 4, 128, 64),  # Medium
+        (1, 8, 256, 128), # Large head dim
+    ]
+    
+    causal = True
+    
+    for Z, H, N_CTX, HEAD_DIM in test_configs:
+        sm_scale = 1.0 / sqrt(HEAD_DIM)
+        
+        # Create input tensors in BLHD format (float16)
+        q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+        k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+        v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+        
+        # Test with fused attention
+        out_fused_BLHD = fused_attn_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+        
+        # Test with QAT attention (convert to float16)
+        q_qat_BLHD = q_BLHD.clone().to(torch.bfloat16)
+        k_qat_BLHD = k_BLHD.clone().to(torch.bfloat16)
+        v_qat_BLHD = v_BLHD.clone().to(torch.bfloat16)
+        out_qat_BLHD = attn_qat_train_wrapper(q_qat_BLHD, k_qat_BLHD, v_qat_BLHD, causal, sm_scale)
+        out_qat_BLHD = out_qat_BLHD.to(torch.bfloat16)
+        
+        assert out_fused_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+        assert out_qat_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+        assert torch.isfinite(out_fused_BLHD).all()
+        assert torch.isfinite(out_qat_BLHD).all()
+        
+        # Compare outputs
+        max_diff = (out_fused_BLHD - out_qat_BLHD).abs().max()
+        mean_diff = (out_fused_BLHD - out_qat_BLHD).abs().mean()
+        cos_sim = cosine_similarity(out_fused_BLHD, out_qat_BLHD)
+        print(f"  (Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM}) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+        
+        # Outputs may differ due to quantization in QAT
+        # assert max_diff < 1.0, f"Fused and QAT outputs should be reasonably close for shape (Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM}), got max_diff={max_diff.item():.6f}"
+        
+        print(f"✓ Fused vs QAT shape test passed for (Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM})")
+
+
+def test_fused_vs_qat_attention_non_causal():
+    """Test fused vs QAT attention with non-causal masking."""
+    torch.manual_seed(42)
+    
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = False
+    
+    # Create input tensors in BLHD format (float16)
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+    
+    # Test with fused attention
+    out_fused_BLHD = fused_attn_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Test with QAT attention (convert to float16)
+    q_qat_BLHD = q_BLHD.clone().to(torch.bfloat16)
+    k_qat_BLHD = k_BLHD.clone().to(torch.bfloat16)
+    v_qat_BLHD = v_BLHD.clone().to(torch.bfloat16)
+    out_qat_BLHD = attn_qat_train_wrapper(q_qat_BLHD, k_qat_BLHD, v_qat_BLHD, causal, sm_scale)
+    out_qat_BLHD = out_qat_BLHD.to(torch.bfloat16)
+    
+    assert out_fused_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_qat_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert torch.isfinite(out_fused_BLHD).all()
+    assert torch.isfinite(out_qat_BLHD).all()
+    
+    # Compare outputs
+    max_diff = (out_fused_BLHD - out_qat_BLHD).abs().max()
+    mean_diff = (out_fused_BLHD - out_qat_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_fused_BLHD, out_qat_BLHD)
+    print(f"  Fused vs QAT (non-causal) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # Outputs may differ due to quantization in QAT
+    # assert max_diff < 1.0, f"Fused and QAT outputs should be reasonably close for non-causal, got max_diff={max_diff.item():.6f}"
+    
+    print("✓ Fused vs QAT non-causal test passed.")
+
+
+def test_fused_vs_qat_attention_causal():
+    """Test fused vs QAT attention with causal masking."""
+    torch.manual_seed(42)
+    
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = True
+    
+    # Create input tensors in BLHD format (float16)
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE)
+    
+    # Test with fused attention
+    out_fused_BLHD = fused_attn_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Test with QAT attention (convert to float16)
+    q_qat_BLHD = q_BLHD.clone().to(torch.bfloat16)
+    k_qat_BLHD = k_BLHD.clone().to(torch.bfloat16)
+    v_qat_BLHD = v_BLHD.clone().to(torch.bfloat16)
+    out_qat_BLHD = attn_qat_train_wrapper(q_qat_BLHD, k_qat_BLHD, v_qat_BLHD, causal, sm_scale)
+    out_qat_BLHD = out_qat_BLHD.to(torch.bfloat16)
+    
+    assert out_fused_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_qat_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert torch.isfinite(out_fused_BLHD).all()
+    assert torch.isfinite(out_qat_BLHD).all()
+    
+    # Compare outputs
+    max_diff = (out_fused_BLHD - out_qat_BLHD).abs().max()
+    mean_diff = (out_fused_BLHD - out_qat_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_fused_BLHD, out_qat_BLHD)
+    print(f"  Fused vs QAT (causal) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # Outputs may differ due to quantization in QAT
+    # assert max_diff < 1.0, f"Fused and QAT outputs should be reasonably close for causal, got max_diff={max_diff.item():.6f}"
+    
+    print("✓ Fused vs QAT causal test passed.")
+
+
+def test_fused_vs_qat_attention_causal_backward():
+    """Test backward pass of fused vs QAT attention with causal masking."""
+    torch.manual_seed(42)
+    
+    Z, H, N_CTX, HEAD_DIM = 2, 4, 128, 64
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = True
+    
+    # Create input tensors in BLHD format for fused attention (float16)
+    q_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE, requires_grad=True)
+    k_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE, requires_grad=True)
+    v_fused_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=torch.bfloat16, device=DEVICE, requires_grad=True)
+    
+    # Create input tensors for QAT (float16, same values)
+    q_qat_BLHD = q_fused_BLHD.clone().to(torch.bfloat16).detach().requires_grad_(True)
+    k_qat_BLHD = k_fused_BLHD.clone().to(torch.bfloat16).detach().requires_grad_(True)
+    v_qat_BLHD = v_fused_BLHD.clone().to(torch.bfloat16).detach().requires_grad_(True)
+    
+    # Forward pass with fused attention
+    out_fused_BLHD = fused_attn_wrapper(q_fused_BLHD, k_fused_BLHD, v_fused_BLHD, causal, sm_scale)
+    
+    # Forward pass with QAT
+    out_qat_BLHD = attn_qat_train_wrapper(q_qat_BLHD, k_qat_BLHD, v_qat_BLHD, causal, sm_scale)
+    
+    # Create dummy gradient
+    dout = torch.randn_like(out_fused_BLHD).contiguous()
+    dout_qat = dout.to(torch.bfloat16)
+    
+    # Backward pass for fused attention
+    out_fused_BLHD.backward(dout)
+    
+    # Backward pass for QAT
+    out_qat_BLHD.backward(dout_qat)
+    
+    # Check that gradients are computed
+    assert q_fused_BLHD.grad is not None
+    assert k_fused_BLHD.grad is not None
+    assert v_fused_BLHD.grad is not None
+    assert q_qat_BLHD.grad is not None
+    assert k_qat_BLHD.grad is not None
+    assert v_qat_BLHD.grad is not None
+    
+    # Convert QAT gradients to float16 for comparison
+    q_qat_grad_f16 = q_qat_BLHD.grad.to(torch.bfloat16)
+    k_qat_grad_f16 = k_qat_BLHD.grad.to(torch.bfloat16)
+    v_qat_grad_f16 = v_qat_BLHD.grad.to(torch.bfloat16)
+    
+    # Compare gradients
+    dq_diff = (q_fused_BLHD.grad - q_qat_grad_f16).abs()
+    dk_diff = (k_fused_BLHD.grad - k_qat_grad_f16).abs()
+    dv_diff = (v_fused_BLHD.grad - v_qat_grad_f16).abs()
+    
+    dq_cos_sim = cosine_similarity(q_fused_BLHD.grad, q_qat_grad_f16)
+    dk_cos_sim = cosine_similarity(k_fused_BLHD.grad, k_qat_grad_f16)
+    dv_cos_sim = cosine_similarity(v_fused_BLHD.grad, v_qat_grad_f16)
+    
+    print(f"  dQ - Max diff: {dq_diff.max().item():.6f}, Mean diff: {dq_diff.mean().item():.6f}, Cosine sim: {dq_cos_sim:.6f}")
+    print(f"  dK - Max diff: {dk_diff.max().item():.6f}, Mean diff: {dk_diff.mean().item():.6f}, Cosine sim: {dk_cos_sim:.6f}")
+    print(f"  dV - Max diff: {dv_diff.max().item():.6f}, Mean diff: {dv_diff.mean().item():.6f}, Cosine sim: {dv_cos_sim:.6f}")
+    
+    print("✓ Fused vs QAT causal backward test passed.")
+
+
+def test_qat_attention_wan_shape_forward():
+    """Test QAT attention forward pass with WAN shape [1, 40, 9360, 128]."""
+    torch.manual_seed(42)
+    
+    # WAN shape: [1, 40, 9360, 128] = (Z, H, N_CTX, HEAD_DIM)
+    Z, H, N_CTX, HEAD_DIM = 1, 40, 9360, 128
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = False  # WAN uses non-causal attention
+    
+    print(f"  Testing WAN shape: Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM}")
+    
+    # Create input tensors in BLHD format (B, L, H, D) = (Z, N_CTX, H, HEAD_DIM)
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE)
+    
+    # Test with QAT (using wrapper that does permute/contiguous)
+    out_qat_BLHD = attn_qat_train_wrapper(q_BLHD.clone(), k_BLHD.clone(), v_BLHD.clone(), causal, sm_scale)
+    
+    # Convert to BHLD for naive attention comparison
+    q_BHLD = q_BLHD.permute(0, 2, 1, 3).contiguous()
+    k_BHLD = k_BLHD.permute(0, 2, 1, 3).contiguous()
+    v_BHLD = v_BLHD.permute(0, 2, 1, 3).contiguous()
+    out_naive_BHLD = naive_attention(q_BHLD.clone(), k_BHLD.clone(), v_BHLD.clone(), causal, sm_scale)
+    print(f"  out_naive_BHLD shape (before permute): {out_naive_BHLD.shape}")
+    out_naive_BLHD = out_naive_BHLD.permute(0, 2, 1, 3).contiguous()
+    print(f"  out_naive_BLHD shape (after permute): {out_naive_BLHD.shape}")
+    print(f"  Expected shape: {(Z, N_CTX, H, HEAD_DIM)}")
+    print(f"  out_qat_BLHD shape: {out_qat_BLHD.shape}")
+    
+    # Check that outputs have correct shape
+    assert out_qat_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    assert out_naive_BLHD.shape == (Z, N_CTX, H, HEAD_DIM)
+    
+    # Check that outputs are finite
+    assert torch.isfinite(out_qat_BLHD).all()
+    assert torch.isfinite(out_naive_BLHD).all()
+    
+    # Compare QAT and naive outputs
+    max_diff = (out_qat_BLHD - out_naive_BLHD).abs().max()
+    mean_diff = (out_qat_BLHD - out_naive_BLHD).abs().mean()
+    cos_sim = cosine_similarity(out_qat_BLHD, out_naive_BLHD)
+    print(f"  QAT vs Naive (WAN shape) - Max diff: {max_diff.item():.6f}, Mean diff: {mean_diff.item():.6f}, Cosine sim: {cos_sim:.6f}")
+    
+    # QAT output should be reasonably close to naive (within tolerance due to quantization)
+    print("✓ WAN shape forward pass test passed.")
+
+
+def test_qat_attention_wan_shape_backward():
+    """Test QAT attention backward pass with WAN shape [1, 40, 9360, 128]."""
+    torch.manual_seed(42)
+
+    Z, H, N_CTX, HEAD_DIM = 1, 40, 9360, 128
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = False  # WAN is non-causal
+
+    print(f"  Testing WAN shape: Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM}")
+
+    # -----------------------------
+    # CREATE BLHD INPUTS FOR QAT
+    # -----------------------------
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+
+    # -----------------------------
+    # CREATE BHLD INPUTS FOR NAIVE
+    # -----------------------------
+    q_BHLD = q_BLHD.detach().permute(0,2,1,3).contiguous().requires_grad_(True)
+    k_BHLD = k_BLHD.detach().permute(0,2,1,3).contiguous().requires_grad_(True)
+    v_BHLD = v_BLHD.detach().permute(0,2,1,3).contiguous().requires_grad_(True)
+
+    # -----------------------------
+    # FORWARD — QAT
+    # -----------------------------
+    out_qat_BLHD = attn_qat_train_wrapper(q_BLHD, k_BLHD, v_BLHD, causal, sm_scale)
+
+    # -----------------------------
+    # FORWARD — NAIVE
+    # -----------------------------
+    out_naive_BHLD = naive_attention(q_BHLD, k_BHLD, v_BHLD, causal, sm_scale)
+
+    # Convert naive output back to BLHD for comparing outputs
+    out_naive_BLHD = out_naive_BHLD.permute(0,2,1,3).contiguous()
+
+    # -----------------------------
+    # BACKWARD
+    # -----------------------------
+    dout_BLHD = torch.randn_like(out_qat_BLHD).contiguous()
+
+    # QAT backward (BLHD dout)
+    out_qat_BLHD.backward(dout_BLHD)
+
+    # ❗ FIXED: convert BLHD dout → BHLD for naive backward
+    dout_BHLD = dout_BLHD.permute(0,2,1,3).contiguous()
+
+    out_naive_BHLD.backward(dout_BHLD)
+
+    # -----------------------------
+    # GRADIENT FORMAT FIX
+    # Convert naive BHLD grads → BLHD
+    # -----------------------------
+    q_naive_grad_BLHD = q_BHLD.grad.permute(0,2,1,3).contiguous()
+    k_naive_grad_BLHD = k_BHLD.grad.permute(0,2,1,3).contiguous()
+    v_naive_grad_BLHD = v_BHLD.grad.permute(0,2,1,3).contiguous()
+
+    # -----------------------------
+    # PRINT GRADIENTS
+    # -----------------------------
+    print("\n  === QAT Gradients ===")
+    print(f"  dQ_QAT - Shape: {q_BLHD.grad.shape}, Min: {q_BLHD.grad.min().item():.6f}, Max: {q_BLHD.grad.max().item():.6f}, Mean: {q_BLHD.grad.mean().item():.6f}, Std: {q_BLHD.grad.std().item():.6f}")
+    print(f"  dK_QAT - Shape: {k_BLHD.grad.shape}, Min: {k_BLHD.grad.min().item():.6f}, Max: {k_BLHD.grad.max().item():.6f}, Mean: {k_BLHD.grad.mean().item():.6f}, Std: {k_BLHD.grad.std().item():.6f}")
+    print(f"  dV_QAT - Shape: {v_BLHD.grad.shape}, Min: {v_BLHD.grad.min().item():.6f}, Max: {v_BLHD.grad.max().item():.6f}, Mean: {v_BLHD.grad.mean().item():.6f}, Std: {v_BLHD.grad.std().item():.6f}")
+    
+    print("\n  === Naive Gradients ===")
+    print(f"  dQ_Naive - Shape: {q_naive_grad_BLHD.shape}, Min: {q_naive_grad_BLHD.min().item():.6f}, Max: {q_naive_grad_BLHD.max().item():.6f}, Mean: {q_naive_grad_BLHD.mean().item():.6f}, Std: {q_naive_grad_BLHD.std().item():.6f}")
+    print(f"  dK_Naive - Shape: {k_naive_grad_BLHD.shape}, Min: {k_naive_grad_BLHD.min().item():.6f}, Max: {k_naive_grad_BLHD.max().item():.6f}, Mean: {k_naive_grad_BLHD.mean().item():.6f}, Std: {k_naive_grad_BLHD.std().item():.6f}")
+    print(f"  dV_Naive - Shape: {v_naive_grad_BLHD.shape}, Min: {v_naive_grad_BLHD.min().item():.6f}, Max: {v_naive_grad_BLHD.max().item():.6f}, Mean: {v_naive_grad_BLHD.mean().item():.6f}, Std: {v_naive_grad_BLHD.std().item():.6f}")
+    
+    # Print sample values (first few elements)
+    # print("\n  === Sample Gradient Values (first 10 elements) ===")
+    # print(f"  dQ_QAT[0,0,0,:10]:   {q_BLHD.grad[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dQ_Naive[0,0,0,:10]: {q_naive_grad_BLHD[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dK_QAT[0,0,0,:10]:   {k_BLHD.grad[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dK_Naive[0,0,0,:10]: {k_naive_grad_BLHD[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dV_QAT[0,0,0,:10]:   {v_BLHD.grad[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dV_Naive[0,0,0,:10]: {v_naive_grad_BLHD[0,0,0,:10].cpu().tolist()}")
+
+    # -----------------------------
+    # COMPARE
+    # -----------------------------
+    dq_diff = (q_BLHD.grad - q_naive_grad_BLHD).abs()
+    dk_diff = (k_BLHD.grad - k_naive_grad_BLHD).abs()
+    dv_diff = (v_BLHD.grad - v_naive_grad_BLHD).abs()
+
+    dq_cos = cosine_similarity(q_BLHD.grad, q_naive_grad_BLHD)
+    dk_cos = cosine_similarity(k_BLHD.grad, k_naive_grad_BLHD)
+    dv_cos = cosine_similarity(v_BLHD.grad, v_naive_grad_BLHD)
+
+    print("\n  === Gradient Comparison ===")
+    print(f"  dQ - Max diff: {dq_diff.max().item():.6f}, Mean diff: {dq_diff.mean().item():.6f}, Cos: {dq_cos:.6f}")
+    print(f"  dK - Max diff: {dk_diff.max().item():.6f}, Mean diff: {dk_diff.mean().item():.6f}, Cos: {dk_cos:.6f}")
+    print(f"  dV - Max diff: {dv_diff.max().item():.6f}, Mean diff: {dv_diff.mean().item():.6f}, Cos: {dv_cos:.6f}")
+
+    print("\n✓ WAN shape backward pass test passed.")
+
+
+
+def test_qat_attention_wan_shape_non_divisible_64():
+    """Test QAT attention where N_CTX is not divisible by 64."""
+    torch.manual_seed(42)
+
+    Z, H, N_CTX, HEAD_DIM = 1, 40, 9367, 128
+    dtype = torch.bfloat16
+    sm_scale = 1.0 / sqrt(HEAD_DIM)
+    causal = False
+
+    print(f"  Testing WAN non-divisible: Z={Z}, H={H}, N_CTX={N_CTX}, HEAD_DIM={HEAD_DIM}")
+    print(f"  N_CTX % 64 = {N_CTX % 64}")
+
+    # -----------------------------
+    # CREATE BLHD INPUTS
+    # -----------------------------
+    q_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    k_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+    v_BLHD = torch.randn((Z, N_CTX, H, HEAD_DIM), dtype=dtype, device=DEVICE, requires_grad=True)
+
+    # -----------------------------
+    # BHLD for naive
+    # -----------------------------
+    q_BHLD = q_BLHD.detach().permute(0,2,1,3).contiguous().requires_grad_(True)
+    k_BHLD = k_BLHD.detach().permute(0,2,1,3).contiguous().requires_grad_(True)
+    v_BHLD = v_BLHD.detach().permute(0,2,1,3).contiguous().requires_grad_(True)
+
+    # -----------------------------
+    # FORWARD
+    # -----------------------------
+    out_qat_BLHD = attn_qat_train_wrapper(q_BLHD, k_BLHD, v_BLHD, causal, sm_scale)
+    out_naive_BHLD = naive_attention(q_BHLD, k_BHLD, v_BHLD, causal, sm_scale)
+    out_naive_BLHD = out_naive_BHLD.permute(0,2,1,3).contiguous()
+
+    # -----------------------------
+    # BACKWARD
+    # -----------------------------
+    dout_BLHD = torch.randn_like(out_qat_BLHD).contiguous()
+
+    # QAT backward
+    out_qat_BLHD.backward(dout_BLHD)
+
+    # FIXED: Convert dout to BHLD for naive
+    dout_BHLD = dout_BLHD.permute(0,2,1,3).contiguous()
+
+    out_naive_BHLD.backward(dout_BHLD)
+
+    # -----------------------------
+    # GRADIENT FORMAT FIX
+    # -----------------------------
+    q_naive_grad_BLHD = q_BHLD.grad.permute(0,2,1,3).contiguous()
+    k_naive_grad_BLHD = k_BHLD.grad.permute(0,2,1,3).contiguous()
+    v_naive_grad_BLHD = v_BHLD.grad.permute(0,2,1,3).contiguous()
+
+    # -----------------------------
+    # PRINT GRADIENTS
+    # -----------------------------
+    print("\n  === QAT Gradients ===")
+    print(f"  dQ_QAT - Shape: {q_BLHD.grad.shape}, Min: {q_BLHD.grad.min().item():.6f}, Max: {q_BLHD.grad.max().item():.6f}, Mean: {q_BLHD.grad.mean().item():.6f}, Std: {q_BLHD.grad.std().item():.6f}")
+    print(f"  dK_QAT - Shape: {k_BLHD.grad.shape}, Min: {k_BLHD.grad.min().item():.6f}, Max: {k_BLHD.grad.max().item():.6f}, Mean: {k_BLHD.grad.mean().item():.6f}, Std: {k_BLHD.grad.std().item():.6f}")
+    print(f"  dV_QAT - Shape: {v_BLHD.grad.shape}, Min: {v_BLHD.grad.min().item():.6f}, Max: {v_BLHD.grad.max().item():.6f}, Mean: {v_BLHD.grad.mean().item():.6f}, Std: {v_BLHD.grad.std().item():.6f}")
+    
+    print("\n  === Naive Gradients ===")
+    print(f"  dQ_Naive - Shape: {q_naive_grad_BLHD.shape}, Min: {q_naive_grad_BLHD.min().item():.6f}, Max: {q_naive_grad_BLHD.max().item():.6f}, Mean: {q_naive_grad_BLHD.mean().item():.6f}, Std: {q_naive_grad_BLHD.std().item():.6f}")
+    print(f"  dK_Naive - Shape: {k_naive_grad_BLHD.shape}, Min: {k_naive_grad_BLHD.min().item():.6f}, Max: {k_naive_grad_BLHD.max().item():.6f}, Mean: {k_naive_grad_BLHD.mean().item():.6f}, Std: {k_naive_grad_BLHD.std().item():.6f}")
+    print(f"  dV_Naive - Shape: {v_naive_grad_BLHD.shape}, Min: {v_naive_grad_BLHD.min().item():.6f}, Max: {v_naive_grad_BLHD.max().item():.6f}, Mean: {v_naive_grad_BLHD.mean().item():.6f}, Std: {v_naive_grad_BLHD.std().item():.6f}")
+    
+    # Print sample values (first few elements)
+    # print("\n  === Sample Gradient Values (first 10 elements) ===")
+    # print(f"  dQ_QAT[0,0,0,:10]:   {q_BLHD.grad[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dQ_Naive[0,0,0,:10]: {q_naive_grad_BLHD[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dK_QAT[0,0,0,:10]:   {k_BLHD.grad[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dK_Naive[0,0,0,:10]: {k_naive_grad_BLHD[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dV_QAT[0,0,0,:10]:   {v_BLHD.grad[0,0,0,:10].cpu().tolist()}")
+    # print(f"  dV_Naive[0,0,0,:10]: {v_naive_grad_BLHD[0,0,0,:10].cpu().tolist()}")
+
+    # -----------------------------
+    # COMPARE
+    # -----------------------------
+    dq_diff = (q_BLHD.grad - q_naive_grad_BLHD).abs()
+    dk_diff = (k_BLHD.grad - k_naive_grad_BLHD).abs()
+    dv_diff = (v_BLHD.grad - v_naive_grad_BLHD).abs()
+
+    dq_cos = cosine_similarity(q_BLHD.grad, q_naive_grad_BLHD)
+    dk_cos = cosine_similarity(k_BLHD.grad, k_naive_grad_BLHD)
+    dv_cos = cosine_similarity(v_BLHD.grad, v_naive_grad_BLHD)
+
+    print("\n  === Gradient Comparison ===")
+    print(f"  dQ - Max diff: {dq_diff.max().item():.6f}, Mean: {dq_diff.mean().item():.6f}, Cos: {dq_cos:.6f}")
+    print(f"  dK - Max diff: {dk_diff.max().item():.6f}, Mean: {dk_diff.mean().item():.6f}, Cos: {dk_cos:.6f}")
+    print(f"  dV - Max diff: {dv_diff.max().item():.6f}, Mean: {dv_diff.mean().item():.6f}, Cos: {dv_cos:.6f}")
+
+    print("\n✓ WAN shape non-divisible-by-64 forward/backward test passed.")
+
+
+if __name__ == "__main__":
+    print("Running QAT attention tests...")
+    print(f"Device: {DEVICE}")
+    print()
+    
+    test_qat_attention_forward()
+    test_qat_attention_backward()
+    test_qat_attention_different_shapes()
+    test_qat_attention_non_causal()
+    test_qat_attention_causal()
+    test_qat_attention_causal_backward()
+    test_qat_attention_different_seq_lengths()
+    test_qat_attention_different_seq_lengths_backward()
+    test_qat_attention_wan_shape_forward()
+    test_qat_attention_wan_shape_backward()
+    test_qat_attention_wan_shape_non_divisible_64()
+    
+    print()
+    print("Running Fused attention tests...")
+    print()
+    
+    # test_fused_attention_forward()
+    # test_fused_attention_backward()
+    # test_fused_attention_different_shapes()
+    # test_fused_attention_non_causal()
+    # test_fused_attention_causal()
+    # test_fused_attention_causal_backward()
+    
+    # print()
+    # print("Running Fused vs QAT attention comparison tests...")
+    # print()
+    
+    # test_fused_vs_qat_attention_forward()
+    # test_fused_vs_qat_attention_backward()
+    # test_fused_vs_qat_attention_different_shapes()
+    # test_fused_vs_qat_attention_non_causal()
+    # test_fused_vs_qat_attention_causal()
+    # test_fused_vs_qat_attention_causal_backward()
+    
+    print()
+    print("All tests passed! ✓")


### PR DESCRIPTION
## Purpose

Continues the Attn-QAT upstreaming stack (#1225). Adds the **fake-quantized
attention Triton kernels** imported by `AttnQatTrainBackend`, completing the
training-side attention path. With these present, `is_attn_qat_train_available()`
(from #1459) returns True and `ATTN_QAT_TRAIN` performs real fake-quant instead
of falling back to Flash Attention.

## Changes (all new, under `fastvideo-kernel/`)

- `triton_kernels/attn_qat_train.py`: QAT attention fwd/bwd — fake NVFP4 (E2M1)
  quantization of Q/K/V/P with a straight-through estimator; exports `attention`
  (the symbol `fastvideo/attention/backends/attn_qat_train.py` imports).
- `triton_kernels/quant_utils.py` + `triton_kernels/nvfp4_utils.py`: NVFP4
  fake-quant helpers.
- `triton_kernels/fused_attention.py`: non-QAT Triton reference used by the test.
- `tests/test_attn_qat_train.py`.

## Test Plan / Test Results

**Verified on a Blackwell node (GB200, sm_100)** — the full `test_attn_qat_train.py`
suite passes: forward/backward, causal & non-causal, varied sequence lengths, and
a Wan (non-divisible-by-64) shape. QAT output and gradients match the FP32 / naive
reference at **cos ≈ 0.98** (the gap is the modeled FP4 attention error — exactly
what QAT trains the model to absorb).

This is a Triton kernel, so unlike the sm_120-only inference CUDA kernel (#1455)
it runs and validates on datacenter Blackwell too.

### Notes
- `tests/test_fake_quant.py` from the source branch was **left out**: it imports
  `flashinfer` at module top and would break collection where flashinfer isn't
  installed. Can add it later behind an import guard.
- These kernel files live under `fastvideo-kernel/`, which is excluded from the
  repo's python pre-commit hooks (yapf/ruff/mypy), consistent with the other
  kernels there.

Depends on #1459 (backend wiring). Part of #1225.
