### PR TITLE
[feat] QAD 5090: env-gate attention torch.compile via FASTVIDEO_DISABLE_ATTENTION_COMPILE (16/12)

### DIFF
--- a/fastvideo/attention/layer.py
+++ b/fastvideo/attention/layer.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import torch
 import torch.nn as nn
 
@@ -11,6 +13,26 @@ from fastvideo.forward_context import ForwardContext, get_forward_context
 from fastvideo.platforms import AttentionBackendEnum
 from fastvideo.utils import get_compute_dtype
 from fastvideo.layers.rotary_embedding import _apply_rotary_emb
+
+
+def _attention_compile_disabled() -> bool:
+    """Whether to keep attention ``forward`` out of the torch.compile graph.
+
+    Defaults to ``True`` (the historical behavior: attention runs eager via
+    ``torch.compiler.disable``). Set ``FASTVIDEO_DISABLE_ATTENTION_COMPILE=0``
+    to let attention be traced/compiled into the surrounding graph.
+    """
+    val = os.environ.get("FASTVIDEO_DISABLE_ATTENTION_COMPILE")
+    if val is None:
+        return True
+    return val.strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def _maybe_compiler_disable(fn):
+    """Apply ``torch.compiler.disable`` unless disabled via env var."""
+    if _attention_compile_disabled():
+        return torch.compiler.disable(fn)
+    return fn
 
 
 class DistributedAttention(nn.Module):
@@ -56,7 +78,7 @@ class DistributedAttention(nn.Module):
         self.backend = backend_name_to_enum(attn_backend.get_name())
         self.dtype = dtype
 
-    @torch.compiler.disable
+    @_maybe_compiler_disable
     def forward(
         self,
         q: torch.Tensor,
@@ -146,7 +168,7 @@ class DistributedAttention_VSA(DistributedAttention):
     """Distributed attention layer with VSA support.
     """
 
-    @torch.compiler.disable
+    @_maybe_compiler_disable
     def forward(
         self,
         q: torch.Tensor,


### PR DESCRIPTION
Stacked on top of #1466 (`pr1225_s15`).

## What
`DistributedAttention.forward` (and the `DistributedAttention_VSA` subclass) in `fastvideo/attention/layer.py` are hard-decorated with `@torch.compiler.disable`, which keeps attention out of the surrounding `torch.compile` graph **unconditionally**.

After #1466 makes the FP4 linear (`nvfp4_qat_config`) and SageAttention3 (`sage_attn3`) paths graph-break-free, the attention `forward` itself is still the one remaining hard stop — so the inference compile path can't be fully realized. This PR makes that disable opt-out.

## Behavior
Gate the decorator on `FASTVIDEO_DISABLE_ATTENTION_COMPILE`:

| value | effect |
|---|---|
| unset / `1` / `true` (default) | keep `torch.compiler.disable` — **current behavior, no change** |
| `0` / `false` / `no` / `off` | drop it, so attention folds into the compile graph |

The env var is read at **import time** (decorators apply at class definition), which matches the multiproc spawn path: each worker re-imports and inherits the parent's env. For runtime toggling you'd need a per-call check instead — not needed here.

## Why stacked on #1466
This is the last piece of #1466's compile path: with #1466's graph-break fixes + this toggle set to `0`, the attention layer can actually be traced. Confirming end-to-end inference performance on top of #1466 next.

Co-authored-by: Loay Rashid <42599591+loaydatrain@users.noreply.github.com>
Co-authored-by: Kaiqin Kong <k1kong@ucsd.edu>
Co-authored-by: William Lin <SolitaryThinker@users.noreply.github.com>