### PR TITLE
[bugfix] Wire Cosmos-Predict2.5 2B to its sampling preset

### DIFF
--- a/fastvideo/registry.py
+++ b/fastvideo/registry.py
@@ -615,6 +615,8 @@ def _register_configs() -> None:
                 "cosmos-predict2.5",
             )) and "14b" not in path.lower(),
         ],
+        model_family="cosmos25",
+        default_preset="cosmos25_predict2_2b",
     )
 
     # Cosmos 2.5 (14B)

--- a/fastvideo/tests/api/test_presets.py
+++ b/fastvideo/tests/api/test_presets.py
@@ -464,6 +464,18 @@ class TestCosmosPresets:
         assert len(presets) == 1
         assert presets[0].name == "cosmos25_predict2_2b"
 
+    def test_cosmos25_2b_path_resolves_to_preset(self) -> None:
+        """Regression: the Cosmos-Predict2.5 2B model path must select the
+        cosmos25 preset (guidance_scale=7.0), not fall back to the generic
+        default (guidance_scale=1.0) which produced blurry output.
+        """
+        import fastvideo.registry  # noqa: F401
+        from fastvideo.api.sampling_param import SamplingParam
+        sp = SamplingParam.from_pretrained(
+            "KyleShao/Cosmos-Predict2.5-2B-Diffusers")
+        assert sp.guidance_scale == 7.0
+        assert sp.num_inference_steps == 35
+
     def test_cosmos_and_cosmos25_different_fps(self) -> None:
         import fastvideo.registry  # noqa: F401
         c = get_preset("cosmos_predict2_2b", "cosmos")


### PR DESCRIPTION
## Summary

The Cosmos-Predict2.5 **2B** registry entry (`KyleShao/Cosmos-Predict2.5-2B-Diffusers`) was missing `model_family` / `default_preset`, so `SamplingParam.from_pretrained` found no preset and fell back to the generic default (`guidance_scale=1.0`, i.e. no CFG) — producing **blurry output**. This points it at the existing `cosmos25_predict2_2b` preset (`guidance_scale=7.0`, `num_inference_steps=35`) — the same wiring the **14B** entry already uses.

## Root cause

In `fastvideo/registry.py`, the 14B Cosmos-2.5 entry sets `model_family="cosmos25"` and `default_preset="cosmos25_predict2_2b"`, but the 2B entry set neither. So `get_preset_selection()` returned no preset for the 2B path and `from_pretrained` silently used library defaults (`guidance_scale=1.0`). The correct preset already existed in `fastvideo/pipelines/basic/cosmos/presets.py` — it just wasn't connected for the 2B model.

## Fix

Two lines: add `model_family="cosmos25"` + `default_preset="cosmos25_predict2_2b"` to the 2B entry. Pure registry config — platform-independent.

## Test

- Adds `test_cosmos25_2b_path_resolves_to_preset` to `fastvideo/tests/api/test_presets.py`, asserting the 2B model path resolves to `guidance_scale=7.0` / `num_inference_steps=35` (runs in the existing `fastvideo/tests/api` unit suite). The prior tests covered preset *existence* but not model-path *resolution*, which is the gap that allowed this.
- Empirical: on an NVIDIA GB10, the default `guidance_scale=1.0` produced blurry text-to-world output (mean per-frame Laplacian-variance sharpness ~92). Re-running with `guidance_scale=7.0` restored sharpness to ~431, matching known-good Wan clips. This change makes 7.0 the default, so no manual override is needed.