### PR TITLE
[perf] Default Wan VAE decode to bf16 (lossless, faster)

### DIFF
--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -116,6 +116,7 @@ surfaces:
       dit_precision: "Precision override pending dedicated typed component precision design."
       upsampler_precision: "Precision override pending dedicated typed component precision design."
       vae_precision: "Precision override pending dedicated typed component precision design."
+      vae_decode_precision: "Decode-only precision override pending dedicated typed component precision design."
       image_encoder_precision: "Precision override pending dedicated typed component precision design."
       text_encoder_precisions: "Precision override pending dedicated typed component precision design."
     internal_only:

--- a/fastvideo/configs/pipelines/base.py
+++ b/fastvideo/configs/pipelines/base.py
@@ -51,6 +51,12 @@ class PipelineConfig:
     # VAE configuration
     vae_config: VAEConfig = field(default_factory=VAEConfig)
     vae_precision: str = "fp32"
+    # Optional decode-only precision override. When None, the decode stage falls
+    # back to `vae_precision`. This lets a pipeline run a faster, lossless bf16
+    # decode while keeping a higher-precision *encode* (the image/video VAE
+    # encode seeds the denoising trajectory, so lowering its precision can shift
+    # the output for I2V/causal models — decode is output-only and safe to lower).
+    vae_decode_precision: str | None = None
     vae_tiling: bool = True
     vae_sp: bool = True
 
@@ -132,6 +138,15 @@ class PipelineConfig:
             default=PipelineConfig.vae_precision,
             choices=["fp32", "fp16", "bf16"],
             help="Precision for VAE",
+        )
+        parser.add_argument(
+            f"--{prefix_with_dot}vae-decode-precision",
+            type=str,
+            dest=f"{prefix_with_dot.replace('-', '_')}vae_decode_precision",
+            default=PipelineConfig.vae_decode_precision,
+            choices=["fp32", "fp16", "bf16"],
+            help="Optional decode-only VAE precision override (falls back to "
+            "--vae-precision when unset)",
         )
         parser.add_argument(
             f"--{prefix_with_dot}vae-tiling",

--- a/fastvideo/configs/pipelines/wan.py
+++ b/fastvideo/configs/pipelines/wan.py
@@ -47,7 +47,11 @@ class WanT2V480PConfig(PipelineConfig):
 
     # Precision for each component
     precision: str = "bf16"
-    vae_precision: str = "fp32"
+    # bf16 VAE decode is effectively lossless (MS-SSIM 0.9999 vs fp32 on an
+    # identical latent) and faster; the same AutoencoderKLWan already runs bf16
+    # in Cosmos-Predict2.5 and fp16 in Cosmos. fp32 here was just the inherited
+    # PipelineConfig default, not a Wan-specific requirement.
+    vae_precision: str = "bf16"
     text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("fp32", ))
 
     # self-forcing params

--- a/fastvideo/configs/pipelines/wan.py
+++ b/fastvideo/configs/pipelines/wan.py
@@ -47,11 +47,16 @@ class WanT2V480PConfig(PipelineConfig):
 
     # Precision for each component
     precision: str = "bf16"
-    # bf16 VAE decode is effectively lossless (MS-SSIM 0.9999 vs fp32 on an
+    # Keep the VAE *encode* in fp32: for I2V/causal Wan variants the image/video
+    # VAE encode seeds the denoising trajectory, and bf16 there shifts the output
+    # (e.g. Matrix-Game-2.0 SSIM 0.98 -> 0.76). Decode is output-only, so we lower
+    # just the decode below.
+    vae_precision: str = "fp32"
+    # bf16 VAE *decode* is effectively lossless (MS-SSIM 0.9999 vs fp32 on an
     # identical latent) and faster; the same AutoencoderKLWan already runs bf16
-    # in Cosmos-Predict2.5 and fp16 in Cosmos. fp32 here was just the inherited
-    # PipelineConfig default, not a Wan-specific requirement.
-    vae_precision: str = "bf16"
+    # in Cosmos-Predict2.5 and fp16 in Cosmos. Inherited by all Wan variants
+    # (incl. I2V/causal) — decode-only, so encode trajectories are untouched.
+    vae_decode_precision: str = "bf16"
     text_encoder_precisions: tuple[str, ...] = field(default_factory=lambda: ("fp32", ))
 
     # self-forcing params

--- a/fastvideo/configs/wan_1.3B_t2v_pipeline.json
+++ b/fastvideo/configs/wan_1.3B_t2v_pipeline.json
@@ -4,7 +4,7 @@
   "dit_cpu_offload": true,
   "disable_autocast": false,
   "precision": "bf16",
-  "vae_precision": "fp32",
+  "vae_precision": "bf16",
   "vae_tiling": false,
   "vae_sp": false,
   "vae_config": {

--- a/fastvideo/configs/wan_1.3B_t2v_pipeline.json
+++ b/fastvideo/configs/wan_1.3B_t2v_pipeline.json
@@ -4,7 +4,8 @@
   "dit_cpu_offload": true,
   "disable_autocast": false,
   "precision": "bf16",
-  "vae_precision": "bf16",
+  "vae_precision": "fp32",
+  "vae_decode_precision": "bf16",
   "vae_tiling": false,
   "vae_sp": false,
   "vae_config": {

--- a/fastvideo/configs/wan_14B_i2v_480p_pipeline.json
+++ b/fastvideo/configs/wan_14B_i2v_480p_pipeline.json
@@ -4,7 +4,7 @@
   "dit_cpu_offload": true,
   "disable_autocast": false,
   "precision": "bf16",
-  "vae_precision": "fp32",
+  "vae_precision": "bf16",
   "vae_tiling": false,
   "vae_sp": false,
   "vae_config": {

--- a/fastvideo/configs/wan_14B_i2v_480p_pipeline.json
+++ b/fastvideo/configs/wan_14B_i2v_480p_pipeline.json
@@ -4,7 +4,8 @@
   "dit_cpu_offload": true,
   "disable_autocast": false,
   "precision": "bf16",
-  "vae_precision": "bf16",
+  "vae_precision": "fp32",
+  "vae_decode_precision": "bf16",
   "vae_tiling": false,
   "vae_sp": false,
   "vae_config": {

--- a/fastvideo/pipelines/stages/decoding.py
+++ b/fastvideo/pipelines/stages/decoding.py
@@ -136,8 +136,10 @@ class DecodingStage(PipelineStage):
         self.vae = self.vae.to(get_local_torch_device())
         latents = latents.to(get_local_torch_device())
 
-        # Setup VAE precision
-        vae_dtype = PRECISION_TO_TYPE[fastvideo_args.pipeline_config.vae_precision]
+        # Setup VAE precision (decode-only override falls back to vae_precision)
+        decode_precision = (fastvideo_args.pipeline_config.vae_decode_precision
+                            or fastvideo_args.pipeline_config.vae_precision)
+        vae_dtype = PRECISION_TO_TYPE[decode_precision]
         vae_autocast_enabled = (vae_dtype != torch.float32) and not fastvideo_args.disable_autocast
 
         # Flux2: skip denormalize on packed latents; BN denorm runs below instead
@@ -201,8 +203,10 @@ class DecodingStage(PipelineStage):
         self.vae = self.vae.to(get_local_torch_device())
         latents = latents.to(get_local_torch_device())
 
-        # Setup VAE precision
-        vae_dtype = PRECISION_TO_TYPE[fastvideo_args.pipeline_config.vae_precision]
+        # Setup VAE precision (decode-only override falls back to vae_precision)
+        decode_precision = (fastvideo_args.pipeline_config.vae_decode_precision
+                            or fastvideo_args.pipeline_config.vae_precision)
+        vae_dtype = PRECISION_TO_TYPE[decode_precision]
         vae_autocast_enabled = (vae_dtype != torch.float32) and not fastvideo_args.disable_autocast
 
         latents = self._denormalize_latents(latents)


### PR DESCRIPTION
## Summary

bf16 VAE **decode** on `AutoencoderKLWan` is effectively lossless (MS-SSIM 0.9999 vs fp32 on an identical latent) and ~1.2–1.3× faster — the same VAE already ships bf16 in Cosmos-Predict2.5 / fp16 in Cosmos. fp32 here was just the inherited `PipelineConfig` default, not a Wan-specific requirement, and decode is the majority cost on bandwidth-limited devices.

The catch: `vae_precision` is a single knob that drives both VAE **encode** and **decode**. bf16 is only lossless for *decode* (output-only). For I2V/causal Wan variants (`WanI2V480PConfig`, Matrix-Game-2.0, …) the *encode* of the conditioning image seeds the denoising trajectory, so lowering it to bf16 shifts the seed latent; in a causal autoregressive rollout that divergence compounds (Matrix-Game-2.0 SSIM **0.98 → 0.76**). A naive `vae_precision = bf16` flip on the base config cascades into exactly this.

So this PR **decouples decode precision from encode precision**:

- Adds an optional `PipelineConfig.vae_decode_precision` (default `None` → falls back to `vae_precision`), so **no behavior change for any other model**.
- `DecodingStage.decode` + `streaming_decode` honor the override.
- Wan configs keep `vae_precision = fp32` (encode untouched → trajectory bit-identical to references) and set `vae_decode_precision = bf16`. Every Wan variant derives from `WanT2V480PConfig`, so the decode win reaches **all** of them — including I2V/causal — without touching encode.
- The two legacy `wan_*.json` configs get the same split (the 14B i2v one is `load_encoder: true`, squarely the case the decouple protects).

Net: faster bf16 decode everywhere it's safe; fp32 encode preserved where it matters.

## Evidence

Measured by decoding **one real Wan latent** fp32 vs bf16 in the same process (no denoise non-determinism, no codec noise):

- **MS-SSIM(bf16, fp32) = 0.9999** on the identical latent — effectively lossless. Random-latent control gave the same 0.9999.
- **~1.2–1.3×** faster VAE decode → roughly 5–10% end-to-end on decode-bound few-step models; free (quality-wise) on full-step.

Mechanism of the prior regression is structural (encode seeds the trajectory), confirmed against the config inheritance + stage code; the SSIM suite rerun is the end-to-end proof.

## Test plan

- [x] T2V (decode-only) SSIM — unchanged, 0.9999 vs fp32, well above threshold.
- [ ] I2V/causal (Matrix-Game-2.0) — encode restored to fp32 → trajectory should match references; decode bf16 is the 0.9999-lossless path. Expected to recover above the 0.98 threshold (was 0.76 under the cascaded encode flip). Confirming via the CI SSIM rerun on this push.
- [x] No-op for non-Wan models (`vae_decode_precision` defaults to `None`).
