### PR TITLE
[bugfix] Fix performance component timing extraction

### DIFF
--- a/docs/contributing/performance_benchmarks.md
+++ b/docs/contributing/performance_benchmarks.md
@@ -105,11 +105,15 @@ Each benchmark records six metrics:
 
 `test_inference_performance.py` temporarily sets `FASTVIDEO_STAGE_LOGGING=1`
 while it runs so pipeline stage execution times are available in
-`generate_video(...).logging_info`. It maps `TextEncodingStage` to
-`text_encoder_time_s`, `DenoisingStage` and `DmdDenoisingStage` to
-`dit_time_s`, and `DecodingStage` to `vae_decode_time_s`. If a pipeline does
-not report one of those stages, that component metric is stored as `null` and
-is skipped by the static threshold and rolling baseline checks.
+`generate_video(...).logging_info`. Stage logs use pipeline-unique keys such as
+`prompt_encoding_stage` so duplicate stage classes do not collide; each entry's
+`stage_class` field is mapped to component metrics. The extractor maps
+`TextEncodingStage` to `text_encoder_time_s`, `DenoisingStage` and
+`DmdDenoisingStage` to `dit_time_s`, and `DecodingStage` to
+`vae_decode_time_s`, with a fallback for older logs that used the class name as
+the stage key. If a pipeline does not report one of those stages, that
+component metric is stored as `null` and is skipped by the static threshold and
+rolling baseline checks.
 
 ## The two gates
 

--- a/docs/contributing/performance_benchmarks.md
+++ b/docs/contributing/performance_benchmarks.md
@@ -106,14 +106,15 @@ Each benchmark records six metrics:
 `test_inference_performance.py` temporarily sets `FASTVIDEO_STAGE_LOGGING=1`
 while it runs so pipeline stage execution times are available in
 `generate_video(...).logging_info`. Stage logs use pipeline-unique keys such as
-`prompt_encoding_stage` so duplicate stage classes do not collide; each entry's
-`stage_class` field is mapped to component metrics. The extractor maps
-`TextEncodingStage` to `text_encoder_time_s`, `DenoisingStage` and
-`DmdDenoisingStage` to `dit_time_s`, and `DecodingStage` to
+`prompt_encoding_stage` so duplicate stage classes do not collide. For
+`PipelineStage` entries, the extractor maps the `stage_class` field:
+`TextEncodingStage` maps to `text_encoder_time_s`, `DenoisingStage` and
+`DmdDenoisingStage` map to `dit_time_s`, and `DecodingStage` maps to
 `vae_decode_time_s`, with a fallback for older logs that used the class name as
-the stage key. If a pipeline does not report one of those stages, that
-component metric is stored as `null` and is skipped by the static threshold and
-rolling baseline checks.
+the stage key. Generator-side timings such as `PostDecodeFrameProcessStage`,
+`VideoSaveStage`, and `AudioMuxStage` are intentionally ignored. If a pipeline
+does not report one of the mapped stages, that component metric is stored as
+`null` and is skipped by the static threshold and rolling baseline checks.
 
 ## The two gates
 

--- a/fastvideo/tests/performance/test_inference_performance.py
+++ b/fastvideo/tests/performance/test_inference_performance.py
@@ -98,10 +98,12 @@ def _extract_component_times(result: dict) -> dict[str, float | None]:
         return component_times
     logger.info("Discovered pipeline stages: %s", list(stages.keys()))
     for stage_name, stage_data in stages.items():
-        metric_key = STAGE_METRIC_MAP.get(stage_name)
+        stage_class = stage_data.get("stage_class", stage_name)
+        metric_key = STAGE_METRIC_MAP.get(stage_class)
         if metric_key is None:
-            logger.debug("Unmapped stage '%s' (%.3fs)",
+            logger.debug("Unmapped stage '%s' class '%s' (%.3fs)",
                          stage_name,
+                         stage_class,
                          stage_data.get("execution_time", 0))
             continue
         elapsed = stage_data.get("execution_time")

--- a/fastvideo/tests/performance/test_inference_performance.py
+++ b/fastvideo/tests/performance/test_inference_performance.py
@@ -98,6 +98,9 @@ def _extract_component_times(result: dict) -> dict[str, float | None]:
         return component_times
     logger.info("Discovered pipeline stages: %s", list(stages.keys()))
     for stage_name, stage_data in stages.items():
+        if not isinstance(stage_data, Mapping):
+            logger.debug("Skipping malformed stage '%s' data: %r", stage_name, stage_data)
+            continue
         stage_class = stage_data.get("stage_class", stage_name)
         metric_key = STAGE_METRIC_MAP.get(stage_class)
         if metric_key is None:

--- a/fastvideo/tests/performance/test_inference_performance_component_times.py
+++ b/fastvideo/tests/performance/test_inference_performance_component_times.py
@@ -17,6 +17,8 @@ def test_extract_component_times_handles_pipeline_logging_info_object():
 
 
 def test_extract_component_times_uses_stage_class_for_pipeline_stage_keys():
+    # Regression guard for #1377: pre-fix code looked up the pipeline stage key
+    # and returned all component metrics as None for this shape.
     result = {
         "logging_info": {
             "stages": {
@@ -44,6 +46,8 @@ def test_extract_component_times_uses_stage_class_for_pipeline_stage_keys():
 
 
 def test_extract_component_times_keeps_legacy_class_name_keys():
+    # Backward-compatibility check for logs produced before pipeline-unique
+    # stage keys carried a separate stage_class field.
     result = {
         "logging_info": {
             "stages": {
@@ -85,6 +89,8 @@ def test_extract_component_times_accumulates_duplicate_component_classes():
 
 
 def test_extract_component_times_ignores_unmapped_stages():
+    # Generator-side bookkeeping timings are intentionally excluded from the
+    # component gates.
     result = {
         "logging_info": {
             "stages": {

--- a/fastvideo/tests/performance/test_inference_performance_component_times.py
+++ b/fastvideo/tests/performance/test_inference_performance_component_times.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from fastvideo.pipelines.pipeline_batch_info import PipelineLoggingInfo
+from fastvideo.tests.performance.test_inference_performance import _extract_component_times
+
+
+def test_extract_component_times_handles_pipeline_logging_info_object():
+    logging_info = PipelineLoggingInfo()
+    logging_info.add_stage_execution_time("prompt_encoding_stage", 1.25)
+    logging_info.add_stage_metric("prompt_encoding_stage", "stage_class", "TextEncodingStage")
+
+    assert _extract_component_times({"logging_info": logging_info}) == {
+        "text_encoder_time_s": 1.25,
+        "dit_time_s": None,
+        "vae_decode_time_s": None,
+    }
+
+
+def test_extract_component_times_uses_stage_class_for_pipeline_stage_keys():
+    result = {
+        "logging_info": {
+            "stages": {
+                "prompt_encoding_stage": {
+                    "execution_time": 1.2,
+                    "stage_class": "TextEncodingStage",
+                },
+                "denoising_stage": {
+                    "execution_time": 3.4,
+                    "stage_class": "DenoisingStage",
+                },
+                "decoding_stage": {
+                    "execution_time": 0.8,
+                    "stage_class": "DecodingStage",
+                },
+            },
+        },
+    }
+
+    assert _extract_component_times(result) == {
+        "text_encoder_time_s": 1.2,
+        "dit_time_s": 3.4,
+        "vae_decode_time_s": 0.8,
+    }
+
+
+def test_extract_component_times_keeps_legacy_class_name_keys():
+    result = {
+        "logging_info": {
+            "stages": {
+                "TextEncodingStage": {"execution_time": 1.0},
+                "DenoisingStage": {"execution_time": 2.0},
+                "DecodingStage": {"execution_time": 3.0},
+            },
+        },
+    }
+
+    assert _extract_component_times(result) == {
+        "text_encoder_time_s": 1.0,
+        "dit_time_s": 2.0,
+        "vae_decode_time_s": 3.0,
+    }
+
+
+def test_extract_component_times_accumulates_duplicate_component_classes():
+    result = {
+        "logging_info": {
+            "stages": {
+                "base_denoising_stage": {
+                    "execution_time": 2.0,
+                    "stage_class": "DenoisingStage",
+                },
+                "refine_denoising_stage": {
+                    "execution_time": 3.5,
+                    "stage_class": "DenoisingStage",
+                },
+            },
+        },
+    }
+
+    assert _extract_component_times(result) == {
+        "text_encoder_time_s": None,
+        "dit_time_s": 5.5,
+        "vae_decode_time_s": None,
+    }
+
+
+def test_extract_component_times_ignores_unmapped_stages():
+    result = {
+        "logging_info": {
+            "stages": {
+                "PostDecodeFrameProcessStage": {"execution_time": 0.2},
+                "VideoSaveStage": {"execution_time": 0.4},
+                "AudioMuxStage": {"execution_time": 0.1},
+            },
+        },
+    }
+
+    assert _extract_component_times(result) == {
+        "text_encoder_time_s": None,
+        "dit_time_s": None,
+        "vae_decode_time_s": None,
+    }

--- a/fastvideo/tests/performance/test_inference_performance_component_times.py
+++ b/fastvideo/tests/performance/test_inference_performance_component_times.py
@@ -100,3 +100,24 @@ def test_extract_component_times_ignores_unmapped_stages():
         "dit_time_s": None,
         "vae_decode_time_s": None,
     }
+
+
+def test_extract_component_times_skips_malformed_stage_data():
+    result = {
+        "logging_info": {
+            "stages": {
+                "prompt_encoding_stage": None,
+                "denoising_stage": "not-a-stage-metric-dict",
+                "decoding_stage": {
+                    "execution_time": 0.8,
+                    "stage_class": "DecodingStage",
+                },
+            },
+        },
+    }
+
+    assert _extract_component_times(result) == {
+        "text_encoder_time_s": None,
+        "dit_time_s": None,
+        "vae_decode_time_s": 0.8,
+    }


### PR DESCRIPTION
## Purpose

  Fixes #1377.

  Restore downstream performance CI component timings after pipeline stage logging moved to pipeline-
  unique stage keys.

  ## Changes

  - Map performance stage timings using each stage entry’s `stage_class`, with fallback to legacy class-
  name stage keys.
  - Add focused tests for real `PipelineLoggingInfo`, pipeline-keyed logs, legacy logs, duplicate
  denoising accumulation, and unmapped stages.
  - Update performance benchmark docs to describe pipeline-unique stage logging and component metric
  extraction.

  ## Test Plan

  ```bash
  python -m pytest \
    fastvideo/tests/performance/test_inference_performance_component_times.py \
    fastvideo/tests/performance/test_compare_baseline_policy.py \
    fastvideo/tests/performance/test_dashboard_service.py \
    fastvideo/tests/performance/test_dashboard_api.py \
    -q
```

 ```bash
  pre-commit run --files \
    docs/contributing/performance_benchmarks.md \
    fastvideo/tests/performance/test_inference_performance.py \
    fastvideo/tests/performance/test_inference_performance_component_times.py
```

  ## Test Results
  <details>
  <summary>Test output</summary>

  ........................                                                 [100%]
  24 passed in 0.96s

  yapf.................................................(no files to check)Skipped
  ruff (legacy alias)..................................(no files to check)Skipped
  codespell................................................................Passed
  PyMarkdown...............................................................Passed
  Lint GitHub Actions workflow files...................(no files to check)Skipped
  mypy.................................................(no files to check)Skipped
  Check for spaces in all filenames........................................Passed
  Suggestion...............................................................Passed
  </details>

  ## Checklist

  - [x] I ran pre-commit on changed files and fixed all issues
  - [x] I added or updated tests for my changes
  - [x] I updated documentation if needed
  - [x] I considered GPU memory impact of my changes

  For model/pipeline changes, also check:

  - [ ] I verified SSIM regression tests pass
  - [ ] I updated the support matrix if adding a new model