### PR TITLE
[ci] mergify: stop auto-syncing ready PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -272,7 +272,7 @@ pull_request_rules:
         remove: [needs-rebase]
 
   # ============================================================
-  # Auto-merge and auto-rebase
+  # Auto-merge
   # ============================================================
 
   - name: auto-merge when ready and all checks pass
@@ -289,16 +289,6 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-
-  - name: auto-update when ready
-    conditions:
-      - label=ready
-      - "#approved-reviews-by>=1"
-      - -conflict
-      - -closed
-      - -draft
-    actions:
-      update: {}
 
   # ============================================================
   # PR title format help


### PR DESCRIPTION
## What

Remove the Mergify `auto-update` rule entirely, so `ready` PRs are no longer auto-rebased onto `main`.

## Why

`auto-update` fired `update: {}` on **every** PR labeled `ready` + approved **whenever `main` advanced** (i.e. whenever any other PR merged). Each update pushed the branch → `synchronize` event → `ci-trigger-full-suite.yml` launched a fresh **full GPU suite on Buildkite/Modal** (cancelling the in-flight one). With N ready PRs that's `O(N × merges)` rebases and full-suite reruns → e-mail notification spam and wasted GPU compute.

Crucially, `main` does **not** require up-to-date branches (`required_status_checks.strict = false`), so `auto-merge` already squash-merges a PR **even when it's behind `main`**. The `auto-update` rule therefore provided **no** pre-merge "tested against latest main" guarantee — it only generated rebase/CI churn. Removing it is behaviorally equivalent for merges and eliminates the spam, consistent with #1200 (merge queue removed to reduce CI complexity).

> If a "test against latest main before merge" guarantee is ever desired, the correct approach is to enable `strict` branch protection **and** add a gated sync rule — not this rule, which did nothing under the current settings.

## Change

- Drop the `auto-update when ready` rule (`update: {}`).
- Rename the section header `Auto-merge and auto-rebase` → `Auto-merge`.

`auto-merge`, merge-protections, type/scope labelers, pre-commit help, and conflict-detection rules are all unchanged.

## Test evidence

Config-only change; `mergify.yml` validated as well-formed YAML (25 `pull_request_rules` parse, down from 26; no rule retains an `update` action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
