### PR TITLE
[ci] bump cuda-toolkit action to v0.2.35 to fix kernel cu130 publish

### DIFF
--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -96,9 +96,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install CUDA ${{ matrix.torch-cuda.cuda-version }}
-        # v0.2.21 predates CUDA 13 (its link table stops at 12.8.0), so the cu130 leg
-        # failed with "Version not available: 13.0.0". v0.2.27+ added CUDA 13.0.0;
-        # v0.2.35 (Node 24) covers both 12.6.3 and 13.0.0.
         uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
         with:

--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -96,7 +96,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install CUDA ${{ matrix.torch-cuda.cuda-version }}
-        uses: Jimver/cuda-toolkit@v0.2.21
+        # v0.2.21 predates CUDA 13 (its link table stops at 12.8.0), so the cu130 leg
+        # failed with "Version not available: 13.0.0". v0.2.27+ added CUDA 13.0.0;
+        # v0.2.35 (Node 24) covers both 12.6.3 and 13.0.0.
+        uses: Jimver/cuda-toolkit@v0.2.35
         id: cuda-toolkit
         with:
           cuda: ${{ matrix.torch-cuda.cuda-version }}


### PR DESCRIPTION
## Problem

The most recent `publish-kernel` run (0.3.0 release, #1478) **failed**, and 0.3.0 was never published to PyPI:

- ✅ Build Wheel (12.6.3, cu126)
- ❌ Build Wheel (13.0.0, cu130) — `Install CUDA 13.0.0` → `Error: Version not available: 13.0.0`
- ⏭️ Publish package — skipped (depends on `build_wheels`)

The #1478 release added the `cu130` matrix leg (CUDA 13.0.0) but left the action pinned at `Jimver/cuda-toolkit@v0.2.21`, whose CUDA link table tops out at 12.8.0. CUDA 13.0.0 wasn't added to the action until **v0.2.27**, so the leg could never resolve a download. Since the publish job only uploads the cu130 wheel, the entire release was blocked.

## Fix

Bump `Jimver/cuda-toolkit@v0.2.21` → `@v0.2.35` (latest). v0.2.35's link table includes both `12.6.3` (cu126 leg) and `13.0.0` (cu130 leg), and it natively targets Node 24 (clearing the deprecation warning for this action).

## Follow-up to ship 0.3.0

This workflow only auto-publishes when `fastvideo-kernel/pyproject.toml`'s version changes. Merging this fix alone won't re-trigger it (version stays 0.3.0). After merge, republish via manual dispatch — every `if:` gate allows `workflow_dispatch`:

```
gh workflow run publish-kernel.yml --ref main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
