### PR TITLE
[bugfix] Warn when a requested attention backend is unsupported by a layer (#1254)

### DIFF
--- a/fastvideo/attention/selector.py
+++ b/fastvideo/attention/selector.py
@@ -115,7 +115,16 @@ def _cached_get_attn_backend(
     # get device-specific attn_backend
     from fastvideo.platforms import current_platform
 
-    if selected_backend not in supported_attention_backends:
+    if selected_backend is not None and \
+            selected_backend not in supported_attention_backends:
+        logger.warning(
+            "Requested attention backend %s is not supported by this "
+            "layer; supported backends are %s. Falling back to automatic "
+            "selection. Set FASTVIDEO_ATTENTION_BACKEND to one of the "
+            "supported backends to silence this warning.",
+            selected_backend.name,
+            [b.name for b in supported_attention_backends],
+        )
         selected_backend = None
     attention_cls = current_platform.get_attn_backend_cls(selected_backend, head_size, dtype)
     if not attention_cls:

--- a/fastvideo/attention/selector.py
+++ b/fastvideo/attention/selector.py
@@ -115,13 +115,12 @@ def _cached_get_attn_backend(
     # get device-specific attn_backend
     from fastvideo.platforms import current_platform
 
-    if selected_backend is not None and \
-            selected_backend not in supported_attention_backends:
+    if (selected_backend is not None and
+            selected_backend not in supported_attention_backends):
         logger.warning(
             "Requested attention backend %s is not supported by this "
             "layer; supported backends are %s. Falling back to automatic "
-            "selection. Set FASTVIDEO_ATTENTION_BACKEND to one of the "
-            "supported backends to silence this warning.",
+            "selection.",
             selected_backend.name,
             [b.name for b in supported_attention_backends],
         )


### PR DESCRIPTION
## Summary

Addresses part of #1254. Model layers declare a small per-layer allowlist of supported attention backends. When a user sets `FASTVIDEO_ATTENTION_BACKEND` (or globally forces a backend) to one **not** in a layer's allowlist, `get_attn_backend` silently reset the choice to `None` and fell back to automatic selection — with **no indication the request was ignored**. This is the root of the confusion reported in #1254 (e.g. setting `SAGE_ATTN` silently runs Torch SDPA, with repeated `Selected backend: None` log lines and no explanation).

This PR makes the fallback **explicit**: before discarding an unsupported choice, it logs a warning naming the requested backend and the layer's supported backends.

## Changes
- `fastvideo/attention/selector.py`: in `_cached_get_attn_backend`, warn when a *non-None* `selected_backend` is not in `supported_attention_backends`, then fall back as before.

## Notes / scope
- **Behavior preserved:** automatic selection (`selected_backend is None`) is unaffected — no warning, same fallback.
- **Not spammy:** the function is `@cache`d on `(head_size, dtype, supported_attention_backends)`, so the warning fires at most once per distinct layer signature, not once per layer instance.
- This is intentionally the **small, safe first step**. The larger fix discussed in the issue — replacing hardcoded per-layer allowlists with a capability/support matrix (mask/varlen/dtype compatibility) — is left as follow-up to avoid silently regressing any model, per @alexzms's caution on the thread.

## Test plan
- [ ] `FASTVIDEO_ATTENTION_BACKEND=SAGE_ATTN python examples/inference/basic/basic.py` → now emits a clear one-time warning instead of silent fallback.
- [ ] Default run (no env var) → no new warnings, behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
