### PR TITLE
[bugfix] nvfp4: cast fp32 inputs to bf16 instead of asserting

### DIFF
--- a/fastvideo/layers/quantization/nvfp4_config.py
+++ b/fastvideo/layers/quantization/nvfp4_config.py
@@ -285,8 +285,12 @@ class NVFP4QuantizeMethod(QuantizeMethodBase):
 
     def quantize_input(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         SfLayout, _, _ = _require_flashinfer()
-        assert x.dtype == torch.bfloat16 or x.dtype == torch.float16, (
-            f"only allow bf16/fp16 inputs to fp4 linear, got {x.dtype}")
+        # The pre-attention norm can emit fp32 (e.g. in eager mode, without the
+        # torch.compile fusion that keeps it bf16). FP4 linear emits bf16 regardless
+        # (see apply(): _mm_fp4 out dtype is bf16), so cast fp32 inputs to bf16
+        # instead of failing — matching the sibling fastvideo/layers/fp4linear.py.
+        if x.dtype not in (torch.bfloat16, torch.float16):
+            x = x.to(torch.bfloat16)
         x_2d = x.view(-1, x.shape[-1])
         x_fp4, x_scale = _nvfp4_quantize(
             x_2d,
@@ -332,8 +336,8 @@ class NVFP4QuantizeMethod(QuantizeMethodBase):
             if x_scale.dim() > 2:
                 x_scale = x_scale.view(-1, x_scale.shape[-1])
         else:
-            assert x.dtype == torch.bfloat16 or x.dtype == torch.float16, (
-                f"only allow bf16/fp16 inputs to fp4 linear, got {x.dtype}")
+            if x.dtype not in (torch.bfloat16, torch.float16):
+                x = x.to(torch.bfloat16)
             x = x.view(-1, x.shape[-1])
             x_global_sf = self.x_global_sf
             x_fp4, x_scale = _nvfp4_quantize(

--- a/fastvideo/layers/quantization/nvfp4_config.py
+++ b/fastvideo/layers/quantization/nvfp4_config.py
@@ -261,6 +261,22 @@ def _mm_fp4(
     )
 
 
+def _coerce_fp4_input_dtype(x: torch.Tensor) -> torch.Tensor:
+    """Coerce an activation to a dtype the FP4 linear accepts.
+
+    The pre-attention norm can emit fp32 (e.g. in eager mode, without the
+    torch.compile fusion that keeps it bf16). The FP4 linear emits bf16
+    regardless (see _mm_fp4 out dtype), so cast fp32 -> bf16 rather than
+    failing, matching the sibling fastvideo/layers/fp4linear.py. Non-floating
+    inputs (e.g. int/bool) are a genuine error and are rejected fast.
+    """
+    if not x.is_floating_point():
+        raise TypeError(f"fp4 linear expects floating-point inputs, got {x.dtype}")
+    if x.dtype not in (torch.bfloat16, torch.float16):
+        x = x.to(torch.bfloat16)
+    return x
+
+
 class NVFP4QuantizeMethod(QuantizeMethodBase):
 
     def __init__(self, layer_prefix: str = ""):
@@ -285,12 +301,7 @@ class NVFP4QuantizeMethod(QuantizeMethodBase):
 
     def quantize_input(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         SfLayout, _, _ = _require_flashinfer()
-        # The pre-attention norm can emit fp32 (e.g. in eager mode, without the
-        # torch.compile fusion that keeps it bf16). FP4 linear emits bf16 regardless
-        # (see apply(): _mm_fp4 out dtype is bf16), so cast fp32 inputs to bf16
-        # instead of failing — matching the sibling fastvideo/layers/fp4linear.py.
-        if x.dtype not in (torch.bfloat16, torch.float16):
-            x = x.to(torch.bfloat16)
+        x = _coerce_fp4_input_dtype(x)
         x_2d = x.view(-1, x.shape[-1])
         x_fp4, x_scale = _nvfp4_quantize(
             x_2d,
@@ -336,8 +347,7 @@ class NVFP4QuantizeMethod(QuantizeMethodBase):
             if x_scale.dim() > 2:
                 x_scale = x_scale.view(-1, x_scale.shape[-1])
         else:
-            if x.dtype not in (torch.bfloat16, torch.float16):
-                x = x.to(torch.bfloat16)
+            x = _coerce_fp4_input_dtype(x)
             x = x.view(-1, x.shape[-1])
             x_global_sf = self.x_global_sf
             x_fp4, x_scale = _nvfp4_quantize(

--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -72,8 +72,12 @@ def _rms_norm_dispatch(
     """Use QuACK RMSNorm only for LTX-2 refine stage, else Torch RMSNorm."""
     if _is_ltx2_refine_stage():
         return _quack_rmsnorm(x, weight=weight, eps=eps)
+    # torch 2.12 added rms_norm to autocast's float32 cast policy, so under
+    # autocast(bfloat16) this norm now returns float32 where torch <= 2.11
+    # returned bfloat16. Restore the input dtype so autocast-blind consumers
+    # downstream don't receive upcast activations.
     return torch.nn.functional.rms_norm(
-        x, (x.shape[-1], ), weight=weight, eps=eps)
+        x, (x.shape[-1], ), weight=weight, eps=eps).to(x.dtype)
 
 
 class StageAwareRMSNorm(nn.RMSNorm):

--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -72,12 +72,8 @@ def _rms_norm_dispatch(
     """Use QuACK RMSNorm only for LTX-2 refine stage, else Torch RMSNorm."""
     if _is_ltx2_refine_stage():
         return _quack_rmsnorm(x, weight=weight, eps=eps)
-    # torch 2.12 added rms_norm to autocast's float32 cast policy, so under
-    # autocast(bfloat16) this norm now returns float32 where torch <= 2.11
-    # returned bfloat16. Restore the input dtype so autocast-blind consumers
-    # downstream don't receive upcast activations.
     return torch.nn.functional.rms_norm(
-        x, (x.shape[-1], ), weight=weight, eps=eps).to(x.dtype)
+        x, (x.shape[-1], ), weight=weight, eps=eps)
 
 
 class StageAwareRMSNorm(nn.RMSNorm):

--- a/fastvideo/tests/ops/quantization/test_nvfp4_config.py
+++ b/fastvideo/tests/ops/quantization/test_nvfp4_config.py
@@ -63,3 +63,30 @@ def _raise_module_on_import(name: str) -> types.ModuleType:
             raise ImportError(f"No module named '{name}.{item}'")
 
     return _RaisingModule(name)
+
+
+def test_coerce_fp4_input_dtype_casts_and_rejects():
+    """The FP4 input-dtype coercion (CPU-only, no flashinfer/CUDA): bf16/fp16
+    pass through, other floats (the fp32 pre-attention norm in eager mode) are
+    cast to bf16, and non-floating inputs are rejected fast."""
+    import torch
+
+    from fastvideo.layers.quantization.nvfp4_config import (
+        _coerce_fp4_input_dtype)
+
+    # bf16 / fp16 pass through untouched.
+    bf16 = torch.zeros(4, 8, dtype=torch.bfloat16)
+    assert _coerce_fp4_input_dtype(bf16) is bf16
+    fp16 = torch.zeros(4, 8, dtype=torch.float16)
+    assert _coerce_fp4_input_dtype(fp16) is fp16
+
+    # Other floating dtypes (fp32 from an unfused norm, fp64) -> bf16.
+    assert _coerce_fp4_input_dtype(
+        torch.zeros(4, 8, dtype=torch.float32)).dtype is torch.bfloat16
+    assert _coerce_fp4_input_dtype(
+        torch.zeros(4, 8, dtype=torch.float64)).dtype is torch.bfloat16
+
+    # Non-floating inputs are a real error, not silently cast.
+    for bad in (torch.int32, torch.int64, torch.bool):
+        with pytest.raises(TypeError, match="floating-point"):
+            _coerce_fp4_input_dtype(torch.zeros(4, 8, dtype=bad))


### PR DESCRIPTION
**Problem.** `NVFP4QuantizeMethod.quantize_input()` and `apply()` assert bf16/fp16 inputs and crash on the fp32 pre-attention norm output when running **without `torch.compile`** (eager mode), where the norm isn't fused back to bf16:

```
AssertionError: only allow bf16/fp16 inputs to fp4 linear, got torch.float32
```

Repro: any `NVFP4Config` inference run in eager mode — e.g. LTX2-distilled on a DGX Spark (sm_121), no compile — fails on the first denoising step.

**Fix.** Cast fp32 inputs to bf16 instead of asserting, in both code paths. This is safe and consistent: the FP4 linear already emits bf16 unconditionally (`_mm_fp4` out dtype), and the sibling `fastvideo/layers/fp4linear.py` already casts non-bf16/fp16 inputs the same way. No change to the compiled path (inputs are already bf16 there).

**Test.** With the fix, LTX2-distilled runs end-to-end under `NVFP4Config` in eager mode on sm_121; output is visually unchanged vs bf16 and the FP4 linears measurably speed up denoising. No new behavior on the existing compiled path. `pre-commit` (yapf/ruff/codespell) passes on the changed file.

