### PR TITLE
[bugfix] Remove incorrect V-row permutation in scaled_fp4_quant_trans_kernel

### DIFF
--- a/fastvideo-kernel/attn_qat_infer/quantization/fp4_quantization_4d.cu
+++ b/fastvideo-kernel/attn_qat_infer/quantization/fp4_quantization_4d.cu
@@ -286,24 +286,19 @@
  
    // load input
    const int token_id = token_block_id * BLOCK_SIZE + threadIdx.x / NUM_THREADS_PER_TOKEN;
-   // Permute V rows within each 32-element block so the PV MMA K-indexed
-   // access reads the correct CLayout N-indexed values (Edenzzzz causal fix).
-   const int k_intra = token_id & 31;
-   const int load_token_id = (token_id & ~31)
-       | ((k_intra & 6) << 2) | ((k_intra & 24) >> 2) | (k_intra & 1);
- 
+
    PackedVec in_vec;
-   
+
    #pragma unroll
    for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
      reinterpret_cast<uint32_t&>(in_vec.elts[i]) = 0;
    }
-   
-   if (load_token_id < num_tokens) {
-     in_vec = reinterpret_cast<PackedVec const*>(input + 
+
+   if (token_id < num_tokens) {
+     in_vec = reinterpret_cast<PackedVec const*>(input +
                                            batch_id * stride_bz_input + // batch dim
                                            head_id * stride_h_input +   // head dim
-                                           load_token_id * stride_seq_input + // seq dim (permuted)
+                                           token_id * stride_seq_input + // seq dim
                                            (threadIdx.x % NUM_THREADS_PER_TOKEN) * CVT_FP4_ELTS_PER_THREAD)[0]; // feature dim
    }
  


### PR DESCRIPTION
The causal attention fix (PR #1455) applied a seq_k row permutation to V in scaled_fp4_quant_trans_kernel before the transpose step. This scrambles V rows after the transpose, causing the PV MMA to read values from wrong tokens and producing broken output for non-causal attention.

<!--
PR TITLE: Must start with a type tag, e.g.:
  [feat] Add new model       [bugfix] Fix VAE tiling      [refactor] Restructure pipeline
  [perf] Optimize kernel     [ci] Update tests             [docs] Add guide
  [misc] Cleanup configs     [new-model] Port Flux2        [infra] Add trace hooks
  [skill] Add agent skill

MERGE WORKFLOW:
  1. Ensure pre-commit passes and you have at least 1 approval
  2. Comment /merge (or add the "ready" label) to enter the Merge Queue
  3. Full Test Suite runs automatically on a staging branch → auto-merge on success

ON-DEMAND TESTING (write access required):
  /test full       — Full Test Suite        /test ssim        — SSIM regression
  /test training   — Training pipeline      /test encoder     — Encoder tests
  /test transformer — Transformer tests     /test vae         — VAE tests
  /test kernel     — CUDA kernel tests      /test unit        — Unit tests
  See docs/contributing/pull_requests.md for all 17 test commands
-->

## Purpose

<!-- What does this PR do? Link the related issue if applicable. -->

Fixes #1492

## Changes

<!-- Describe your changes concisely. What approach did you take? -->

Removed the V-row permutation from scaled_fp4_quant_trans_kernel in fastvideo-kernel/attn_qat_infer/quantization/fp4_quantization_4d.cu 

## Test Plan

<!-- How did you verify your changes? Paste exact commands and output. -->

Ran example nvfp4 inference script with ATTN_QAT_INFER backend.

```bash
FASTVIDEO_DISABLE_ATTENTION_COMPILE=0 FASTVIDEO_ATTENTION_BACKEND=ATTN_QAT_INFER python examples/inference/optimizations/FastWan_QAD_TAEHV.py --model FastVideo/FastWan-QAD-1.3B --distilled_model "" --taehv_checkpoint /root/taehv/taew2_1.pth

```


## Test Results

<!-- Paste test output, before/after comparisons, or SSIM scores for model changes. -->

Video output quality was restored after reverting the #1455 change.

## Checklist

- [ ] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [ ] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model
