### PR TITLE
[ci] train-framework model coverage: Cosmos/MatrixGame2 finetune grad-norm + Cosmos/LongCat/MatrixGame2 loading smokes

### DIFF
--- a/fastvideo/tests/train/fixtures/cosmos_t2w_finetune_min.yaml
+++ b/fastvideo/tests/train/fixtures/cosmos_t2w_finetune_min.yaml
@@ -1,0 +1,50 @@
+# Minimum config to run a single training step of FineTuneMethod on
+# CosmosModel for the per-method smoke test. Uses the real
+# Cosmos-Predict2.5-2B checkpoint (~2B, fits one L40S) with tiny
+# synthetic latents. Cosmos requires training_cfg_rate=0 (it rejects
+# CFG dropout: real Reason1 negative embeddings are not wired up) and
+# precondition_outputs=false (velocity prediction, no preconditioning).
+
+models:
+  student:
+    _target_: fastvideo.train.models.cosmos.CosmosModel
+    init_from: KyleShao/Cosmos-Predict2.5-2B-Diffusers
+    trainable: true
+    flow_shift: 1.0
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  dit_precision: bf16
+
+  distributed:
+    num_gpus: 1
+    sp_size: 1
+    tp_size: 1
+
+  data:
+    seed: 42
+    train_batch_size: 1
+    training_cfg_rate: 0.0
+    num_latent_t: 4
+    num_height: 64
+    num_width: 64
+    num_frames: 13
+
+  optimizer:
+    learning_rate: 1.0e-6
+    betas: [0.9, 0.999]
+    weight_decay: 0.01
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    max_train_steps: 1
+    gradient_accumulation_steps: 1
+
+  model:
+    precondition_outputs: false
+
+pipeline:
+  flow_shift: 1.0

--- a/fastvideo/tests/train/fixtures/cosmos_t2w_min.yaml
+++ b/fastvideo/tests/train/fixtures/cosmos_t2w_min.yaml
@@ -1,0 +1,20 @@
+# Minimum config to instantiate CosmosModel for the loading + forward
+# smoke test. Real Cosmos-Predict2.5-2B checkpoint (~2B) loaded via
+# load_module_from_path. Cosmos uses a single Reason1 text encoder
+# (crossattn_proj_in_channels=100352) and the Wan-family VAE (z_dim=16).
+
+models:
+  student:
+    _target_: fastvideo.train.models.cosmos.CosmosModel
+    init_from: KyleShao/Cosmos-Predict2.5-2B-Diffusers
+    trainable: false
+    flow_shift: 1.0
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  dit_precision: bf16
+
+pipeline:
+  flow_shift: 1.0

--- a/fastvideo/tests/train/fixtures/longcat_t2v_min.yaml
+++ b/fastvideo/tests/train/fixtures/longcat_t2v_min.yaml
@@ -1,0 +1,23 @@
+# Minimum config to instantiate LongCatModel for the loading + forward
+# smoke test. Real LongCat-Video-T2V checkpoint (~13.6B at bf16) loaded
+# via load_module_from_path. flow_shift=12.0 matches the released
+# LongCat scheduler config (0.0 would collapse FlowMatch timesteps).
+#
+# Forward-only: a single-GPU backward of the 13.6B transformer exceeds
+# the L40S CI runner, so LongCat is covered by this loading smoke only
+# (no per-method grad-norm test).
+
+models:
+  student:
+    _target_: fastvideo.train.models.longcat.LongCatModel
+    init_from: FastVideo/LongCat-Video-T2V-Diffusers
+    trainable: false
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  dit_precision: bf16
+
+pipeline:
+  flow_shift: 12.0

--- a/fastvideo/tests/train/fixtures/matrixgame2_finetune_min.yaml
+++ b/fastvideo/tests/train/fixtures/matrixgame2_finetune_min.yaml
@@ -1,0 +1,50 @@
+# Minimum config to run a single training step of FineTuneMethod on
+# MatrixGame2Model for the per-method smoke test. Matrix-Game 2.0 is an
+# action-conditioned I2V world model (no text): the synthetic batch
+# supplies vae_latent + clip_feature + first_frame_latent + all-ones
+# keyboard/mouse actions.
+#
+# NOTE: Matrix-Game-2.0-Base is ~14B at bf16, so a single-GPU backward
+# (params + grads) exceeds the L40S CI runner. This test validates the
+# grad path on larger dev GPUs (H200/GB200); see the per-device skip in
+# the test body.
+
+models:
+  student:
+    _target_: fastvideo.train.models.matrixgame2.matrixgame2.MatrixGame2Model
+    init_from: FastVideo/Matrix-Game-2.0-Base-Diffusers
+    trainable: true
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  dit_precision: bf16
+
+  distributed:
+    num_gpus: 1
+    sp_size: 1
+    tp_size: 1
+
+  data:
+    seed: 42
+    train_batch_size: 1
+    training_cfg_rate: 0.0
+    num_latent_t: 4
+    num_height: 64
+    num_width: 64
+    num_frames: 13
+
+  optimizer:
+    learning_rate: 1.0e-6
+    betas: [0.9, 0.999]
+    weight_decay: 0.01
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    max_train_steps: 1
+    gradient_accumulation_steps: 1
+
+pipeline:
+  flow_shift: 3

--- a/fastvideo/tests/train/fixtures/matrixgame2_min.yaml
+++ b/fastvideo/tests/train/fixtures/matrixgame2_min.yaml
@@ -1,0 +1,20 @@
+# Minimum config to instantiate MatrixGame2Model for the loading +
+# forward smoke test. Real Matrix-Game-2.0-Base checkpoint (~14B at
+# bf16) loaded via load_module_from_path. Matrix-Game 2.0 is an
+# action-conditioned I2V world model: no text encoder, image-action
+# cross-attention (image_dim=1280).
+
+models:
+  student:
+    _target_: fastvideo.train.models.matrixgame2.matrixgame2.MatrixGame2Model
+    init_from: FastVideo/Matrix-Game-2.0-Base-Diffusers
+    trainable: false
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  dit_precision: bf16
+
+pipeline:
+  flow_shift: 3

--- a/fastvideo/tests/train/methods/grad_norm_refs.json
+++ b/fastvideo/tests/train/methods/grad_norm_refs.json
@@ -1,6 +1,7 @@
 {
   "test_cosmos_finetune": {
-    "H200": 5.2763
+    "H200": 5.2763,
+    "L40S": 4.1553
   },
   "test_matrixgame2_finetune": {
     "H200": 4.8247

--- a/fastvideo/tests/train/methods/grad_norm_refs.json
+++ b/fastvideo/tests/train/methods/grad_norm_refs.json
@@ -1,4 +1,10 @@
 {
+  "test_cosmos_finetune": {
+    "H200": 5.2763
+  },
+  "test_matrixgame2_finetune": {
+    "H200": 4.8247
+  },
   "test_wan_causal_dfsft": {
     "GB200": 2.9781,
     "L40S": 3.2562

--- a/fastvideo/tests/train/methods/grad_norm_regression.py
+++ b/fastvideo/tests/train/methods/grad_norm_regression.py
@@ -55,6 +55,7 @@ _DEVICE_MAPPINGS: tuple[tuple[str, str], ...] = (
     ("L40S", "L40S"),
     ("GB200", "GB200"),
     ("B200", "GB200"),  # same Blackwell arch as GB200
+    ("H200", "H200"),
 )
 
 
@@ -78,6 +79,27 @@ def resolve_device_key(device_name: str | None = None) -> str | None:
     return None
 
 
+# Transformer block-list attribute names across model families. Wan / causal
+# Wan / Matrix-Game expose ``.blocks``; Cosmos (diffusers-derived) exposes
+# ``.transformer_blocks``. First non-empty match wins.
+_BLOCK_LIST_ATTRS: tuple[str, ...] = ("blocks", "transformer_blocks")
+
+
+def resolve_blocks(transformer):
+    """Return transformer block 0's containing ModuleList, or None.
+
+    Block 0 is the reference surface for the grad-norm check: its grad is the
+    *last* one produced during backprop, so a healthy value implies the whole
+    forward + chain-rule path is intact. Different model families name the
+    list differently (see ``_BLOCK_LIST_ATTRS``).
+    """
+    for attr in _BLOCK_LIST_ATTRS:
+        blocks = getattr(transformer, attr, None)
+        if blocks is not None and len(blocks) > 0:
+            return blocks
+    return None
+
+
 def layer0_grad_norm(transformer) -> float:
     """Global L2 norm of transformer block 0's trainable gradients.
 
@@ -88,15 +110,20 @@ def layer0_grad_norm(transformer) -> float:
     Accumulates the squared sums on the GPU and does a single CPU-GPU sync
     (``.item()``) at the end, rather than one per parameter.
     """
-    blocks = getattr(transformer, "blocks", None)
+    blocks = resolve_blocks(transformer)
     assert blocks is not None and len(blocks) > 0, (
-        "transformer is expected to expose a non-empty ``.blocks``")
+        "transformer is expected to expose a non-empty block list "
+        f"(one of {_BLOCK_LIST_ATTRS})")
     grads = [
         p.grad for p in blocks[0].parameters()
         if p.requires_grad and p.grad is not None
     ]
     if not grads:
         return 0.0
+    # Some loaders (e.g. Cosmos via fsdp_load) keep parameters/grads as
+    # DTensors even at world_size=1; localize so the reduction stays on plain
+    # tensors. ``to_local`` is a no-op for ordinary tensors at ws=1.
+    grads = [g.to_local() if hasattr(g, "to_local") else g for g in grads]
     sq_sum = torch.zeros((), device=grads[0].device, dtype=torch.float32)
     for g in grads:
         sq_sum += g.detach().float().pow(2).sum()

--- a/fastvideo/tests/train/methods/test_cosmos_finetune.py
+++ b/fastvideo/tests/train/methods/test_cosmos_finetune.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-method GPU smoke test: ``CosmosModel`` + ``FineTuneMethod``.
+
+Mirrors ``test_wan_finetune.py`` for the Cosmos-Predict2.5 plugin.
+The harness is intentionally identical so the tests are easy to
+compare; the only Cosmos-specific differences are in the synthetic
+``raw_batch`` (a single Reason1 text embedding with width
+``crossattn_proj_in_channels=100352`` instead of Wan's T5 4096) and
+the fixture (``training_cfg_rate=0`` is required, and
+``precondition_outputs=false`` for velocity prediction).
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29521")
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from fastvideo.train.methods.fine_tuning.finetune import (
+    FineTuneMethod, )
+from fastvideo.train.models.cosmos import CosmosModel
+from fastvideo.train.utils.config import load_run_config
+
+from .grad_norm_regression import (
+    check_grad_norm_regression,
+    resolve_blocks,
+)
+
+_FIXTURE = str(
+    Path(__file__).resolve().parent.parent / "fixtures"
+    / "cosmos_t2w_finetune_min.yaml")
+
+# Cosmos 2.5 Reason1 (Qwen2.5-VL) text embedding width.
+_COSMOS_TEXT_DIM = 100352
+
+
+def _build_synthetic_batch(
+    device: torch.device,
+    dtype: torch.dtype,
+) -> dict[str, torch.Tensor]:
+    """Tiny synthetic ``raw_batch`` matching ``CosmosModel.prepare_batch``.
+
+    Cosmos uses the Wan-family VAE (``z_dim=16``) but a single Reason1
+    text encoder, so ``text_embedding`` is 100352-wide.
+    """
+    batch_size = 1
+    return {
+        "text_embedding":
+        torch.randn(batch_size, 16, _COSMOS_TEXT_DIM, device=device,
+                    dtype=dtype),
+        "text_attention_mask":
+        torch.ones(batch_size, 16, device=device),
+        "vae_latent":
+        torch.randn(batch_size, 16, 4, 8, 8, device=device, dtype=dtype),
+    }
+
+
+@pytest.mark.usefixtures("distributed_setup")
+def test_cosmos_finetune_single_train_step(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    cfg = load_run_config(_FIXTURE)
+
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+
+    # Feed a synthetic ``raw_batch`` straight into ``single_train_step``,
+    # so the parquet train dataloader built by ``init_preprocessors`` is
+    # never iterated. Stub it out so construction does not require a real
+    # ``training.data.data_path``.
+    monkeypatch.setattr(
+        "fastvideo.train.utils.dataloader."
+        "build_parquet_t2v_train_dataloader",
+        lambda *args, **kwargs: None,
+    )
+
+    model = CosmosModel(
+        init_from=cfg.models["student"]["init_from"],
+        training_config=cfg.training,
+        trainable=True,
+    )
+    model.transformer = model.transformer.to(device=device, dtype=dtype)
+
+    method = FineTuneMethod(
+        cfg=cfg,
+        role_models={"student": model},
+    )
+    method.on_train_start()
+
+    batch = _build_synthetic_batch(device, dtype)
+    loss_map, outputs, _metrics = method.single_train_step(batch, iteration=0)
+
+    loss = loss_map["total_loss"]
+    assert torch.is_tensor(loss), "total_loss must be a torch.Tensor"
+    assert torch.isfinite(loss).item(), (
+        f"total_loss is not finite: {loss.item()}")
+
+    method.backward(loss_map, outputs, grad_accum_rounds=1)
+
+    blocks = resolve_blocks(model.transformer)
+    assert blocks is not None and len(blocks) > 0, (
+        "transformer is expected to expose a non-empty block list")
+    layer0 = blocks[0]
+
+    trainable = [p for p in layer0.parameters() if p.requires_grad]
+    assert len(trainable) > 0, "layer 0 has no trainable parameters"
+
+    for i, p in enumerate(trainable):
+        assert p.grad is not None, f"layer 0 param[{i}] has None grad"
+        assert torch.isfinite(p.grad).all().item(), (
+            f"layer 0 param[{i}] grad contains NaN/Inf")
+
+    any_nonzero = any(
+        p.grad.detach().float().norm().item() > 0.0 for p in trainable)
+    assert any_nonzero, (
+        "all layer-0 grads are exactly zero; backward did not "
+        "reach the first transformer block")
+
+    # 5a-ii: device-keyed grad-norm regression on top of the same harness.
+    # Skips when the current GPU has no seeded reference.
+    check_grad_norm_regression("test_cosmos_finetune", model.transformer)

--- a/fastvideo/tests/train/methods/test_matrixgame2_finetune.py
+++ b/fastvideo/tests/train/methods/test_matrixgame2_finetune.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-method GPU smoke test: ``MatrixGame2Model`` + ``FineTuneMethod``.
+
+Mirrors ``test_wan_finetune.py`` for the Matrix-Game 2.0 plugin, which
+is an action-conditioned I2V world model (no text encoder). The
+synthetic ``raw_batch`` therefore supplies ``vae_latent`` +
+``clip_feature`` (CLIP image embeds, ``image_dim=1280``) +
+``first_frame_latent`` instead of text embeddings, plus all-ones
+mouse/keyboard action conditioning so block 0's action modules also
+receive gradients. The goal is to validate the training grad path
+(forward + chain rule reaches block 0), not output realism.
+
+Matrix-Game-2.0-Base is ~14B at bf16. A single-GPU backward (params +
+grads, no FSDP) needs well over the L40S CI runner's 48 GB, so this
+test skips on memory-constrained GPUs and only exercises the grad path
+on larger dev GPUs (H200 / GB200). LongCat (13.6B) is likewise covered
+by a loading-only smoke for the same reason.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29522")
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from fastvideo.train.methods.fine_tuning.finetune import (
+    FineTuneMethod, )
+from fastvideo.train.models.matrixgame2.matrixgame2 import MatrixGame2Model
+from fastvideo.train.utils.config import load_run_config
+
+from .grad_norm_regression import (
+    check_grad_norm_regression,
+    resolve_blocks,
+)
+
+_FIXTURE = str(
+    Path(__file__).resolve().parent.parent / "fixtures"
+    / "matrixgame2_finetune_min.yaml")
+
+# Matrix-Game 2.0 CLIP image-embedding width.
+_MG2_IMAGE_DIM = 1280
+
+# A 14B bf16 backward (params + grads) needs ~56 GB before activations;
+# skip on GPUs that can't hold it (e.g. the 48 GB L40S CI runner).
+_MIN_GPU_MEM_BYTES = 60 * (1024**3)
+
+
+def _build_synthetic_batch(
+    device: torch.device,
+    dtype: torch.dtype,
+) -> dict[str, torch.Tensor]:
+    """Tiny synthetic ``raw_batch`` matching ``MatrixGame2Model.prepare_batch``.
+
+    Matrix-Game 2.0 conditions on the first-frame latent + CLIP image
+    embeds (no text). ``first_frame_latent`` carries 16 VAE channels;
+    the model builds the mask/cond concat internally.
+    """
+    batch_size = 1
+    # Action conditioning frames = (num_latent_t - 1) * vae_time_compression
+    # + 1 = (4 - 1) * 4 + 1 = 13 (MatrixGame2Model._expected_action_frames).
+    # Supplying actions (keyboard_dim_in=6, mouse_dim_in=2 in the loaded
+    # checkpoint) exercises the image-action cross-attention so block 0's
+    # action-module params receive gradients.
+    action_frames = 13
+    return {
+        "vae_latent":
+        torch.randn(batch_size, 16, 4, 8, 8, device=device, dtype=dtype),
+        "clip_feature":
+        torch.randn(batch_size, 257, _MG2_IMAGE_DIM, device=device,
+                    dtype=dtype),
+        "first_frame_latent":
+        torch.randn(batch_size, 16, 4, 8, 8, device=device, dtype=dtype),
+        "keyboard_cond":
+        torch.ones(batch_size, action_frames, 6, device=device, dtype=dtype),
+        "mouse_cond":
+        torch.ones(batch_size, action_frames, 2, device=device, dtype=dtype),
+    }
+
+
+@pytest.mark.usefixtures("distributed_setup")
+def test_matrixgame2_finetune_single_train_step(
+        monkeypatch: pytest.MonkeyPatch) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    total_mem = torch.cuda.get_device_properties(0).total_memory
+    if total_mem < _MIN_GPU_MEM_BYTES:
+        pytest.skip(
+            f"Matrix-Game 2.0 (~14B) backward needs ~56 GB; this GPU has "
+            f"{total_mem / 1024**3:.0f} GB. Loading is covered by "
+            "test_load_matrixgame2.py; the grad path runs on larger dev GPUs.")
+
+    cfg = load_run_config(_FIXTURE)
+
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+
+    # Matrix-Game 2.0 uses its own parquet dataloader; stub it out so
+    # construction does not require a real ``training.data.data_path``.
+    monkeypatch.setattr(
+        "fastvideo.train.utils.dataloader."
+        "build_parquet_matrixgame2_train_dataloader",
+        lambda *args, **kwargs: None,
+    )
+
+    model = MatrixGame2Model(
+        init_from=cfg.models["student"]["init_from"],
+        training_config=cfg.training,
+        trainable=True,
+    )
+    model.transformer = model.transformer.to(device=device, dtype=dtype)
+
+    method = FineTuneMethod(
+        cfg=cfg,
+        role_models={"student": model},
+    )
+    method.on_train_start()
+
+    batch = _build_synthetic_batch(device, dtype)
+    loss_map, outputs, _metrics = method.single_train_step(batch, iteration=0)
+
+    loss = loss_map["total_loss"]
+    assert torch.is_tensor(loss), "total_loss must be a torch.Tensor"
+    assert torch.isfinite(loss).item(), (
+        f"total_loss is not finite: {loss.item()}")
+
+    method.backward(loss_map, outputs, grad_accum_rounds=1)
+
+    blocks = resolve_blocks(model.transformer)
+    assert blocks is not None and len(blocks) > 0, (
+        "transformer is expected to expose a non-empty block list")
+    layer0 = blocks[0]
+
+    named = [(n, p) for n, p in layer0.named_parameters() if p.requires_grad]
+    assert len(named) > 0, "layer 0 has no trainable parameters"
+
+    # Matrix-Game 2.0 is text-free I2V: block 0's text cross-attention
+    # (``attn2.*`` and its residual norm) never activates without text
+    # conditioning, so those params legitimately get no grad. Assert the
+    # *active* path (self-attn, ffn, image cross-attn, action modules) is
+    # intact rather than requiring every block-0 param to receive a grad.
+    with_grad = [(n, p) for n, p in named if p.grad is not None]
+    assert len(with_grad) > 0, (
+        "no layer-0 params received a gradient; backward did not reach "
+        "the first transformer block")
+
+    for n, p in with_grad:
+        assert torch.isfinite(p.grad).all().item(), (
+            f"layer 0 param '{n}' grad contains NaN/Inf")
+
+    any_nonzero = any(
+        p.grad.detach().float().norm().item() > 0.0 for _, p in with_grad)
+    assert any_nonzero, (
+        "all layer-0 grads are exactly zero; backward did not "
+        "reach the first transformer block")
+
+    # 5a-ii: device-keyed grad-norm regression on top of the same harness.
+    # Skips when the current GPU has no seeded reference.
+    check_grad_norm_regression("test_matrixgame2_finetune", model.transformer)

--- a/fastvideo/tests/train/models/test_load_cosmos.py
+++ b/fastvideo/tests/train/models/test_load_cosmos.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GPU loading + forward smoke test for ``CosmosModel``.
+
+Loads the real Cosmos-Predict2.5-2B checkpoint (~2B at bf16) via
+``CosmosModel.__init__`` and runs one transformer forward pass on
+synthetic inputs. Catches loader or forward-signature regressions in
+``fastvideo.train.models.cosmos.CosmosModel`` and the underlying
+``Cosmos25Transformer3DModel``.
+
+Cosmos's transformer takes a different forward signature than Wan: a
+single Reason1 text embedding (``crossattn_proj_in_channels=100352``),
+plus ``condition_mask`` / ``padding_mask`` / ``fps``. This mirrors the
+kwargs in ``CosmosModel._build_distill_input_kwargs``.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Required by the ``distributed_setup`` fixture pulled from
+# ``fastvideo/tests/conftest.py``.  Set before any fastvideo import.
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29518")
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from fastvideo.forward_context import set_forward_context
+from fastvideo.train.models.cosmos import CosmosModel
+from fastvideo.train.utils.config import load_run_config
+
+_FIXTURE = str(
+    Path(__file__).resolve().parent.parent / "fixtures" / "cosmos_t2w_min.yaml")
+
+# Cosmos 2.5 Reason1 (Qwen2.5-VL) text embedding width.
+_COSMOS_TEXT_DIM = 100352
+
+
+@pytest.mark.usefixtures("distributed_setup")
+def test_cosmos_model_loads_and_forwards():
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    cfg = load_run_config(_FIXTURE)
+    model = CosmosModel(
+        init_from=cfg.models["student"]["init_from"],
+        training_config=cfg.training,
+        trainable=False,
+    )
+
+    transformer = model.transformer
+    assert isinstance(transformer, torch.nn.Module)
+    assert sum(p.numel() for p in transformer.parameters()) > 0
+
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+    transformer = transformer.to(device=device, dtype=dtype).eval()
+
+    # Cosmos transformer takes [B, C, T, H, W] (out_channels=16) plus a
+    # condition_mask / padding_mask and a single Reason1 text embedding.
+    # Small spatial + few frames so this fits next to the 2B model.
+    b, c, t, h, w = 1, 16, 4, 32, 32
+    hidden_states = torch.randn(b, c, t, h, w, device=device, dtype=dtype)
+    encoder_hidden_states = torch.randn(b,
+                                        16,
+                                        _COSMOS_TEXT_DIM,
+                                        device=device,
+                                        dtype=dtype)
+    timestep = torch.tensor([[500]], device=device, dtype=dtype)
+    condition_mask = torch.zeros(b, 1, t, h, w, device=device, dtype=dtype)
+    padding_mask = torch.zeros(1, 1, h, w, device=device, dtype=dtype)
+
+    with torch.no_grad(), set_forward_context(
+            current_timestep=0,
+            attn_metadata=None,
+    ):
+        out = transformer(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            timestep=timestep,
+            condition_mask=condition_mask,
+            padding_mask=padding_mask,
+            fps=16,
+        )
+
+    if isinstance(out, tuple):
+        out = out[0]
+    assert out.shape == hidden_states.shape, (
+        f"output shape {tuple(out.shape)} != input shape "
+        f"{tuple(hidden_states.shape)}")
+    assert torch.isfinite(out).all().item(), "output contains NaN/Inf"

--- a/fastvideo/tests/train/models/test_load_longcat.py
+++ b/fastvideo/tests/train/models/test_load_longcat.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GPU loading + forward smoke test for ``LongCatModel``.
+
+Loads the real LongCat-Video-T2V checkpoint (~13.6B at bf16) via
+``LongCatModel.__init__`` and runs one transformer forward pass on
+synthetic inputs. Catches loader or forward-signature regressions in
+``fastvideo.train.models.longcat.LongCatModel`` and the underlying
+``LongCatTransformer3DModel``.
+
+Forward-only (``trainable=False``, ``torch.no_grad``): a single-GPU
+backward of the 13.6B transformer exceeds the L40S CI runner, so
+LongCat training is not covered by a per-method grad-norm test. The
+forward fits (the ~13B HunyuanModel loading test already runs on the
+same runner).
+"""
+
+from __future__ import annotations
+
+import os
+
+# Required by the ``distributed_setup`` fixture pulled from
+# ``fastvideo/tests/conftest.py``.  Set before any fastvideo import.
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29519")
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from fastvideo.forward_context import set_forward_context
+from fastvideo.train.models.longcat import LongCatModel
+from fastvideo.train.utils.config import load_run_config
+
+_FIXTURE = str(
+    Path(__file__).resolve().parent.parent / "fixtures" / "longcat_t2v_min.yaml")
+
+# LongCat caption_channels (text embedding width).
+_LONGCAT_TEXT_DIM = 4096
+
+
+@pytest.mark.usefixtures("distributed_setup")
+def test_longcat_model_loads_and_forwards():
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    cfg = load_run_config(_FIXTURE)
+    model = LongCatModel(
+        init_from=cfg.models["student"]["init_from"],
+        training_config=cfg.training,
+        trainable=False,
+    )
+
+    transformer = model.transformer
+    assert isinstance(transformer, torch.nn.Module)
+    assert sum(p.numel() for p in transformer.parameters()) > 0
+
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+    transformer = transformer.to(device=device, dtype=dtype).eval()
+
+    # LongCat transformer takes [B, C, T, H, W] (in_channels=16,
+    # patch_size=(1,2,2)) and a [B, N_text, 4096] text embedding.
+    hidden_states = torch.randn(1, 16, 4, 32, 32, device=device, dtype=dtype)
+    encoder_hidden_states = torch.randn(1,
+                                        16,
+                                        _LONGCAT_TEXT_DIM,
+                                        device=device,
+                                        dtype=dtype)
+    encoder_attention_mask = torch.ones(1, 16, device=device, dtype=dtype)
+    timestep = torch.tensor([500], device=device, dtype=dtype)
+
+    with torch.no_grad(), set_forward_context(
+            current_timestep=0,
+            attn_metadata=None,
+    ):
+        out = transformer(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            timestep=timestep,
+            encoder_attention_mask=encoder_attention_mask,
+        )
+
+    if isinstance(out, tuple):
+        out = out[0]
+    assert out.shape == hidden_states.shape, (
+        f"output shape {tuple(out.shape)} != input shape "
+        f"{tuple(hidden_states.shape)}")
+    assert torch.isfinite(out).all().item(), "output contains NaN/Inf"

--- a/fastvideo/tests/train/models/test_load_matrixgame2.py
+++ b/fastvideo/tests/train/models/test_load_matrixgame2.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GPU loading + forward smoke test for ``MatrixGame2Model``.
+
+Loads the real Matrix-Game-2.0-Base checkpoint (~14B at bf16) via
+``MatrixGame2Model.__init__`` and runs one transformer forward pass on
+synthetic inputs. Catches loader or forward-signature regressions in
+``fastvideo.train.models.matrixgame2.MatrixGame2Model`` and the
+underlying ``MatrixGame2WanModel``.
+
+Matrix-Game 2.0 is an action-conditioned I2V world model: no text
+encoder, image-action cross-attention (``image_dim=1280``). The
+forward concatenates conditioning latents onto the noisy latents, so
+``hidden_states`` is built at the transformer's loaded ``in_channels``.
+Action inputs (mouse/keyboard) are left ``None`` (optional). This
+mirrors ``MatrixGame2Model._build_distill_input_kwargs``.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Required by the ``distributed_setup`` fixture pulled from
+# ``fastvideo/tests/conftest.py``.  Set before any fastvideo import.
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29520")
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from fastvideo.forward_context import set_forward_context
+from fastvideo.train.models.matrixgame2.matrixgame2 import MatrixGame2Model
+from fastvideo.train.utils.config import load_run_config
+
+_FIXTURE = str(
+    Path(__file__).resolve().parent.parent / "fixtures" / "matrixgame2_min.yaml")
+
+# Matrix-Game 2.0 CLIP image-embedding width.
+_MG2_IMAGE_DIM = 1280
+
+
+@pytest.mark.usefixtures("distributed_setup")
+def test_matrixgame2_model_loads_and_forwards():
+    if not torch.cuda.is_available():
+        pytest.skip("requires CUDA")
+
+    cfg = load_run_config(_FIXTURE)
+    model = MatrixGame2Model(
+        init_from=cfg.models["student"]["init_from"],
+        training_config=cfg.training,
+        trainable=False,
+    )
+
+    transformer = model.transformer
+    assert isinstance(transformer, torch.nn.Module)
+    assert sum(p.numel() for p in transformer.parameters()) > 0
+
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+    transformer = transformer.to(device=device, dtype=dtype).eval()
+
+    # Read the loaded in_channels off the patch embedding so the
+    # synthetic latents match the conditioning-concatenated width the
+    # transformer expects (16 noise + image/mask cond channels).
+    in_channels = transformer.patch_embedding.proj.in_channels
+
+    hidden_states = torch.randn(1, in_channels, 4, 32, 32, device=device,
+                                dtype=dtype)
+    # CLIP image embeds drive the image-action cross-attention; no text.
+    encoder_hidden_states_image = torch.randn(1, 257, _MG2_IMAGE_DIM,
+                                              device=device, dtype=dtype)
+    timestep = torch.tensor([500], device=device, dtype=torch.long)
+
+    with torch.no_grad(), set_forward_context(
+            current_timestep=0,
+            attn_metadata=None,
+    ):
+        out = transformer(
+            hidden_states=hidden_states,
+            encoder_hidden_states=None,
+            timestep=timestep,
+            encoder_hidden_states_image=encoder_hidden_states_image,
+            mouse_cond=None,
+            keyboard_cond=None,
+            return_dict=False,
+        )
+
+    if isinstance(out, tuple):
+        out = out[0]
+    # out has out_channels (16); compare the non-channel dims.
+    assert out.shape[0] == hidden_states.shape[0]
+    assert out.shape[2:] == hidden_states.shape[2:], (
+        f"output spatial/temporal shape {tuple(out.shape)} != input "
+        f"{tuple(hidden_states.shape)}")
+    assert torch.isfinite(out).all().item(), "output contains NaN/Inf"


### PR DESCRIPTION
## Purpose

Extends the `fastvideo/train` GPU CI beyond the Wan-only baseline along both axes — per-method grad-norm (A) and model-loading smoke (B) — following the same 5a-ii harness (`single_train_step` + `backward` → layer-0 grad-norm vs a device-keyed reference).

Coverage before → after:

| | before | after |
|---|---|---|
| **Loading smokes** | wan, wan_causal, hunyuan | **+ cosmos, longcat, matrixgame2** |
| **Per-method grad-norm** | finetune×wan, dfsft×wan_causal | **+ finetune×cosmos, finetune×matrixgame2** |

## Changes

**Loading smokes** (forward-only; LongCat 13.6B load+forward fits one L40S, mirroring the ~13B Hunyuan smoke):
- `test_load_cosmos.py`, `test_load_longcat.py`, `test_load_matrixgame2.py` (+ min fixtures)

**Per-method grad-norm** (copy the `test_wan_finetune.py` template):
- `test_cosmos_finetune.py` — `FineTuneMethod × CosmosModel`. Synthetic batch matches `CosmosModel.prepare_batch`: Reason1 text-embed width **100352**, Wan-family VAE `z_dim=16`, `training_cfg_rate=0` + `precondition_outputs=false` (velocity prediction).
- `test_matrixgame2_finetune.py` — `FineTuneMethod × MatrixGame2Model`. MatrixGame2 is text-free action-conditioned I2V, so the synthetic batch supplies `vae_latent` + `clip_feature` (CLIP `image_dim=1280`) + `first_frame_latent` + all-ones keyboard/mouse actions. The block-0 assertion is scoped to *active* params (its text cross-attn `attn2.*` legitimately gets no grad without text). Goal: grad-path correctness, not output realism.

**Shared harness** (`grad_norm_regression.py`, backward-compatible):
- `resolve_blocks()` — Cosmos exposes `transformer_blocks`, others `blocks` (Wan path unchanged: `blocks` matched first).
- localize DTensor grads before the norm reduction (Cosmos params are DTensors even at `world_size=1`); a no-op for plain tensors.
- add `H200` device key + seed H200 grad-norm refs.

## Test Results (H200, single GPU)

```
5 passed in 69.10s
```
- loading: cosmos 2.06B (6s), longcat 13.6B load+forward (48s), matrixgame2 ~14B (6s)
- grad-norm refs seeded: `test_cosmos_finetune[H200]=5.2763`, `test_matrixgame2_finetune[H200]=4.8247`; both re-pass against the seeded ref (rtol 0.10) without the update env.

## Known coverage gaps (by necessity, documented in-test)

- **MatrixGame2 (~14B)** single-GPU backward needs ~56 GB → the grad-norm test **skips on the 48 GB L40S CI runner** (per-device memory guard) and validates the grad path only on larger dev GPUs (H200/GB200). L40S still runs the matrixgame2 loading smoke.
- **LongCat (13.6B)** backward likewise OOMs L40S → loading smoke only.
- **`test_cosmos_finetune` carries only an H200 ref so far.** On L40S CI it runs the grad-path asserts (2B fits) but **skips the grad-norm regression assertion** until an L40S ref is seeded via `modal run … seed_grad_norm_references`. Will seed that before merge.

## Test plan
- [x] `pytest fastvideo/tests/train/models/test_load_{cosmos,longcat,matrixgame2}.py fastvideo/tests/train/methods/test_{cosmos,matrixgame2}_finetune.py` (H200) → 5 passed
- [ ] seed L40S ref for `test_cosmos_finetune` via Modal, then `/test train-framework`