### PR TITLE
[bugfix] Make enable_torch_compile_vae actually compile the Wan VAE

### DIFF
--- a/fastvideo/models/vaes/wanvae.py
+++ b/fastvideo/models/vaes/wanvae.py
@@ -1087,6 +1087,19 @@ def unpatchify(x, patch_size):
 
     return x
 
+
+def _is_wan_vae_codec(name: str, submodule: nn.Module) -> bool:
+    """Match the Wan VAE's encoder/decoder for in-place torch.compile.
+
+    Compiling the codec submodules' ``forward`` in place (rather than replacing
+    the whole VAE module) ensures the compiled version is the one held by the
+    already-constructed DecodingStage. Without this, ``enable_torch_compile_vae``
+    falls back to replacing ``self.modules["vae"]`` and is a no-op for Wan.
+    """
+    return (name == "encoder" and isinstance(submodule, WanEncoder3d)) or (
+        name == "decoder" and isinstance(submodule, WanDecoder3d))
+
+
 class AutoencoderKLWan(nn.Module, ParallelTiledVAE):
     r"""
     A VAE model with KL loss for encoding videos into latents and decoding latent representations into videos.
@@ -1094,6 +1107,7 @@ class AutoencoderKLWan(nn.Module, ParallelTiledVAE):
     """
 
     _supports_gradient_checkpointing = False
+    _compile_conditions = [_is_wan_vae_codec]
 
     def __init__(
         self,

--- a/fastvideo/tests/vaes/test_wan_vae_compile.py
+++ b/fastvideo/tests/vaes/test_wan_vae_compile.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the Wan VAE torch.compile wiring.
+
+Regression coverage for the fix that makes ``enable_torch_compile_vae`` actually
+compile ``AutoencoderKLWan``. Without ``_compile_conditions`` the pipeline takes
+the full-module-replace fallback in ``_maybe_compile_pipeline_module`` and the
+compiled VAE is never used by the already-constructed ``DecodingStage`` (no-op).
+
+These tests are intentionally lightweight (no GPU, no weights): they only check
+that the compile-condition predicate is registered on the class and matches the
+encoder/decoder submodules by name and type.
+"""
+import torch.nn as nn
+
+from fastvideo.models.vaes.wanvae import (AutoencoderKLWan, WanDecoder3d,
+                                          WanEncoder3d, _is_wan_vae_codec)
+
+
+def test_wan_vae_registers_compile_conditions():
+    # The class must declare _compile_conditions so _compile_with_conditions
+    # compiles the codec in place instead of falling back to a no-op replace.
+    conditions = getattr(AutoencoderKLWan, "_compile_conditions", None)
+    assert conditions, "AutoencoderKLWan must declare _compile_conditions"
+    assert _is_wan_vae_codec in conditions
+
+
+def test_is_wan_vae_codec_matches_encoder_decoder():
+    # object.__new__ gives a correctly-typed instance without running __init__,
+    # so the isinstance check can be exercised without a config or GPU.
+    decoder = object.__new__(WanDecoder3d)
+    encoder = object.__new__(WanEncoder3d)
+
+    assert _is_wan_vae_codec("decoder", decoder) is True
+    assert _is_wan_vae_codec("encoder", encoder) is True
+
+
+def test_is_wan_vae_codec_rejects_other_submodules():
+    decoder = object.__new__(WanDecoder3d)
+    encoder = object.__new__(WanEncoder3d)
+
+    # Right name but wrong type (e.g. a small conv/linear at the same name).
+    assert _is_wan_vae_codec("decoder", nn.Linear(1, 1)) is False
+    # Right type but not the top-level codec name.
+    assert _is_wan_vae_codec("decoder.something", decoder) is False
+    assert _is_wan_vae_codec("post_quant_conv", decoder) is False
+    # Mismatched name and type (each name must match its own codec type).
+    assert _is_wan_vae_codec("encoder", decoder) is False
+    assert _is_wan_vae_codec("decoder", encoder) is False


### PR DESCRIPTION
## Purpose

`enable_torch_compile_vae=True` is silently a no-op for the Wan VAE (`AutoencoderKLWan`): the compiled module is built but never executed during decode.

## Changes

**Root cause:** `DecodingStage` is constructed with a direct reference to the VAE module, then `_maybe_compile_pipeline_module` replaces `self.modules["vae"]` with a `torch.compile`-wrapped object. Because `AutoencoderKLWan` had no `_compile_conditions`, it took the full-module-replace fallback, so the stage kept using the original uncompiled reference and the compiled VAE never ran. (`LTX2CausalVideoAutoencoder` avoids this via `_compile_conditions`, which compiles the codec `forward` in place.)

- Add `_compile_conditions` to `AutoencoderKLWan` matching its `encoder`/`decoder` submodules, so compilation happens in place and the existing `DecodingStage` reference uses it.
- Add a lightweight (no-GPU) regression test that the predicate is registered and matches the codec submodules.

## Test Plan

```bash
# Unit test (no GPU / no weights)
pytest fastvideo/tests/vaes/test_wan_vae_compile.py -v

# End-to-end profiling: FastWan2.1-T2V-1.3B, 3-step DMD, GB10 (sm_121),
# enable_torch_compile=True; enable_torch_compile_vae=True before vs after this fix.
nsys profile -t cuda,nvtx -o run python run_infer.py
nsys stats --report cuda_gpu_kern_sum run.nsys-rep
```

## Test Results

Unit test: 3 passed (registers `_compile_conditions` / matches encoder-decoder / rejects others).

GENERATE-phase GPU kernels (DiT `torch.compile` on in both rows; only the VAE differs):

| Config | generate (s) | elementwise (ms) | total kernels |
|---|---|---|---|
| flag on, no `_compile_conditions` (no-op) | 26.3 | 13107 | 17598 |
| flag on, **this PR** | 24.1 | 10027 | 15854 |

- Before the fix the kernel count is identical to not setting the flag at all (the no-op). After, the log shows the in-place path: `Enabled torch.compile for 1 submodules in vae via _compile_conditions`.
- VAE-decode elementwise fuses (−3080 ms, −1744 kernels), ~8% faster end-to-end on top of DiT compile.
- **Quality:** MS-SSIM **0.9910** between the uncompiled-VAE and compiled-VAE outputs at identical seed/DiT (isolates the VAE change) — near-lossless. Measured with the repo's `compute_video_ssim_torchvision`.

## Checklist

- [x] I ran `pre-commit run` (changed source is under `fastvideo/models/`, which is excluded from pre-commit by design)
- [x] I added or updated tests for my changes
- [x] I considered GPU memory impact of my changes
