### PR TITLE
[feat] Selector: warn when resolved backend is capability-incompatible (#1254)

### DIFF
--- a/fastvideo/attention/backends/abstract.py
+++ b/fastvideo/attention/backends/abstract.py
@@ -107,6 +107,7 @@ class AttentionBackend(ABC):
         dtype: torch.dtype,
         *,
         needs_attention_mask: bool = False,
+        needs_varlen: bool = False,
     ) -> str | None:
         """Return None if this backend is compatible with the given
         requirements, else a human-readable reason for the mismatch.
@@ -125,6 +126,9 @@ class AttentionBackend(ABC):
         if needs_attention_mask and not cls.supports_attention_mask():
             return (f"{cls.get_name()} cannot consume the attention mask this "
                     "layer requires")
+        if needs_varlen and not cls.supports_varlen():
+            return (f"{cls.get_name()} does not support variable-length "
+                    "sequence packing (varlen)")
         return None
 
 

--- a/fastvideo/attention/backends/abstract.py
+++ b/fastvideo/attention/backends/abstract.py
@@ -71,8 +71,8 @@ class AttentionBackend(ABC):
         """
         return True
 
-    @classmethod
-    def get_supported_head_sizes(cls) -> list[int] | None:
+    @staticmethod
+    def get_supported_head_sizes() -> list[int] | None:
         """Attention head sizes this backend supports.
 
         Return None for no restriction.

--- a/fastvideo/attention/backends/abstract.py
+++ b/fastvideo/attention/backends/abstract.py
@@ -47,6 +47,86 @@ class AttentionBackend(ABC):
     def get_builder_cls() -> type["AttentionMetadataBuilder"]:
         raise NotImplementedError
 
+    # ------------------------------------------------------------------
+    # Capability self-description
+    #
+    # These let the selector validate a requested backend against a
+    # layer's needs and emit a clear reason when falling back, instead of
+    # silently discarding the choice (see #1254). They are additive: the
+    # defaults describe the least-restrictive behavior, so a backend that
+    # does not override them keeps today's behavior. Several backends
+    # already declare ``get_supported_head_sizes``; this formalizes that
+    # hook on the base class and adds the other capability axes.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """Whether this backend's third-party dependencies are importable.
+
+        Defaults to True. NOTE: backends import heavy deps at module scope
+        today, so wiring this into platform selection (to replace the
+        scattered ``try/except ImportError`` blocks in
+        ``get_attn_backend_cls``) also requires moving those imports behind
+        this method -- left as a follow-up.
+        """
+        return True
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int] | None:
+        """Attention head sizes this backend supports.
+
+        Return None for no restriction.
+        """
+        return None
+
+    @classmethod
+    def get_supported_dtypes(cls) -> tuple[torch.dtype, ...]:
+        """Floating-point dtypes this backend supports."""
+        return (torch.float16, torch.bfloat16)
+
+    @classmethod
+    def supports_attention_mask(cls) -> bool:
+        """Whether this backend can consume an explicit attention mask/bias.
+
+        Dense backends generally can; tiled/sparse video backends generally
+        cannot, since they impose their own sparsity pattern.
+        """
+        return True
+
+    @classmethod
+    def supports_varlen(cls) -> bool:
+        """Whether this backend supports single-launch variable-length
+        sequence packing (``cu_seqlens``), as in ``flash_attn_varlen_func``.
+        """
+        return False
+
+    @classmethod
+    def validate_compatibility(
+        cls,
+        head_size: int,
+        dtype: torch.dtype,
+        *,
+        needs_attention_mask: bool = False,
+    ) -> str | None:
+        """Return None if this backend is compatible with the given
+        requirements, else a human-readable reason for the mismatch.
+
+        The selector logs this reason when falling back, so an unsupported
+        request is never silently dropped.
+        """
+        if not cls.is_available():
+            return f"{cls.get_name()} dependencies are not installed"
+        supported_sizes = cls.get_supported_head_sizes()
+        if supported_sizes is not None and head_size not in supported_sizes:
+            return (f"{cls.get_name()} does not support head_size="
+                    f"{head_size} (supported: {supported_sizes})")
+        if dtype not in cls.get_supported_dtypes():
+            return f"{cls.get_name()} does not support dtype={dtype}"
+        if needs_attention_mask and not cls.supports_attention_mask():
+            return (f"{cls.get_name()} cannot consume the attention mask this "
+                    "layer requires")
+        return None
+
 
 @dataclass
 class AttentionMetadata:

--- a/fastvideo/attention/backends/sdpa.py
+++ b/fastvideo/attention/backends/sdpa.py
@@ -17,6 +17,11 @@ class SDPABackend(AttentionBackend):
     def get_supported_head_sizes() -> list[int]:
         return [32, 64, 96, 128, 160, 192, 224, 256]
 
+    @classmethod
+    def get_supported_dtypes(cls) -> tuple[torch.dtype, ...]:
+        # torch.scaled_dot_product_attention also runs in fp32.
+        return (torch.float16, torch.bfloat16, torch.float32)
+
     @staticmethod
     def get_name() -> str:
         return "SDPA"

--- a/fastvideo/attention/backends/video_sparse_attn.py
+++ b/fastvideo/attention/backends/video_sparse_attn.py
@@ -112,6 +112,17 @@ class VideoSparseAttentionBackend(AttentionBackend):
     def get_supported_head_sizes() -> list[int]:
         return [64, 128]
 
+    @classmethod
+    def supports_attention_mask(cls) -> bool:
+        # VSA imposes its own tiled sparsity pattern; it does not consume a
+        # general dense attention mask.
+        return False
+
+    @classmethod
+    def supports_varlen(cls) -> bool:
+        # Single-launch variable-length packing added in #1319.
+        return True
+
     @staticmethod
     def get_name() -> str:
         return "VIDEO_SPARSE_ATTN"

--- a/fastvideo/attention/backends/vmoba.py
+++ b/fastvideo/attention/backends/vmoba.py
@@ -18,6 +18,17 @@ class VMOBAAttentionBackend(AttentionBackend):
 
     accept_output_buffer: bool = True
 
+    @classmethod
+    def supports_attention_mask(cls) -> bool:
+        # VMOBA selects blocks via its own MoBA routing; it does not consume
+        # a general dense attention mask.
+        return False
+
+    @classmethod
+    def supports_varlen(cls) -> bool:
+        # Built on moba_attn_varlen (cu_seqlens sequence packing).
+        return True
+
     @staticmethod
     def get_name() -> str:
         return "VMOBA_ATTN"

--- a/fastvideo/attention/selector.py
+++ b/fastvideo/attention/selector.py
@@ -79,6 +79,27 @@ def get_global_forced_attn_backend() -> AttentionBackendEnum | None:
     return forced_attn_backend
 
 
+def warn_if_backend_incompatible(
+    backend: type[AttentionBackend],
+    head_size: int,
+    dtype: torch.dtype,
+) -> None:
+    """Log a warning if the resolved backend cannot serve this layer's
+    head_size/dtype, using the backend's self-described capabilities
+    (see #1254).
+
+    The platform only validates these for the FlashAttention default path,
+    so an explicitly requested backend (e.g. VIDEO_SPARSE_ATTN with an
+    unsupported head size) would otherwise fail later with an opaque kernel
+    error. This is diagnostic only -- it does not change which backend is
+    returned.
+    """
+    reason = backend.validate_compatibility(head_size, dtype)
+    if reason is not None:
+        logger.warning("Selected attention backend %s may be incompatible with this "
+                       "layer: %s", backend.get_name(), reason)
+
+
 def get_attn_backend(
     head_size: int,
     dtype: torch.dtype,
@@ -120,7 +141,9 @@ def _cached_get_attn_backend(
     attention_cls = current_platform.get_attn_backend_cls(selected_backend, head_size, dtype)
     if not attention_cls:
         raise ValueError(f"Invalid attention backend for {current_platform.device_name}")
-    return cast(type[AttentionBackend], resolve_obj_by_qualname(attention_cls))
+    backend = cast(type[AttentionBackend], resolve_obj_by_qualname(attention_cls))
+    warn_if_backend_incompatible(backend, head_size, dtype)
+    return backend
 
 
 @contextmanager

--- a/fastvideo/attention/selector.py
+++ b/fastvideo/attention/selector.py
@@ -92,9 +92,14 @@ def warn_if_backend_incompatible(
     so an explicitly requested backend (e.g. VIDEO_SPARSE_ATTN with an
     unsupported head size) would otherwise fail later with an opaque kernel
     error. This is diagnostic only -- it does not change which backend is
-    returned.
+    returned, and never raises: a misbehaving (e.g. custom/third-party)
+    backend must not be able to crash model initialization from this check.
     """
-    reason = backend.validate_compatibility(head_size, dtype)
+    try:
+        reason = backend.validate_compatibility(head_size, dtype)
+    except Exception as exc:  # noqa: BLE001 - diagnostic must never block init
+        logger.debug("Could not validate compatibility for backend %s: %s", backend.get_name(), exc)
+        return
     if reason is not None:
         logger.warning("Selected attention backend %s may be incompatible with this "
                        "layer: %s", backend.get_name(), reason)

--- a/fastvideo/tests/attention/test_backend_capabilities.py
+++ b/fastvideo/tests/attention/test_backend_capabilities.py
@@ -7,9 +7,7 @@ third-party attention packages installed.
 """
 import torch
 
-from fastvideo.attention.backends.abstract import (AttentionBackend,
-                                                   AttentionImpl,
-                                                   AttentionMetadata,
+from fastvideo.attention.backends.abstract import (AttentionBackend, AttentionImpl, AttentionMetadata,
                                                    AttentionMetadataBuilder)
 
 
@@ -40,8 +38,8 @@ class _RestrictedBackend(_DummyBackend):
     def get_name() -> str:
         return "RESTRICTED"
 
-    @classmethod
-    def get_supported_head_sizes(cls) -> list[int]:
+    @staticmethod
+    def get_supported_head_sizes() -> list[int]:
         return [64, 128]
 
     @classmethod
@@ -81,8 +79,7 @@ def test_supported_head_size_passes():
 
 
 def test_mask_requirement_reports_reason():
-    reason = _RestrictedBackend.validate_compatibility(
-        64, torch.float16, needs_attention_mask=True)
+    reason = _RestrictedBackend.validate_compatibility(64, torch.float16, needs_attention_mask=True)
     assert reason is not None
     assert "mask" in reason
 

--- a/fastvideo/tests/attention/test_backend_capabilities.py
+++ b/fastvideo/tests/attention/test_backend_capabilities.py
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the AttentionBackend capability self-description API.
+
+These exercise the additive capability hooks added for #1254 using a small
+dummy backend, so they run on CPU without GPU kernels or optional
+third-party attention packages installed.
+"""
+import torch
+
+from fastvideo.attention.backends.abstract import (AttentionBackend,
+                                                   AttentionImpl,
+                                                   AttentionMetadata,
+                                                   AttentionMetadataBuilder)
+
+
+class _DummyBackend(AttentionBackend):
+    """Minimal concrete backend that relies on the base-class defaults."""
+
+    @staticmethod
+    def get_name() -> str:
+        return "DUMMY"
+
+    @staticmethod
+    def get_impl_cls() -> type[AttentionImpl]:
+        raise NotImplementedError
+
+    @staticmethod
+    def get_metadata_cls() -> type[AttentionMetadata]:
+        raise NotImplementedError
+
+    @staticmethod
+    def get_builder_cls() -> type[AttentionMetadataBuilder]:
+        raise NotImplementedError
+
+
+class _RestrictedBackend(_DummyBackend):
+    """Overrides the capability hooks to a restrictive set."""
+
+    @staticmethod
+    def get_name() -> str:
+        return "RESTRICTED"
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return [64, 128]
+
+    @classmethod
+    def supports_attention_mask(cls) -> bool:
+        return False
+
+
+def test_defaults_are_permissive():
+    assert _DummyBackend.is_available() is True
+    assert _DummyBackend.get_supported_head_sizes() is None
+    assert _DummyBackend.supports_varlen() is False
+    assert _DummyBackend.supports_attention_mask() is True
+    assert torch.float16 in _DummyBackend.get_supported_dtypes()
+    assert torch.bfloat16 in _DummyBackend.get_supported_dtypes()
+
+
+def test_compatible_request_returns_none():
+    # No head-size restriction, supported dtype, no mask required.
+    assert _DummyBackend.validate_compatibility(123, torch.float16) is None
+
+
+def test_unsupported_dtype_reports_reason():
+    reason = _DummyBackend.validate_compatibility(64, torch.float32)
+    assert reason is not None
+    assert "dtype" in reason
+    assert "DUMMY" in reason
+
+
+def test_unsupported_head_size_reports_reason():
+    reason = _RestrictedBackend.validate_compatibility(96, torch.float16)
+    assert reason is not None
+    assert "head_size" in reason
+
+
+def test_supported_head_size_passes():
+    assert _RestrictedBackend.validate_compatibility(128, torch.float16) is None
+
+
+def test_mask_requirement_reports_reason():
+    reason = _RestrictedBackend.validate_compatibility(
+        64, torch.float16, needs_attention_mask=True)
+    assert reason is not None
+    assert "mask" in reason
+
+
+def test_real_backends_declare_capabilities():
+    # Backends that ship head-size lists should expose them through the hook.
+    from fastvideo.attention.backends.sdpa import SDPABackend
+    assert SDPABackend.get_supported_head_sizes() is not None
+    assert torch.float32 in SDPABackend.get_supported_dtypes()

--- a/fastvideo/tests/attention/test_backend_capabilities.py
+++ b/fastvideo/tests/attention/test_backend_capabilities.py
@@ -84,6 +84,13 @@ def test_mask_requirement_reports_reason():
     assert "mask" in reason
 
 
+def test_varlen_requirement_reports_reason():
+    # _DummyBackend uses the default supports_varlen() == False.
+    reason = _DummyBackend.validate_compatibility(64, torch.float16, needs_varlen=True)
+    assert reason is not None
+    assert "varlen" in reason
+
+
 def test_real_backends_declare_capabilities():
     # Backends that ship head-size lists should expose them through the hook.
     from fastvideo.attention.backends.sdpa import SDPABackend

--- a/fastvideo/tests/attention/test_selector_capability_warning.py
+++ b/fastvideo/tests/attention/test_selector_capability_warning.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the selector's capability-mismatch warning (#1254, step 3).
+
+`warn_if_backend_incompatible` is exercised in isolation with a dummy
+backend, so these run on CPU without GPU kernels or the platform machinery.
+"""
+from unittest import mock
+
+import torch
+
+from fastvideo.attention import selector
+from fastvideo.attention.backends.abstract import (AttentionBackend, AttentionImpl, AttentionMetadata,
+                                                   AttentionMetadataBuilder)
+
+
+class _Restricted(AttentionBackend):
+    """Backend that only supports head sizes 64 and 128."""
+
+    @staticmethod
+    def get_name() -> str:
+        return "RESTRICTED"
+
+    @staticmethod
+    def get_supported_head_sizes() -> list[int]:
+        return [64, 128]
+
+    @staticmethod
+    def get_impl_cls() -> type[AttentionImpl]:
+        raise NotImplementedError
+
+    @staticmethod
+    def get_metadata_cls() -> type[AttentionMetadata]:
+        raise NotImplementedError
+
+    @staticmethod
+    def get_builder_cls() -> type[AttentionMetadataBuilder]:
+        raise NotImplementedError
+
+
+def test_warns_on_incompatible_head_size():
+    with mock.patch.object(selector.logger, "warning") as mock_warn:
+        selector.warn_if_backend_incompatible(_Restricted, head_size=96, dtype=torch.float16)
+    mock_warn.assert_called_once()
+    # backend name and reason are passed as format args.
+    assert "RESTRICTED" in mock_warn.call_args.args
+
+
+def test_warns_on_incompatible_dtype():
+    with mock.patch.object(selector.logger, "warning") as mock_warn:
+        selector.warn_if_backend_incompatible(_Restricted, head_size=64, dtype=torch.float32)
+    mock_warn.assert_called_once()
+
+
+def test_no_warning_when_compatible():
+    with mock.patch.object(selector.logger, "warning") as mock_warn:
+        selector.warn_if_backend_incompatible(_Restricted, head_size=128, dtype=torch.float16)
+    mock_warn.assert_not_called()

--- a/fastvideo/tests/attention/test_selector_capability_warning.py
+++ b/fastvideo/tests/attention/test_selector_capability_warning.py
@@ -55,3 +55,18 @@ def test_no_warning_when_compatible():
     with mock.patch.object(selector.logger, "warning") as mock_warn:
         selector.warn_if_backend_incompatible(_Restricted, head_size=128, dtype=torch.float16)
     mock_warn.assert_not_called()
+
+
+def test_validation_error_does_not_crash():
+    """A backend whose validate_compatibility raises must not break init."""
+
+    class _Broken(_Restricted):
+
+        @classmethod
+        def validate_compatibility(cls, *args, **kwargs) -> str | None:
+            raise RuntimeError("boom")
+
+    with mock.patch.object(selector.logger, "warning") as mock_warn:
+        # Should not raise.
+        selector.warn_if_backend_incompatible(_Broken, head_size=64, dtype=torch.float16)
+    mock_warn.assert_not_called()


### PR DESCRIPTION
## Summary

Step 3 of #1254. **Stacked on #1489** (uses the `validate_compatibility` API added there) — the diff will shrink to just the selector change once #1489 merges.

After the platform resolves an attention backend, this validates it against the layer's `head_size`/`dtype` via `AttentionBackend.validate_compatibility` and logs a clear warning on mismatch. The platform's `get_attn_backend_cls` only runs these checks for the FlashAttention default path, so an *explicitly requested* backend that doesn't fit the layer — e.g. forcing `VIDEO_SPARSE_ATTN`, which only supports head sizes 64/128 — would otherwise fail later with an opaque kernel error. This surfaces the reason up front.

## Changes
- `fastvideo/attention/selector.py`: extract `warn_if_backend_incompatible(backend, head_size, dtype)` and call it on the resolved backend in `_cached_get_attn_backend`.
- `fastvideo/tests/attention/test_selector_capability_warning.py`: CPU-only unit tests (dummy backend; patches the module logger — no GPU or log-propagation assumptions).

## Scope
- **Diagnostic only** — does not change which backend is returned, so no behavior/perf regression risk.
- Complements #1486 (which warns when a requested backend isn't in a layer's allowlist). Together: #1486 catches "not allowed here", this catches "allowed but capability-incompatible".
- The `needs_attention_mask` axis is not wired here — that requires layer-side plumbing (a layer declaring it needs a mask) and is left as follow-up.

## Relationship to the #1254 plan
1. ✅ Warn on silent fallback (#1486)
2. ✅ Capability self-description API (#1489)
3. ➡️ **This PR** — wire `validate_compatibility` into the selector
4. ⏳ Centralize the per-layer allowlists across the ~16 model files into one declarative source of truth (the larger refactor; deliberately separate, and best done after maintainer direction given @alexzms's caution about silently regressing models)

## Test plan
- [x] `fastvideo/tests/attention/test_selector_capability_warning.py` — warns on incompatible head size and dtype; silent when compatible.

> Authored without a local GPU/torch env; the test is pure-CPU and should run in CI. `ruff`/`yapf`/`codespell` (pinned versions) pass locally.

Refs #1254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
