### PR TITLE
[bugfix] Fix causal attention mask for Blackwell FP4 MMA column layout

### DIFF
--- a/fastvideo-kernel/attn_qat_infer/blackwell/mainloop_tma_ws.h
+++ b/fastvideo-kernel/attn_qat_infer/blackwell/mainloop_tma_ws.h
@@ -740,10 +740,6 @@ struct CollectiveMainloopFwd {
         auto col_limit_causal = [&](int row, int n_block) {
             return row + 1 + seqlen_k - n_block * kBlockN - seqlen_q + m_block * kBlockM;
         };
-        // The Blackwell FP4 MMA accumulator's N-dimension is laid out with bits 1↔3 and 2↔4
-        // swapped within each 32-column block relative to the natural matrix column order.
-        // partition_C of the identity tensor reflects this internal order, so we must undo
-        // the permutation to recover the actual matrix column before applying the causal mask.
         auto actual_col = [](int c) {
             int local = c & 31;
             return (c & ~31) | (local & 1) | ((local & 24) >> 2) | ((local & 6) << 2);

--- a/fastvideo-kernel/attn_qat_infer/blackwell/mainloop_tma_ws.h
+++ b/fastvideo-kernel/attn_qat_infer/blackwell/mainloop_tma_ws.h
@@ -740,16 +740,25 @@ struct CollectiveMainloopFwd {
         auto col_limit_causal = [&](int row, int n_block) {
             return row + 1 + seqlen_k - n_block * kBlockN - seqlen_q + m_block * kBlockM;
         };
+        // The Blackwell FP4 MMA accumulator's N-dimension is laid out with bits 1↔3 and 2↔4
+        // swapped within each 32-column block relative to the natural matrix column order.
+        // partition_C of the identity tensor reflects this internal order, so we must undo
+        // the permutation to recover the actual matrix column before applying the causal mask.
+        auto actual_col = [](int c) {
+            int local = c & 31;
+            return (c & ~31) | (local & 1) | ((local & 24) >> 2) | ((local & 6) << 2);
+        };
         {
             Tensor cS = cute::make_identity_tensor(select<0, 1>(TileShape_MNK{}));
             Tensor tScS = thread_mma_qk.partition_C(cS);
             CUTLASS_PRAGMA_UNROLL
             for (int i = 0; i < size(tSrS); ++i) {
+                int col = actual_col(int(get<1>(tScS(i))));
                 if constexpr (!Is_causal) {  // Just masking based on col
-                    if (int(get<1>(tScS(i))) >= int(unpadded_seqlen_k - n_block * kBlockN)) { tSrS(i) = -INFINITY; }
-                } else { 
-                    if (int(get<1>(tScS(i))) >= std::min(seqlen_k - n_block * kBlockN,
-                                                        col_limit_causal(int(get<0>(tScS(i))), n_block))) {
+                    if (col >= int(unpadded_seqlen_k - n_block * kBlockN)) { tSrS(i) = -INFINITY; }
+                } else {
+                    if (col >= std::min(seqlen_k - n_block * kBlockN,
+                                       col_limit_causal(int(get<0>(tScS(i))), n_block))) {
                         tSrS(i) = -INFINITY;
                     }
                 }
@@ -846,7 +855,8 @@ struct CollectiveMainloopFwd {
             Tensor tScS = thread_mma_qk.partition_C(cS);
             #pragma unroll
             for (int i = 0; i < size(tSrS); ++i) {
-                if (int(get<1>(tScS(i))) >= col_limit_causal(int(get<0>(tScS(i))), n_block)) {
+                int col = actual_col(int(get<1>(tScS(i))));
+                if (col >= col_limit_causal(int(get<0>(tScS(i))), n_block)) {
                     tSrS(i) = -INFINITY;
                 }
             }
@@ -868,7 +878,7 @@ struct CollectiveMainloopFwd {
             }
             pipeline_v.consumer_release(smem_pipe_read_v);
             ++smem_pipe_read_v;
-            if (masking_step > 0) { softmax_fused.rescale_o(tOrO_store, tOrO); }
+            softmax_fused.rescale_o(tOrO_store, tOrO);
         }
 
         #pragma unroll 1

--- a/fastvideo-kernel/tests/test_attn_qat_infer.py
+++ b/fastvideo-kernel/tests/test_attn_qat_infer.py
@@ -69,7 +69,7 @@ def bench(B, H, L, D, is_causal, warmup=20, iters=100):
     torch.cuda.synchronize()
 
     ms = start.elapsed_time(end) / iters
-    flops = 4 * B * H * L * L * D / 1e12
+    flops = (2 if is_causal else 4) * B * H * L * L * D / 1e12
     tflops = flops / (ms / 1e3)
     return ms, tflops
 

--- a/fastvideo-kernel/tests/test_attn_qat_infer.py
+++ b/fastvideo-kernel/tests/test_attn_qat_infer.py
@@ -23,9 +23,6 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from attn_qat_infer.api import sageattn_blackwell
-# sys.path.insert(0, "/home/kevin/workspace/SageAttention/sageattention3_blackwell")
-# sys.path.insert(0, "/home/kevin/workspace/SageAttentionE/sageattention3_blackwell")
-# from sageattn3.api import sageattn3_blackwell as sageattn_blackwell
 
 DEVICE = torch.device("cuda")
 

--- a/fastvideo-kernel/tests/test_attn_qat_infer.py
+++ b/fastvideo-kernel/tests/test_attn_qat_infer.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Correctness tests for the sageattn_blackwell (ATTN_QAT_INFER) FP4 inference kernel.
+
+Compares causal and non-causal outputs against a naive float32 reference to verify
+that the V-row permutation in scaled_fp4_quant_trans_kernel is correct (or absent).
+
+Requires a Blackwell GPU (sm_120a) and fp4attn_cuda / fp4quant_cuda extensions built
+via `cd fastvideo-kernel && ./build.sh`.
+
+Run from the fastvideo-kernel directory:
+    python tests/test_attn_qat_infer.py
+or via pytest:
+    pytest tests/test_attn_qat_infer.py -v
+"""
+
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import torch
+import torch.nn.functional as F
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+from attn_qat_infer.api import sageattn_blackwell
+# sys.path.insert(0, "/home/kevin/workspace/SageAttention/sageattention3_blackwell")
+# sys.path.insert(0, "/home/kevin/workspace/SageAttentionE/sageattention3_blackwell")
+# from sageattn3.api import sageattn3_blackwell as sageattn_blackwell
+
+DEVICE = torch.device("cuda")
+
+
+def cosine_similarity(a: torch.Tensor, b: torch.Tensor) -> float:
+    a_flat = a.flatten().float()
+    b_flat = b.flatten().float()
+    norm_a = torch.norm(a_flat)
+    norm_b = torch.norm(b_flat)
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return (torch.dot(a_flat, b_flat) / (norm_a * norm_b)).item()
+
+
+def reference_sdpa(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                   is_causal: bool) -> torch.Tensor:
+    """PyTorch math-backend SDPA reference in float32."""
+    with sdpa_kernel([SDPBackend.MATH]):
+        out = F.scaled_dot_product_attention(
+            q.float(), k.float(), v.float(), is_causal=is_causal
+        )
+    return out.to(q.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark
+# ---------------------------------------------------------------------------
+
+def bench(B, H, L, D, is_causal, warmup=20, iters=100):
+    q = torch.randn(B, H, L, D, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn(B, H, L, D, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(B, H, L, D, device="cuda", dtype=torch.bfloat16)
+
+    for _ in range(warmup):
+        sageattn_blackwell(q, k, v, is_causal=is_causal)
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        sageattn_blackwell(q, k, v, is_causal=is_causal)
+    end.record()
+    torch.cuda.synchronize()
+
+    ms = start.elapsed_time(end) / iters
+    flops = 4 * B * H * L * L * D / 1e12
+    tflops = flops / (ms / 1e3)
+    return ms, tflops
+
+
+def run_benchmark():
+    B, H = 2, 32
+    print(f"{'B':>2} {'H':>2} {'L':>5} {'D':>4} {'causal':>6}  {'ms':>8}  {'TFLOPS':>7}")
+    print("-" * 50)
+    for is_causal in [False, True]:
+        for L in [512, 1024, 2048, 4096]:
+            for D in [64, 128]:
+                ms, tflops = bench(B, H, L, D, is_causal)
+                print(
+                    f"{B:>2} {H:>2} {L:>5} {D:>4} {str(is_causal):>6}"
+                    f"  {ms:>8.3f}  {tflops:>7.2f}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+import pytest
+
+
+@pytest.mark.parametrize("B,H,L,D", [
+    (2, 4,  128,  64), (2, 4,  128, 128),
+    (2, 4,  256,  64), (2, 4,  256, 128),
+    (2, 4,  512,  64), (2, 4,  512, 128),
+    (2, 4, 1024,  64), (2, 4, 1024, 128),
+    (2, 4, 2048,  64), (2, 4, 2048, 128),
+    (2, 4, 4096,  64), (2, 4, 4096, 128),
+    (1, 4,  128, 128),
+    (2, 8,  256, 128),
+    (1, 4,  384, 128),
+])
+@pytest.mark.parametrize("causal", [False, True], ids=["non_causal", "causal"])
+def test_accuracy_sdpa(causal: bool, B: int, H: int, L: int, D: int):
+    """SDPA-reference accuracy sweep with 0.3-scaled inputs."""
+    torch.manual_seed(42)
+    q = torch.randn(B, H, L, D, dtype=torch.bfloat16, device=DEVICE)
+    k = torch.randn(B, H, L, D, dtype=torch.bfloat16, device=DEVICE)
+    v = torch.randn(B, H, L, D, dtype=torch.bfloat16, device=DEVICE)
+    ref = reference_sdpa(q, k, v, is_causal=causal)
+    out = sageattn_blackwell(q.clone(), k.clone(), v.clone(), is_causal=causal)
+    cos = cosine_similarity(out, ref)
+    label = "causal" if causal else "non-causal"
+    print(f"  [{label}] B={B} H={H} L={L} D={D} — cos_sim={cos:.6f}")
+    assert cos >= 0.97, f"({label}) B={B} H={H} L={L} D={D} cos_sim={cos:.4f} < 0.97"
+
+
+if __name__ == "__main__":
+    print("=" * 65)
+    print("sageattn_blackwell (ATTN_QAT_INFER) inference correctness tests")
+    print("=" * 65)
+    print()
+
+    print("Accuracy sweep — SDPA reference:")
+    for causal in [False, True]:
+        for B, H, L, D in [
+            (2, 4,  128,  64), (2, 4,  128, 128),
+            (2, 4,  256,  64), (2, 4,  256, 128),
+            (2, 4,  512,  64), (2, 4,  512, 128),
+            (2, 4, 1024,  64), (2, 4, 1024, 128),
+            (2, 4, 2048,  64), (2, 4, 2048, 128),
+            (2, 4, 4096,  64), (2, 4, 4096, 128),
+            (1, 4,  128, 128),
+            (2, 8,  256, 128),
+            (1, 4,  384, 128),
+        ]:
+            test_accuracy_sdpa(causal, B, H, L, D)
+    print()
+    print("All tests completed.")
+    print()
+    print("Benchmark (B=2, H=32, bf16):")
+    run_benchmark()

--- a/fastvideo/attention/selector.py
+++ b/fastvideo/attention/selector.py
@@ -115,8 +115,7 @@ def _cached_get_attn_backend(
     # get device-specific attn_backend
     from fastvideo.platforms import current_platform
 
-    if (selected_backend is not None and
-            selected_backend not in supported_attention_backends):
+    if (selected_backend is not None and selected_backend not in supported_attention_backends):
         logger.warning(
             "Requested attention backend %s is not supported by this "
             "layer; supported backends are %s. Falling back to automatic "


### PR DESCRIPTION
<!--
PR TITLE: Must start with a type tag, e.g.:
  [feat] Add new model       [bugfix] Fix VAE tiling      [refactor] Restructure pipeline
  [perf] Optimize kernel     [ci] Update tests             [docs] Add guide
  [misc] Cleanup configs     [new-model] Port Flux2        [infra] Add trace hooks
  [skill] Add agent skill

MERGE WORKFLOW:
  1. Ensure pre-commit passes and you have at least 1 approval
  2. Comment /merge (or add the "ready" label) to enter the Merge Queue
  3. Full Test Suite runs automatically on a staging branch → auto-merge on success

ON-DEMAND TESTING (write access required):
  /test full       — Full Test Suite        /test ssim        — SSIM regression
  /test training   — Training pipeline      /test encoder     — Encoder tests
  /test transformer — Transformer tests     /test vae         — VAE tests
  /test kernel     — CUDA kernel tests      /test unit        — Unit tests
  See docs/contributing/pull_requests.md for all 17 test commands
-->

## Purpose

<!-- What does this PR do? Link the related issue if applicable. -->

#1493 fixed non-causal attention by removing an incorrect V-row permutation in scaled_fp4_quant_trans_kernel. Causal attention remained broken due to a separate issue in the mask logic, which is addressed through this PR.

## Changes

<!-- Describe your changes concisely. What approach did you take? -->

The Blackwell FP4 MMA accumulator stores its N-dimension output with bits 1↔3 and 2↔4 swapped within each 32-column block relative to natural matrix column order. The causal mask in mainloop_tma_ws.h was comparing raw column indices from partition_C of the identity tensor directly against mask boundaries without undoing this permutation, causing wrong positions to be masked to -inf.

The fix is to add an actual_col lambda that undoes the MMA column permutation before any mask comparison:

```
auto actual_col = [](int c) {
    int local = c & 31;
    return (c & ~31) | (local & 1) | ((local & 24) >> 2) | ((local & 6) << 2);
};
```

Also removed the `masking_step > 0 guard on softmax_fused.rescale_o`, which was incorrectly skipping the output rescale on the first masking iteration.

```
Accuracy sweep — SDPA reference:
  [non-causal] B=2 H=4 L=128 D=64 — cos_sim=0.981914
  [non-causal] B=2 H=4 L=128 D=128 — cos_sim=0.982216
  [non-causal] B=2 H=4 L=256 D=64 — cos_sim=0.981776
  [non-causal] B=2 H=4 L=256 D=128 — cos_sim=0.982060
  [non-causal] B=2 H=4 L=512 D=64 — cos_sim=0.981425
  [non-causal] B=2 H=4 L=512 D=128 — cos_sim=0.981921
  [non-causal] B=2 H=4 L=1024 D=64 — cos_sim=0.981429
  [non-causal] B=2 H=4 L=1024 D=128 — cos_sim=0.981684
  [non-causal] B=2 H=4 L=2048 D=64 — cos_sim=0.980905
  [non-causal] B=2 H=4 L=2048 D=128 — cos_sim=0.982081
  [non-causal] B=2 H=4 L=4096 D=64 — cos_sim=0.981517
  [non-causal] B=2 H=4 L=4096 D=128 — cos_sim=0.981837
  [non-causal] B=1 H=4 L=128 D=128 — cos_sim=0.982467
  [non-causal] B=2 H=8 L=256 D=128 — cos_sim=0.982017
  [non-causal] B=1 H=4 L=384 D=128 — cos_sim=0.981758
  [causal] B=2 H=4 L=128 D=64 — cos_sim=0.985981
  [causal] B=2 H=4 L=128 D=128 — cos_sim=0.986065
  [causal] B=2 H=4 L=256 D=64 — cos_sim=0.985610
  [causal] B=2 H=4 L=256 D=128 — cos_sim=0.985546
  [causal] B=2 H=4 L=512 D=64 — cos_sim=0.984660
  [causal] B=2 H=4 L=512 D=128 — cos_sim=0.985709
  [causal] B=2 H=4 L=1024 D=64 — cos_sim=0.984427
  [causal] B=2 H=4 L=1024 D=128 — cos_sim=0.984969
  [causal] B=2 H=4 L=2048 D=64 — cos_sim=0.984374
  [causal] B=2 H=4 L=2048 D=128 — cos_sim=0.984268
  [causal] B=2 H=4 L=4096 D=64 — cos_sim=0.984169
  [causal] B=2 H=4 L=4096 D=128 — cos_sim=0.984206
  [causal] B=1 H=4 L=128 D=128 — cos_sim=0.986197
  [causal] B=2 H=8 L=256 D=128 — cos_sim=0.985849
  [causal] B=1 H=4 L=384 D=128 — cos_sim=0.985029

All tests completed.

Benchmark (B=2, H=32, bf16):
 B  H     L    D causal        ms   TFLOPS
--------------------------------------------------
 2 32   512   64  False     0.045    95.41
 2 32   512  128  False     0.044   193.73
 2 32  1024   64  False     0.052   330.02
 2 32  1024  128  False     0.079   437.42
 2 32  2048   64  False     0.141   487.37
 2 32  2048  128  False     0.259   529.92
 2 32  4096   64  False     0.523   525.36
 2 32  4096  128  False     0.821   669.54
 2 32   512   64   True     0.044    96.72
 2 32   512  128   True     0.044   193.56
 2 32  1024   64   True     0.045   382.84
 2 32  1024  128   True     0.062   555.48
 2 32  2048   64   True     0.103   670.25
 2 32  2048  128   True     0.181   758.90
 2 32  4096   64   True     0.365   752.11
 2 32  4096  128   True     0.512  1073.05

```
## Test Plan

Added fastvideo-kernel/tests/test_attn_qat_infer.py, a pytest suite comparing sageattn_blackwell against PyTorch's float32 SDPA reference across shapes (L∈{128…4096}, D∈{64,128}) in both causal and non-causal modes.

<!-- How did you verify your changes? Paste exact commands and output. -->

```bash
python fastvideo-kernel/tests/test_attn_qat_infer.py
```

## Test Results

<!-- Paste test output, before/after comparisons, or SSIM scores for model changes. -->

<details>
<summary>Test output</summary>

```
Accuracy sweep — SDPA reference:
  [non-causal] B=2 H=4 L=128 D=64 — cos_sim=0.981914
  [non-causal] B=2 H=4 L=128 D=128 — cos_sim=0.982216
  [non-causal] B=2 H=4 L=256 D=64 — cos_sim=0.981776
  [non-causal] B=2 H=4 L=256 D=128 — cos_sim=0.982060
  [non-causal] B=2 H=4 L=512 D=64 — cos_sim=0.981425
  [non-causal] B=2 H=4 L=512 D=128 — cos_sim=0.981921
  [non-causal] B=2 H=4 L=1024 D=64 — cos_sim=0.981429
  [non-causal] B=2 H=4 L=1024 D=128 — cos_sim=0.981684
  [non-causal] B=2 H=4 L=2048 D=64 — cos_sim=0.980905
  [non-causal] B=2 H=4 L=2048 D=128 — cos_sim=0.982081
  [non-causal] B=2 H=4 L=4096 D=64 — cos_sim=0.981517
  [non-causal] B=2 H=4 L=4096 D=128 — cos_sim=0.981837
  [non-causal] B=1 H=4 L=128 D=128 — cos_sim=0.982467
  [non-causal] B=2 H=8 L=256 D=128 — cos_sim=0.982017
  [non-causal] B=1 H=4 L=384 D=128 — cos_sim=0.981758
  [causal] B=2 H=4 L=128 D=64 — cos_sim=0.985981
  [causal] B=2 H=4 L=128 D=128 — cos_sim=0.986065
  [causal] B=2 H=4 L=256 D=64 — cos_sim=0.985610
  [causal] B=2 H=4 L=256 D=128 — cos_sim=0.985546
  [causal] B=2 H=4 L=512 D=64 — cos_sim=0.984660
  [causal] B=2 H=4 L=512 D=128 — cos_sim=0.985709
  [causal] B=2 H=4 L=1024 D=64 — cos_sim=0.984427
  [causal] B=2 H=4 L=1024 D=128 — cos_sim=0.984969
  [causal] B=2 H=4 L=2048 D=64 — cos_sim=0.984374
  [causal] B=2 H=4 L=2048 D=128 — cos_sim=0.984268
  [causal] B=2 H=4 L=4096 D=64 — cos_sim=0.984169
  [causal] B=2 H=4 L=4096 D=128 — cos_sim=0.984206
  [causal] B=1 H=4 L=128 D=128 — cos_sim=0.986197
  [causal] B=2 H=8 L=256 D=128 — cos_sim=0.985849
  [causal] B=1 H=4 L=384 D=128 — cos_sim=0.985029

All tests completed.

Benchmark (B=2, H=32, bf16):
 B  H     L    D causal        ms   TFLOPS
--------------------------------------------------
 2 32   512   64  False     0.045    95.41
 2 32   512  128  False     0.044   193.73
 2 32  1024   64  False     0.052   330.02
 2 32  1024  128  False     0.079   437.42
 2 32  2048   64  False     0.141   487.37
 2 32  2048  128  False     0.259   529.92
 2 32  4096   64  False     0.523   525.36
 2 32  4096  128  False     0.821   669.54
 2 32   512   64   True     0.044    96.72
 2 32   512  128   True     0.044   193.56
 2 32  1024   64   True     0.045   382.84
 2 32  1024  128   True     0.062   555.48
 2 32  2048   64   True     0.103   670.25
 2 32  2048  128   True     0.181   758.90
 2 32  4096   64   True     0.365   752.11
 2 32  4096  128   True     0.512  1073.05
```

</details>

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues
- [x] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [ ] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model
