### PR TITLE
[bugfix] compile FP4 (attn_qat_infer) kernels for sm_120a only via per-arch split

### DIFF
--- a/fastvideo-kernel/CMakeLists.txt
+++ b/fastvideo-kernel/CMakeLists.txt
@@ -158,6 +158,29 @@ endif()
 # Always try to build the extension if CUDA is available, but conditionally add sources/flags
 set(BUILD_CXX_KERNELS ON)
 
+# ---------------------------------------------------------------------------
+# Per-arch split for the Blackwell FP4 (attn_qat_infer) build
+# ---------------------------------------------------------------------------
+# The FP4 kernels are sm_120a-only (they emit `cvt.e2m1x2` etc.), while the main
+# extension (Hopper-only TK + generic turbodiffusion) targets the full arch list.
+# find_package(Torch) injects ONE global -gencode list into CMAKE_CUDA_FLAGS that
+# forces every target onto every arch, so the FP4 sources also get the sm_90a pass
+# and ptxas rejects their Blackwell instructions. Strip that global list and drive
+# arch per target via CUDA_ARCHITECTURES instead (the fp4* targets pin 120a below;
+# the main extension gets the full list). Only do this for the FP4 build with an
+# explicit arch list, so the cu126 / local autodetect paths stay untouched.
+if(ENABLE_ATTN_QAT_INFER AND TORCH_CUDA_ARCH_LIST)
+    message(STATUS "[per-arch] CMAKE_CUDA_FLAGS before strip: ${CMAKE_CUDA_FLAGS}")
+    string(REGEX REPLACE "-gencode[ =]+arch=[^ ]+" "" CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
+    string(REGEX REPLACE " +" " " CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS}")
+    message(STATUS "[per-arch] CMAKE_CUDA_FLAGS after strip:  ${CMAKE_CUDA_FLAGS}")
+    # Convert TORCH_CUDA_ARCH_LIST ("9.0a;12.0a") to CMake form ("90a;120a").
+    set(FASTVIDEO_MAIN_CUDA_ARCHS "${TORCH_CUDA_ARCH_LIST}")
+    string(REPLACE "sm_" "" FASTVIDEO_MAIN_CUDA_ARCHS "${FASTVIDEO_MAIN_CUDA_ARCHS}")
+    string(REPLACE "." "" FASTVIDEO_MAIN_CUDA_ARCHS "${FASTVIDEO_MAIN_CUDA_ARCHS}")
+    message(STATUS "[per-arch] main extension archs=${FASTVIDEO_MAIN_CUDA_ARCHS}, fp4* archs=120a")
+endif()
+
 # Compiler flags
 set(CUDA_FLAGS
     "-DNDEBUG"
@@ -206,6 +229,15 @@ if(BUILD_CXX_KERNELS)
     Python_add_library(fastvideo_kernel_ops MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI
         ${EXTENSION_SOURCES}
     )
+
+    # When the per-arch split is active (FP4 build), torch's global gencode was
+    # stripped above, so set this target's arch explicitly. TK is guarded down to
+    # sm_90a in source; the turbodiffusion kernels are generic, so the main
+    # extension targets the full list. (No-FP4 builds keep torch's global gencode.)
+    if(ENABLE_ATTN_QAT_INFER AND FASTVIDEO_MAIN_CUDA_ARCHS)
+        set_target_properties(fastvideo_kernel_ops PROPERTIES
+            CUDA_ARCHITECTURES "${FASTVIDEO_MAIN_CUDA_ARCHS}")
+    endif()
 
     # Build compile definitions list
     set(COMPILE_DEFS TORCH_EXTENSION_NAME=fastvideo_kernel_ops)


### PR DESCRIPTION
## Problem

This is the **mirror** of the ThunderKittens arch issue fixed in #1507 (merged). The cu130 wheel builds a `9.0a;12.0a` fat binary, and `find_package(Torch)` injects **one global** `-gencode` list into `CMAKE_CUDA_FLAGS` that forces every target onto every arch. So the Blackwell FP4 kernels (`attn_qat_infer/blackwell/api.cu`, `attn_qat_infer/quantization/fp4_quantization_4d.cu`) also get the **sm_90a** pass, where ptxas rejects their Blackwell `cvt.e2m1x2`:

```
ptxas .../api.compute_90a.ptx: error : Instruction 'cvt with .e2m1x2' not supported on .target 'sm_90a'
```

(#1507 guarded TK down to sm_90a in source. This is the sm_120a side.)

## Fix

The FP4 targets (`fp4attn_cuda`, `fp4quant_cuda`) are already separate and already declare `CUDA_ARCHITECTURES "120a"` — they only got the sm_90a pass from torch's global gencode. So strip torch's global `-gencode` from `CMAKE_CUDA_FLAGS` and drive arch **per target**: FP4 targets compile sm_120a-only, the main extension (`fastvideo_kernel_ops` = generic turbodiffusion + the sm_90a-guarded TK) gets the full list. Scoped to the FP4 build with an explicit `TORCH_CUDA_ARCH_LIST`, so the cu126 / local-autodetect paths are untouched.

| Target | Arch(es) | How |
|--------|----------|-----|
| `fastvideo_kernel_ops` | `90a;120a` | per-target (set explicitly after the strip) |
| `fp4attn_cuda`, `fp4quant_cuda` | `120a` only | per-target `CUDA_ARCHITECTURES` (already declared) |

Unlike TK, the FP4 kernels don't need a source guard because they live in their own targets that can be pinned to sm_120a directly — TK couldn't, since it shares the dual-arch `fastvideo_kernel_ops` target with the generic kernels.

## Testing

- Validated the gencode-strip regex and the `9.0a;12.0a → 90a;120a` conversion with a standalone `cmake -P` (handles both `-gencode arch=` and `-gencode=arch=` forms).
- Added `[per-arch]` STATUS messages printing `CMAKE_CUDA_FLAGS` before/after the strip and the resolved per-target arches, so a CI build shows whether the split took effect.
- Not runnable from PR CI: `publish-kernel.yml` only triggers on `workflow_dispatch` / a push to `pyproject.toml`, and a dispatch **publishes 0.3.0 on a green build**. After merge, dispatch on `main` to build (OOM cap #1483 + TK guard #1507 + this) and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
