### PR TITLE
[bugfix]: Restrict Python version metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fastvideo"
 version = "0.2.0"
 description = "FastVideo"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
## Summary

- restrict package metadata to the supported Python window, `>=3.10,<3.13`

## Validation

- Not run locally; change is a one-line package metadata update.

Replaces #1510.