### PR TITLE
[bugfix]: Restrict Python version metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "fastvideo"
 version = "0.2.0"
 description = "FastVideo"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
## Summary

Closes #1490.

- restrict package metadata to the supported Python window, `>=3.10,<3.13`

## Validation

- Not run locally; change is a one-line package metadata update.
- Modal L40S: `pre-commit run --all-files --hook-stage manual` passed.
  - https://modal.com/apps/hao-ai-lab/main/ap-oekTgldMecqvAWDJ7T1PNm
- Modal L40S: wheel metadata test passed; built wheel exposes `Requires-Python: <3.13,>=3.10` and the spec allows 3.10/3.12 while excluding 3.13.
  - https://modal.com/apps/hao-ai-lab/main/ap-kTStv2VcxMMrx3ezXOCc4R

Replaces #1511.

# Checklist

- [x] I ran pre-commit run --all-files and fixed all issues
  - Modal L40S: `pre-commit run --all-files --hook-stage manual` passed.
- [x] I added or updated tests for my changes
  - Modal L40S: targeted wheel metadata test passed for the package metadata change.
- [x] I updated documentation if needed
  - No docs update needed; existing docs already state Python 3.10-3.12 support.
- [x] I considered GPU memory impact of my changes
  - No GPU/runtime code changes.

For model/pipeline changes, also check:

- [x] I verified targeted Wan T2V SSIM regression tests pass on L40S
  - Not applicable: this is not a model or pipeline change.
- [x] I updated the support matrix if adding a new model
  - Not applicable: no model is being added.
