### PR TITLE
[bugfix]: preserve FSDP hooks for RMSNorm qk norms

### DIFF
--- a/fastvideo/models/dits/causal_wanvideo.py
+++ b/fastvideo/models/dits/causal_wanvideo.py
@@ -323,9 +323,9 @@ class CausalWanTransformerBlock(nn.Module):
         value, _ = self.to_v(norm_hidden_states)
 
         if self.norm_q is not None:
-            query = self.norm_q.forward_native(query)
+            query = self.norm_q(query)
         if self.norm_k is not None:
-            key = self.norm_k.forward_native(key)
+            key = self.norm_k(key)
 
         query = query.squeeze(1).unflatten(2, (self.num_attention_heads, -1))
         key = key.squeeze(1).unflatten(2, (self.num_attention_heads, -1))

--- a/fastvideo/models/dits/matrixgame2/causal_model.py
+++ b/fastvideo/models/dits/matrixgame2/causal_model.py
@@ -537,9 +537,9 @@ class CausalMatrixGame2TransformerBlock(nn.Module):
         value, _ = self.to_v(norm_hidden_states)
 
         if self.norm_q is not None:
-            query = self.norm_q.forward_native(query)
+            query = self.norm_q(query)
         if self.norm_k is not None:
-            key = self.norm_k.forward_native(key)
+            key = self.norm_k(key)
 
         query = query.squeeze(1).unflatten(2, (self.num_attention_heads, -1))
         key = key.squeeze(1).unflatten(2, (self.num_attention_heads, -1))

--- a/fastvideo/tests/layers/test_rmsnorm_forward_dispatch.py
+++ b/fastvideo/tests/layers/test_rmsnorm_forward_dispatch.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import socket
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -15,14 +14,9 @@ import torch
 import torch.distributed as dist
 from torch.distributed import init_device_mesh
 from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard
+from torch.distributed.tensor import DTensor
 
 from fastvideo.layers.layernorm import RMSNorm
-
-try:
-    from torch.distributed.tensor import DTensor
-except ImportError:
-    from torch.distributed._tensor import DTensor
-
 
 WORLD_SIZE = 2
 HIDDEN_SIZE = 8
@@ -30,21 +24,14 @@ SEED = 1379
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
-def _free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
-
-
 def _run_torchrun(script_path: Path, mode: str, output_path: Path) -> None:
+    # --standalone binds the rendezvous port atomically, avoiding the
+    # free-port-probe race a hand-picked --master_port would have.
     cmd = [
         "torchrun",
-        "--nnodes",
-        "1",
+        "--standalone",
         "--nproc_per_node",
         str(WORLD_SIZE),
-        "--master_port",
-        str(_free_port()),
         str(script_path),
         "--rmsnorm-fsdp-worker",
         "--mode",
@@ -112,9 +99,12 @@ def _run_worker(mode: str, output_path: Path) -> None:
         fsdp_kwargs: dict[str, Any] = {"mesh": mesh}
         if mode.endswith("cpu_offload"):
             fsdp_kwargs["offload_policy"] = CPUOffloadPolicy(pin_memory=False)
-        sharded_norm = fully_shard(norm, **fsdp_kwargs)
-        if sharded_norm is not None:
-            norm = sharded_norm
+        # fully_shard is applied to the bare RMSNorm to make the hook bypass
+        # observable. Production sharding (fsdp_load.shard_model) only wraps
+        # whole transformer blocks, whose pre-forward all-gather localizes norm
+        # weights before the qk-norm call sites run, so this pins the dispatch
+        # invariant rather than reproducing a production topology.
+        fully_shard(norm, **fsdp_kwargs)
 
         x = torch.randn(2, 3, HIDDEN_SIZE, device=device, dtype=torch.bfloat16)
         call_kind = "direct" if mode.startswith("direct") else "module"
@@ -179,18 +169,21 @@ def test_rmsnorm_forward_native_bypasses_fsdp_hooks(mode: str, expect_ok: bool, 
     successes = [result for result in results if result["ok"]]
     assert not successes, json.dumps(results, indent=2)
     error_text = "\n".join(result.get("error", "") for result in results)
-    assert "DTensor" in error_text and "Tensor" in error_text, json.dumps(results, indent=2)
+    # Pin the specific bypassed-hook failure: "got mixed torch.Tensor and
+    # DTensor" ("Tensor" alone is a substring of "DTensor", so it adds nothing).
+    assert "mixed" in error_text and "DTensor" in error_text, json.dumps(results, indent=2)
 
 
-def test_qk_rmsnorm_call_sites_use_module_dispatch() -> None:
-    target_paths = [
-        REPO_ROOT / "fastvideo/models/dits/causal_wanvideo.py",
-        REPO_ROOT / "fastvideo/models/dits/matrixgame2/causal_model.py",
+def test_no_direct_forward_native_calls_in_models() -> None:
+    """Direct .forward_native(...) calls bypass nn.Module.__call__ and FSDP
+    hooks (issue #1379); model code must use module dispatch instead."""
+    models_dir = REPO_ROOT / "fastvideo" / "models"
+    offenders = [
+        str(path.relative_to(REPO_ROOT))
+        for path in sorted(models_dir.rglob("*.py"))
+        if ".forward_native(" in path.read_text(encoding="utf-8")
     ]
-    for path in target_paths:
-        source = path.read_text(encoding="utf-8")
-        assert ".norm_q.forward_native(" not in source
-        assert ".norm_k.forward_native(" not in source
+    assert not offenders, f"Replace .forward_native(...) with module dispatch in: {offenders}"
 
 
 def _parse_args() -> argparse.Namespace:

--- a/fastvideo/tests/layers/test_rmsnorm_forward_dispatch.py
+++ b/fastvideo/tests/layers/test_rmsnorm_forward_dispatch.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.distributed import init_device_mesh
+from torch.distributed.fsdp import CPUOffloadPolicy, fully_shard
+
+from fastvideo.layers.layernorm import RMSNorm
+
+try:
+    from torch.distributed.tensor import DTensor
+except ImportError:
+    from torch.distributed._tensor import DTensor
+
+
+WORLD_SIZE = 2
+HIDDEN_SIZE = 8
+SEED = 1379
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _run_torchrun(script_path: Path, mode: str, output_path: Path) -> None:
+    cmd = [
+        "torchrun",
+        "--nnodes",
+        "1",
+        "--nproc_per_node",
+        str(WORLD_SIZE),
+        "--master_port",
+        str(_free_port()),
+        str(script_path),
+        "--rmsnorm-fsdp-worker",
+        "--mode",
+        mode,
+        "--output",
+        str(output_path),
+    ]
+    env = os.environ.copy()
+    env.setdefault("TORCHDYNAMO_DISABLE", "1")
+    process = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    if process.returncode != 0:
+        raise RuntimeError(
+            f"{mode} worker failed with code {process.returncode}\n"
+            f"STDOUT:\n{process.stdout}\n"
+            f"STDERR:\n{process.stderr}"
+        )
+
+
+def _summarize_tensor(tensor: torch.Tensor | Any) -> dict[str, Any]:
+    return {
+        "type": type(tensor).__name__,
+        "is_dtensor": isinstance(tensor, DTensor),
+        "shape": list(tensor.shape) if hasattr(tensor, "shape") else None,
+        "device": str(tensor.device) if hasattr(tensor, "device") else None,
+        "dtype": str(tensor.dtype) if hasattr(tensor, "dtype") else None,
+    }
+
+
+def _run_worker(mode: str, output_path: Path) -> None:
+    if mode not in {
+        "module_no_offload",
+        "direct_no_offload",
+        "module_cpu_offload",
+        "direct_cpu_offload",
+    }:
+        raise ValueError(f"Unsupported mode: {mode}")
+
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    device = torch.device(f"cuda:{local_rank}")
+    torch.cuda.set_device(device)
+    torch.manual_seed(SEED + rank)
+
+    try:
+        mesh = init_device_mesh("cuda", (world_size,))
+        norm = RMSNorm(HIDDEN_SIZE, eps=1e-6, has_weight=True).to(device)
+        with torch.no_grad():
+            norm.weight.fill_(1.0)
+
+        fsdp_kwargs: dict[str, Any] = {"mesh": mesh}
+        if mode.endswith("cpu_offload"):
+            fsdp_kwargs["offload_policy"] = CPUOffloadPolicy(pin_memory=False)
+        sharded_norm = fully_shard(norm, **fsdp_kwargs)
+        if sharded_norm is not None:
+            norm = sharded_norm
+
+        x = torch.randn(2, 3, HIDDEN_SIZE, device=device, dtype=torch.bfloat16)
+        call_kind = "direct" if mode.startswith("direct") else "module"
+
+        try:
+            if call_kind == "direct":
+                output = norm.forward_native(x)
+            else:
+                output = norm(x)
+            torch.cuda.synchronize(device)
+            result = {
+                "rank": rank,
+                "ok": True,
+                "mode": mode,
+                "weight": _summarize_tensor(norm.weight),
+                "output": _summarize_tensor(output),
+            }
+        except Exception as exc:
+            result = {
+                "rank": rank,
+                "ok": False,
+                "mode": mode,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+                "weight": _summarize_tensor(norm.weight),
+            }
+
+        gathered = [None for _ in range(world_size)] if rank == 0 else None
+        dist.gather_object(result, object_gather_list=gathered, dst=0)
+        if rank == 0:
+            output_path.write_text(json.dumps(gathered, indent=2), encoding="utf-8")
+        dist.barrier()
+    finally:
+        dist.destroy_process_group()
+
+
+@pytest.mark.parametrize(
+    ("mode", "expect_ok"),
+    [
+        ("module_no_offload", True),
+        ("direct_no_offload", False),
+        ("module_cpu_offload", True),
+        ("direct_cpu_offload", False),
+    ],
+)
+def test_rmsnorm_forward_native_bypasses_fsdp_hooks(mode: str, expect_ok: bool, tmp_path: Path) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("This test requires CUDA.")
+    if torch.cuda.device_count() < WORLD_SIZE:
+        pytest.skip(f"This test requires at least {WORLD_SIZE} CUDA devices.")
+
+    output_path = tmp_path / f"{mode}.json"
+    _run_torchrun(Path(__file__).resolve(), mode, output_path)
+    results = json.loads(output_path.read_text(encoding="utf-8"))
+    print(f"\n{mode} results:\n{json.dumps(results, indent=2)}")
+
+    if expect_ok:
+        failures = [result for result in results if not result["ok"]]
+        assert not failures, json.dumps(results, indent=2)
+        return
+
+    successes = [result for result in results if result["ok"]]
+    assert not successes, json.dumps(results, indent=2)
+    error_text = "\n".join(result.get("error", "") for result in results)
+    assert "DTensor" in error_text and "Tensor" in error_text, json.dumps(results, indent=2)
+
+
+def test_qk_rmsnorm_call_sites_use_module_dispatch() -> None:
+    target_paths = [
+        REPO_ROOT / "fastvideo/models/dits/causal_wanvideo.py",
+        REPO_ROOT / "fastvideo/models/dits/matrixgame2/causal_model.py",
+    ]
+    for path in target_paths:
+        source = path.read_text(encoding="utf-8")
+        assert ".norm_q.forward_native(" not in source
+        assert ".norm_k.forward_native(" not in source
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rmsnorm-fsdp-worker", action="store_true")
+    parser.add_argument("--mode", type=str, default=None)
+    parser.add_argument("--output", type=str, default=None)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    if not args.rmsnorm_fsdp_worker:
+        raise SystemExit("This module is intended to be run by pytest.")
+    if args.mode is None or args.output is None:
+        raise SystemExit("--mode and --output are required in worker mode.")
+    _run_worker(mode=args.mode, output_path=Path(args.output))

--- a/fastvideo/tests/layers/test_rmsnorm_forward_dispatch.py
+++ b/fastvideo/tests/layers/test_rmsnorm_forward_dispatch.py
@@ -54,7 +54,20 @@ def _run_torchrun(script_path: Path, mode: str, output_path: Path) -> None:
     ]
     env = os.environ.copy()
     env.setdefault("TORCHDYNAMO_DISABLE", "1")
-    process = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    try:
+        process = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise RuntimeError(
+            f"{mode} worker timed out after 120 seconds\n"
+            f"STDOUT:\n{error.stdout}\n"
+            f"STDERR:\n{error.stderr}"
+        ) from error
     if process.returncode != 0:
         raise RuntimeError(
             f"{mode} worker failed with code {process.returncode}\n"


### PR DESCRIPTION
## Summary

Fixes #1379.

This replaces the remaining direct q/k RMSNorm `forward_native(...)` calls with normal module dispatch so FSDP hooks run:

- `self.norm_q.forward_native(query)` -> `self.norm_q(query)`
- `self.norm_k.forward_native(key)` -> `self.norm_k(key)`

The remaining production call sites were in causal Wan and MatrixGame2 causal transformer blocks. This keeps the selected RMSNorm implementation unchanged while avoiding bypassing `nn.Module.__call__` under FSDP.

## Root Cause

Calling `RMSNorm.forward_native(...)` directly bypasses FSDP2 module hooks. With sharded RMSNorm weights, this can leave `self.weight` as a `DTensor`, and the native multiply fails with a mixed Tensor/DTensor error. Calling `RMSNorm(x)` lets FSDP unwrap/localize parameters as expected.

## Issue #1379 Investigation Checklist

- [x] Reliable reproducer: added `fastvideo/tests/layers/test_rmsnorm_forward_dispatch.py` and reproduced on Modal 2x L40S with PyTorch `2.11.0+cu128`, FSDP2 `fully_shard`, and both regular sharding and `CPUOffloadPolicy`.
- [x] Upstream issue determination: no exact matching PyTorch issue was found. The repro shows `RMSNorm(x)` works while direct `RMSNorm.forward_native(x)` fails, so this appears to be FastVideo bypassing FSDP module hooks rather than an FSDP-side bug.
- [x] Unit test for CPU-offload + DTensor weight path: the new test covers `direct_cpu_offload`, where `norm.weight` remains a CPU `DTensor` and direct `forward_native` fails with the mixed Tensor/DTensor error; it also verifies module dispatch succeeds with CPU offload.
- [x] Behavioral spec: not final-layer-only. The failure can affect any FSDP-sharded `RMSNorm(has_weight=True)` called directly through `forward_native`; it reproduces with and without CPU offload.

## Tests

- `uvx pre-commit==4.0.1 run --all-files`
  - passed after the review follow-up commit
- Modal L40S: `pytest fastvideo/tests/layers/test_rmsnorm_forward_dispatch.py -vs`
  - 2x L40S, latest branch includes the 120-second `torchrun` timeout follow-up
  - `5 passed, 14 warnings in 38.28s`
- Modal L40S: `pytest fastvideo/tests/transformers/test_wanvideo.py -vs`
  - 1x L40S, production fix applied
  - `1 passed, 14 warnings in 50.05s`
- Modal L40S targeted Wan T2V SSIM:
  - `FASTVIDEO_SSIM_MODEL_ID=Wan2.1-T2V-1.3B-Diffusers pytest fastvideo/tests/ssim/test_wan_t2v_similarity.py -vs`
  - 2x L40S, commit `75e1659310ae306d342b6bfcd0e8ef7ebb0b5caa`
  - `2 passed, 18 warnings in 123.41s`
  - `FLASH_ATTN`-parametrized mean SSIM: `0.976557461420695`
  - `TORCH_SDPA` mean SSIM: `0.9821627881791857`
  - Note: the Modal image's FlashAttention import failed and the `FLASH_ATTN`-parametrized run fell back to Torch SDPA.

## Checklist

- [x] I ran pre-commit run --all-files and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

For model/pipeline changes, also check:

- [x] I verified targeted Wan T2V SSIM regression tests pass on L40S
- [x] I updated the support matrix if adding a new model

Documentation/support-matrix notes: no docs or support matrix update was needed; this does not add a model or user-facing API. GPU memory impact should be neutral because this only routes existing RMSNorm calls through module dispatch so FSDP hooks can run.
