### PR TITLE
[ci] build + publish aarch64 (Grace Hopper) kernel wheels alongside x86_64

### DIFF
--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -47,12 +47,11 @@ jobs:
     name: Build Wheel
     needs: check-version-change
     if: ${{ needs.check-version-change.outputs.version-changed == 'true' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.platform.os }}
 
     strategy:
       fail-fast: false
       matrix:
-          os: [ubuntu-22.04]
           python-version: ['3.12']
           torch-cuda:
             # torch 2.12 dropped cu128; cu130 (CUDA 13) is the default wheel, cu126 covers older drivers.
@@ -62,6 +61,16 @@ jobs:
             - torch-version: '2.12.0'
               cuda-version: '13.0.0'
               torch-cuda-short: 'cu130'
+          platform:
+            # x86_64: full set; the cu130 leg additionally ships Blackwell sm_120a FP4.
+            - os: ubuntu-22.04
+              arch: x86_64
+              wheel-plat: manylinux_2_35_x86_64
+            # aarch64 (Grace Hopper / GH200): Hopper sm_90a only. Consumer Blackwell
+            # sm_120a is x86, so the FP4 kernels are not built here.
+            - os: ubuntu-22.04-arm
+              arch: aarch64
+              wheel-plat: manylinux_2_35_aarch64
 
     steps:
       - name: Free up disk space
@@ -144,15 +153,15 @@ jobs:
 
           cd fastvideo-kernel
           git submodule update --init --recursive  # Ensure ThunderKittens submodule is initialized
-          # Release builds run on GPU-less runners, so force-enable TK and set the arch explicitly.
-          # The CUDA 13 (cu130) leg additionally targets Blackwell sm_120a and builds the
-          # attn_qat_infer FP4 inference kernels (they need CUDA Toolkit 12.8+, so the cu126 leg
-          # stays Hopper-only and ships without them).
-          # Cap Ninja build concurrency to fit the 16 GB standard runner. CUTLASS FP4
-          # and ThunderKittens template TUs each need several GB; Ninja's default
-          # (cores+2 ≈ 6 parallel jobs) exhausts RAM and the host OOM-kills the build
-          # (SIGTERM / exit 143, surfaced as "runner lost communication").
-          if [ "${{ matrix.torch-cuda.torch-cuda-short }}" = "cu130" ]; then
+          # Release builds run on GPU-less runners, so force-enable TK and set the arch
+          # explicitly. The Blackwell sm_120a FP4 (attn_qat_infer) kernels are consumer
+          # Blackwell, which only exists on x86, so they ship only on the x86_64 cu130
+          # leg. Every other leg — the cu126 (older-driver) wheels and all aarch64
+          # (Grace Hopper / GH200) builds — stays Hopper sm_90a only.
+          # CMAKE_BUILD_PARALLEL_LEVEL caps Ninja to fit the 16 GB runner: CUTLASS FP4
+          # and ThunderKittens template TUs each need several GB, and Ninja's default
+          # (cores+2 ≈ 6) OOM-kills the build (SIGTERM / exit 143).
+          if [ "${{ matrix.torch-cuda.torch-cuda-short }}" = "cu130" ] && [ "${{ matrix.platform.arch }}" = "x86_64" ]; then
             export TORCH_CUDA_ARCH_LIST="9.0a;12.0a"
             export CMAKE_ARGS="${CMAKE_ARGS:-} -DFASTVIDEO_KERNEL_BUILD_TK=ON -DFASTVIDEO_KERNEL_BUILD_ATTN_QAT_INFER=ON -DCMAKE_CUDA_ARCHITECTURES=90a"
             # A single FP4 TU (attn_qat_infer) can use ~8-12 GB on its own, so serialize.
@@ -160,9 +169,8 @@ jobs:
           else
             export TORCH_CUDA_ARCH_LIST="9.0a"
             export CMAKE_ARGS="${CMAKE_ARGS:-} -DFASTVIDEO_KERNEL_BUILD_TK=ON -DCMAKE_CUDA_ARCHITECTURES=90a"
-            # No FP4 here; only the two TK TUs are heavy (single-arch) and they fit
-            # side by side. Uncapped (cores+2=6) has built but occasionally OOMs when
-            # the light TUs pile on; -j4 overlaps them safely (~12-14 GB peak).
+            # Hopper-only: the two TK TUs are the heavy ones (single-arch) and fit side
+            # by side; -j4 overlaps the light TUs without OOMing (~12-14 GB peak).
             export CMAKE_BUILD_PARALLEL_LEVEL=4
           fi
 
@@ -180,8 +188,8 @@ jobs:
           PY
           )
           export LD_LIBRARY_PATH="${TORCH_LIB_DIR}:${LD_LIBRARY_PATH}"
-          # Target manylinux_2_35 (Ubuntu 22.04 native)
-          auditwheel repair dist/*.whl --plat manylinux_2_35_x86_64 -w fixed_dist \
+          # Target manylinux_2_35 (Ubuntu 22.04 native), per-arch plat tag.
+          auditwheel repair dist/*.whl --plat ${{ matrix.platform.wheel-plat }} -w fixed_dist \
             --exclude libtorch_cuda.so \
             --exclude libtorch_cpu.so \
             --exclude libtorch.so \
@@ -197,7 +205,7 @@ jobs:
         # The publish job below selects which CUDA build is pushed to PyPI.
         uses: actions/upload-artifact@v4
         with:
-          name: fastvideo_kernel-py${{ matrix.python-version }}-${{ matrix.torch-cuda.torch-cuda-short }}-torch${{ matrix.torch-cuda.torch-version }}
+          name: fastvideo_kernel-py${{ matrix.python-version }}-${{ matrix.torch-cuda.torch-cuda-short }}-${{ matrix.platform.arch }}-torch${{ matrix.torch-cuda.torch-version }}
           path: fastvideo-kernel/dist/*.whl
           retention-days: 90
 
@@ -217,8 +225,10 @@ jobs:
           python-version: '3.12'
 
       - name: Download PyPI wheels
-        # Publish only the cu130 (CUDA 13) wheel to PyPI — it includes the Blackwell FP4 kernels.
-        # The cu126 wheel stays available as a build artifact / GitHub-release asset.
+        # Publish the cu130 (CUDA 13) wheels to PyPI for both architectures:
+        #   x86_64  — Hopper sm_90a + Blackwell sm_120a FP4 kernels
+        #   aarch64 — Hopper sm_90a (Grace Hopper / GH200); consumer-Blackwell FP4 is x86-only
+        # The cu126 wheels stay available as build artifacts / GitHub-release assets.
         uses: actions/download-artifact@v4
         with:
           path: fastvideo-kernel/dist/


### PR DESCRIPTION
## What

Publish **aarch64** kernel wheels (NVIDIA Grace Hopper / GH200) alongside x86_64, using native GitHub arm64 runners (`ubuntu-22.04-arm`) — no QEMU. Implemented as a `platform` matrix dimension, so each torch-cuda leg builds on both arches:

| Leg | Runner | Builds | Published? |
|-----|--------|--------|------------|
| x86_64 · cu126 | `ubuntu-22.04` | Hopper sm_90a (TK) | artifact |
| x86_64 · cu130 | `ubuntu-22.04` | Hopper + Blackwell FP4 (sm_90a;sm_120a) | ✅ PyPI |
| aarch64 · cu126 | `ubuntu-22.04-arm` | Hopper sm_90a (TK) | artifact |
| aarch64 · cu130 | `ubuntu-22.04-arm` | Hopper sm_90a (TK) | ✅ PyPI |

`pip`/`uv` select the right wheel automatically via the platform tag (`manylinux_2_35_{x86_64,aarch64}`), so `uv pip install fastvideo-kernel` resolves per host arch.

## Why FP4 is x86-only

The FP4/`attn_qat_infer` kernels are **consumer Blackwell sm_120a**, which only exists on x86 (RTX 50xx). aarch64 GPUs are Grace Hopper (sm_90a) — served by the TK kernels. aarch64 Blackwell (DGX Spark, sm_121a) would be a separate kernel port, not a build flag. So the aarch64 wheel is Hopper-only by design.

## Changes (`publish-kernel.yml` only)

- Add `platform` matrix dim (`os` / `arch` / `wheel-plat`); `runs-on: matrix.platform.os`.
- Gate FP4 on `cu130 && x86_64` (every other leg is Hopper-only sm_90a).
- Parametrize `auditwheel --plat` and the artifact name by arch.
- Publish job uploads both arches' cu130 wheels (pattern already globs both; distinct platform tags, no collision).

Wheels stay `manylinux_2_35` (matches the existing x86 policy — fine for current CUDA-13 / Ubuntu 22.04+ / DGX OS 6 systems).

## Caveats / to verify on a dispatch

- **Untested** — GitHub arm64 + CUDA build can't be dry-run locally; `publish-kernel.yml` only runs on `workflow_dispatch` / `pyproject.toml` push (and dispatch **publishes on green**). The `[per-arch]`-style diagnostics aren't here, but `fail-fast: false` lets each leg report independently.
- **`Jimver/cuda-toolkit@v0.2.35`** supports arm64 (since v0.2.21); confirm it has aarch64 installers for the exact `12.6.3` / `13.0.0` versions (CI will show it — easy to bump a patch version if not).
- **`manylinux_2_35_aarch64`** should be accepted by auditwheel (the x86 `2_35` leg already works), but it's worth confirming on the first run.
- **Depends on the FP4 per-arch split (#1508).** This branch is off `main`, whose x86_64 cu130 leg builds FP4 and currently fails on the sm_90a pass until #1508 lands. `publish` needs all build legs green, so sequence #1508 first (or rebase this on top of it). The aarch64 legs are Hopper-only and don't depend on it.

Prereqs verified (web): arm64 hosted runners are GA + free for public repos; PyTorch ships aarch64 cu126/cu130 wheels (manylinux 2.28) since 2.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
