### PR TITLE
[bugfix] -fsigned-char so ThunderKittens compiles on aarch64 (Grace Hopper)

### DIFF
--- a/fastvideo-kernel/CMakeLists.txt
+++ b/fastvideo-kernel/CMakeLists.txt
@@ -191,6 +191,11 @@ set(CUDA_FLAGS
     "--expt-relaxed-constexpr"
     "-Xcompiler=-fno-strict-aliasing"
     "-Xcompiler=-fPIC"
+    # ARM/aarch64 defaults `char` to unsigned, but ThunderKittens headers assume the
+    # x86 signed-char behavior (else base_types.cuh hits "narrowing conversion from
+    # char to signed char"). Force signed char so TK compiles on Grace Hopper; this
+    # is a no-op on x86_64, where char is already signed.
+    "-Xcompiler=-fsigned-char"
     "-DTORCH_COMPILE"
     "-Xnvlink=--verbose"
     "-Xptxas=--verbose"


### PR DESCRIPTION
## Problem

The aarch64 (Grace Hopper) legs added in #1514 fail to compile the ThunderKittens kernels ([run 28397363156](https://github.com/hao-ai-lab/FastVideo/actions/runs/28397363156)):

```
include/tk/include/common/base_types.cuh(242): error: invalid narrowing conversion from "char" to "signed char"
... 4 errors → st_attn_h100.cu and block_sparse_h100.cu fail
```

Plain `char` is **signed on x86_64** but **unsigned on aarch64**. TK's `base_types.cuh` does a braced/`constexpr` `char → signed char` conversion that's fine where `char` is already signed but is a **narrowing conversion on aarch64** — a hard error. So the TK kernels (correctly targeting sm_90a / Grace Hopper) won't compile on ARM. It's a ThunderKittens portability issue, surfaced for the first time now that we build on aarch64; the x86 legs never hit it.

(In that run, all three x86_64 legs — including cu130 with the FP4 kernels — passed, so this aarch64 TK compile is the last blocker for the 0.3.0 publish.)

## Fix

Add `-Xcompiler=-fsigned-char` to the kernel `CUDA_FLAGS`, forcing plain `char` to be signed (matching x86, which compiles cleanly):

- **No-op on x86_64** (char is already signed), so the passing x86 wheels are unchanged.
- nvcc keeps host/device `char` signedness consistent, so the flag covers both compilation passes — the standard fix for this TK/CUTLASS-on-GH200 error.

## Testing

Can't dry-run locally (no aarch64 + CUDA here) — the aarch64 `workflow_dispatch` build is the test. Diagnosis is from the build log; the flag is the well-established fix for ARM `char`-signedness narrowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
