### PR TITLE
[ci] aarch64 kernel wheel: build for Blackwell (sm_100a/sm_120a), not Hopper

### DIFF
--- a/.github/workflows/publish-kernel.yml
+++ b/.github/workflows/publish-kernel.yml
@@ -62,15 +62,24 @@ jobs:
               cuda-version: '13.0.0'
               torch-cuda-short: 'cu130'
           platform:
-            # x86_64: full set; the cu130 leg additionally ships Blackwell sm_120a FP4.
+            # x86_64 builds the full cu126 + cu130 set (cu130 ships the consumer
+            # Blackwell sm_120a FP4 kernels).
             - os: ubuntu-22.04
               arch: x86_64
               wheel-plat: manylinux_2_35_x86_64
-            # aarch64 (Grace Hopper / GH200): Hopper sm_90a only. Consumer Blackwell
-            # sm_120a is x86, so the FP4 kernels are not built here.
-            - os: ubuntu-22.04-arm
-              arch: aarch64
-              wheel-plat: manylinux_2_35_aarch64
+          # aarch64 is Blackwell (GB200 sm_100a + DGX Spark / consumer sm_120a), not
+          # Hopper, and Blackwell needs CUDA >= 12.8 — so only the cu130 leg applies.
+          # Added via include so x86 keeps cu126 + cu130 while aarch64 stays cu130-only.
+          include:
+            - python-version: '3.12'
+              torch-cuda:
+                torch-version: '2.12.0'
+                cuda-version: '13.0.0'
+                torch-cuda-short: 'cu130'
+              platform:
+                os: ubuntu-22.04-arm
+                arch: aarch64
+                wheel-plat: manylinux_2_35_aarch64
 
     steps:
       - name: Free up disk space
@@ -153,15 +162,22 @@ jobs:
 
           cd fastvideo-kernel
           git submodule update --init --recursive  # Ensure ThunderKittens submodule is initialized
-          # Release builds run on GPU-less runners, so force-enable TK and set the arch
-          # explicitly. The Blackwell sm_120a FP4 (attn_qat_infer) kernels are consumer
-          # Blackwell, which only exists on x86, so they ship only on the x86_64 cu130
-          # leg. Every other leg — the cu126 (older-driver) wheels and all aarch64
-          # (Grace Hopper / GH200) builds — stays Hopper sm_90a only.
-          # CMAKE_BUILD_PARALLEL_LEVEL caps Ninja to fit the 16 GB runner: CUTLASS FP4
-          # and ThunderKittens template TUs each need several GB, and Ninja's default
-          # (cores+2 ≈ 6) OOM-kills the build (SIGTERM / exit 143).
-          if [ "${{ matrix.torch-cuda.torch-cuda-short }}" = "cu130" ] && [ "${{ matrix.platform.arch }}" = "x86_64" ]; then
+          # Release builds run on GPU-less runners, so set kernels + arch explicitly:
+          #   * aarch64 = Blackwell (GB200 sm_100a + DGX Spark/consumer sm_120a), NOT
+          #     Hopper, so TK (sm_90a wgmma) is OFF. The C++ FP4 (attn_qat_infer, SM120)
+          #     covers sm_120a; turbodiffusion covers sm_100a+sm_120a. The sm_100 FP4
+          #     forward is the FA4 CuTe DSL path in the fastvideo package (PR #1221),
+          #     JIT-compiled at runtime — not built into this wheel.
+          #   * x86_64 cu130 = Hopper TK + consumer Blackwell sm_120a FP4.
+          #   * x86_64 cu126 = Hopper TK only (older drivers; CUDA < 12.8 has no FP4).
+          # The per-arch split in CMakeLists pins the FP4 targets to sm_120a and builds
+          # the main extension for the full arch list. CMAKE_BUILD_PARALLEL_LEVEL caps
+          # Ninja so heavy CUTLASS/TK template TUs don't OOM the 16 GB runner (exit 143).
+          if [ "${{ matrix.platform.arch }}" = "aarch64" ]; then
+            export TORCH_CUDA_ARCH_LIST="10.0a;12.0a"
+            export CMAKE_ARGS="${CMAKE_ARGS:-} -DFASTVIDEO_KERNEL_BUILD_TK=OFF -DFASTVIDEO_KERNEL_BUILD_ATTN_QAT_INFER=ON"
+            export CMAKE_BUILD_PARALLEL_LEVEL=1
+          elif [ "${{ matrix.torch-cuda.torch-cuda-short }}" = "cu130" ]; then
             export TORCH_CUDA_ARCH_LIST="9.0a;12.0a"
             export CMAKE_ARGS="${CMAKE_ARGS:-} -DFASTVIDEO_KERNEL_BUILD_TK=ON -DFASTVIDEO_KERNEL_BUILD_ATTN_QAT_INFER=ON -DCMAKE_CUDA_ARCHITECTURES=90a"
             # A single FP4 TU (attn_qat_infer) can use ~8-12 GB on its own, so serialize.
@@ -226,9 +242,11 @@ jobs:
 
       - name: Download PyPI wheels
         # Publish the cu130 (CUDA 13) wheels to PyPI for both architectures:
-        #   x86_64  — Hopper sm_90a + Blackwell sm_120a FP4 kernels
-        #   aarch64 — Hopper sm_90a (Grace Hopper / GH200); consumer-Blackwell FP4 is x86-only
-        # The cu126 wheels stay available as build artifacts / GitHub-release assets.
+        #   x86_64  — Hopper sm_90a TK + consumer Blackwell sm_120a FP4
+        #   aarch64 — Blackwell: turbodiffusion (sm_100a/sm_120a) + C++ FP4 (sm_120a);
+        #             no TK (Hopper). sm_100 FP4 forward is the FA4 CuTe DSL path in the
+        #             fastvideo package (#1221), shipped/JIT separately.
+        # The x86_64 cu126 wheel stays available as a build artifact / GitHub-release asset.
         uses: actions/download-artifact@v4
         with:
           path: fastvideo-kernel/dist/


### PR DESCRIPTION
## Problem

The aarch64 legs added in #1514 build for **Hopper** (`sm_90a` + ThunderKittens) — but our aarch64 fleet is **Blackwell** (GB200 `sm_100a`, DGX Spark / consumer `sm_120a`), **not** Hopper. So those legs target the wrong architecture: they build the Hopper TK kernels (which can't run on Blackwell), and that's what was failing in the publish dispatches (the TK `char2` narrowing on ARM — run [28402671106](https://github.com/hao-ai-lab/FastVideo/actions/runs/28402671106)).

## Fix — aarch64 = Blackwell

Rework the aarch64 leg to a Blackwell build:

| | arch list | TK | C++ FP4 (attn_qat_infer, SM120) | turbodiffusion |
|---|---|---|---|---|
| **aarch64 · cu130** | `10.0a;12.0a` | **off** | sm_120a | sm_100a + sm_120a |
| x86_64 · cu130 | `9.0a;12.0a` | on | sm_120a | sm_90a + sm_120a |
| x86_64 · cu126 | `9.0a` | on | — | sm_90a |

- **TK off on aarch64** — it's Hopper-only (`wgmma`); Blackwell can't run it, so it's correctly dropped (not a degradation). This also makes #1515 (`-fsigned-char` to compile TK on ARM) **moot** — closing it.
- **aarch64 is cu130-only** — Blackwell needs CUDA ≥ 12.8, so a cu126 aarch64 leg can't target `sm_100a/sm_120a`. Implemented via `matrix.include` so x86 keeps cu126 + cu130 while aarch64 stays cu130-only (3 legs total).
- The per-arch split (already on main) pins the **C++ FP4** to `sm_120a` and builds **turbodiffusion** for `sm_100a;sm_120a`.
- The **sm_10.x FP4 forward** is the **FA4 CuTe DSL** path in the `fastvideo` package (#1221) — Python, JIT-compiled at runtime, shipped separately. It is **not** part of this C++ wheel, so the wheel build doesn't (and can't) compile it.

## Caveats / to verify on a dispatch

- **Untested** — no local aarch64 + CUDA build; the `workflow_dispatch` is the test. The C++ FP4 (SM120) and turbodiffusion compiling for `sm_100a`/`sm_120a` on aarch64 CUDA 13 is unproven (could surface arch-specific issues, like the TK `char` one did).
- **Arch-list assumption: `10.0a;12.0a`.** If you need `10.3a` (B300/GB300) or `12.1a` (DGX Spark GB10) spelled out — vs. relying on `sm_100a`/`sm_120a` base coverage — say so and I'll add them.
- Supersedes/closes **#1515**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
