### PR TITLE
[bugfix]: compute VSA topk from padded blocks

### DIFF
--- a/fastvideo/attention/backends/video_sparse_attn.py
+++ b/fastvideo/attention/backends/video_sparse_attn.py
@@ -157,6 +157,11 @@ class VideoSparseAttentionMetadata(AttentionMetadata):
     cache_tile_buf: bool = True
 
 
+def _compute_cur_topk(attn_metadata: VideoSparseAttentionMetadata) -> int:
+    num_kv_blocks = attn_metadata.variable_block_sizes.numel()
+    return math.ceil((1 - attn_metadata.VSA_sparsity) * num_kv_blocks)
+
+
 class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):
 
     def __init__(self) -> None:
@@ -286,9 +291,8 @@ class VideoSparseAttentionImpl(AttentionImpl):
         gate_compress: torch.Tensor,
         attn_metadata: VideoSparseAttentionMetadata,
     ) -> torch.Tensor:
-        VSA_sparsity = attn_metadata.VSA_sparsity
         block_elements = math.prod(VSA_TILE_SIZE)
-        cur_topk = math.ceil((1 - VSA_sparsity) * (attn_metadata.total_seq_length / block_elements))
+        cur_topk = _compute_cur_topk(attn_metadata)
 
         # 256-element tiles auto-route to the FA4 CuTe BSHD fastpath, which
         # consumes [B, S, H, D] directly -- skip the transpose round-trip.

--- a/fastvideo/attention/backends/video_sparse_attn.py
+++ b/fastvideo/attention/backends/video_sparse_attn.py
@@ -159,7 +159,8 @@ class VideoSparseAttentionMetadata(AttentionMetadata):
 
 def _compute_cur_topk(attn_metadata: VideoSparseAttentionMetadata) -> int:
     num_kv_blocks = attn_metadata.variable_block_sizes.numel()
-    return math.ceil((1 - attn_metadata.VSA_sparsity) * num_kv_blocks)
+    cur_topk = math.ceil((1 - attn_metadata.VSA_sparsity) * num_kv_blocks)
+    return max(1, min(cur_topk, num_kv_blocks))
 
 
 class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):

--- a/fastvideo/tests/attention/test_video_sparse_attention_metadata.py
+++ b/fastvideo/tests/attention/test_video_sparse_attention_metadata.py
@@ -1,17 +1,21 @@
+import math
+
 import torch
 
+from fastvideo.attention.backends import video_sparse_attn as vsa_module
 from fastvideo.attention.backends.video_sparse_attn import (
+    VSA_TILE_SIZE,
     VideoSparseAttentionImpl,
     VideoSparseAttentionMetadataBuilder,
 )
 
 
-def _build_metadata(cache_tile_buf: bool, raw_latent_shape=(4, 4, 4)):
+def _build_metadata(cache_tile_buf: bool, raw_latent_shape=(4, 4, 4), VSA_sparsity=0.5):
     return VideoSparseAttentionMetadataBuilder().build(
         current_timestep=0,
         raw_latent_shape=raw_latent_shape,
         patch_size=(1, 1, 1),
-        VSA_sparsity=0.5,
+        VSA_sparsity=VSA_sparsity,
         device=torch.device("cpu"),
         cache_tile_buf=cache_tile_buf,
     )
@@ -58,3 +62,39 @@ def test_vsa_tile_cached_and_uncached_produce_identical_values():
     # The cached path stashes the buffer; the uncached path does not.
     assert md_cached.tile_buf is not None
     assert md_uncached.tile_buf is None
+
+
+def test_vsa_forward_cur_topk_uses_padded_kv_block_count(monkeypatch):
+    impl = object.__new__(VideoSparseAttentionImpl)
+    metadata = _build_metadata(cache_tile_buf=True, raw_latent_shape=(5, 32, 32), VSA_sparsity=0.75)
+    block_elements = math.prod(VSA_TILE_SIZE)
+    padded_seq_len = metadata.variable_block_sizes.numel() * block_elements
+    expected_topk = math.ceil((1 - metadata.VSA_sparsity) * metadata.variable_block_sizes.numel())
+    unpadded_topk = math.ceil((1 - metadata.VSA_sparsity) * (metadata.total_seq_length / block_elements))
+    captured = {}
+
+    def fake_video_sparse_attn(
+        query,
+        key,
+        value,
+        variable_block_sizes,
+        q_variable_block_sizes,
+        topk,
+        block_size,
+        compress_attn_weight,
+    ):
+        captured["topk"] = topk
+        captured["block_size"] = block_size
+        assert torch.equal(variable_block_sizes, metadata.variable_block_sizes)
+        assert torch.equal(q_variable_block_sizes, metadata.variable_block_sizes)
+        return query
+
+    monkeypatch.setattr(vsa_module, "video_sparse_attn", fake_video_sparse_attn)
+
+    query = torch.ones(1, padded_seq_len, 1, 1)
+    output = impl.forward(query, query, query, query, metadata)
+
+    assert unpadded_topk < expected_topk
+    assert captured["topk"] == expected_topk
+    assert captured["block_size"] == VSA_TILE_SIZE
+    assert output.shape == query.shape

--- a/fastvideo/tests/attention/test_video_sparse_attention_metadata.py
+++ b/fastvideo/tests/attention/test_video_sparse_attention_metadata.py
@@ -7,6 +7,7 @@ from fastvideo.attention.backends.video_sparse_attn import (
     VSA_TILE_SIZE,
     VideoSparseAttentionImpl,
     VideoSparseAttentionMetadataBuilder,
+    _compute_cur_topk,
 )
 
 
@@ -98,3 +99,13 @@ def test_vsa_forward_cur_topk_uses_padded_kv_block_count(monkeypatch):
     assert captured["topk"] == expected_topk
     assert captured["block_size"] == VSA_TILE_SIZE
     assert output.shape == query.shape
+
+
+def test_vsa_cur_topk_clamps_to_valid_block_range():
+    metadata = _build_metadata(cache_tile_buf=True, raw_latent_shape=(5, 32, 32), VSA_sparsity=1.0)
+    num_kv_blocks = metadata.variable_block_sizes.numel()
+
+    assert _compute_cur_topk(metadata) == 1
+
+    metadata.VSA_sparsity = -0.01
+    assert _compute_cur_topk(metadata) == num_kv_blocks


### PR DESCRIPTION
## Summary

- compute VSA `cur_topk` from the actual padded KV block count
- clamp `cur_topk` to `[1, num_kv_blocks]` for fully sparse or over-dense edge cases
- keep exact-tile behavior unchanged while fixing partial-tile shapes
- add regressions that verify padded-block top-k and clamp behavior

Closes #854.

## Test Plan

- Modal L40S: `pytest fastvideo/tests/attention/test_video_sparse_attention_metadata.py -q`
  - Result: `5 passed, 14 warnings in 0.04s`
  - Run: https://modal.com/apps/hao-ai-lab/main/ap-gg6abCiQK39tkA09jrnP4j
- Modal L40S: `pre-commit run --files fastvideo/attention/backends/video_sparse_attn.py fastvideo/tests/attention/test_video_sparse_attention_metadata.py`
  - Result: yapf, ruff, codespell, mypy, filename-space check, and suggestion passed; markdown/actionlint skipped as no files to check
  - Run: https://modal.com/apps/hao-ai-lab/main/ap-8pGWQWZI6Yy2Xwl8ljqXFA
- Modal L40S: `pre-commit run --all-files`
  - Result: yapf, ruff, codespell, PyMarkdown, actionlint, mypy, filename-space check, and suggestion passed
  - Run: https://modal.com/apps/hao-ai-lab/main/ap-1UGzmL5XrdX866RR1HFOFs

# Checklist
- [x] I ran pre-commit run --all-files and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes
For model/pipeline changes, also check:
- [ ] I verified SSIM regression tests pass (N/A: not a model/pipeline change)
- [ ] I updated the support matrix if adding a new model (N/A: not adding a model)
