### PR TITLE
[ci] cover Hunyuan 1.5 chat-list text preprocessing

### DIFF
--- a/fastvideo/tests/modal/pr_test.py
+++ b/fastvideo/tests/modal/pr_test.py
@@ -276,7 +276,7 @@ def run_self_forcing_tests():
 @app.function(gpu="L40S:1", image=image, timeout=900)
 def run_unit_test():
     run_test(
-        "pytest ./fastvideo/tests/api/ ./fastvideo/tests/contract/ ./fastvideo/tests/dataset/ ./fastvideo/tests/workflow/ ./fastvideo/tests/entrypoints/ ./fastvideo/tests/train/ --ignore=./fastvideo/tests/entrypoints/test_openai_api_integration.py --ignore=./fastvideo/tests/train/models --ignore=./fastvideo/tests/train/methods -vs"
+        "pytest ./fastvideo/tests/api/ ./fastvideo/tests/contract/ ./fastvideo/tests/dataset/ ./fastvideo/tests/workflow/ ./fastvideo/tests/entrypoints/ ./fastvideo/tests/train/ ./fastvideo/tests/stages/ --ignore=./fastvideo/tests/entrypoints/test_openai_api_integration.py --ignore=./fastvideo/tests/train/models --ignore=./fastvideo/tests/train/methods -vs"
     )
 
 

--- a/fastvideo/tests/stages/test_text_encoding.py
+++ b/fastvideo/tests/stages/test_text_encoding.py
@@ -21,6 +21,26 @@ class FakeTokenizer:
             "attention_mask": torch.ones(B, seq_len, dtype=torch.long),
         })
 
+
+class FakeChatTokenizer:
+    def __init__(self):
+        self.last_messages = None
+        self.last_kwargs = None
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.last_messages = messages
+        self.last_kwargs = kwargs
+        assert isinstance(messages[0], list)
+        assert messages[0][0]["role"] == "system"
+        assert messages[0][1]["role"] == "user"
+        B = len(messages)
+        seq_len = int(kwargs.get("max_length", 4))
+        return TensorDict({
+            "input_ids": torch.arange(B * seq_len).view(B, seq_len),
+            "attention_mask": torch.ones(B, seq_len, dtype=torch.long),
+        })
+
+
 class FakeTextEncoder(torch.nn.Module):
     def __init__(self, hidden_size=8):
         super().__init__()
@@ -37,6 +57,14 @@ class FakeTextEncoder(torch.nn.Module):
 
 def id_preprocess(x: str) -> str:
     return x
+
+
+def chat_list_preprocess(x: str):
+    return [
+        {"role": "system", "content": "Describe the video."},
+        {"role": "user", "content": x if x else " "},
+    ]
+
 
 def take_mean_postprocess(outputs: BaseEncoderOutput) -> torch.Tensor:
     # [B, T, H] -> [B, H]
@@ -156,3 +184,32 @@ def test_encode_text_does_not_force_hidden_states_for_ltx2_prefix():
     stage.encode_text("a", fastvideo_args, encoder_index=[0])
 
     assert stage.text_encoders[0].last_output_hidden_states is False
+
+
+def test_chat_list_preprocess_output_is_not_stripped():
+    fastvideo_args, hidden = make_args(num_encoders=1, text_len=5, hidden_size=8)
+    encoder_config = fastvideo_args.pipeline_config.text_encoder_configs[0]
+    encoder_config.is_chat_model = True
+    encoder_config.treat_empty_as_dot = True
+    fastvideo_args.pipeline_config.preprocess_text_funcs = (chat_list_preprocess, )
+
+    tokenizer = FakeChatTokenizer()
+    stage = TextEncodingStage(
+        text_encoders=[FakeTextEncoder(hidden_size=hidden)],
+        tokenizers=[tokenizer],
+    )
+
+    embeds, masks = stage.encode_text(
+        "a robotic arm welding a metal structure",
+        fastvideo_args,
+        encoder_index=[0],
+        return_attention_mask=True,
+    )
+
+    assert embeds[0].shape == (1, hidden)
+    assert masks[0].shape == (1, 5)
+    assert tokenizer.last_messages == [[
+        {"role": "system", "content": "Describe the video."},
+        {"role": "user", "content": "a robotic arm welding a metal structure"},
+    ]]
+    assert tokenizer.last_kwargs["return_tensors"] == "pt"


### PR DESCRIPTION
## Summary

Adds a focused regression test for the HunyuanVideo-1.5 text-encoding crash reported in #1387.

The production fix already appears to have landed through #1349: `TextEncodingStage` now guards `.strip()` behind `isinstance(processed_text, str)` and preserves preformatted chat message lists for chat tokenizers. This PR adds a small unit regression so that a `preprocess_func` returning `list[dict]` cannot regress into the original `list.strip` failure mode.

The test uses a fake chat tokenizer and fake text encoder, so it does not require downloading HunyuanVideo-1.5 weights.

## Validation

- Modal L40S focused regression run:
  - Run: https://modal.com/apps/hao-ai-lab/main/ap-DoQuaisjuemPI2guPqewnN
  - Command: `pytest fastvideo/tests/stages/test_text_encoding.py -q`
  - Result: `5 passed in 0.23s`

Prior actual-model validation on the issue thread also passed for both issue-named variants:

- `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v`
- `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_i2v`

Issue comment with full L40S/A100 actual-model smoke details:
https://github.com/hao-ai-lab/FastVideo/issues/1387#issuecomment-4841217668

## Checklist

- [ ] I ran pre-commit run --all-files and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

For model/pipeline changes, also check:

- [ ] I verified targeted Wan T2V SSIM regression tests pass on L40S
- [ ] I updated the support matrix if adding a new model

Notes:

- `pre-commit run --all-files` was not run; this is a test-only change under `fastvideo/tests/`, which the repo guidance notes is pre-commit-excluded.
- The Wan SSIM and support-matrix checklist items are not applicable because this PR does not change a model or pipeline.
