### PR TITLE
[infra] Auto-rebuild CUDA images when docker/Dockerfile changes on main

### DIFF
--- a/.github/workflows/infra-build-image.yml
+++ b/.github/workflows/infra-build-image.yml
@@ -13,11 +13,30 @@ on:
         required: false
         default: false
         type: boolean
+  # Auto-rebuild the CUDA images when their Dockerfile changes on main. The CUDA
+  # matrix is the only lane that builds from docker/Dockerfile, so a path-scoped
+  # push trigger is a sufficient change detector on its own -- no separate
+  # detect-changes/paths-filter job is needed now that there is a single
+  # in-scope Dockerfile. Dreamverse (apps/dreamverse/docker/Dockerfile) and the
+  # rocm Dockerfile stay manual-dispatch only.
+  push:
+    branches: [main]
+    paths:
+      - 'docker/Dockerfile'
 
 
 permissions:
   contents: read
   packages: write
+
+# Scope the group by event type so push-triggered auto-rebuilds and manual
+# workflow_dispatch runs on main (both on refs/heads/main) never share a group
+# and cancel each other. Only a newer Dockerfile push supersedes an older push;
+# manual dispatches always run to completion so a zero-job dispatch can never
+# silently kill an in-progress rebuild (and vice versa).
+concurrency:
+  group: infra-build-image-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   # CUDA matrix: Python 3.12 x {12.6.3, 13.0.0} x {amd64, arm64}. Each architecture
@@ -28,7 +47,9 @@ jobs:
   # aliases; 13.0.0/cu130 is published under explicit versioned tags. Flash-attn
   # 2.8.3 comes from the architecture-specific prebuilt releases.
   build-cuda-images:
-    if: ${{ github.event.inputs.build_cuda_matrix == 'true' }}
+    # Runs on a manual dispatch when build_cuda_matrix is set, or automatically
+    # on a push that changed docker/Dockerfile (inputs are null on push).
+    if: ${{ github.event_name == 'push' || github.event.inputs.build_cuda_matrix == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -77,8 +98,9 @@ jobs:
   publish-cuda-manifests:
     # !cancelled(): a failed sibling build leg must not skip the manifests for a
     # CUDA lane whose own digests all exist; the digest-count check below fails
-    # the incomplete lane loudly instead.
-    if: ${{ !cancelled() && github.event.inputs.build_cuda_matrix == 'true' }}
+    # the incomplete lane loudly instead. Mirror build-cuda-images' trigger so
+    # manifests publish on both manual dispatch and Dockerfile-push rebuilds.
+    if: ${{ !cancelled() && (github.event_name == 'push' || github.event.inputs.build_cuda_matrix == 'true') }}
     needs: build-cuda-images
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/infra-build-image.yml
+++ b/.github/workflows/infra-build-image.yml
@@ -50,8 +50,10 @@ jobs:
   # 2.8.3 comes from the architecture-specific prebuilt releases.
   build-cuda-images:
     # Runs on a manual dispatch when build_cuda_matrix is set, or automatically
-    # on a push that changed docker/Dockerfile (inputs are null on push).
-    if: ${{ github.event_name == 'push' || github.event.inputs.build_cuda_matrix == 'true' }}
+    # on a push that changed docker/Dockerfile (inputs are null on push). The
+    # repository guard keeps fork syncs from auto-building; manual dispatch
+    # still works in forks.
+    if: ${{ (github.event_name == 'push' && github.repository == 'hao-ai-lab/FastVideo') || github.event.inputs.build_cuda_matrix == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -102,7 +104,7 @@ jobs:
     # CUDA lane whose own digests all exist; the digest-count check below fails
     # the incomplete lane loudly instead. Mirror build-cuda-images' trigger so
     # manifests publish on both manual dispatch and Dockerfile-push rebuilds.
-    if: ${{ !cancelled() && (github.event_name == 'push' || github.event.inputs.build_cuda_matrix == 'true') }}
+    if: ${{ !cancelled() && ((github.event_name == 'push' && github.repository == 'hao-ai-lab/FastVideo') || github.event.inputs.build_cuda_matrix == 'true') }}
     needs: build-cuda-images
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/infra-build-image.yml
+++ b/.github/workflows/infra-build-image.yml
@@ -29,14 +29,16 @@ permissions:
   contents: read
   packages: write
 
-# Scope the group by event type so push-triggered auto-rebuilds and manual
-# workflow_dispatch runs on main (both on refs/heads/main) never share a group
-# and cancel each other. Only a newer Dockerfile push supersedes an older push;
-# manual dispatches always run to completion so a zero-job dispatch can never
-# silently kill an in-progress rebuild (and vice versa).
+# One static group, no cancellation: every run of this workflow writes the same
+# mutable registry tags (latest, py3.12-latest, ...), so runs must serialize —
+# concurrent push/dispatch runs would race on those tags, and cancelling a run
+# mid-publish can strand the cu126/cu130 tag families at different commits. An
+# in-flight superseded build wastes its runner time, but its tags are then
+# overwritten by the newer queued run. GitHub keeps a single pending run per
+# group: the newest queued run replaces any older queued one.
 concurrency:
-  group: infra-build-image-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  group: infra-build-image
+  cancel-in-progress: false
 
 jobs:
   # CUDA matrix: Python 3.12 x {12.6.3, 13.0.0} x {amd64, arm64}. Each architecture

--- a/.github/workflows/infra-build-image.yml
+++ b/.github/workflows/infra-build-image.yml
@@ -100,11 +100,10 @@ jobs:
     secrets: inherit
 
   publish-cuda-manifests:
-    # !cancelled(): a failed sibling build leg must not skip the manifests for a
-    # CUDA lane whose own digests all exist; the digest-count check below fails
-    # the incomplete lane loudly instead. Mirror build-cuda-images' trigger so
-    # manifests publish on both manual dispatch and Dockerfile-push rebuilds.
-    if: ${{ !cancelled() && ((github.event_name == 'push' && github.repository == 'hao-ai-lab/FastVideo') || github.event.inputs.build_cuda_matrix == 'true') }}
+    # !cancelled(): publish lanes whose digests exist even if a sibling build
+    # leg failed (the digest-count check fails incomplete lanes); it also
+    # bypasses skipped-needs propagation, hence the explicit skipped check.
+    if: ${{ !cancelled() && needs.build-cuda-images.result != 'skipped' }}
     needs: build-cuda-images
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Purpose

Rebuild the CUDA images automatically when their Dockerfile changes on `main`, instead of only via manual dispatch. This is ticket T6 from the CI/CD improvement tickets doc; no dedicated GitHub issue exists for it.

## Changes

- Added a `push` trigger scoped to `docker/Dockerfile` on `main`. The CUDA matrix is the only lane that builds from that file, so the path filter alone is a sufficient change detector — no detect-changes job. Dreamverse (`apps/dreamverse/docker/Dockerfile`) and `docker/rocm7_1.Dockerfile` stay manual-dispatch only.
- `build-cuda-images` now runs on a Dockerfile push or a manual dispatch with `build_cuda_matrix`. The push arm is guarded to `github.repository == 'hao-ai-lab/FastVideo'` so forks don't start unattended builds when they sync past a Dockerfile change; manual dispatch still works in forks.
- `publish-cuda-manifests` derives its gate from the build job (`!cancelled() && needs.build-cuda-images.result != 'skipped'`) instead of mirroring the trigger expression, so the two conditions cannot drift apart.
- Added a single static concurrency group with `cancel-in-progress: false`. Every run of this workflow writes the same mutable tags (`latest`, `py3.12-latest`, …), so runs must serialize: concurrent push/dispatch runs would race on those tags, and cancelling a run mid-publish could strand the cu126/cu130 tag families at different commits. GitHub keeps one pending run per group, so the newest queued run replaces older queued ones; a superseded in-flight build finishes and is then overwritten by the newer run.
- `_template-build-image.yml` untouched (read-only reference per the ticket).

## Test Plan

Trigger selection was verified end-to-end on a personal fork (on an earlier revision of this PR whose trigger semantics for the single in-scope Dockerfile are the same):

- Dockerfile push → CUDA build triggered
- Unrelated file push (e.g. README) → no workflow run created
- Manual dispatch with all inputs false → zero jobs, no errors
- Manual dispatch with one input true → only that lane runs (regression check against existing behavior)
- Dreamverse jobs untouched by Dockerfile pushes, still work via manual dispatch

The concurrency block and job gates were reworked after review (serialization instead of event-scoped cancellation, fork guard, derived publish gate); those rely on documented GitHub Actions concurrency/`needs` semantics and were validated with:

```bash
actionlint .github/workflows/infra-build-image.yml
pre-commit run --files .github/workflows/infra-build-image.yml
```

## Test Results

<details>
<summary>Test output</summary>

actionlint: exit 0, no output
pre-commit (scoped to the changed file):
codespell.................Passed
Lint GitHub Actions workflow files.................Passed
(all other hooks skipped — not applicable to this file type)

</details>

## Notes

- Known gap, follow-up welcome: the path filter watches only `docker/Dockerfile`, but the image also depends on `docker/uv-excludes` (COPY'd and passed to `uv pip install --excludes`) and on build args defined in this workflow file. Changes to those still require a manual dispatch.
- `ci_architecture.md` is deliberately not updated per-ticket; the ticket doc says to update it once all CI/CD tickets are done.

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues *(ran scoped to the one changed file; other hooks don't apply to workflow YAML)*
- [x] I added or updated tests for my changes *(CI/CD workflow change — verified via live runs on a fork, see Test Plan)*
- [x] I updated documentation if needed *(see Notes: ci_architecture.md is updated once all CI/CD tickets land)*
- [x] I considered GPU memory impact of my changes *(not applicable, no runtime/GPU code touched)*
