### PR TITLE
[build] Bump fastvideo-kernel pin to 0.3.2

### DIFF
--- a/apps/dreamverse/docker/README.md
+++ b/apps/dreamverse/docker/README.md
@@ -47,7 +47,7 @@ Do not set `CUDA_TAG` and `CUDA_VERSION` together. The image installs FastVideo
 from this checkout with the `dreamverse` extra, including FA4 flash-attention
 and FlashInfer for NVFP4 quantization, and builds native FFmpeg.
 
-FastVideo's pinned `fastvideo-kernel==0.3.1` package is installed by default.
+FastVideo's pinned `fastvideo-kernel==0.3.2` package is installed by default.
 To rebuild `fastvideo-kernel` from this checkout during the image build, set:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
     "remote-pdb",
 
     # Kernel & Packaging
-    "fastvideo-kernel==0.3.1",
+    "fastvideo-kernel==0.3.2",
     "wheel",
 
     # Training Dependencies


### PR DESCRIPTION
## Summary

Follow-up to #1539, closing the loop on the kernel release flow: the 0.3.2 wheels auto-published on merge (verified on PyPI: x86_64 + aarch64 cp312 wheels + sdist), and 0.3.2 is the first release carrying the CuTe BSA wrapper's upstream FA4 `tile_mn` port. Moving the pin from `==0.3.1` to `==0.3.2` makes the pinned wheel match the pinned `flash-attn-4` revision — the published 0.3.1 still calls the old `m_block_size`/`n_block_size` API and would `TypeError` on the `FASTVIDEO_VSA_CUTEDSL=1` path against upstream FA4.

Also updates the `fastvideo-kernel==0.3.1` mention in the dreamverse docker README.

## Validation

- `fastvideo_kernel-0.3.2` wheels verified present on PyPI (manylinux x86_64 + aarch64, sdist).
- `pre-commit run --files <changed>` passes.
- CI builds and tests the in-tree kernel either way; the pin governs PyPI installs of fastvideo.