### PR TITLE
[bugfix]: initialize distill negative conditioning

### DIFF
--- a/examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P/README.md
+++ b/examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P/README.md
@@ -1,5 +1,5 @@
-# Wan2.1-T2V-1.3B Distill Example
-These are end-to-end example scripts for distilling Wan2.1 T2V 1.3B model using DMD-only and DMD+VSA methods.
+# Wan2.1-T2V Distill Example
+These are end-to-end example scripts for distilling Wan2.1 T2V models using DMD-only and DMD+VSA methods.
 
 ### 0. Make sure you have installed VSA
 
@@ -12,14 +12,27 @@ uv pip install vsa
 bash examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P/download_dataset.sh
 ```
 
-### 2. Configure and run distillation:
+### 2. Configure validation:
+
+The example scripts log validation samples by default. Set `VALIDATION_DATASET_FILE` to a real validation JSON, such as:
+
+```bash
+VALIDATION_DATASET_FILE="examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P/validation_64.json"
+```
+
+### 3. Configure and run distillation:
 
 #### For DMD-only distillation:
 ```bash
-sbatch examples/distill/Wan-Syn-480P/distill_dmd_t2v.slurm
+sbatch examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P/distill_dmd_t2v_1.3B.slurm
 ```
 
-#### For DMD+VSA distillation:
+#### For DMD+VSA distillation on Wan2.1-T2V-1.3B:
 ```bash
-sbatch examples/distill/Wan-Syn-480P/distill_dmd_VSA_t2v.slurm
+sbatch examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P/distill_dmd_VSA_t2v_1.3B.slurm
+```
+
+#### For DMD+VSA distillation on Wan2.1-T2V-14B:
+```bash
+sbatch examples/distill/Wan2.1-T2V/Wan-Syn-Data-480P/distill_dmd_VSA_t2v_14B.slurm
 ```

--- a/fastvideo/tests/training/distill/test_distill_negative_conditioning.py
+++ b/fastvideo/tests/training/distill/test_distill_negative_conditioning.py
@@ -1,0 +1,83 @@
+import types
+
+import torch
+
+from fastvideo.api.sampling_param import SamplingParam
+from fastvideo.pipelines import ForwardBatch, TrainingBatch
+from fastvideo.training.distillation_pipeline import DistillationPipeline
+
+
+class _PromptEncodingStage:
+
+    def __init__(self):
+        self.calls = 0
+        self.prompts = []
+
+    def __call__(self, batch: ForwardBatch, _training_args):
+        self.calls += 1
+        self.prompts.append(batch.prompt)
+        batch.prompt_embeds.append(torch.ones(1, 2, 3))
+        assert batch.prompt_attention_mask is not None
+        batch.prompt_attention_mask.append(torch.ones(1, 2))
+        return batch
+
+
+class _ValidationPipeline:
+
+    def __init__(self):
+        self.prompt_encoding_stage = _PromptEncodingStage()
+
+
+class _DistillationPipelineForTest(DistillationPipeline):
+
+    def initialize_validation_pipeline(self, training_args):
+        self.validation_pipeline_init_calls += 1
+        self.validation_pipeline = _ValidationPipeline()
+
+
+def _make_pipeline():
+    pipeline = object.__new__(_DistillationPipelineForTest)
+    pipeline.validation_pipeline_init_calls = 0
+    return pipeline
+
+
+def test_negative_prompt_conditioning_initializes_without_validation_enabled(monkeypatch):
+    pipeline = _make_pipeline()
+    training_args = types.SimpleNamespace(model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+    monkeypatch.setattr(
+        SamplingParam,
+        "from_pretrained",
+        staticmethod(lambda _model_path: types.SimpleNamespace(negative_prompt="low quality")),
+    )
+
+    pipeline._ensure_negative_prompt_conditioning(training_args)
+
+    assert pipeline.validation_pipeline_init_calls == 1
+    assert pipeline.validation_pipeline.prompt_encoding_stage.calls == 1
+    assert pipeline.validation_pipeline.prompt_encoding_stage.prompts == ["low quality"]
+    assert torch.equal(pipeline.negative_prompt_embeds, torch.ones(1, 2, 3))
+    assert torch.equal(pipeline.negative_prompt_attention_mask, torch.ones(1, 2))
+
+    pipeline._ensure_negative_prompt_conditioning(training_args)
+
+    assert pipeline.validation_pipeline_init_calls == 1
+    assert pipeline.validation_pipeline.prompt_encoding_stage.calls == 1
+
+
+def test_initialized_negative_prompt_conditioning_builds_unconditional_kwargs():
+    pipeline = _make_pipeline()
+    training_args = types.SimpleNamespace(model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+    pipeline._ensure_negative_prompt_conditioning(training_args, negative_prompt="low quality")
+    training_batch = TrainingBatch()
+    text_dict = {
+        "encoder_hidden_states": pipeline.negative_prompt_embeds,
+        "encoder_attention_mask": pipeline.negative_prompt_attention_mask,
+    }
+    noise_input = torch.zeros(1, 2, 3, 4, 5)
+    timestep = torch.tensor([1])
+
+    pipeline._build_distill_input_kwargs(noise_input, timestep, text_dict, training_batch)
+
+    assert training_batch.input_kwargs["encoder_hidden_states"] is pipeline.negative_prompt_embeds
+    assert training_batch.input_kwargs["encoder_attention_mask"] is pipeline.negative_prompt_attention_mask
+    assert training_batch.input_kwargs["hidden_states"].shape == (1, 3, 2, 4, 5)

--- a/fastvideo/tests/training/distill/test_distill_negative_conditioning.py
+++ b/fastvideo/tests/training/distill/test_distill_negative_conditioning.py
@@ -35,14 +35,16 @@ class _DistillationPipelineForTest(DistillationPipeline):
         self.validation_pipeline = _ValidationPipeline()
 
 
-def _make_pipeline():
+def _make_pipeline(device=None):
     pipeline = object.__new__(_DistillationPipelineForTest)
     pipeline.validation_pipeline_init_calls = 0
+    if device is not None:
+        pipeline.device = device
     return pipeline
 
 
 def test_negative_prompt_conditioning_initializes_without_validation_enabled(monkeypatch):
-    pipeline = _make_pipeline()
+    pipeline = _make_pipeline(device=torch.device("cpu"))
     training_args = types.SimpleNamespace(model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
     monkeypatch.setattr(
         SamplingParam,
@@ -55,8 +57,8 @@ def test_negative_prompt_conditioning_initializes_without_validation_enabled(mon
     assert pipeline.validation_pipeline_init_calls == 1
     assert pipeline.validation_pipeline.prompt_encoding_stage.calls == 1
     assert pipeline.validation_pipeline.prompt_encoding_stage.prompts == ["low quality"]
-    assert torch.equal(pipeline.negative_prompt_embeds, torch.ones(1, 2, 3))
-    assert torch.equal(pipeline.negative_prompt_attention_mask, torch.ones(1, 2))
+    assert torch.equal(pipeline.negative_prompt_embeds, torch.ones(1, 2, 3, dtype=torch.bfloat16))
+    assert torch.equal(pipeline.negative_prompt_attention_mask, torch.ones(1, 2, dtype=torch.bfloat16))
 
     pipeline._ensure_negative_prompt_conditioning(training_args)
 
@@ -65,9 +67,13 @@ def test_negative_prompt_conditioning_initializes_without_validation_enabled(mon
 
 
 def test_initialized_negative_prompt_conditioning_builds_unconditional_kwargs():
-    pipeline = _make_pipeline()
+    pipeline = _make_pipeline(device=torch.device("cpu"))
     training_args = types.SimpleNamespace(model_path="Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
     pipeline._ensure_negative_prompt_conditioning(training_args, negative_prompt="low quality")
+    assert pipeline.negative_prompt_embeds.device.type == "cpu"
+    assert pipeline.negative_prompt_embeds.dtype == torch.bfloat16
+    assert pipeline.negative_prompt_attention_mask.device.type == "cpu"
+    assert pipeline.negative_prompt_attention_mask.dtype == torch.bfloat16
     training_batch = TrainingBatch()
     text_dict = {
         "encoder_hidden_states": pipeline.negative_prompt_embeds,

--- a/fastvideo/training/distillation_pipeline.py
+++ b/fastvideo/training/distillation_pipeline.py
@@ -348,12 +348,19 @@ class DistillationPipeline(TrainingPipeline):
             prompt_attention_mask=[],
         )
         result_batch = prompt_encoding_stage(batch_negative, training_args)
+        prompt_embeds = result_batch.prompt_embeds
         prompt_attention_mask = result_batch.prompt_attention_mask
-        if (not result_batch.prompt_embeds or prompt_attention_mask is None or len(prompt_attention_mask) == 0):
+        if (not prompt_embeds or prompt_embeds[0] is None or prompt_attention_mask is None
+                or len(prompt_attention_mask) == 0 or prompt_attention_mask[0] is None):
             raise RuntimeError("Failed to initialize negative prompt conditioning for distillation")
 
-        self.negative_prompt_embeds = result_batch.prompt_embeds[0]
-        self.negative_prompt_attention_mask = prompt_attention_mask[0]
+        device = getattr(self, "device", None)
+        if device is not None:
+            self.negative_prompt_embeds = prompt_embeds[0].to(device=device, dtype=torch.bfloat16)
+            self.negative_prompt_attention_mask = prompt_attention_mask[0].to(device=device, dtype=torch.bfloat16)
+        else:
+            self.negative_prompt_embeds = prompt_embeds[0]
+            self.negative_prompt_attention_mask = prompt_attention_mask[0]
         logger.info("Initialized negative prompt conditioning for distillation")
 
     def apply_ema_to_model(self, model):

--- a/fastvideo/training/distillation_pipeline.py
+++ b/fastvideo/training/distillation_pipeline.py
@@ -318,6 +318,44 @@ class DistillationPipeline(TrainingPipeline):
         """Initialize validation pipeline - must be implemented by subclasses."""
         raise NotImplementedError("Distillation pipelines must implement this method")
 
+    @torch.no_grad()
+    def _ensure_negative_prompt_conditioning(self,
+                                             training_args: TrainingArgs,
+                                             negative_prompt: str | None = None) -> None:
+        if (getattr(self, "negative_prompt_embeds", None) is not None
+                and getattr(self, "negative_prompt_attention_mask", None) is not None):
+            return
+
+        validation_pipeline = getattr(self, "validation_pipeline", None)
+        if validation_pipeline is None:
+            self.initialize_validation_pipeline(training_args)
+            validation_pipeline = getattr(self, "validation_pipeline", None)
+        if validation_pipeline is None:
+            raise RuntimeError("Distillation requires negative prompt conditioning, but validation pipeline is not set")
+
+        prompt_encoding_stage = getattr(validation_pipeline, "prompt_encoding_stage", None)
+        if prompt_encoding_stage is None:
+            raise RuntimeError("Distillation requires negative prompt conditioning, but validation pipeline has no "
+                               "prompt_encoding_stage")
+
+        if negative_prompt is None:
+            negative_prompt = SamplingParam.from_pretrained(training_args.model_path).negative_prompt
+
+        batch_negative = ForwardBatch(
+            data_type="video",
+            prompt=negative_prompt,
+            prompt_embeds=[],
+            prompt_attention_mask=[],
+        )
+        result_batch = prompt_encoding_stage(batch_negative, training_args)
+        prompt_attention_mask = result_batch.prompt_attention_mask
+        if (not result_batch.prompt_embeds or prompt_attention_mask is None or len(prompt_attention_mask) == 0):
+            raise RuntimeError("Failed to initialize negative prompt conditioning for distillation")
+
+        self.negative_prompt_embeds = result_batch.prompt_embeds[0]
+        self.negative_prompt_attention_mask = prompt_attention_mask[0]
+        logger.info("Initialized negative prompt conditioning for distillation")
+
     def apply_ema_to_model(self, model):
         """Apply EMA weights to the model for validation or inference."""
         if model is self.transformer and self.generator_ema is not None:
@@ -1018,6 +1056,7 @@ class DistillationPipeline(TrainingPipeline):
 
         # Create sampling parameters if not provided
         sampling_param = SamplingParam.from_pretrained(training_args.model_path)
+        self._ensure_negative_prompt_conditioning(training_args, sampling_param.negative_prompt)
 
         # Set deterministic seed for validation
 
@@ -1079,18 +1118,6 @@ class DistillationPipeline(TrainingPipeline):
                 audio_sample_rates: list[Any] = []
                 for validation_batch in validation_dataloader:
                     batch = self._prepare_validation_batch(sampling_param, training_args, validation_batch, steps)
-
-                    negative_prompt = batch.negative_prompt
-                    batch_negative = ForwardBatch(
-                        data_type="video",
-                        prompt=negative_prompt,
-                        prompt_embeds=[],
-                        prompt_attention_mask=[],
-                    )
-                    result_batch = self.validation_pipeline.prompt_encoding_stage(  # type: ignore
-                        batch_negative, training_args)
-                    self.negative_prompt_embeds, self.negative_prompt_attention_mask = result_batch.prompt_embeds[
-                        0], result_batch.prompt_attention_mask[0]
 
                     logger.info("rank: %s: rank_in_sp_group: %s, batch.prompt: %s",
                                 self.global_rank,
@@ -1314,6 +1341,7 @@ class DistillationPipeline(TrainingPipeline):
         step_times: deque[float] = deque(maxlen=100)
 
         self._log_training_info()
+        self._ensure_negative_prompt_conditioning(self.training_args)
         self._log_validation(self.transformer, self.training_args, self.init_steps)
 
         progress_bar = tqdm(


### PR DESCRIPTION
## Summary

- Initialize legacy distillation negative prompt conditioning before the first training step, so the unconditional real-score CFG branch has a text dict even when validation is disabled.
- Reuse the same initializer from validation instead of relying on validation as the training prewarm side effect.
- Add a focused regression test for the negative-conditioning invariant and fix stale Wan2.1 distill README script paths.

Fixes #913

## Validation

- `uvx pre-commit run --all-files` passed from `/tmp/fv_issue_913_worktree` with the same patch applied. The issue worktree path contains hyphens, which made mypy reject the root package name when run there.
- Modal L40S via the `interleavethinker` launcher: `pytest fastvideo/tests/training/distill/test_distill_negative_conditioning.py -q` passed with `2 passed in 2.09s`.
- Modal run: https://modal.com/apps/hao-ai-lab/main/ap-k5eoIc7sTGbrh1ep3Vted2
- First Modal attempt with `--install-extra dev` failed before tests because `fastvideo-kernel==0.3.2` sdist build could not find `cutlass/cutlass.h`; the passing retry used the baked dev image with `--install-extra none`.

## GPU Memory Impact

This caches one preset negative prompt embedding and attention mask for the training pipeline. When validation is disabled, it also lazily initializes the existing validation/prompt pipeline so training can encode that negative prompt before DMD CFG uses it.

# Checklist
- [x] I ran pre-commit run --all-files and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes
For model/pipeline changes, also check:
- [ ] I verified targeted Wan T2V SSIM regression tests pass on L40S (not applicable: training-only fix; targeted Modal regression covered the crash path)
- [ ] I updated the support matrix if adding a new model (not applicable: no model added)
