### PR TITLE
[ci] Normalize performance stage component metrics (#1475)

### DIFF
--- a/docs/contributing/performance_benchmarks.md
+++ b/docs/contributing/performance_benchmarks.md
@@ -107,10 +107,11 @@ Each benchmark records six metrics:
 while it runs so pipeline stage execution times are available in
 `generate_video(...).logging_info`. Stage logs use pipeline-unique keys such as
 `prompt_encoding_stage` so duplicate stage classes do not collide. For
-`PipelineStage` entries, the extractor maps the `stage_class` field:
-`TextEncodingStage` maps to `text_encoder_time_s`, `DenoisingStage` and
-`DmdDenoisingStage` map to `dit_time_s`, and `DecodingStage` maps to
-`vae_decode_time_s`, with a fallback for older logs that used the class name as
+`PipelineStage` entries, shared component stage bases emit a stable
+`component_metric`: text encoding stages map to `text_encoder_time_s`,
+denoising stages and subclasses map to `dit_time_s`, and decoding stages map to
+`vae_decode_time_s`. The extractor falls back to known `stage_class` names for
+older logs that do not include `component_metric` or that used the class name as
 the stage key. Generator-side timings such as `PostDecodeFrameProcessStage`,
 `VideoSaveStage`, and `AudioMuxStage` are intentionally ignored. If a pipeline
 does not report one of the mapped stages, that component metric is stored as
@@ -336,5 +337,5 @@ pipelines that did not report a mapped component stage.
 
 **Component timing is `null`** — the generated result did not include a mapped
 stage in `logging_info.stages`. Check that the pipeline emits stage logging
-and that the stage name is listed in `STAGE_METRIC_MAP` in
-`test_inference_performance.py`.
+and that the stage emits `component_metric` or is covered by the legacy
+`STAGE_METRIC_MAP` fallback in `test_inference_performance.py`.

--- a/fastvideo/pipelines/stages/base.py
+++ b/fastvideo/pipelines/stages/base.py
@@ -34,6 +34,7 @@ class PipelineStage(ABC):
     composed with other stages to create a complete pipeline. Each stage is responsible
     for a specific part of the process, such as prompt encoding, latent preparation, etc.
     """
+    performance_component_metric: str | None = None
 
     def verify_input(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> VerificationResult:
         """
@@ -155,6 +156,9 @@ class PipelineStage(ABC):
                 logger.info("[%s] Execution completed in %s ms", stage_name, execution_time * 1000)
                 batch.logging_info.add_stage_execution_time(stage_key, execution_time)
                 batch.logging_info.add_stage_metric(stage_key, "stage_class", stage_class_name)
+                component_metric = getattr(self, "performance_component_metric", None)
+                if component_metric is not None:
+                    batch.logging_info.add_stage_metric(stage_key, "component_metric", component_metric)
             except Exception as e:
                 torch.cuda.synchronize()
                 execution_time = time.perf_counter() - start_time

--- a/fastvideo/pipelines/stages/base.py
+++ b/fastvideo/pipelines/stages/base.py
@@ -156,7 +156,7 @@ class PipelineStage(ABC):
                 logger.info("[%s] Execution completed in %s ms", stage_name, execution_time * 1000)
                 batch.logging_info.add_stage_execution_time(stage_key, execution_time)
                 batch.logging_info.add_stage_metric(stage_key, "stage_class", stage_class_name)
-                component_metric = getattr(self, "performance_component_metric", None)
+                component_metric = self.performance_component_metric
                 if component_metric is not None:
                     batch.logging_info.add_stage_metric(stage_key, "component_metric", component_metric)
             except Exception as e:

--- a/fastvideo/pipelines/stages/decoding.py
+++ b/fastvideo/pipelines/stages/decoding.py
@@ -28,6 +28,7 @@ class DecodingStage(PipelineStage):
     This stage handles the decoding of latent representations into the final
     output format (e.g., pixel values).
     """
+    performance_component_metric = "vae_decode_time_s"
 
     def __init__(self, vae, pipeline=None) -> None:
         self.vae: ParallelTiledVAE = vae

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -51,6 +51,7 @@ class DenoisingStage(PipelineStage):
     This stage handles the iterative denoising process that transforms
     the initial noise into the final output.
     """
+    performance_component_metric = "dit_time_s"
 
     def __init__(self, transformer, scheduler, pipeline=None, transformer_2=None, vae=None) -> None:
         super().__init__()

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -1188,6 +1188,7 @@ class Cosmos25V2WDenoisingStage(Cosmos25DenoisingStage):
 
 class Cosmos25AutoDenoisingStage(PipelineStage):
     """Route Cosmos 2.5 denoising to T2W vs V2W/I2W."""
+    performance_component_metric = "dit_time_s"
 
     def __init__(self, transformer, scheduler) -> None:
         super().__init__()

--- a/fastvideo/pipelines/stages/text_encoding.py
+++ b/fastvideo/pipelines/stages/text_encoding.py
@@ -351,6 +351,7 @@ class Cosmos25TextEncodingStage(PipelineStage):
     Cosmos 2.5 uses Reason1 (Qwen2.5-VL) and relies on the encoder's
     `compute_text_embeddings_online()`.
     """
+    performance_component_metric = "text_encoder_time_s"
 
     def __init__(self, text_encoder) -> None:
         super().__init__()

--- a/fastvideo/pipelines/stages/text_encoding.py
+++ b/fastvideo/pipelines/stages/text_encoding.py
@@ -24,6 +24,7 @@ class TextEncodingStage(PipelineStage):
     This stage handles the encoding of text prompts into the embedding space
     expected by the diffusion model.
     """
+    performance_component_metric = "text_encoder_time_s"
 
     def __init__(self, text_encoders, tokenizers) -> None:
         """

--- a/fastvideo/tests/performance/test_inference_performance.py
+++ b/fastvideo/tests/performance/test_inference_performance.py
@@ -102,7 +102,11 @@ def _extract_component_times(result: dict) -> dict[str, float | None]:
             logger.debug("Skipping malformed stage '%s' data: %r", stage_name, stage_data)
             continue
         stage_class = stage_data.get("stage_class", stage_name)
-        metric_key = STAGE_METRIC_MAP.get(stage_class)
+        component_metric = stage_data.get("component_metric")
+        if isinstance(component_metric, str) and component_metric in component_times:
+            metric_key = component_metric
+        else:
+            metric_key = STAGE_METRIC_MAP.get(stage_class)
         if metric_key is None:
             logger.debug("Unmapped stage '%s' class '%s' (%.3fs)",
                          stage_name,

--- a/fastvideo/tests/performance/test_inference_performance_component_times.py
+++ b/fastvideo/tests/performance/test_inference_performance_component_times.py
@@ -1,13 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from fastvideo.pipelines.pipeline_batch_info import PipelineLoggingInfo
+from fastvideo.pipelines.stages.denoising import DenoisingStage
 from fastvideo.tests.performance.test_inference_performance import _extract_component_times
+
+
+class SubclassStyleDenoisingStage(DenoisingStage):
+    pass
 
 
 def test_extract_component_times_handles_pipeline_logging_info_object():
     logging_info = PipelineLoggingInfo()
     logging_info.add_stage_execution_time("prompt_encoding_stage", 1.25)
     logging_info.add_stage_metric("prompt_encoding_stage", "stage_class", "TextEncodingStage")
+    logging_info.add_stage_metric("prompt_encoding_stage", "component_metric", "text_encoder_time_s")
 
     assert _extract_component_times({"logging_info": logging_info}) == {
         "text_encoder_time_s": 1.25,
@@ -42,6 +48,30 @@ def test_extract_component_times_uses_stage_class_for_pipeline_stage_keys():
         "text_encoder_time_s": 1.2,
         "dit_time_s": 3.4,
         "vae_decode_time_s": 0.8,
+    }
+
+
+def test_denoising_stage_subclasses_inherit_component_metric():
+    assert SubclassStyleDenoisingStage.performance_component_metric == "dit_time_s"
+
+
+def test_extract_component_times_uses_component_metric_for_stage_subclasses():
+    result = {
+        "logging_info": {
+            "stages": {
+                "denoising_stage": {
+                    "execution_time": 4.2,
+                    "stage_class": "CosmosDenoisingStage",
+                    "component_metric": "dit_time_s",
+                },
+            },
+        },
+    }
+
+    assert _extract_component_times(result) == {
+        "text_encoder_time_s": None,
+        "dit_time_s": 4.2,
+        "vae_decode_time_s": None,
     }
 
 

--- a/fastvideo/tests/performance/test_inference_performance_component_times.py
+++ b/fastvideo/tests/performance/test_inference_performance_component_times.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from fastvideo.pipelines.pipeline_batch_info import PipelineLoggingInfo
-from fastvideo.pipelines.stages.denoising import DenoisingStage
+from fastvideo.pipelines.stages.denoising import Cosmos25AutoDenoisingStage, DenoisingStage
+from fastvideo.pipelines.stages.text_encoding import Cosmos25TextEncodingStage
 from fastvideo.tests.performance.test_inference_performance import _extract_component_times
 
 
@@ -53,6 +54,11 @@ def test_extract_component_times_uses_stage_class_for_pipeline_stage_keys():
 
 def test_denoising_stage_subclasses_inherit_component_metric():
     assert SubclassStyleDenoisingStage.performance_component_metric == "dit_time_s"
+
+
+def test_cosmos25_direct_pipeline_stages_define_component_metrics():
+    assert Cosmos25TextEncodingStage.performance_component_metric == "text_encoder_time_s"
+    assert Cosmos25AutoDenoisingStage.performance_component_metric == "dit_time_s"
 
 
 def test_extract_component_times_uses_component_metric_for_stage_subclasses():


### PR DESCRIPTION
## Summary

Fixes #1475.

- Add stable `component_metric` metadata to shared pipeline stage logging.
- Mark text encoding, denoising, and decoding base stages with their performance component metric keys.
- Prefer `component_metric` during performance timing extraction while preserving the legacy `STAGE_METRIC_MAP` fallback.
- Add coverage for denoising subclass timing extraction and update performance benchmark docs.

## Validation

- Modal L40S targeted test:
  `pytest fastvideo/tests/performance/test_inference_performance_component_times.py -q`
  - Result: `9 passed in 0.03s`
  - Modal app: https://modal.com/apps/hao-ai-lab/main/ap-ZqHvOhSMX6q8yFjnLfvlE3
- Modal L40S full pre-commit:
  `pre-commit run --all-files`
  - Passed
  - Modal app: https://modal.com/apps/hao-ai-lab/main/ap-bOQ9tJfMy6hZZp8GpAcNEu

Note: an initial Modal run with `--install-extra test` failed before pytest because `fastvideo-kernel==0.3.2` sdist build could not find `cutlass/cutlass.h`; the passing validation used the baked dev image with `--install-extra none`.

## GPU Memory Impact

Only stage logging metadata and performance test extraction change. No model execution, tensor allocation, kernel, or attention behavior changes outside `FASTVIDEO_STAGE_LOGGING` metadata.

# Checklist
- [x] I ran pre-commit run --all-files and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes
For model/pipeline changes, also check:
- [ ] I verified targeted Wan T2V SSIM regression tests pass on L40S
- [ ] I updated the support matrix if adding a new model

Model/pipeline checklist items are not applicable; this is performance CI timing metadata and extraction.
