### PR TITLE
[ci]: emit v2 performance result schema

### DIFF
--- a/docs/contributing/performance_benchmarks.md
+++ b/docs/contributing/performance_benchmarks.md
@@ -416,11 +416,14 @@ point is `fastvideo/tests/modal/pr_test.py:run_performance_tests` and the
 Buildkite artifact upload is in
 `.buildkite/scripts/pr_test.sh:upload_performance_artifacts`.
 
-Each performance build runs pytest first. If that fixed-threshold phase fails,
-PR/direct runs skip `compare_baseline.py` because they only upload passing
-records. Scheduled-main runs still execute `compare_baseline.py` with
-`PERF_PYTEST_RC` set so the failed canonical attempt is visible in normalized
-JSON and dashboard history. The dashboard runs best-effort for observability.
+Each performance build runs pytest first. PR and direct runs only continue to
+`compare_baseline.py` when that fixed-threshold phase passes; if pytest fails,
+Markdown summaries and normalized JSON artifacts are not emitted. Scheduled
+main runs set `PERF_UPLOAD_POLICY=always`, so they still run
+`compare_baseline.py` (with `PERF_PYTEST_RC` set) after a fixed-threshold
+failure. Those failed scheduled main runs emit summaries and normalized
+records, upload records with `success=false`, and are excluded from future
+rolling baselines. The dashboard still runs best-effort for observability.
 When the rolling-baseline phase runs, it emits:
 
 * **Markdown summary** — appended to `$GITHUB_STEP_SUMMARY` when that variable

--- a/docs/contributing/performance_benchmarks.md
+++ b/docs/contributing/performance_benchmarks.md
@@ -241,7 +241,7 @@ Written by `test_inference_performance.py`. One file per benchmark run.
 ```jsonc
 {
   "benchmark_id": "wan-t2v-1.3b-2gpu",
-  "config_schema_version": 2,
+  "result_schema_version": 2,
   "workload_id": "wan-t2v",
   "variant_id": "1.3b-sp2",
   "benchmark_version": 2,
@@ -270,8 +270,15 @@ Written by `test_inference_performance.py`. One file per benchmark run.
     }
   },
   "commit": "<full sha>",
+  "run_source": "pr",
+  "branch": "feature/perf-change",
   "pr_number": "1234",
+  "test_scope": "direct",
+  "build_url": "https://buildkite.example/build",
+  "build_id": "<buildkite-build-id>",
+  "job_id": "<buildkite-job-id>",
   "timestamp": "2026-05-08T22:00:00+00:00",
+  "quality_metadata": { "quality_status": "canonical" },
   "text_encoder_time_s": 2.141,
   "dit_time_s": 8.437,
   "vae_decode_time_s": 3.208,
@@ -322,6 +329,7 @@ result, used as the rolling-baseline source of truth.
 ```jsonc
 {
   "model_id": "wan-t2v-1.3b-2gpu",
+  "result_schema_version": 2,
   "workload_id": "wan-t2v",
   "variant_id": "1.3b-sp2",
   "benchmark_version": 2,
@@ -345,17 +353,27 @@ result, used as the rolling-baseline source of truth.
   "hardware_profile_id": "hw-<sha256-prefix>",
   "software_profile_id": "sw-<sha256-prefix>",
   "environment_fingerprint": "env-<sha256-prefix>",
+  "run_source": "pr",
+  "branch": "feature/perf-change",
+  "pr_number": "1234",
+  "test_scope": "direct",
+  "build_url": "https://buildkite.example/build",
+  "build_id": "<buildkite-build-id>",
+  "job_id": "<buildkite-job-id>",
+  "quality_metadata": { "quality_status": "canonical" },
   "success": true
 }
 ```
 
 ### Compatibility with legacy records
 
-Older records in the HF dataset may not have component timing fields. The
-comparator ignores missing or `null` metrics when computing a median, and the
-dashboard lists skipped plots for metric series that have no non-null values.
-Records missing both `run_source` and `baseline_eligible` are treated as legacy
-successful main/full-suite uploads and remain eligible for rolling baselines.
+Older records in the HF dataset may not have `result_schema_version`,
+component timing fields, or v2 identity/profile fields. Records without
+`result_schema_version` are treated as v1. The comparator ignores missing or
+`null` metrics when computing a median, and the dashboard lists skipped plots
+for metric series that have no non-null values. Records missing both
+`run_source` and `baseline_eligible` are treated as legacy successful
+main/full-suite uploads and remain eligible for rolling baselines.
 
 New records compare only against the same `model_id`, `gpu_type`,
 `workload_id`, `variant_id`, `benchmark_version`, `recipe_fingerprint`,
@@ -377,7 +395,7 @@ FlashInfer, Cutlass DSL, SageAttention, Triton, and xFormers when installed.
 | `PERF_REPORTS_DIR` | `/root/data/perf_reports` | `compare_baseline.py`, `dashboard.py` | Where the Markdown summary and Plotly HTML get written for Buildkite to pick up. |
 | `HF_REPO_ID` | `FastVideo/performance-tracking` | `fastvideo/performance/hf_store.py` | HF dataset repo holding rolling-baseline records. |
 | `HF_API_KEY`, `HUGGINGFACE_HUB_TOKEN`, `HF_TOKEN` | unset | `fastvideo/performance/hf_store.py` | Required for upload or private dataset reads. |
-| `PERF_RUN_SOURCE` | inferred | `compare_baseline.py` | Source metadata for uploaded records: `pr`, `local`, `scheduled_main`, or `unknown`. |
+| `PERF_RUN_SOURCE` | inferred | `compare_baseline.py`, `test_inference_performance.py` | Source metadata for uploaded records: `pr`, `local`, `scheduled_main`, or `unknown`. |
 | `PERF_UPLOAD_POLICY` | `never` | `compare_baseline.py` | Upload policy: `never`, `pass`, or `always`. |
 | `PERF_PYTEST_RC` | unset | `compare_baseline.py` | Static-threshold pytest exit code, used so scheduled-main failures can be uploaded with `success=false`. |
 | `TEST_SCOPE` | unset | `compare_baseline.py` | CI context used to infer scheduled-main runs together with `BUILDKITE_BRANCH=main`. |

--- a/docs/contributing/performance_benchmarks.md
+++ b/docs/contributing/performance_benchmarks.md
@@ -79,10 +79,11 @@ fastvideo/performance/
 ```
 
 The HF dataset (`FastVideo/performance-tracking` by default) holds one
-normalized JSON per `(model_id, gpu_type, run)` tuple. The rolling baseline is
-the median of the last 5 successful, baseline-eligible records for that
-model+GPU. PR and local records are visible in the dashboard but are not
-baseline eligible.
+normalized JSON per run. For v2 records, the rolling baseline is the median of
+the last 5 successful, baseline-eligible records in the same comparison cohort:
+`model_id`, `gpu_type`, `workload_id`, `variant_id`, `benchmark_version`,
+`recipe_fingerprint`, `hardware_profile_id`, and `software_profile_id`. PR and
+local records are visible in the dashboard but are not baseline eligible.
 
 ## Planned Coverage
 
@@ -158,13 +159,16 @@ unrealistic memory growth, and optionally large component-specific slowdowns
 even when the rolling baseline is empty. They are hand-set with generous
 headroom and almost never need touching.
 
-### Rolling baseline (per `(model_id, gpu_type)`)
+### Rolling baseline (per comparison cohort)
 
 `compare_baseline.py` loads the last 5 successful, baseline-eligible records
-for the same `(model_id, gpu_type)` from the HF dataset, computes the median
-for each available metric, and evaluates the current run with the metric's
-rolling regression policy. For latency, memory, and component times, higher
-values are regressions. For throughput, lower values are regressions.
+for the same comparison cohort from the HF dataset, computes the median for
+each available metric, and evaluates the current run with the metric's
+rolling regression policy. For v2 records, that cohort is `model_id`,
+`gpu_type`, `workload_id`, `variant_id`, `benchmark_version`,
+`recipe_fingerprint`, `hardware_profile_id`, and `software_profile_id`. For
+latency, memory, and component times, higher values are regressions. For
+throughput, lower values are regressions.
 
 A metric exceeds its rolling threshold when both of these are true:
 
@@ -424,7 +428,7 @@ When the rolling-baseline phase runs, it emits:
   per-benchmark row with current vs. baseline values for latency, throughput,
   memory, text encoder time, DiT time, and VAE decode time.
 * **Plotly dashboard** — `dashboard_<sha>_<ts>.html` showing time-series for
-  each metric grouped by `(model_id, gpu_type)`.
+  each metric grouped by comparison cohort.
 * **Normalized records** — `normalized_perf_*.json`, one per benchmark.
   Useful as input to the
   [`reseed-performance-baseline`](https://github.com/hao-ai-lab/FastVideo/blob/main/.agents/skills/reseed-performance-baseline/SKILL.md)
@@ -498,8 +502,8 @@ When the rolling-baseline phase runs, it emits:
 
 ## Troubleshooting
 
-**"No baseline for ... Initializing"** — first run for this `(model_id,
-gpu_type)`. Run will pass and (if persisting) seed the first record.
+**"No baseline for ... Initializing"** — first run for this comparison cohort.
+Run will pass and (if persisting) seed the first record.
 
 **Persistent failure right after a torch / kernel / image upgrade** —
 genuine regression *or* baseline drift. Compare the failing normalized record

--- a/docs/contributing/performance_benchmarks.md
+++ b/docs/contributing/performance_benchmarks.md
@@ -234,8 +234,10 @@ Recipe fingerprinting, hardware/software profile IDs, exact-identity
 comparison, and dashboard cohort grouping land with this change: v2 records
 compare only within their identity cohort, and a record that opens a NEW
 cohort is marked `baseline_status: "initialized_new_cohort"` (regression
-gating starts once that cohort accumulates history). Legacy v1 configs keep
-the `(model_id, gpu_type)` rolling-baseline comparison. Metric-specific
+gating starts once that cohort accumulates history). Legacy v1 configs still
+run and are normalized for reporting, but their records skip rolling-baseline
+comparison entirely (`baseline_status: "skipped_missing_identity"`, never
+baseline eligible); only static thresholds gate them. Metric-specific
 threshold policies and promoted baselines remain separate follow-ups.
 
 ### Raw record (`results/perf_*.json`)
@@ -378,6 +380,9 @@ component timing fields, or v2 identity/profile fields. Records without
 for metric series that have no non-null values. Records missing both
 `run_source` and `baseline_eligible` are treated as legacy successful
 main/full-suite uploads and remain eligible for rolling baselines.
+Current `perf_*.json` artifacts that lack the v2 comparison identity are
+normalized for reporting but skip rolling-baseline comparison and are not marked
+baseline eligible.
 
 New records compare only against the same `model_id`, `gpu_type`,
 `workload_id`, `variant_id`, `benchmark_version`, `recipe_fingerprint`,

--- a/fastvideo/performance_dashboard/service.py
+++ b/fastvideo/performance_dashboard/service.py
@@ -86,20 +86,32 @@ def record_metadata(record: Record) -> Record:
     }
 
 
+def _cohort_metadata_value(value: Any) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, str) and not value.strip():
+        return ""
+    return value
+
+
+def _cohort_key_value(value: Any) -> str:
+    return str(_cohort_metadata_value(value))
+
+
 def record_comparison_metadata(record: Record) -> Record:
-    return {key: record.get(key) or "" for key in COMPARISON_COHORT_KEYS}
+    return {key: _cohort_metadata_value(record.get(key)) for key in COMPARISON_COHORT_KEYS}
 
 
 def comparison_cohort_key(record: Record) -> CohortKey:
     return (
         str(record.get("model_id") or "unknown"),
         str(record.get("gpu_type") or "unknown"),
-        str(record.get("workload_id") or ""),
-        str(record.get("variant_id") or ""),
-        str(record.get("benchmark_version") or ""),
-        str(record.get("recipe_fingerprint") or ""),
-        str(record.get("hardware_profile_id") or ""),
-        str(record.get("software_profile_id") or ""),
+        _cohort_key_value(record.get("workload_id")),
+        _cohort_key_value(record.get("variant_id")),
+        _cohort_key_value(record.get("benchmark_version")),
+        _cohort_key_value(record.get("recipe_fingerprint")),
+        _cohort_key_value(record.get("hardware_profile_id")),
+        _cohort_key_value(record.get("software_profile_id")),
     )
 
 
@@ -146,9 +158,10 @@ def build_latest_summary(records: list[Record],
             continue
 
         latest = latest_candidates[-1]
+        latest_index = next(index for index, record in enumerate(group) if record is latest)
         baseline_pool = [
-            record for record in group
-            if record is not latest and record.get("success", True) and is_baseline_eligible_record(record)
+            record for record in group[:latest_index]
+            if record.get("success", True) and is_baseline_eligible_record(record)
         ]
         baseline_records = baseline_pool[-baseline_window:]
         metric_policies = resolve_metric_policies(latest.get("regression_thresholds"))

--- a/fastvideo/tests/performance/compare_baseline.py
+++ b/fastvideo/tests/performance/compare_baseline.py
@@ -66,6 +66,7 @@ UPLOAD_POLICY = os.environ.get("PERF_UPLOAD_POLICY", "never").strip().lower()
 VALID_UPLOAD_POLICIES = {"never", "pass", "always"}
 VALID_RUN_SOURCES = {"pr", "local", "scheduled_main", "unknown"}
 IDENTITY_KEYS = (
+    "result_schema_version",
     "workload_id",
     "variant_id",
     "benchmark_version",
@@ -77,6 +78,8 @@ IDENTITY_KEYS = (
     "software_profile_id",
     "environment_metadata",
     "environment_fingerprint",
+    "quality_metadata",
+    "variant_metadata",
 )
 COMPARISON_IDENTITY_KEYS = (
     "workload_id",
@@ -143,18 +146,22 @@ def _result_failed_static_thresholds() -> bool:
 
 
 def _record_metadata(run_source: str, result: dict[str, Any]) -> dict[str, Any]:
+    raw_run_source = str(result.get("run_source") or "").strip().lower()
+    if raw_run_source in VALID_RUN_SOURCES:
+        run_source = raw_run_source
+
     pr_number = result.get("pr_number") or os.environ.get("BUILDKITE_PULL_REQUEST", "")
     if not _truthy_pr_number(str(pr_number)):
         pr_number = ""
     return {
         "run_source": run_source,
         "baseline_eligible": False,
-        "branch": os.environ.get("BUILDKITE_BRANCH", ""),
+        "branch": result.get("branch") or os.environ.get("BUILDKITE_BRANCH", ""),
         "pr_number": pr_number,
-        "test_scope": os.environ.get("TEST_SCOPE", ""),
-        "build_url": os.environ.get("BUILDKITE_BUILD_URL", ""),
-        "build_id": os.environ.get("BUILDKITE_BUILD_ID", ""),
-        "job_id": os.environ.get("BUILDKITE_JOB_ID", ""),
+        "test_scope": result.get("test_scope") or os.environ.get("TEST_SCOPE", ""),
+        "build_url": result.get("build_url") or os.environ.get("BUILDKITE_BUILD_URL", ""),
+        "build_id": result.get("build_id") or os.environ.get("BUILDKITE_BUILD_ID", ""),
+        "job_id": result.get("job_id") or os.environ.get("BUILDKITE_JOB_ID", ""),
     }
 
 

--- a/fastvideo/tests/performance/compare_baseline.py
+++ b/fastvideo/tests/performance/compare_baseline.py
@@ -185,17 +185,24 @@ def _comparison_identity_filters(record: dict[str, Any]) -> dict[str, str]:
         key for key in COMPARISON_IDENTITY_KEYS
         if key not in record or record[key] is None or (isinstance(record[key], str) and not record[key].strip())
     ]
-    if len(missing) == len(COMPARISON_IDENTITY_KEYS):
-        # Legacy v1 record: no identity fields at all. Keep the pre-v2
-        # (model_id, gpu_type) rolling-baseline comparison instead of
-        # crashing — v1 configs are documented as loadable.
-        return {}
     if missing:
         raise ValueError("Performance record missing required comparison identity fields: " + ", ".join(missing))
     return {
         key: str(record[key])
         for key in COMPARISON_IDENTITY_KEYS
     }
+
+
+def _comparison_identity_filters_or_none(record: dict[str, Any]) -> dict[str, str] | None:
+    try:
+        return _comparison_identity_filters(record)
+    except ValueError as exc:
+        print("Skipping rolling baseline comparison for "
+              f"{record.get('model_id', 'unknown')} on "
+              f"{record.get('gpu_type', 'unknown')}: {exc}. "
+              "The normalized artifact will still be written, but this record "
+              "will not be baseline eligible.")
+        return None
 
 
 def _format_identity_filters(filters: dict[str, str]) -> str:
@@ -488,43 +495,53 @@ def main() -> int:
     for raw in current_results:
         record = _normalize_record(raw)
         metric_policies = resolve_metric_policies(record.get("regression_thresholds"))
+        identity_filters = _comparison_identity_filters_or_none(record)
 
-        baseline_records = load_records_for_model(
-            TRACKING_ROOT,
-            record["model_id"],
-            record["gpu_type"],
-            **_comparison_identity_filters(record),
-            last_n=5,
-            successful_only=True,
-            baseline_eligible_only=True,
-        )
-
-        if not baseline_records:
-            # A brand-new cohort has NO regression gating until history
-            # accumulates — make that loud and machine-readable instead of
-            # an indistinguishable pass, so a cohort shift (intended or
-            # accidental, e.g. an identity-field change) never silently
-            # blinds the comparison.
-            record["baseline_status"] = "initialized_new_cohort"
-            print("=" * 72)
-            print(f"WARNING: NO BASELINE — initializing a NEW cohort for "
-                  f"{record['model_id']} on {record['gpu_type']}"
-                  f"{_format_identity_filters(_comparison_identity_filters(record))}")
-            print("Regression gating is INACTIVE for this cohort until "
-                  "baseline history accumulates. If this cohort shift is "
-                  "unexpected, check the identity fields above.")
-            print("=" * 72)
+        baseline_records: list[dict[str, Any]] = []
+        if identity_filters is None:
+            # Records without the full v2 identity block skip rolling-baseline
+            # comparison entirely: only the static thresholds gate them and
+            # they never become baseline eligible.
+            record["baseline_status"] = "skipped_missing_identity"
             failures: list[str] = []
-            record["success"] = True
         else:
-            record["baseline_status"] = "compared"
-            failures = _check_regressions(record, baseline_records, metric_policies)
+            baseline_records = load_records_for_model(
+                TRACKING_ROOT,
+                record["model_id"],
+                record["gpu_type"],
+                **identity_filters,
+                last_n=5,
+                successful_only=True,
+                baseline_eligible_only=True,
+            )
+
+            if not baseline_records:
+                # A brand-new cohort has NO regression gating until history
+                # accumulates — make that loud and machine-readable instead of
+                # an indistinguishable pass, so a cohort shift (intended or
+                # accidental, e.g. an identity-field change) never silently
+                # blinds the comparison.
+                record["baseline_status"] = "initialized_new_cohort"
+                print("=" * 72)
+                print(f"WARNING: NO BASELINE — initializing a NEW cohort for "
+                      f"{record['model_id']} on {record['gpu_type']}"
+                      f"{_format_identity_filters(identity_filters)}")
+                print("Regression gating is INACTIVE for this cohort until "
+                      "baseline history accumulates. If this cohort shift is "
+                      "unexpected, check the identity fields above.")
+                print("=" * 72)
+                failures = []
+            else:
+                record["baseline_status"] = "compared"
+                failures = _check_regressions(record, baseline_records, metric_policies)
         if static_threshold_failed:
             failures.append(f"{record['model_id']} fixed-threshold phase failed "
                             f"(PERF_PYTEST_RC={os.environ.get('PERF_PYTEST_RC')})")
 
         record["success"] = not failures
-        record["baseline_eligible"] = _is_baseline_eligible(record["run_source"], record["success"])
+        record["baseline_eligible"] = (
+            identity_filters is not None and _is_baseline_eligible(record["run_source"], record["success"])
+        )
         all_failures.extend(failures)
 
         _write_normalized_artifact(record)

--- a/fastvideo/tests/performance/test_benchmark_config_validation.py
+++ b/fastvideo/tests/performance/test_benchmark_config_validation.py
@@ -14,9 +14,9 @@ def _v2_config():
     return {
         "benchmark_id": "wan-t2v-1.3b-2gpu",
         "config_schema_version": 2,
-        "workload_id": "wan-t2v-1.3b",
-        "variant_id": "canonical",
-        "benchmark_version": 1,
+        "workload_id": "wan-t2v",
+        "variant_id": "1.3b-sp2",
+        "benchmark_version": 2,
     }
 
 
@@ -41,9 +41,9 @@ def test_v2_benchmark_config_identity_validates_and_is_preserved():
     assert _is_v2_config(cfg) is True
     assert _config_identity_metadata(cfg) == {
         "config_schema_version": 2,
-        "workload_id": "wan-t2v-1.3b",
-        "variant_id": "canonical",
-        "benchmark_version": 1,
+        "workload_id": "wan-t2v",
+        "variant_id": "1.3b-sp2",
+        "benchmark_version": 2,
         "quality_metadata": {"some": "data"},
     }
 
@@ -91,9 +91,9 @@ def test_v2_benchmark_config_rejects_invalid_benchmark_version_values(value):
 def test_partial_v2_identity_requires_schema_version():
     cfg = {
         "benchmark_id": "wan-t2v-1.3b-2gpu",
-        "workload_id": "wan-t2v-1.3b",
-        "variant_id": "canonical",
-        "benchmark_version": 1,
+        "workload_id": "wan-t2v",
+        "variant_id": "1.3b-sp2",
+        "benchmark_version": 2,
     }
 
     expected = "wan.json: v2 benchmark identity fields require config_schema_version=2"
@@ -105,9 +105,9 @@ def test_optional_v2_metadata_fields_must_be_objects():
     cfg = {
         "benchmark_id": "wan-t2v-1.3b-2gpu",
         "config_schema_version": 2,
-        "workload_id": "wan-t2v-1.3b",
-        "variant_id": "canonical",
-        "benchmark_version": 1,
+        "workload_id": "wan-t2v",
+        "variant_id": "1.3b-sp2",
+        "benchmark_version": 2,
         "quality_metadata": ["not", "an", "object"],
     }
 

--- a/fastvideo/tests/performance/test_compare_baseline_policy.py
+++ b/fastvideo/tests/performance/test_compare_baseline_policy.py
@@ -125,6 +125,7 @@ def test_normalized_record_preserves_identity_metadata(monkeypatch):
     monkeypatch.setenv("PERF_RUN_SOURCE", "pr")
     raw = _raw_result()
     raw.update({
+        "result_schema_version": 2,
         "workload_id": "wan-t2v",
         "variant_id": "1.3b-sp2",
         "benchmark_version": 2,
@@ -146,10 +147,14 @@ def test_normalized_record_preserves_identity_metadata(monkeypatch):
             },
         },
         "environment_fingerprint": "env-1",
+        "quality_metadata": {
+            "quality_status": "canonical",
+        },
     })
 
     record = compare_baseline.normalize_performance_result(raw)
 
+    assert record["result_schema_version"] == 2
     assert record["workload_id"] == "wan-t2v"
     assert record["variant_id"] == "1.3b-sp2"
     assert record["benchmark_version"] == 2
@@ -161,6 +166,46 @@ def test_normalized_record_preserves_identity_metadata(monkeypatch):
     assert record["software_profile_id"] == "sw-1"
     assert record["environment_metadata"] == {"env": {"IMAGE_VERSION": "latest"}}
     assert record["environment_fingerprint"] == "env-1"
+    assert record["quality_metadata"] == {"quality_status": "canonical"}
+
+
+def test_normalized_record_prefers_raw_v2_provenance(monkeypatch):
+    monkeypatch.setenv("PERF_RUN_SOURCE", "pr")
+    monkeypatch.setenv("BUILDKITE_BRANCH", "feature/from-env")
+    monkeypatch.setenv("TEST_SCOPE", "direct")
+    monkeypatch.setenv("BUILDKITE_BUILD_URL", "https://buildkite.example/env")
+    monkeypatch.setenv("BUILDKITE_BUILD_ID", "env-build")
+    monkeypatch.setenv("BUILDKITE_JOB_ID", "env-job")
+    raw = _raw_result()
+    raw.update({
+        "result_schema_version": 2,
+        "run_source": "scheduled_main",
+        "branch": "main",
+        "test_scope": "full",
+        "build_url": "https://buildkite.example/raw",
+        "build_id": "raw-build",
+        "job_id": "raw-job",
+        "pr_number": "false",
+    })
+
+    record = compare_baseline.normalize_performance_result(raw)
+
+    assert record["result_schema_version"] == 2
+    assert record["run_source"] == "scheduled_main"
+    assert record["branch"] == "main"
+    assert record["test_scope"] == "full"
+    assert record["build_url"] == "https://buildkite.example/raw"
+    assert record["build_id"] == "raw-build"
+    assert record["job_id"] == "raw-job"
+    assert record["pr_number"] == ""
+
+
+def test_v1_normalized_record_has_no_result_schema_version(monkeypatch):
+    monkeypatch.setenv("PERF_RUN_SOURCE", "pr")
+
+    record = compare_baseline.normalize_performance_result(_raw_result())
+
+    assert "result_schema_version" not in record
 
 
 def test_normalized_record_reads_identity_labels_from_recipe(monkeypatch):

--- a/fastvideo/tests/performance/test_compare_baseline_policy.py
+++ b/fastvideo/tests/performance/test_compare_baseline_policy.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+
 import pytest
 
 from fastvideo.tests.performance import compare_baseline
@@ -206,6 +208,47 @@ def test_v1_normalized_record_has_no_result_schema_version(monkeypatch):
     record = compare_baseline.normalize_performance_result(_raw_result())
 
     assert "result_schema_version" not in record
+
+
+def test_main_writes_v1_current_artifact_without_comparison_identity(monkeypatch, tmp_path, capsys):
+    results_dir = tmp_path / "results"
+    reports_dir = tmp_path / "reports"
+    tracking_root = tmp_path / "tracking"
+    results_dir.mkdir()
+    (results_dir / "perf_legacy.json").write_text(json.dumps(_raw_result()), encoding="utf-8")
+    uploaded_records = []
+
+    monkeypatch.setenv("PERF_RUN_SOURCE", "scheduled_main")
+    monkeypatch.delenv("PERF_PYTEST_RC", raising=False)
+    monkeypatch.setattr(compare_baseline, "RESULTS_DIR", str(results_dir))
+    monkeypatch.setattr(compare_baseline, "PERF_REPORTS_DIR", str(reports_dir))
+    monkeypatch.setattr(compare_baseline, "TRACKING_ROOT", str(tracking_root))
+    monkeypatch.setattr(compare_baseline, "UPLOAD_POLICY", "always")
+    monkeypatch.setattr(compare_baseline, "sync_from_hf", lambda local_dir, strict=False: local_dir)
+
+    def fail_load_records_for_model(*_args, **_kwargs):
+        raise AssertionError("legacy current records should skip v2 baseline lookup")
+
+    def fake_upload_record(_path, record, *, strict=False):
+        uploaded_records.append(record.copy())
+
+    monkeypatch.setattr(compare_baseline, "load_records_for_model", fail_load_records_for_model)
+    monkeypatch.setattr(compare_baseline, "upload_record", fake_upload_record)
+
+    assert compare_baseline.main() == 0
+
+    output = capsys.readouterr().out
+    normalized_files = list((reports_dir / "results").glob("normalized_perf_*.json"))
+    assert "Skipping rolling baseline comparison" in output
+    assert "workload_id" in output
+    assert len(normalized_files) == 1
+
+    normalized = json.loads(normalized_files[0].read_text(encoding="utf-8"))
+    assert "result_schema_version" not in normalized
+    assert normalized["success"] is True
+    assert normalized["baseline_eligible"] is False
+    assert len(uploaded_records) == 1
+    assert uploaded_records[0]["baseline_eligible"] is False
 
 
 def test_normalized_record_reads_identity_labels_from_recipe(monkeypatch):

--- a/fastvideo/tests/performance/test_dashboard_api.py
+++ b/fastvideo/tests/performance/test_dashboard_api.py
@@ -154,8 +154,8 @@ def test_dashboard_endpoints_filter_and_return_run_source_metadata():
     assert summary["count"] == 1
     assert summary["rows"][0]["run_source"] == "pr"
     assert summary["rows"][0]["pr_number"] == "123"
-    assert summary["rows"][0]["baseline_n"] == 1
-    assert summary["rows"][0]["metrics"]["latency"]["baseline"] == 11.0
+    assert summary["rows"][0]["baseline_n"] == 0
+    assert summary["rows"][0]["metrics"]["latency"]["baseline"] is None
     assert summary["filters"]["run_source"] == "pr"
     assert trends["count"] == 1
     assert trends["groups"][0]["points"][0]["run_source"] == "pr"

--- a/fastvideo/tests/performance/test_dashboard_service.py
+++ b/fastvideo/tests/performance/test_dashboard_service.py
@@ -142,6 +142,47 @@ def test_build_latest_summary_separates_informational_threshold_crossing():
     assert rows[0]["threshold_exceeded_metrics"] == ["latency"]
     assert rows[0]["failing_metrics"] == []
     assert rows[0]["computed_regression_status"] == "pass"
+
+
+def test_build_latest_summary_run_source_filter_excludes_future_baselines():
+    records = [
+        _record(
+            "2026-01-01T00:00:00+00:00",
+            "a" * 40,
+            10.0,
+            10.0,
+            run_source="scheduled_main",
+            baseline_eligible=True,
+        ),
+        _record(
+            "2026-01-02T00:00:00+00:00",
+            "b" * 40,
+            11.0,
+            9.0,
+            run_source="pr",
+            baseline_eligible=False,
+            pr_number="123",
+        ),
+        _record(
+            "2026-01-03T00:00:00+00:00",
+            "c" * 40,
+            30.0,
+            3.0,
+            run_source="scheduled_main",
+            baseline_eligible=True,
+        ),
+    ]
+
+    rows = build_latest_summary(records, run_source="pr")
+
+    assert len(rows) == 1
+    assert rows[0]["run_source"] == "pr"
+    assert rows[0]["baseline_n"] == 1
+    assert rows[0]["metrics"]["latency"]["baseline"] == 10.0
+    assert rows[0]["metrics"]["throughput"]["baseline"] == 10.0
+
+
+
 def test_build_latest_summary_keeps_identity_cohorts_separate():
     records = [
         _record(
@@ -247,6 +288,58 @@ def test_build_latest_summary_keeps_variant_versions_separate():
     assert len(rows) == 2
     assert version_2_row["baseline_n"] == 1
     assert version_2_row["metrics"]["latency"]["baseline"] == 20.0
+
+
+def test_dashboard_identity_preserves_zero_benchmark_version():
+    records = [
+        _record(
+            "2026-01-01T00:00:00+00:00",
+            "a" * 40,
+            10.0,
+            10.0,
+            workload_id="wan-t2v",
+            variant_id="1.3b-sp2",
+            benchmark_version=0,
+            recipe_fingerprint="recipe-a",
+            hardware_profile_id="hw-l40s",
+            software_profile_id="sw-cu130",
+            run_source="scheduled_main",
+            baseline_eligible=True,
+        ),
+        _record(
+            "2026-01-02T00:00:00+00:00",
+            "b" * 40,
+            11.0,
+            9.0,
+            workload_id="wan-t2v",
+            variant_id="1.3b-sp2",
+            benchmark_version=0,
+            recipe_fingerprint="recipe-a",
+            hardware_profile_id="hw-l40s",
+            software_profile_id="sw-cu130",
+        ),
+        _record(
+            "2026-01-03T00:00:00+00:00",
+            "c" * 40,
+            20.0,
+            5.0,
+        ),
+    ]
+
+    rows = build_latest_summary(records)
+    version_zero_row = next(row for row in rows if row["benchmark_version"] == 0)
+    legacy_row = next(row for row in rows if row["benchmark_version"] == "")
+    trends = build_trends(records)
+    version_zero_trend = next(trend for trend in trends if trend["benchmark_version"] == 0)
+    legacy_trend = next(trend for trend in trends if trend["benchmark_version"] == "")
+
+    assert len(rows) == 2
+    assert version_zero_row["baseline_n"] == 1
+    assert version_zero_row["metrics"]["latency"]["baseline"] == 10.0
+    assert legacy_row["baseline_n"] == 0
+    assert len(trends) == 2
+    assert version_zero_trend["points"][0]["benchmark_version"] == 0
+    assert legacy_trend["points"][0]["benchmark_version"] == ""
 
 
 def test_filter_records_and_trends_preserve_metric_points():

--- a/fastvideo/tests/performance/test_inference_performance.py
+++ b/fastvideo/tests/performance/test_inference_performance.py
@@ -55,6 +55,9 @@ V2_OPTIONAL_METADATA_FIELDS = (
     "metric_threshold_policy",
     "quality_metadata",
 )
+RESULT_SCHEMA_VERSION = 2
+VALID_RUN_SOURCES = {"pr", "local", "scheduled_main", "unknown"}
+OPTIONAL_RESULT_METADATA_FIELDS = ("quality_metadata", "variant_metadata")
 
 # -- Config discovery -------------------------------------------------------
 
@@ -231,6 +234,7 @@ def _run_generation(generator, prompt, generation_kwargs):
     component_times = _extract_component_times(result)
     return elapsed, peak_memory_mb, component_times
 
+
 def _write_results(results):
     """Write JSON results to the results directory."""
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -351,6 +355,99 @@ def _build_identity_fields(cfg, init_kwargs, prompt, runtime_identity):
     }
 
 
+def _truthy_pr_number(value: str | None) -> bool:
+    return bool(value and value not in {"false", "0", "None", "none"})
+
+
+def _detect_run_source() -> str:
+    explicit = os.environ.get("PERF_RUN_SOURCE", "").strip().lower()
+    if explicit in VALID_RUN_SOURCES:
+        return explicit
+    if _truthy_pr_number(os.environ.get("BUILDKITE_PULL_REQUEST")):
+        return "pr"
+    if os.environ.get("BUILDKITE_BRANCH") == "main" and os.environ.get("TEST_SCOPE") == "full":
+        return "scheduled_main"
+    if not os.environ.get("BUILDKITE_COMMIT"):
+        return "local"
+    return "unknown"
+
+
+def _ci_provenance_fields() -> dict[str, str]:
+    pr_number = os.environ.get("BUILDKITE_PULL_REQUEST", "")
+    if not _truthy_pr_number(pr_number):
+        pr_number = ""
+    return {
+        "run_source": _detect_run_source(),
+        "branch": os.environ.get("BUILDKITE_BRANCH", ""),
+        "pr_number": pr_number,
+        "test_scope": os.environ.get("TEST_SCOPE", ""),
+        "build_url": os.environ.get("BUILDKITE_BUILD_URL", ""),
+        "build_id": os.environ.get("BUILDKITE_BUILD_ID", ""),
+        "job_id": os.environ.get("BUILDKITE_JOB_ID", ""),
+    }
+
+
+def _configured_result_metadata(cfg: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        field: cfg[field]
+        for field in OPTIONAL_RESULT_METADATA_FIELDS
+        if field in cfg and cfg[field] is not None
+    }
+
+
+def _build_result_record(
+    *,
+    cfg: Mapping[str, Any],
+    model_info: Mapping[str, Any],
+    init_kwargs: Mapping[str, Any],
+    gen_kwargs: Mapping[str, Any],
+    num_warmup: int,
+    num_measure: int,
+    thresholds: Mapping[str, Any],
+    times: list[float],
+    peak_memories: list[float],
+    all_component_times: list[dict],
+    prompt: str,
+    runtime_identity: Mapping[str, Any],
+    device_name: str,
+    timestamp: str | None = None,
+) -> dict[str, Any]:
+    avg_time = sum(times) / len(times)
+    max_peak_memory = max(peak_memories)
+    num_frames = gen_kwargs.get("num_frames")
+    throughput_fps = (1.0 / avg_time) if avg_time > 0 else None
+    if isinstance(num_frames, (int, float)) and avg_time > 0:
+        throughput_fps = num_frames / avg_time
+
+    return {
+        "benchmark_id": cfg["benchmark_id"],
+        "result_schema_version": RESULT_SCHEMA_VERSION,
+        "model_short_name": model_info.get("model_short_name", ""),
+        "device": device_name,
+        "num_gpus": init_kwargs.get("num_gpus", 1),
+        "num_warmup_runs": num_warmup,
+        "num_measurement_runs": num_measure,
+        "avg_generation_time_s": round(avg_time, 3),
+        "individual_times_s": [round(t, 3) for t in times],
+        "throughput_fps": round(throughput_fps, 3)
+        if throughput_fps is not None else None,
+        "max_peak_memory_mb": round(max_peak_memory, 1),
+        "individual_peak_memories_mb": [round(m, 1) for m in peak_memories],
+        "thresholds": dict(thresholds),
+        "regression_thresholds": cfg.get("regression_thresholds", {}),
+        "commit": os.environ.get("BUILDKITE_COMMIT", ""),
+        **_ci_provenance_fields(),
+        "timestamp": timestamp or datetime.now(timezone.utc).isoformat(),
+        **_configured_result_metadata(cfg),
+        "text_encoder_time_s": _avg_component(all_component_times,
+                                              "text_encoder_time_s"),
+        "dit_time_s": _avg_component(all_component_times, "dit_time_s"),
+        "vae_decode_time_s": _avg_component(all_component_times,
+                                            "vae_decode_time_s"),
+        **_build_identity_fields(cfg, init_kwargs, prompt, runtime_identity),
+    }
+
+
 # -- Test -------------------------------------------------------------------
 
 def _run_benchmark(cfg):
@@ -414,37 +511,21 @@ def _run_benchmark(cfg):
     avg_time = sum(times) / len(times)
     max_peak_memory = max(peak_memories)
     device_name = torch.cuda.get_device_name()
-    num_frames = gen_kwargs.get("num_frames")
-    throughput_fps = (1.0 / avg_time) if avg_time > 0 else None
-    if isinstance(num_frames, (int, float)) and avg_time > 0:
-        throughput_fps = num_frames / avg_time
-
-    results = {
-        "benchmark_id": cfg["benchmark_id"],
-        **_config_identity_metadata(cfg),
-        "model_short_name": model_info.get("model_short_name", ""),
-        "device": device_name,
-        "num_gpus": init_kwargs.get("num_gpus", 1),
-        "num_warmup_runs": num_warmup,
-        "num_measurement_runs": num_measure,
-        "avg_generation_time_s": round(avg_time, 3),
-        "individual_times_s": [round(t, 3) for t in times],
-        "throughput_fps": round(throughput_fps, 3)
-        if throughput_fps is not None else None,
-        "max_peak_memory_mb": round(max_peak_memory, 1),
-        "individual_peak_memories_mb": [round(m, 1) for m in peak_memories],
-        "thresholds": thresholds,
-        "regression_thresholds": cfg.get("regression_thresholds", {}),
-        "commit": os.environ.get("BUILDKITE_COMMIT", ""),
-        "pr_number": os.environ.get("BUILDKITE_PULL_REQUEST", ""),
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "text_encoder_time_s": _avg_component(all_component_times,
-                                              "text_encoder_time_s"),
-        "dit_time_s": _avg_component(all_component_times, "dit_time_s"),
-        "vae_decode_time_s": _avg_component(all_component_times,
-                                            "vae_decode_time_s"),
-        **_build_identity_fields(cfg, init_kwargs, prompt, runtime_identity),
-    }
+    results = _build_result_record(
+        cfg=cfg,
+        model_info=model_info,
+        init_kwargs=init_kwargs,
+        gen_kwargs=gen_kwargs,
+        num_warmup=num_warmup,
+        num_measure=num_measure,
+        thresholds=thresholds,
+        times=times,
+        peak_memories=peak_memories,
+        all_component_times=all_component_times,
+        prompt=prompt,
+        runtime_identity=runtime_identity,
+        device_name=device_name,
+    )
 
     logger.info(
         "Performance results: avg_time=%.2fs, "

--- a/fastvideo/tests/performance/test_inference_performance.py
+++ b/fastvideo/tests/performance/test_inference_performance.py
@@ -235,6 +235,16 @@ def _run_generation(generator, prompt, generation_kwargs):
     return elapsed, peak_memory_mb, component_times
 
 
+def _validate_run_counts(run_config: Mapping[str, Any], benchmark_id: str) -> tuple[int, int]:
+    num_warmup = run_config.get("num_warmup_runs", 1)
+    num_measure = run_config.get("num_measurement_runs", 3)
+    if isinstance(num_warmup, bool) or not isinstance(num_warmup, int) or num_warmup < 0:
+        raise ValueError(f"{benchmark_id}: run_config.num_warmup_runs must be a non-negative integer")
+    if isinstance(num_measure, bool) or not isinstance(num_measure, int) or num_measure < 1:
+        raise ValueError(f"{benchmark_id}: run_config.num_measurement_runs must be a positive integer")
+    return num_warmup, num_measure
+
+
 def _write_results(results):
     """Write JSON results to the results directory."""
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -412,6 +422,8 @@ def _build_result_record(
     device_name: str,
     timestamp: str | None = None,
 ) -> dict[str, Any]:
+    if not times or not peak_memories:
+        raise ValueError("Cannot build a performance result record without measurement runs")
     avg_time = sum(times) / len(times)
     max_peak_memory = max(peak_memories)
     num_frames = gen_kwargs.get("num_frames")
@@ -463,8 +475,7 @@ def _run_benchmark(cfg):
     prompts = cfg.get("test_prompts", ["A cinematic video."])
     prompt = prompts[0]
 
-    num_warmup = run_config.get("num_warmup_runs", 1)
-    num_measure = run_config.get("num_measurement_runs", 3)
+    num_warmup, num_measure = _validate_run_counts(run_config, cfg["benchmark_id"])
     thresholds = _get_thresholds(cfg)
 
     # Remap JSON keys to VideoGenerator kwargs

--- a/fastvideo/tests/performance/test_inference_performance_result_schema.py
+++ b/fastvideo/tests/performance/test_inference_performance_result_schema.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from fastvideo.tests.performance import test_inference_performance as perf_test
+
+
+def _benchmark_config():
+    return {
+        "benchmark_id": "wan-t2v-1.3b-2gpu",
+        "workload_id": "wan-t2v",
+        "variant_id": "1.3b-sp2",
+        "benchmark_version": 2,
+        "quality_metadata": {
+            "quality_status": "canonical",
+        },
+        "model": {
+            "model_path": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+            "model_short_name": "Wan2.1-T2V-1.3B",
+        },
+        "generation_kwargs": {
+            "num_frames": 45,
+        },
+    }
+
+
+def _identity_fields():
+    return {
+        "workload_id": "wan-t2v",
+        "variant_id": "1.3b-sp2",
+        "benchmark_version": 2,
+        "recipe": {
+            "recipe_schema_version": 1,
+            "benchmark": {
+                "benchmark_id": "wan-t2v-1.3b-2gpu",
+                "workload_id": "wan-t2v",
+                "variant_id": "1.3b-sp2",
+                "benchmark_version": 2,
+            },
+        },
+        "recipe_fingerprint": "recipe-1",
+        "hardware_profile": {
+            "device_type": "cuda",
+            "gpu_count": 2,
+        },
+        "hardware_profile_id": "hw-l40s",
+        "software_profile": {
+            "python": "3.12",
+            "pytorch": "2.12",
+            "cuda": "13.0",
+        },
+        "software_profile_id": "sw-cu130",
+        "environment_metadata": {
+            "env": {
+                "IMAGE_VERSION": "py3.12-cuda13.0.0",
+            },
+        },
+        "environment_fingerprint": "env-ci",
+    }
+
+
+def test_build_result_record_emits_v2_wan_shape(monkeypatch):
+    monkeypatch.setenv("PERF_RUN_SOURCE", "scheduled_main")
+    monkeypatch.setenv("BUILDKITE_COMMIT", "a" * 40)
+    monkeypatch.setenv("BUILDKITE_PULL_REQUEST", "false")
+    monkeypatch.setenv("BUILDKITE_BRANCH", "main")
+    monkeypatch.setenv("TEST_SCOPE", "full")
+    monkeypatch.setenv("BUILDKITE_BUILD_URL", "https://buildkite.example/build")
+    monkeypatch.setenv("BUILDKITE_BUILD_ID", "build-1")
+    monkeypatch.setenv("BUILDKITE_JOB_ID", "job-1")
+    monkeypatch.setattr(perf_test, "_build_identity_fields", lambda *_args: _identity_fields())
+
+    record = perf_test._build_result_record(
+        cfg=_benchmark_config(),
+        model_info={"model_short_name": "Wan2.1-T2V-1.3B"},
+        init_kwargs={"num_gpus": 2},
+        gen_kwargs={"num_frames": 45},
+        num_warmup=2,
+        num_measure=3,
+        thresholds={
+            "max_generation_time_s": 34.0,
+            "max_peak_memory_mb": 11000.0,
+        },
+        times=[30.0, 31.0, 32.0],
+        peak_memories=[10000.0, 10100.0, 10050.0],
+        all_component_times=[
+            {
+                "text_encoder_time_s": 1.0,
+                "dit_time_s": 8.0,
+                "vae_decode_time_s": 3.0,
+            },
+            {
+                "text_encoder_time_s": 1.2,
+                "dit_time_s": 8.2,
+                "vae_decode_time_s": 3.2,
+            },
+            {
+                "text_encoder_time_s": None,
+                "dit_time_s": 8.4,
+                "vae_decode_time_s": 3.4,
+            },
+        ],
+        prompt="A cinematic video.",
+        runtime_identity={
+            "resolved_attention_backend": "FLASH_ATTN",
+        },
+        device_name="NVIDIA L40S",
+        timestamp="2026-07-05T00:00:00+00:00",
+    )
+
+    assert record["result_schema_version"] == perf_test.RESULT_SCHEMA_VERSION
+    assert record["benchmark_id"] == "wan-t2v-1.3b-2gpu"
+    assert record["workload_id"] == "wan-t2v"
+    assert record["variant_id"] == "1.3b-sp2"
+    assert record["benchmark_version"] == 2
+    assert record["recipe_fingerprint"] == "recipe-1"
+    assert record["hardware_profile_id"] == "hw-l40s"
+    assert record["software_profile_id"] == "sw-cu130"
+    assert record["environment_fingerprint"] == "env-ci"
+    assert record["environment_metadata"]["env"]["IMAGE_VERSION"] == "py3.12-cuda13.0.0"
+    assert record["quality_metadata"] == {"quality_status": "canonical"}
+    assert record["run_source"] == "scheduled_main"
+    assert record["branch"] == "main"
+    assert record["test_scope"] == "full"
+    assert record["build_url"] == "https://buildkite.example/build"
+    assert record["build_id"] == "build-1"
+    assert record["job_id"] == "job-1"
+    assert record["pr_number"] == ""
+    assert record["commit"] == "a" * 40
+    assert record["avg_generation_time_s"] == 31.0
+    assert record["throughput_fps"] == 1.452
+    assert record["max_peak_memory_mb"] == 10100.0
+    assert record["text_encoder_time_s"] == 1.1
+    assert record["dit_time_s"] == 8.2
+    assert record["vae_decode_time_s"] == 3.2

--- a/fastvideo/tests/performance/test_inference_performance_result_schema.py
+++ b/fastvideo/tests/performance/test_inference_performance_result_schema.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 from fastvideo.tests.performance import test_inference_performance as perf_test
 
 
@@ -131,3 +133,44 @@ def test_build_result_record_emits_v2_wan_shape(monkeypatch):
     assert record["text_encoder_time_s"] == 1.1
     assert record["dit_time_s"] == 8.2
     assert record["vae_decode_time_s"] == 3.2
+
+
+def test_validate_run_counts_rejects_zero_measurement_runs():
+    with pytest.raises(ValueError, match="num_measurement_runs"):
+        perf_test._validate_run_counts({
+            "num_warmup_runs": 1,
+            "num_measurement_runs": 0,
+        }, "wan-t2v-1.3b-2gpu")
+
+
+def test_validate_run_counts_rejects_negative_warmup_runs():
+    with pytest.raises(ValueError, match="num_warmup_runs"):
+        perf_test._validate_run_counts({
+            "num_warmup_runs": -1,
+            "num_measurement_runs": 3,
+        }, "wan-t2v-1.3b-2gpu")
+
+
+def test_validate_run_counts_returns_defaults():
+    assert perf_test._validate_run_counts({}, "wan-t2v-1.3b-2gpu") == (1, 3)
+
+
+def test_build_result_record_rejects_empty_measurements(monkeypatch):
+    monkeypatch.setattr(perf_test, "_build_identity_fields", lambda *_args: _identity_fields())
+
+    with pytest.raises(ValueError, match="measurement runs"):
+        perf_test._build_result_record(
+            cfg=_benchmark_config(),
+            model_info={},
+            init_kwargs={},
+            gen_kwargs={},
+            num_warmup=0,
+            num_measure=0,
+            thresholds={},
+            times=[],
+            peak_memories=[],
+            all_component_times=[],
+            prompt="A cinematic video.",
+            runtime_identity={},
+            device_name="NVIDIA L40S",
+        )


### PR DESCRIPTION
## Summary

Fixes #1531.

Depends on #1546.

Adds v2 performance result emission and normalization for the performance benchmark flow:

- emits `result_schema_version=2` raw benchmark records with CI provenance, comparable cohort identity, profile fingerprints, component metrics, and optional quality/variant metadata
- preserves v2 fields in normalized records while keeping legacy v1 records readable
- updates dashboard/cohort handling so filtered PR/local summaries do not use future baselines and `benchmark_version=0` stays distinct from missing legacy identity
- tolerates legacy current `perf_*.json` artifacts by skipping v2 rolling-baseline lookup with a warning while still writing normalized artifacts
- validates benchmark measurement counts so zero-measurement configs fail clearly instead of producing empty timing/memory lists
- updates performance benchmark docs for the v2 result schema, full comparison cohort, scheduled-main failure uploads, and legacy-current behavior

## Stacking note

This draft is stacked on #1546 (`issue/1530-fingerprinting-cohorts`). Until #1546 lands and this branch is rebased, the PR diff includes the #1546 fingerprint/cohort commits in addition to the #1531 commits. GitHub keeps this PR based on `main` because the #1546 parent branch is on the fork, not in `hao-ai-lab/FastVideo`.

## Validation

- Modal L40S targeted performance tests: `57 passed, 16 warnings`
  - `ap-q6LSTjMXkchw05Lu5aHSTs`
- Modal 2x L40S Wan performance benchmark path: `1 passed, 24 warnings`
  - `ap-sillVl6g8cjw1YYo0pJwHh`
- Modal L40S dashboard/comparator review-fix tests: `36 passed, 16 warnings`
  - `ap-n9dlyy2vmU6MI1uYLAUEX7`
- Modal L40S legacy-current comparator tests: `16 passed, 16 warnings`
  - `ap-VjbiBeGwFmImnwmxIXr44U`
- Modal L40S measurement-count validation tests: `5 passed, 16 warnings`
  - `ap-nEviwYLPjwlSKYJn9AR5e5`
- Modal L40S rebased-stack performance tests on `0cbbb3b1`: `64 passed, 16 warnings`
  - `ap-V41T4Bs6pjcvZJAYuzAzLX`
- Modal changed-file pre-commit checks passed for each follow-up patch, latest:
  - `ap-uAASsexUEgGCIApGcXc38P`
- Modal L40S `pre-commit run --all-files`: passed on `0cbbb3b1`
  - `ap-zRpXinPP6f7YZTMJxFK7aw`
- `git diff --check` passed.

# Checklist
- [x] I ran pre-commit run --all-files and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes
For model/pipeline changes, also check:
- [ ] I verified targeted Wan T2V SSIM regression tests pass on L40S
- [ ] I updated the support matrix if adding a new model
