### PR TITLE
[ci]: run pre-commit on fork PRs without manual approval

### DIFF
--- a/.github/workflows/ci-precommit.yml
+++ b/.github/workflows/ci-precommit.yml
@@ -1,7 +1,11 @@
 name: pre-commit
 
 on:
-  pull_request:
+  # pull_request_target instead of pull_request: the workflow definition and
+  # the hook config are always taken from the BASE branch, so fork /
+  # first-time-contributor PRs run immediately without a maintainer clicking
+  # "Approve and run". The PR head is checked out as data only.
+  pull_request_target:
     branches: [main]
   workflow_call:
     inputs:
@@ -15,12 +19,25 @@ permissions:
 
 jobs:
   pre-commit:
-    if: github.event_name == 'workflow_call' || github.event.pull_request.draft != true
+    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref || '' }}
+    # For PR events, lint the PR head — but keep the hook definitions from
+    # the base branch so an untrusted PR cannot alter what gets executed.
+    - name: Save trusted hook config
+      if: github.event_name == 'pull_request_target'
+      run: cp .pre-commit-config.yaml "$RUNNER_TEMP/trusted-pre-commit-config.yaml"
+    - uses: actions/checkout@v4
+      if: github.event_name == 'pull_request_target'
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        persist-credentials: false
+    - name: Restore trusted hook config
+      if: github.event_name == 'pull_request_target'
+      run: cp "$RUNNER_TEMP/trusted-pre-commit-config.yaml" .pre-commit-config.yaml
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"


### PR DESCRIPTION
## Problem
Pre-commit is a required check, but for fork PRs from first-time contributors the workflow sits in "awaiting approval" until a maintainer clicks Approve and run — so exactly the PRs that most need the fast lint signal don't get it.

## Solution
Switch the trigger to `pull_request_target`, which runs without approval because the workflow definition comes from the base branch. The PR head is checked out as data only; the base branch's `.pre-commit-config.yaml` is restored on top of it so an untrusted PR cannot alter which hooks execute.

## Why this is safe
- The workflow file itself always comes from the base branch (that's what `pull_request_target` means) — a PR can't modify it.
- Hook definitions come from the trusted base config; all `repo: local` hooks there are inline bash, no repo scripts run.
- The tools that do run against PR code (yapf, ruff, codespell, mypy, actionlint) parse files, they don't execute them.
- `permissions: contents: read`, no secrets referenced, `persist-credentials: false` on the untrusted checkout.
- Buildkite already runs full test suites on fork PR code, so this adds no new execution surface.

## Compatibility
- The `workflow_call` trigger and `ref` input are unchanged — `/test pre-commit` via ci-slash-commands keeps working.
- Job and workflow names unchanged, so the required `pre-commit` status and mergify protections are unaffected.
- Draft PRs still skipped.

Requested by @SolitaryThinker.