### PR TITLE
[ci]: wire fastvideo/tests/ops/ into the unit-test lane

### DIFF
--- a/fastvideo/tests/contract/test_ci_test_collection.py
+++ b/fastvideo/tests/contract/test_ci_test_collection.py
@@ -35,7 +35,6 @@ ALLOWLIST = {
     "hooks": "no lane yet — run manually",
     "layers": "no lane yet — torchrun FSDP dispatch tests, run manually",
     "nightly": "by design: nightly cadence, not per-PR",
-    "ops": "no lane yet — GPU op tests, run manually",
     "modal": "CI infrastructure itself, not a test suite",
 }
 

--- a/fastvideo/tests/modal/pr_test.py
+++ b/fastvideo/tests/modal/pr_test.py
@@ -276,7 +276,7 @@ def run_self_forcing_tests():
 @app.function(gpu="L40S:1", image=image, timeout=900)
 def run_unit_test():
     run_test(
-        "pytest ./fastvideo/tests/api/ ./fastvideo/tests/contract/ ./fastvideo/tests/dataset/ ./fastvideo/tests/workflow/ ./fastvideo/tests/entrypoints/ ./fastvideo/tests/train/ ./fastvideo/tests/stages/ --ignore=./fastvideo/tests/entrypoints/test_openai_api_integration.py --ignore=./fastvideo/tests/train/models --ignore=./fastvideo/tests/train/methods -vs"
+        "pytest ./fastvideo/tests/api/ ./fastvideo/tests/contract/ ./fastvideo/tests/dataset/ ./fastvideo/tests/workflow/ ./fastvideo/tests/entrypoints/ ./fastvideo/tests/train/ ./fastvideo/tests/stages/ ./fastvideo/tests/ops/ --ignore=./fastvideo/tests/entrypoints/test_openai_api_integration.py --ignore=./fastvideo/tests/train/models --ignore=./fastvideo/tests/train/methods -vs"
     )
 
 

--- a/fastvideo/tests/ops/quantization/test_absmax_fp8.py
+++ b/fastvideo/tests/ops/quantization/test_absmax_fp8.py
@@ -34,6 +34,9 @@ class TestAbsMaxFP8LinearMethod(unittest.TestCase):
             method._convert_scale(scale)
 
     def test_create_weights_rejects_invalid_dtype(self):
+        # float64 is outside the supported set (bf16/fp16/fp32). The test
+        # originally passed float32, which create_weights has accepted since
+        # PR #981 — it never ran in CI, so the mismatch went unnoticed.
         method = AbsMaxFP8LinearMethod()
         layer = nn.Module()
         with self.assertRaisesRegex(AssertionError, "only supports"):
@@ -43,7 +46,7 @@ class TestAbsMaxFP8LinearMethod(unittest.TestCase):
                 output_partition_sizes=[3],
                 input_size=2,
                 output_size=3,
-                params_dtype=torch.float32,
+                params_dtype=torch.float64,
             )
 
     def test_absmax_fp8_parameter_weight_loader(self):


### PR DESCRIPTION
## Problem
`fastvideo/tests/ops/` (17 tests: absmax FP8 linear-method coverage plus the NVFP4 lazy-import and LTX-2 NVFP4 wiring contracts) has never run in CI. Three independent reviews on 2026-07-05 flagged it as a dark directory; it was sitting on the allowlist in the CI-collection guard.

## Solution
- Add `./fastvideo/tests/ops/` to the pytest directory list in `run_unit_test` in `fastvideo/tests/modal/pr_test.py` (L40S unit lane).
- Remove the now-stale `ops` entry from the allowlist in `fastvideo/tests/contract/test_ci_test_collection.py`.
- Fix `test_create_weights_rejects_invalid_dtype` in `test_absmax_fp8.py`: it passed `torch.float32` expecting rejection, but the implementation has accepted float32 since PR #981 — the test was born broken and never ran anywhere to reveal it. It now uses `torch.float64`, which is genuinely outside the supported set.

No hardware skip guards were needed: two files are CPU-only by design, and the LTX-2 wiring test needs only a CUDA device (any compute capability — it never invokes the Blackwell/flashinfer kernels), which the L40S lane provides.

## Test evidence
- GB200 (Blackwell, CUDA 13): `python -m pytest fastvideo/tests/ops/ -v -ra` → 17 passed in 0.49s (the first run at the wiring commit surfaced the born-broken assert above; fixed and re-verified green).
- All three guard checks in `test_ci_test_collection.py` pass standalone.
- Adds ~0.5s to the unit lane.