### PR TITLE
[bugfix]: bump FA4 pin to the CuTe DSL 4.6 compatible rev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,7 +68,7 @@ ARG FLASH_ATTN_WHEEL_RELEASE_ARM64=https://github.com/mjun0812/flash-attention-p
 # cutlass-4.4 `cute.core.ThrMma` API, which crashes on the cutlass-dsl 4.5 that
 # flashinfer/quack pull in. After the wheel install we overlay this cutlass-4.5-safe
 # upstream cute (flash-attn-4) so the image runs FA4 instead of the FA2 fallback.
-ARG FA4_CUTE_REF=940cd9680f3315f2f06b43ab5bea2c2cf2d96806
+ARG FA4_CUTE_REF=82d6441eec5d4dfec120153db2c0145ae855a083
 
 # Provided automatically by BuildKit/buildx (e.g. "amd64" / "arm64") and used to
 # select the prebuilt flash-attn wheel. Empty under a plain `docker build` without
@@ -161,7 +161,7 @@ RUN --mount=type=cache,target=/opt/uv/cache \
         uv pip install flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation; \
     fi
 
-# Overlay the cutlass-4.5-safe upstream FA4 cute (FA4_CUTE_REF) over the
+# Overlay the CuTe-DSL-4.6-compatible upstream FA4 cute (FA4_CUTE_REF) over the
 # wheel/source one so the image runs FA4, not the FA2 fallback. This pulls the FA4
 # runtime stack (cutlass-dsl, quack-kernels, apache-tvm-ffi, torch-c-dlpack-ext) --
 # the same deps the [dreamverse] extra already installs in CI; the installed torch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ fastvideo-kernel = [
 imagebind = { git = "https://github.com/facebookresearch/ImageBind.git", rev = "53680b02d7e37b19b124fa37bae4b6c98c38f5be" }
 # FA4 cute, pinned to a cutlass-4.5-compatible revision. torch.compile support
 # comes from FastVideo's own custom_op wrappers.
-flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", rev = "940cd9680f3315f2f06b43ab5bea2c2cf2d96806", subdirectory = "flash_attn/cute" }
+flash-attn-4 = { git = "https://github.com/Dao-AILab/flash-attention.git", rev = "82d6441eec5d4dfec120153db2c0145ae855a083", subdirectory = "flash_attn/cute" }
 
 [project.optional-dependencies]
 


### PR DESCRIPTION
## Problem
The 2026-07-05 CI image rebuild resolved the unpinned transitive `nvidia-cutlass-dsl` to 4.6.0. Our FA4 cute overlay pin (940cd968) is cutlass-4.5-era — its `nvvm.fmax` call signature no longer matches, so the FA4 JIT crashes on every no-grad attention call. With `FASTVIDEO_FA4=1` forced in CI (#1540), **every full-suite lane fails on every PR** regardless of diff (#1505/#1461/#1509 all reproduced the identical fmax TypeError twice; the same crash hit the Kandinsky SSIM lane).

Proof it's the image, not the code: the exact lora-training lane content passes on a GB200 (no FA4 image) at origin/main.

## Solution
Bump both FA4 pins — `FA4_CUTE_REF` in docker/Dockerfile and the `flash-attn-4` rev in pyproject.toml — to upstream `82d6441e` ("Fix compatibility issues with CuTe DSL 4.6.0+", Dao-AILab/flash-attention#2648). Merging auto-rebuilds the image via infra-build-image.yml.

## Risk & rollback
Two-line pin change to upstream's dedicated compat fix; revert one commit. After merge + image rebuild (~1h) I re-trigger the affected PRs' full suites.