### PR TITLE
[bugfix]: free CUDA memory between train-framework model tests (LongCat OOM on L40S)

### DIFF
--- a/fastvideo/distributed/parallel_state.py
+++ b/fastvideo/distributed/parallel_state.py
@@ -23,6 +23,7 @@ If you only need to use the distributed environment without model parallelism,
  you can skip the model parallel initialization and destruction steps.
 """
 import contextlib
+import gc
 import os
 import pickle
 import weakref
@@ -1006,6 +1007,13 @@ def cleanup_dist_env_and_memory(shutdown_ray: bool = False):
     if shutdown_ray:
         import ray  # Lazy import Ray
         ray.shutdown()
+    # Actually free GPU memory, as the name promises. FSDP-wrapped modules sit
+    # in reference cycles (module <-> FSDP state <-> hooks), so dropping the
+    # last user reference does not free their parameters until a gc pass runs.
+    # Without this, back-to-back model-load tests in one pytest session OOM.
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
 
 def get_same_node_ranks(pg: ProcessGroup | StatelessProcessGroup, source_rank: int = 0) -> list[int]:


### PR DESCRIPTION
## Problem

`fastvideo/tests/train/models/test_load_longcat.py::test_longcat_model_loads_and_forwards` OOMs in the Buildkite `test-tube-train-framework-tests` lane on PR full-suite runs (e.g. [build 4104](https://buildkite.com/fastvideo/ci/builds/4104), same on 4099/4100/4103), blocking merges:

```
torch.OutOfMemoryError: CUDA out of memory. Tried to allocate 86.00 MiB.
GPU 0 has a total capacity of 44.39 GiB of which 49.38 MiB is free.
... 42.07 GiB is allocated by PyTorch
```

The lane runs all `fastvideo/tests/train/{models,methods}` tests in one pytest session on a single L40S. LongCat is just the victim: by the time it loads, the Cosmos and Hunyuan (~13B) models from the two preceding tests are still resident on the GPU.

## Root cause

Every test in the lane uses the `distributed_setup` fixture (`fastvideo/tests/conftest.py`), whose teardown calls `cleanup_dist_env_and_memory()`. Despite its name, that function only tore down the process groups — it never freed GPU memory. FSDP-sharded modules sit in reference cycles (module <-> FSDP state <-> hooks), so dropping the last test-local reference does not release their parameters until a `gc` pass happens to run. Whether one runs before the next big model loads is up to the cycle-GC's allocation heuristics — which is why the failure is intermittent and order-dependent.

## Fix

Make `cleanup_dist_env_and_memory()` do what its name says: `gc.collect()` + `torch.cuda.empty_cache()` after destroying the process groups (matching the vLLM function this was ported from). One shared function, so every `distributed_setup` user — and every other caller — gets deterministic cleanup.

## Verification (GB200, single pytest session, same selection as the CI lane)

Ran `pytest fastvideo/tests/train/models fastvideo/tests/train/methods -v -s` with a temporary plugin printing `torch.cuda.memory_allocated()` after each test's teardown.

Before (origin/main @ a25313be) — memory accumulates monotonically, `18:09` runtime:

```
after test_load_cosmos:      allocated= 3.91 GiB
after test_load_hunyuan:     allocated=27.80 GiB
after test_load_longcat:     allocated=25.33 GiB   <- would OOM a 44.39 GiB L40S mid-load
after test_load_wan_causal:  allocated= 8.74 GiB  reserved=30.41 GiB
after test_wan_finetune:     allocated=26.51 GiB  reserved=82.31 GiB
```

After (this branch) — every model-load test returns to baseline, `4:30` runtime:

```
after test_load_cosmos:      allocated=0.03 GiB
after test_load_hunyuan:     allocated=0.03 GiB
after test_load_longcat:     allocated=0.03 GiB
after test_load_wan_causal:  allocated=0.03 GiB
after test_wan_finetune:     allocated=0.06 GiB  reserved=0.22 GiB
```

Both runs finish `1 failed, 8 passed, 1 skipped` — identical pass/fail pattern before and after the fix, so no regressions. (The one failure, `test_matrixgame2_finetune`, is a pre-existing environment gap on the verification cluster — `FileNotFoundError: No parquet files found under dataset path` — present on origin/main too; that test is skipped on the L40S CI runner.)
