### PR TITLE
[misc]: reserve CPU/memory for timing-sensitive Modal CI lanes

### DIFF
--- a/fastvideo/tests/modal/pr_test.py
+++ b/fastvideo/tests/modal/pr_test.py
@@ -187,6 +187,8 @@ def run_transformer_tests():
 
 
 @app.function(gpu="L40S:4",
+              cpu=8.0,
+              memory=32768,
               image=image,
               timeout=900,
               secrets=[
@@ -201,6 +203,8 @@ def run_training_tests():
 
 
 @app.function(gpu="L40S:2",
+              cpu=8.0,
+              memory=32768,
               image=image,
               timeout=900,
               secrets=[
@@ -318,6 +322,8 @@ def run_dreamverse_app_tests():
 
 
 @app.function(gpu="L40S:1",
+              cpu=8.0,
+              memory=32768,
               image=image,
               timeout=1800,
               secrets=[
@@ -400,6 +406,8 @@ def run_lora_extraction_tests():
 
 
 @app.function(gpu="L40S:2",
+              cpu=8.0,
+              memory=32768,
               image=image,
               timeout=1800,
               secrets=[


### PR DESCRIPTION
## Problem

The perf, training, lora-training, and train-framework lanes gate on wall-time or run near the memory limit, but request no explicit CPU. On a packed Modal host the container is starved and compute phases run ~1.7x slow at full GPU clocks — proven by telemetry on #1538 (SM clocks pinned at 2505-2520/2520 MHz, power 100W under limit, yet DiT 82% over baseline). This caused the recurring perf-gate failures, training step-time assertion failures, and lora-lane timeouts across #1505/#1488/#1494/#1471.

## Fix

Add `cpu=8.0, memory=32768` to the four @app.function decorators: run_training_tests, run_training_lora_tests, run_train_framework_tests, run_performance_tests. Nothing else.

## Evidence

The identical change on #1538's perf function (02de503d) took its lane from 4 consecutive failures to green in one run. #1538 carries the perf-function hunk on its branch — whichever merges second rebases trivially.

Approved as maintainer review r29.