### PR TITLE
[bugfix]: retry remote image downloads in load_image

### DIFF
--- a/fastvideo/models/vision_utils.py
+++ b/fastvideo/models/vision_utils.py
@@ -111,6 +111,13 @@ def _fetch_image_bytes(url: str,
             response.raise_for_status()
             return response.content
         except requests.RequestException as e:
+            status = getattr(getattr(e, "response", None), "status_code",
+                             None)
+            # Permanent client errors (4xx except 408/429) won't heal on
+            # retry — fail fast.
+            if (status is not None and 400 <= status < 500
+                    and status not in (408, 429)):
+                raise
             if attempt == attempts - 1:
                 raise
             backoff = 2**attempt

--- a/fastvideo/models/vision_utils.py
+++ b/fastvideo/models/vision_utils.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import io
 import os
 import tempfile
+import time
 from collections.abc import Callable
 from typing import Any
 from urllib.parse import unquote, urlparse
@@ -15,6 +17,10 @@ import torch
 import torch.nn.functional as F
 import torchvision.transforms.functional as TF
 from packaging import version
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
 
 if version.parse(version.parse(
         PIL.__version__).base_version) >= version.parse("9.1.0"):
@@ -89,6 +95,32 @@ def normalize(images: np.ndarray | torch.Tensor) -> np.ndarray | torch.Tensor:
     return 2.0 * images - 1.0
 
 
+def _fetch_image_bytes(url: str,
+                       attempts: int = 3,
+                       timeout: float = 30.0) -> bytes:
+    """Download ``url`` fully, retrying transient network errors.
+
+    Reads the whole body via ``response.content`` instead of handing PIL a
+    ``.raw`` stream: a connection dropped mid-body (e.g. an HF-CDN
+    ``IncompleteRead``) then fails here, where it can be retried, instead of
+    surfacing as a truncated image inside PIL.
+    """
+    for attempt in range(attempts):
+        try:
+            response = requests.get(url, timeout=timeout)
+            response.raise_for_status()
+            return response.content
+        except requests.RequestException as e:
+            if attempt == attempts - 1:
+                raise
+            backoff = 2**attempt
+            logger.warning(
+                "Failed to download image %s (attempt %d/%d): %s. "
+                "Retrying in %ds.", url, attempt + 1, attempts, e, backoff)
+            time.sleep(backoff)
+    raise AssertionError("unreachable")
+
+
 # adapted from diffusers.utils import load_image
 def load_image(
     image: str | PIL.Image.Image,
@@ -110,7 +142,7 @@ def load_image(
     """
     if isinstance(image, str):
         if image.startswith("http://") or image.startswith("https://"):
-            image = PIL.Image.open(requests.get(image, stream=True).raw)
+            image = PIL.Image.open(io.BytesIO(_fetch_image_bytes(image)))
         elif os.path.isfile(image):
             image = PIL.Image.open(image)
         else:

--- a/fastvideo/tests/dataset/test_load_image_retry.py
+++ b/fastvideo/tests/dataset/test_load_image_retry.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only tests for load_image URL retry behavior.
+
+A HF-CDN IncompleteRead mid-body previously killed SSIM runs (build 4202,
+test_wan_i2v) because load_image handed PIL a partial ``.raw`` stream with no
+retry. These tests mock requests.get: a transient failure must be retried and
+a full-body success must yield a usable PIL image.
+"""
+import io
+from unittest import mock
+
+import PIL.Image
+import pytest
+import requests
+
+from fastvideo.models import vision_utils
+
+URL = "https://example.com/image.png"
+
+
+def _png_bytes() -> bytes:
+    buf = io.BytesIO()
+    PIL.Image.new("RGB", (4, 4), (255, 0, 0)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _good_response() -> mock.Mock:
+    response = mock.Mock()
+    response.content = _png_bytes()
+    response.raise_for_status = mock.Mock()
+    return response
+
+
+def test_load_image_retries_transient_error_then_succeeds(monkeypatch):
+    monkeypatch.setattr(vision_utils.time, "sleep", lambda _s: None)
+    get = mock.Mock(side_effect=[
+        # The shape that broke build 4202: connection dropped mid-body.
+        requests.exceptions.ChunkedEncodingError(
+            "IncompleteRead(1024 bytes read, 2048 more expected)"),
+        _good_response(),
+    ])
+    monkeypatch.setattr(vision_utils.requests, "get", get)
+
+    image = vision_utils.load_image(URL)
+
+    assert get.call_count == 2
+    assert get.call_args.kwargs["timeout"] == 30.0
+    assert isinstance(image, PIL.Image.Image)
+    assert image.size == (4, 4)
+    assert image.mode == "RGB"
+
+
+def test_load_image_raises_after_exhausting_retries(monkeypatch):
+    sleeps: list[float] = []
+    monkeypatch.setattr(vision_utils.time, "sleep", sleeps.append)
+    get = mock.Mock(
+        side_effect=requests.exceptions.ConnectionError("connection reset"))
+    monkeypatch.setattr(vision_utils.requests, "get", get)
+
+    with pytest.raises(requests.exceptions.ConnectionError):
+        vision_utils.load_image(URL)
+
+    assert get.call_count == 3
+    assert sleeps == [1, 2]

--- a/fastvideo/tests/dataset/test_load_image_retry.py
+++ b/fastvideo/tests/dataset/test_load_image_retry.py
@@ -62,3 +62,19 @@ def test_load_image_raises_after_exhausting_retries(monkeypatch):
 
     assert get.call_count == 3
     assert sleeps == [1, 2]
+
+
+def test_load_image_does_not_retry_on_client_error(monkeypatch):
+    sleeps: list[float] = []
+    monkeypatch.setattr(vision_utils.time, "sleep", sleeps.append)
+    response = mock.Mock(status_code=404)
+    error = requests.HTTPError("404 Client Error", response=response)
+    response.raise_for_status.side_effect = error
+    get = mock.Mock(return_value=response)
+    monkeypatch.setattr(vision_utils.requests, "get", get)
+
+    with pytest.raises(requests.HTTPError):
+        vision_utils.load_image("https://example.com/missing.png")
+
+    assert get.call_count == 1
+    assert sleeps == []


### PR DESCRIPTION
## Problem

load_image in fastvideo/models/vision_utils.py fetched remote images with a bare requests.get(image, stream=True).raw — no timeout, no retry, and PIL consumed a partial stream. On PR #1488 (build 4202, test_wan_i2v), an HF-CDN IncompleteRead mid-body killed an otherwise-green SSIM lane (triage signature 12). All image-loading callers (validation_dataset, input_validation stage, LTX-2 image conditioning) route through this one function.

## Fix

- New _fetch_image_bytes: per-request 30s timeout, raise_for_status(), and the FULL body via response.content — a mid-body drop now raises inside the helper where it can be retried, instead of surfacing as a truncated image inside PIL.
- Bounded retry: 3 attempts, exponential backoff (1s/2s), warning log per retry, original exception re-raised on final failure.
- No new deps; local-path and PIL-input branches unchanged.

## Testing

CPU unit tests in fastvideo/tests/dataset/test_load_image_retry.py (collected by the unit lane): mocked requests.get reproducing the exact IncompleteRead failure shape then succeeding (asserts one retry, timeout passed, RGB image loads), and retry exhaustion (asserts 3 attempts, 1s/2s backoff, exception propagates). pytest fastvideo/tests/dataset/: 10 passed.

Approved as maintainer review r36.