### PR TITLE
[bugfix] Skip CUDA-only fastvideo-kernel/flashinfer-python deps on non-Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,10 @@ dependencies = [
     "torch==2.12.0",
     "torchvision",
     "torchaudio",
-    "flashinfer-python",
+    # CUDA-only: no wheels for non-Linux platforms, and the sdist build shells
+    # out to nvcc unconditionally. Gate on sys_platform so installs on macOS
+    # (MPS) and other non-Linux platforms don't try to build it from source.
+    "flashinfer-python; sys_platform == 'linux'",
 
     # Acceleration & Optimization
     "accelerate==1.0.1",
@@ -73,7 +76,12 @@ dependencies = [
     "remote-pdb",
 
     # Kernel & Packaging
-    "fastvideo-kernel==0.3.2",
+    # CUDA-only: PyPI only publishes manylinux wheels, and the sdist build
+    # requires nvcc via CMake. Gate on sys_platform so installs on macOS
+    # (MPS) and other non-Linux platforms don't try to build it from source;
+    # every fastvideo_kernel import elsewhere is already guarded to degrade
+    # gracefully when the package is absent.
+    "fastvideo-kernel==0.3.2; sys_platform == 'linux'",
     "wheel",
 
     # Training Dependencies


### PR DESCRIPTION
## Summary

- `fastvideo-kernel` and `flashinfer-python` are listed as unconditional dependencies in `pyproject.toml`, but both are CUDA-only native packages with no install path on non-Linux platforms:
  - `fastvideo-kernel` only publishes manylinux wheels on PyPI; its sdist build requires `nvcc` via CMake.
  - `flashinfer-python` publishes **no wheels at all** (source-only), and its sdist build shells out to `nvcc` directly.
- As a result, `uv pip install -e .` fails on macOS even though `docs/getting_started/installation/mps.md` documents that exact command for Apple Silicon.
- Every import of `fastvideo_kernel`/`flashinfer` in the codebase is already guarded (`try/except ImportError` or `importlib.util.find_spec`), so the package is designed to degrade gracefully without them — this is purely a packaging-metadata gap, not a functional dependency.
- This gates both packages on `sys_platform == 'linux'`, matching the existing platform-marker convention already used for `fastvideo-kernel`'s local source path in `[tool.uv.sources]` (for the DGX Spark aarch64 case). Linux+CUDA installs are unaffected.

## Test plan

- [x] Clean `uv venv --python 3.12 --seed` + `uv pip install -e ".[dev]"` on arm64 macOS completes without attempting to build either package.
- [x] `import fastvideo, torch` succeeds; `torch.backends.mps.is_available()` is `True`.
- [x] `fastvideo --help` runs successfully.
- [x] `pre-commit run --files pyproject.toml` passes.
- [ ] Linux+CUDA install path (unaffected by this change, but should be confirmed by CI/a maintainer since I don't have Linux+CUDA hardware to test on).