### PR TITLE
[ci] Trigger performance benchmarks for performance code changes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -481,6 +481,7 @@ steps:
                 - "fastvideo/layers/**"
                 - "fastvideo/worker/**"
                 - "fastvideo/entrypoints/**"
+                - "fastvideo/performance/**"
                 - "fastvideo/tests/performance/**"
                 - ".buildkite/performance-benchmarks/**"
                 - "pyproject.toml"


### PR DESCRIPTION
[bugfix]   Ensure Buildkite performance benchmark CI runs when files under `fastvideo/performance/**` change in the Full suite lane.