### PR TITLE
[bugfix]: keep LTX2 rms_norm outputs bf16 under torch 2.12 autocast

### DIFF
--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -72,8 +72,13 @@ def _rms_norm_dispatch(
     """Use QuACK RMSNorm only for LTX-2 refine stage, else Torch RMSNorm."""
     if _is_ltx2_refine_stage():
         return _quack_rmsnorm(x, weight=weight, eps=eps)
+    # Official LTX-2 runs the DiT natively in bf16 with no autocast, so its
+    # rms_norm outputs stay bf16 on every torch version. torch 2.12 added
+    # rms_norm to autocast's float32 cast policy, which under our
+    # autocast(bfloat16) forward returns float32 instead. Restore the input
+    # dtype to match the official numerics (and torch <= 2.11 behavior).
     return torch.nn.functional.rms_norm(
-        x, (x.shape[-1], ), weight=weight, eps=eps)
+        x, (x.shape[-1], ), weight=weight, eps=eps).to(x.dtype)
 
 
 class StageAwareRMSNorm(nn.RMSNorm):


### PR DESCRIPTION
## Problem

torch 2.12 added `rms_norm` to autocast's float32 cast policy. Our LTX2 forward runs under autocast(bf16), so `_rms_norm_dispatch` (the scale-shift/ada-LN path) silently switched from bf16 to fp32 outputs. Official LTX-2 (Lightricks) runs the DiT natively in bf16 with **no autocast** — its rms_norm outputs are bf16 on every torch version — so we drifted from the reference implementation's numerics by accident.

## Solution

Downcast `_rms_norm_dispatch`'s output to the input dtype, matching the q/k norms (`StageAwareRMSNorm`) which already do this, and matching official numerics ("fp32 math, bf16 out" — identical to torch <= 2.11 autocast behavior). One line + comment.

Two-stack note: shared forward path — training under autocast(bf16) on torch 2.12 also drifted to fp32 rms_norm; this restores pre-2.12 numerics for both stacks.

## Known expected-red

The current LTX2-Distilled SSIM references encode the accidental fp32 numerics (proven: this fix diverges from them, slice cosine 0.34 vs 5e-3 — build 4189). The SSIM lane on this PR is **expected red until the references are re-seeded**; the reseed is deliberately deferred (maintainer review r32: "open PR but do not reseed").

Research record: official repo has zero dtype handling in rms_norm (`ltx_core/utils.py`), bare `nn.RMSNorm` q/k norms, `torch~=2.7` pin, autocast only around the audio vocoder.
