### PR TITLE
[ci]: skip the gate self-test on PR heads that predate the gate

### DIFF
--- a/.github/workflows/ci-precommit.yml
+++ b/.github/workflows/ci-precommit.yml
@@ -49,4 +49,12 @@ jobs:
         extra_args: --all-files --hook-stage manual
     # After pre-commit so a self-test failure cannot mask lint failures.
     - name: Full-suite gate self-test
-      run: bash .github/scripts/test_gate_full_suite.sh
+      # Guard: PR heads branched before the gate landed lack the script
+      # (workflow file comes from the merge context, checkout from the
+      # head) — nothing to self-test there.
+      run: |
+        if [ -f .github/scripts/test_gate_full_suite.sh ]; then
+          bash .github/scripts/test_gate_full_suite.sh
+        else
+          echo "gate self-test script not on this head (pre-gate branch) — skipping"
+        fi


### PR DESCRIPTION
## Problem

Since #1572 merged, every PR whose branch was cut **before** it fails the pre-commit lane with exit 127: the "Full-suite gate self-test" step comes from the merge-context workflow file, but `bash` runs against the checked-out PR **head** (ci-precommit.yml checks out `pull_request.head.sha`), where `.github/scripts/test_gate_full_suite.sh` doesn't exist. Found on #1587; affects any pre-#1572 branch.

## Solution

One guard: run the self-test only when the script exists on the head; otherwise print a skip notice. Semantics are right — the self-test guards the gate script, and a head without the gate script has nothing to test. Heads that DO have the script (post-#1572 branches and main itself) still run it unconditionally.

Fixes a breakage introduced by my own #1572 fix wave; the author directed "fix pre-commit" on the affected PR.
