### PR TITLE
Add flaky GPU test retry

### DIFF
--- a/fastvideo/tests/modal/pr_test.py
+++ b/fastvideo/tests/modal/pr_test.py
@@ -86,6 +86,7 @@ wandb_secret = modal.Secret.from_dict(
 
 def run_test(pytest_command: str):
     """Helper function to run a test suite with custom pytest command"""
+    pytest_command += ' --reruns 2 --reruns-delay 10 --only-rerun "CUDA error|NCCL|out of memory|RuntimeError: CUDA"'
     run_test_command(pytest_command, build_kernel=True)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ lint = [
 test = [
     "av",
     "pytorch-msssim>=1.0.0",
+    "pytest-rerunfailures",
     "pytest",
     "pandas",
     "plotly",


### PR DESCRIPTION
## Summary

Implemented the T7: Flaky GPU Test Retry changes locally to understand the FastVideo CI workflow.

Changes:
- Added `pytest-rerunfailures` dependency in `pyproject.toml`
- Added transient GPU error retry arguments to pytest commands in `fastvideo/tests/modal/pr_test.py`
- Limited retries to CUDA/NCCL/OOM related failures only

## Testing

Not run locally because Modal GPU CI environment is required.

## Notes

This PR was created as a learning exercise while tracing the Buildkite → Modal → pytest workflow.
