### PR TITLE
[bugfix]: fix FlashAttention resolver tests after tuple return

### DIFF
--- a/fastvideo/tests/attention/test_flash_attn_no_pad_resolver.py
+++ b/fastvideo/tests/attention/test_flash_attn_no_pad_resolver.py
@@ -50,9 +50,10 @@ def test_resolver_skips_cute_without_opt_in(monkeypatch) -> None:
     monkeypatch.setattr(builtins, "__import__", spying_import)
 
     mod = _reload_resolver_module()
-    resolved = mod._resolve_flash_attn_varlen_func()
+    resolved, version = mod._resolve_flash_attn_varlen_func()
     assert resolved is not None
     assert resolved.__name__ == "flash_attn_varlen_func"
+    assert version in ("2", "3")
     assert "fastvideo.attention.utils.flash_attn_cute" not in attempted
 
 
@@ -92,9 +93,10 @@ def test_resolver_returns_flash_attn_when_interface_unavailable(monkeypatch) -> 
     monkeypatch.setattr(builtins, "__import__", patched_import)
 
     mod = _reload_resolver_module()
-    resolved = mod._resolve_flash_attn_varlen_func()
+    resolved, version = mod._resolve_flash_attn_varlen_func()
     assert resolved is not None
     assert resolved.__module__.startswith("flash_attn")
+    assert version == "2"
 
 
 def test_module_level_impl_is_resolver_output() -> None:


### PR DESCRIPTION
## Summary

- unpack the `(function, FlashAttention version)` tuple returned by `_resolve_flash_attn_varlen_func()` in its two stale resolver tests
- assert the selected FA version alongside the existing function assertions
- restore the post-#1388 microscope unit lane without touching production code

This is the semantic test conflict between #1388's tuple-return change and #1540's resolver tests. Current main `c1abc427` still contains both stale assertions.

## Test evidence

- `git range-diff 0c63528c..5d36f835 c1abc427..d140b465`: clean (`=`)
- `git diff --check origin/main..d140b465`: pass
- `python -m py_compile fastvideo/tests/attention/test_flash_attn_no_pad_resolver.py`: pass
- no local pytest on macOS; the microscope unit lane is the runtime proof

## Risk and rollback

Test-only change. Revert the single commit to roll back.

Prior failure: https://buildkite.com/fastvideo/pr-fastcheck/builds/671
