### PR TITLE
[perf]: enable per-block torch.compile for LTX2 with persistent cache

### DIFF
--- a/apps/dreamverse/scripts/launch/launch_backend_dreamverse.sh
+++ b/apps/dreamverse/scripts/launch/launch_backend_dreamverse.sh
@@ -39,15 +39,16 @@ export FASTVIDEO_GENERATION_SEGMENT_CAP="${FASTVIDEO_GENERATION_SEGMENT_CAP:-6}"
 export FASTVIDEO_PROMPT_AUTO_SLEEP_MS="${FASTVIDEO_PROMPT_AUTO_SLEEP_MS:-120}"
 export FASTVIDEO_PROMPT_AUTO_TIMEOUT_MS="${FASTVIDEO_PROMPT_AUTO_TIMEOUT_MS:-1800}"
 
-# Persistent torch.compile cache so warmup pays the full autotune/codegen cost only on the first launch.
-# Later launches on the same box reload the Inductor FX-graph + AOTAutograd + Triton artifacts from disk.
-export DREAMVERSE_TORCH_COMPILE_CACHE_ROOT="${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT:-${HOME}/.cache/dreamverse/torch_compile}"
-export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT}/inductor}"
-export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT}/triton}"
-export TORCHINDUCTOR_FX_GRAPH_CACHE="${TORCHINDUCTOR_FX_GRAPH_CACHE:-1}"
-export TORCHINDUCTOR_AUTOGRAD_CACHE="${TORCHINDUCTOR_AUTOGRAD_CACHE:-1}"
-mkdir -p "${TORCHINDUCTOR_CACHE_DIR}" "${TRITON_CACHE_DIR}"
-echo "[launch-demo] torch.compile cache: ${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT} (first launch builds it, later launches reload it)"
+if [[ "${ENABLE_TORCH_COMPILE}" == "1" ]]; then
+  # Persist Inductor, AOTAutograd, and Triton artifacts across launches.
+  export DREAMVERSE_TORCH_COMPILE_CACHE_ROOT="${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT:-${HOME}/.cache/dreamverse/torch_compile}"
+  export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT}/inductor}"
+  export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT}/triton}"
+  export TORCHINDUCTOR_FX_GRAPH_CACHE="${TORCHINDUCTOR_FX_GRAPH_CACHE:-1}"
+  export TORCHINDUCTOR_AUTOGRAD_CACHE="${TORCHINDUCTOR_AUTOGRAD_CACHE:-1}"
+  mkdir -p "${TORCHINDUCTOR_CACHE_DIR}" "${TRITON_CACHE_DIR}"
+  echo "[launch-demo] torch.compile cache: ${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT}"
+fi
 
 cd "${DREAMVERSE_ROOT}"
 

--- a/apps/dreamverse/scripts/launch/launch_backend_dreamverse.sh
+++ b/apps/dreamverse/scripts/launch/launch_backend_dreamverse.sh
@@ -40,7 +40,7 @@ export FASTVIDEO_PROMPT_AUTO_SLEEP_MS="${FASTVIDEO_PROMPT_AUTO_SLEEP_MS:-120}"
 export FASTVIDEO_PROMPT_AUTO_TIMEOUT_MS="${FASTVIDEO_PROMPT_AUTO_TIMEOUT_MS:-1800}"
 
 # Persistent torch.compile cache so warmup pays the full autotune/codegen cost only on the first launch.
-# This allows later launches on the same box reload the Inductor FX-graph + AOTAutograd + Triton artifacts from disk
+# Later launches on the same box reload the Inductor FX-graph + AOTAutograd + Triton artifacts from disk.
 export DREAMVERSE_TORCH_COMPILE_CACHE_ROOT="${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT:-${HOME}/.cache/dreamverse/torch_compile}"
 export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT}/inductor}"
 export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT}/triton}"

--- a/apps/dreamverse/scripts/launch/launch_backend_dreamverse.sh
+++ b/apps/dreamverse/scripts/launch/launch_backend_dreamverse.sh
@@ -39,6 +39,16 @@ export FASTVIDEO_GENERATION_SEGMENT_CAP="${FASTVIDEO_GENERATION_SEGMENT_CAP:-6}"
 export FASTVIDEO_PROMPT_AUTO_SLEEP_MS="${FASTVIDEO_PROMPT_AUTO_SLEEP_MS:-120}"
 export FASTVIDEO_PROMPT_AUTO_TIMEOUT_MS="${FASTVIDEO_PROMPT_AUTO_TIMEOUT_MS:-1800}"
 
+# Persistent torch.compile cache so warmup pays the full autotune/codegen cost only on the first launch.
+# This allows later launches on the same box reload the Inductor FX-graph + AOTAutograd + Triton artifacts from disk
+export DREAMVERSE_TORCH_COMPILE_CACHE_ROOT="${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT:-${HOME}/.cache/dreamverse/torch_compile}"
+export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT}/inductor}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT}/triton}"
+export TORCHINDUCTOR_FX_GRAPH_CACHE="${TORCHINDUCTOR_FX_GRAPH_CACHE:-1}"
+export TORCHINDUCTOR_AUTOGRAD_CACHE="${TORCHINDUCTOR_AUTOGRAD_CACHE:-1}"
+mkdir -p "${TORCHINDUCTOR_CACHE_DIR}" "${TRITON_CACHE_DIR}"
+echo "[launch-demo] torch.compile cache: ${DREAMVERSE_TORCH_COMPILE_CACHE_ROOT} (first launch builds it, later launches reload it)"
+
 cd "${DREAMVERSE_ROOT}"
 
 if ! command -v dreamverse-server >/dev/null 2>&1; then

--- a/fastvideo/attention/backends/flash_attn.py
+++ b/fastvideo/attention/backends/flash_attn.py
@@ -180,7 +180,8 @@ class FlashAttentionImpl(AttentionImpl):
         # SP). Cast through bf16 and restore, matching TORCH_SDPA's tolerance.
         orig_dtype = query.dtype
         if orig_dtype not in (torch.float16, torch.bfloat16):
-            # we keep logging and its Python lru_cache out of compiled traces so that the AOTAutograd cache can serialize.
+            # Keep logging (and its Python lru_cache) out of compiled traces
+            # so that the AOTAutograd cache can serialize.
             if not torch.compiler.is_compiling():
                 logger.warning_once(f"FLASH_ATTN received {orig_dtype} inputs; casting to "
                                     f"bfloat16 for the kernel and restoring on output.")

--- a/fastvideo/attention/backends/flash_attn.py
+++ b/fastvideo/attention/backends/flash_attn.py
@@ -180,8 +180,10 @@ class FlashAttentionImpl(AttentionImpl):
         # SP). Cast through bf16 and restore, matching TORCH_SDPA's tolerance.
         orig_dtype = query.dtype
         if orig_dtype not in (torch.float16, torch.bfloat16):
-            logger.warning_once(f"FLASH_ATTN received {orig_dtype} inputs; casting to "
-                                f"bfloat16 for the kernel and restoring on output.")
+            # we keep logging and its Python lru_cache out of compiled traces so that the AOTAutograd cache can serialize.
+            if not torch.compiler.is_compiling():
+                logger.warning_once(f"FLASH_ATTN received {orig_dtype} inputs; casting to "
+                                    f"bfloat16 for the kernel and restoring on output.")
             query = query.to(torch.bfloat16)
             key = key.to(torch.bfloat16)
             value = value.to(torch.bfloat16)

--- a/fastvideo/attention/utils/flash_attn_cute.py
+++ b/fastvideo/attention/utils/flash_attn_cute.py
@@ -51,7 +51,7 @@ def _check_dropout(dropout_p: float) -> None:
 
 
 def _sm90_or_newer() -> bool:
-    # compiled callers only read a boolean nstead of tracing through a memoized platform query.
+    # Compiled callers only read a boolean instead of tracing through a memoized platform query.
     return _IS_SM90_OR_NEWER
 
 

--- a/fastvideo/attention/utils/flash_attn_cute.py
+++ b/fastvideo/attention/utils/flash_attn_cute.py
@@ -42,7 +42,8 @@ except ImportError:
     _flash_attn_2_func = None
     _flash_attn_2_varlen_func = None
 
-_IS_SM90_OR_NEWER = current_platform.has_device_capability(90)
+# Dynamo unwraps functools caches, so keep this cache inside the opaque helper.
+_SM90_OR_NEWER_BY_DEVICE: dict[int, bool] = {}
 
 
 def _check_dropout(dropout_p: float) -> None:
@@ -50,13 +51,17 @@ def _check_dropout(dropout_p: float) -> None:
         raise NotImplementedError(f"flash_attn.cute does not support dropout (got dropout_p={dropout_p})")
 
 
-def _sm90_or_newer() -> bool:
-    # Compiled callers only read a boolean instead of tracing through a memoized platform query.
-    return _IS_SM90_OR_NEWER
+@torch.compiler.assume_constant_result
+def _sm90_or_newer(device_id: int) -> bool:
+    if device_id not in _SM90_OR_NEWER_BY_DEVICE:
+        _SM90_OR_NEWER_BY_DEVICE[device_id] = (current_platform.has_device_capability(90, device_id))
+    return _SM90_OR_NEWER_BY_DEVICE[device_id]
 
 
 def _use_fa2(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> bool:
-    if _sm90_or_newer():
+    device_id = q.device.index
+    assert device_id is not None
+    if _sm90_or_newer(device_id):
         return False
     # Pre-sm90 FA4 cute limitations, both served by FA2 (deterministic
     # capability gate, not a runtime fallback):

--- a/fastvideo/attention/utils/flash_attn_cute.py
+++ b/fastvideo/attention/utils/flash_attn_cute.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import functools
 from collections.abc import Callable
 
 import torch
@@ -43,15 +42,17 @@ except ImportError:
     _flash_attn_2_func = None
     _flash_attn_2_varlen_func = None
 
+_IS_SM90_OR_NEWER = current_platform.has_device_capability(90)
+
 
 def _check_dropout(dropout_p: float) -> None:
     if dropout_p != 0.0:
         raise NotImplementedError(f"flash_attn.cute does not support dropout (got dropout_p={dropout_p})")
 
 
-@functools.cache
 def _sm90_or_newer() -> bool:
-    return current_platform.has_device_capability(90)
+    # compiled callers only read a boolean nstead of tracing through a memoized platform query.
+    return _IS_SM90_OR_NEWER
 
 
 def _use_fa2(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> bool:

--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -5,6 +5,7 @@ LTX-2 transformer implementation
 
 from dataclasses import dataclass, replace
 from enum import Enum
+import functools
 import math
 import os
 from pathlib import Path
@@ -767,14 +768,9 @@ def _apply_ltx_split_rotary_emb(
     return output
 
 
-def generate_ltx_freq_grid_float64(
+def _generate_ltx_freq_grid_float64(
     positional_embedding_theta: float, positional_embedding_max_pos_count: int, inner_dim: int
 ) -> torch.Tensor:
-    """Generate LTX-2 rotary frequencies with float64 precision.
-
-    Implemented in pure torch and free of Python memoization so it is safe
-    for callers that may be captured and reused by torch.compile.
-    """
     theta = positional_embedding_theta
     start = 1
     end = theta
@@ -791,10 +787,24 @@ def generate_ltx_freq_grid_float64(
     return (pow_indices * math.pi / 2).to(dtype=torch.float32)
 
 
-def generate_ltx_freq_grid_pytorch(
+_cached_generate_ltx_freq_grid_float64 = functools.lru_cache(maxsize=5)(
+    _generate_ltx_freq_grid_float64)
+
+
+def generate_ltx_freq_grid_float64(
     positional_embedding_theta: float, positional_embedding_max_pos_count: int, inner_dim: int
 ) -> torch.Tensor:
-    """Generate LTX-2 rotary frequencies in torch for speed."""
+    """Generate an eager-cached, compile-safe float64 LTX-2 rotary grid."""
+    if torch.compiler.is_compiling():
+        return _generate_ltx_freq_grid_float64(
+            positional_embedding_theta, positional_embedding_max_pos_count, inner_dim)
+    return _cached_generate_ltx_freq_grid_float64(
+        positional_embedding_theta, positional_embedding_max_pos_count, inner_dim)
+
+
+def _generate_ltx_freq_grid_pytorch(
+    positional_embedding_theta: float, positional_embedding_max_pos_count: int, inner_dim: int
+) -> torch.Tensor:
     theta = positional_embedding_theta
     start = 1
     end = theta
@@ -809,6 +819,21 @@ def generate_ltx_freq_grid_pytorch(
     )
     indices = indices.to(dtype=torch.float32)
     return indices * math.pi / 2
+
+
+_cached_generate_ltx_freq_grid_pytorch = functools.lru_cache(maxsize=5)(
+    _generate_ltx_freq_grid_pytorch)
+
+
+def generate_ltx_freq_grid_pytorch(
+    positional_embedding_theta: float, positional_embedding_max_pos_count: int, inner_dim: int
+) -> torch.Tensor:
+    """Generate an eager-cached, compile-safe float32 LTX-2 rotary grid."""
+    if torch.compiler.is_compiling():
+        return _generate_ltx_freq_grid_pytorch(
+            positional_embedding_theta, positional_embedding_max_pos_count, inner_dim)
+    return _cached_generate_ltx_freq_grid_pytorch(
+        positional_embedding_theta, positional_embedding_max_pos_count, inner_dim)
 
 
 def _ltx_get_fractional_positions(indices_grid: torch.Tensor, max_pos: list[int]) -> torch.Tensor:

--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -5,13 +5,10 @@ LTX-2 transformer implementation
 
 from dataclasses import dataclass, replace
 from enum import Enum
-import functools
 import math
 import os
 from pathlib import Path
 from typing import Any, Optional, Tuple, Callable
-
-import numpy as np
 
 import torch
 import torch.nn as nn
@@ -770,28 +767,29 @@ def _apply_ltx_split_rotary_emb(
     return output
 
 
-@functools.lru_cache(maxsize=5)
 def generate_ltx_freq_grid_np(
     positional_embedding_theta: float, positional_embedding_max_pos_count: int, inner_dim: int
 ) -> torch.Tensor:
-    """Generate LTX-2 rotary frequencies with high-precision numpy."""
+    """Generate LTX-2 rotary frequencies with float64 precision.
+
+    Implemented in pure torch and free of Python memoization so it is suitable for callers that may be captured and reused by torch.compile.
+    """
     theta = positional_embedding_theta
     start = 1
     end = theta
     n_elem = 2 * positional_embedding_max_pos_count
-    pow_indices = np.power(
+    pow_indices = torch.pow(
         theta,
-        np.linspace(
-            np.log(start) / np.log(theta),
-            np.log(end) / np.log(theta),
+        torch.linspace(
+            math.log(start) / math.log(theta),
+            math.log(end) / math.log(theta),
             inner_dim // n_elem,
-            dtype=np.float64,
+            dtype=torch.float64,
         ),
     )
-    return torch.tensor(pow_indices * math.pi / 2, dtype=torch.float32)
+    return (pow_indices * math.pi / 2).to(dtype=torch.float32)
 
 
-@functools.lru_cache(maxsize=5)
 def generate_ltx_freq_grid_pytorch(
     positional_embedding_theta: float, positional_embedding_max_pos_count: int, inner_dim: int
 ) -> torch.Tensor:
@@ -2065,20 +2063,26 @@ class BasicAVTransformerBlock(torch.nn.Module):
             """
             bsz = values.shape[0]
             keep = torch.ones((bsz, ), device=values.device, dtype=values.dtype)
-            if self.idx == self.stg_block_idx:
-                if torch.is_tensor(skip_flag):
-                    if skip_flag.ndim == 0:
-                        perturb = skip_flag.reshape(1).expand(bsz)
-                    else:
-                        if skip_flag.shape[0] != bsz:
-                            raise ValueError(
-                                "Per-sample STG mask batch size mismatch: "
-                                f"got {skip_flag.shape[0]}, expected {bsz}")
-                        perturb = skip_flag.reshape(bsz)
-                    keep = 1.0 - perturb.to(device=values.device,
-                                            dtype=values.dtype)
-                elif bool(skip_flag):
-                    keep.zero_()
+            # The ``idx == stg_block_idx`` gate lives in the eager
+            # ``_process_transformer_blocks`` caller, not here: reading the
+            # per-instance ``self.idx`` inside this compiled forward forces
+            # torch.compile to specialize a distinct graph per block (48x),
+            # blowing the Dynamo recompile limit and defeating regional
+            # compilation. The caller only passes a truthy ``skip_flag`` to the
+            # configured STG block, so applying it unconditionally here is
+            # equivalent while keeping the graph identical across all 48 blocks.
+            if torch.is_tensor(skip_flag):
+                if skip_flag.ndim == 0:
+                    perturb = skip_flag.reshape(1).expand(bsz)
+                else:
+                    if skip_flag.shape[0] != bsz:
+                        raise ValueError(
+                            "Per-sample STG mask batch size mismatch: "
+                            f"got {skip_flag.shape[0]}, expected {bsz}")
+                    perturb = skip_flag.reshape(bsz)
+                keep = 1.0 - perturb.to(device=values.device, dtype=values.dtype)
+            elif bool(skip_flag):
+                keep.zero_()
             return keep.view(bsz, *([1] * (values.ndim - 1)))
 
         if run_vx:
@@ -2656,8 +2660,10 @@ class LTXModel(torch.nn.Module):
         skip_audio_self_attn_block_set = set(skip_audio_self_attn_blocks or [])
 
         for idx, block in enumerate(self.transformer_blocks):
-            skip_v_sa = idx in skip_video_self_attn_block_set
-            skip_a_sa = idx in skip_audio_self_attn_block_set
+            # Preserve the original STG block condition in eager code so it does not introduce a block index guard in the compiled forward
+            is_stg_block = idx == block.stg_block_idx
+            skip_v_sa = is_stg_block and idx in skip_video_self_attn_block_set
+            skip_a_sa = is_stg_block and idx in skip_audio_self_attn_block_set
             video, audio = block(
                 video=video,
                 audio=audio,
@@ -2768,6 +2774,7 @@ class LTX2Transformer3DModel(BaseDiT):
     reverse_param_names_mapping = LTX2VideoConfig().reverse_param_names_mapping
     lora_param_names_mapping = LTX2VideoConfig().lora_param_names_mapping
     _fsdp_shard_conditions = LTX2VideoConfig()._fsdp_shard_conditions
+    _compile_conditions = LTX2VideoConfig()._compile_conditions
 
     def __init__(self, config: LTX2VideoConfig, hf_config: dict[str, Any]):
         super().__init__(config=config, hf_config=hf_config)

--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -767,12 +767,13 @@ def _apply_ltx_split_rotary_emb(
     return output
 
 
-def generate_ltx_freq_grid_np(
+def generate_ltx_freq_grid_float64(
     positional_embedding_theta: float, positional_embedding_max_pos_count: int, inner_dim: int
 ) -> torch.Tensor:
     """Generate LTX-2 rotary frequencies with float64 precision.
 
-    Implemented in pure torch and free of Python memoization so it is suitable for callers that may be captured and reused by torch.compile.
+    Implemented in pure torch and free of Python memoization so it is safe
+    for callers that may be captured and reused by torch.compile.
     """
     theta = positional_embedding_theta
     start = 1
@@ -1010,7 +1011,7 @@ class TransformerArgsPreprocessor:
         x_dtype: torch.dtype,
     ) -> torch.Tensor:
         if self.double_precision_rope:
-            freq_grid_generator = generate_ltx_freq_grid_np
+            freq_grid_generator = generate_ltx_freq_grid_float64
         else:
             freq_grid_generator = generate_ltx_freq_grid_pytorch
         return precompute_ltx_freqs_cis(
@@ -2056,7 +2057,9 @@ class BasicAVTransformerBlock(torch.nn.Module):
             """STG keep-mask for self-attention.
 
             Returns a per-sample multiplier (1 keep, 0 perturb) broadcastable
-            over ``values``. Only the configured ``stg_block_idx`` is perturbed.
+            over ``values``. Applied unconditionally: the eager caller
+            (``_process_transformer_blocks``) enforces that only the
+            configured ``stg_block_idx`` block receives a truthy flag.
             Supports both the LTX-2.0 bool flag and an LTX-2.3 per-sample
             tensor ``[B]`` (1/True == perturb). When skip_flag is False/0 the
             multiplier is all ones, reproducing the un-skipped LTX-2.0 path.
@@ -2281,6 +2284,9 @@ class BasicAVTransformerBlock(torch.nn.Module):
                 1 + ascale_mlp) + ashift_mlp
             ax = ax + self.audio_ff(ax_scaled) * agate_mlp
 
+        # Debug-only: reading ``self.idx`` (and .item() syncs) here means
+        # enabling this env var re-specializes the compiled graph per block,
+        # defeating the shared-graph regional compilation.
         if os.getenv("LTX2_PIPELINE_DEBUG_LOG", "0") == "1":
             video_sum = vx.float().sum().item() if vx is not None else 0.0
             audio_sum = ax.float().sum().item() if ax is not None else 0.0

--- a/fastvideo/models/encoders/gemma.py
+++ b/fastvideo/models/encoders/gemma.py
@@ -15,7 +15,7 @@ from fastvideo.models.dits.ltx2 import (
     FeedForward,
     LTXRopeType,
     apply_ltx_rotary_emb,
-    generate_ltx_freq_grid_np,
+    generate_ltx_freq_grid_float64,
     generate_ltx_freq_grid_pytorch,
     precompute_ltx_freqs_cis,
 )
@@ -330,7 +330,7 @@ class Embeddings1DConnector(nn.Module):
         )
         indices_grid = indices_grid[None, None, :]
         freq_grid_generator = (
-            generate_ltx_freq_grid_np
+            generate_ltx_freq_grid_float64
             if self.double_precision_rope
             else generate_ltx_freq_grid_pytorch
         )

--- a/fastvideo/tests/attention/test_flash_attn_cute_custom_op.py
+++ b/fastvideo/tests/attention/test_flash_attn_cute_custom_op.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -53,6 +54,44 @@ def _extract_out(x):
     if isinstance(x, tuple):
         return x[0]
     return x
+
+
+def test_capability_gate_is_lazy_and_device_keyed(monkeypatch) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required to import flash_attn.cute")
+    try:
+        mod = _load_local_flash_attn_cute_module()
+    except ImportError as exc:
+        pytest.skip(f"flash_attn.cute is not available: {exc}")
+    calls: list[tuple[int, int]] = []
+
+    def has_device_capability(capability: int, device_id: int) -> bool:
+        calls.append((capability, device_id))
+        return device_id == 1
+
+    def tensor_stub(device_id: int, heads: int):
+        return SimpleNamespace(
+            device=torch.device("cuda", device_id),
+            shape=(1, 1, heads, 64),
+            requires_grad=False,
+        )
+
+    mod._SM90_OR_NEWER_BY_DEVICE.clear()
+    monkeypatch.setattr(
+        mod.current_platform,
+        "has_device_capability",
+        has_device_capability,
+    )
+    try:
+        q0, k0, v0 = tensor_stub(0, 4), tensor_stub(0, 2), tensor_stub(0, 2)
+        assert mod._use_fa2(q0, k0, v0)
+        assert mod._use_fa2(q0, k0, v0)
+
+        q1, k1, v1 = tensor_stub(1, 4), tensor_stub(1, 2), tensor_stub(1, 2)
+        assert not mod._use_fa2(q1, k1, v1)
+        assert calls == [(90, 0), (90, 1)]
+    finally:
+        mod._SM90_OR_NEWER_BY_DEVICE.clear()
 
 
 @pytest.fixture(scope="module")

--- a/fastvideo/tests/contract/test_ltx2_compile_conditions.py
+++ b/fastvideo/tests/contract/test_ltx2_compile_conditions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Contract test: LTX2's per-block torch.compile wiring stays intact.
+"""Contract tests for LTX2 torch.compile integration.
 
 ``ComposedPipelineBase._compile_with_conditions`` compiles the submodules
 matched by ``model._compile_conditions`` and falls back to compiling the
@@ -11,13 +11,14 @@ wiring and the block matcher so a refactor can't reintroduce the fallback
 unnoticed. CPU-only; no model instantiation.
 """
 
+import torch
+
 from fastvideo.configs.models.dits.ltx2 import LTX2VideoConfig, is_ltx2_blocks
+from fastvideo.models.dits import ltx2
 
 
 def test_ltx2_model_exposes_compile_conditions():
-    from fastvideo.models.dits.ltx2 import LTX2Transformer3DModel
-
-    conditions = LTX2Transformer3DModel._compile_conditions
+    conditions = ltx2.LTX2Transformer3DModel._compile_conditions
     assert conditions, (
         "LTX2Transformer3DModel._compile_conditions is empty: "
         "torch.compile falls back to a whole-model fullgraph")
@@ -33,3 +34,29 @@ def test_is_ltx2_blocks_matches_only_top_level_blocks():
     assert not is_ltx2_blocks("transformer_blocks", None)
     assert not is_ltx2_blocks("transformer_blocks.0.attn1", None)
     assert not is_ltx2_blocks("audio_transformer_blocks.0", None)
+
+
+def test_freq_grid_cache_is_bypassed_while_compiling():
+    args = (10000.0, 3, 96)
+    for generator, cached_generator in (
+        (
+            ltx2.generate_ltx_freq_grid_float64,
+            ltx2._cached_generate_ltx_freq_grid_float64,
+        ),
+        (
+            ltx2.generate_ltx_freq_grid_pytorch,
+            ltx2._cached_generate_ltx_freq_grid_pytorch,
+        ),
+    ):
+        cached_generator.cache_clear()
+        eager = generator(*args)
+        assert generator(*args) is eager
+
+        cached_generator.cache_clear()
+        compiled_generator = torch.compile(
+            lambda zero: generator(*args) + zero,
+            backend="eager",
+            fullgraph=True,
+        )
+        torch.testing.assert_close(compiled_generator(torch.tensor(0.0)), eager)
+        assert cached_generator.cache_info().currsize == 0

--- a/fastvideo/tests/contract/test_ltx2_compile_conditions.py
+++ b/fastvideo/tests/contract/test_ltx2_compile_conditions.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contract test: LTX2's per-block torch.compile wiring stays intact.
+
+``ComposedPipelineBase._compile_with_conditions`` compiles the submodules
+matched by ``model._compile_conditions`` and falls back to compiling the
+whole model as one fullgraph when the list is empty. LTX2 shipped with the
+conditions declared on its arch config but never exposed on the model
+class, so it silently took the whole-model fallback (enormous unportable
+graphs, 10+ minute cold compiles). These assertions pin the class-level
+wiring and the block matcher so a refactor can't reintroduce the fallback
+unnoticed. CPU-only; no model instantiation.
+"""
+
+from fastvideo.configs.models.dits.ltx2 import LTX2VideoConfig, is_ltx2_blocks
+
+
+def test_ltx2_model_exposes_compile_conditions():
+    from fastvideo.models.dits.ltx2 import LTX2Transformer3DModel
+
+    conditions = LTX2Transformer3DModel._compile_conditions
+    assert conditions, (
+        "LTX2Transformer3DModel._compile_conditions is empty: "
+        "torch.compile falls back to a whole-model fullgraph")
+    assert is_ltx2_blocks in conditions
+    assert LTX2VideoConfig()._compile_conditions == conditions
+
+
+def test_is_ltx2_blocks_matches_only_top_level_blocks():
+    assert is_ltx2_blocks("transformer_blocks.0", None)
+    assert is_ltx2_blocks("model.transformer_blocks.47", None)
+    # Submodules and lookalike names must not match — compiling them would
+    # nest compiled regions inside the per-block graphs.
+    assert not is_ltx2_blocks("transformer_blocks", None)
+    assert not is_ltx2_blocks("transformer_blocks.0.attn1", None)
+    assert not is_ltx2_blocks("audio_transformer_blocks.0", None)


### PR DESCRIPTION
Cache LTX2 graphs and allow all 48 blocks to share one compiled graph. Also added compile to the dreamverse backend launch.

## Purpose

Dreamverse LTX2 startup compilation cost is very high (10+ minutes) and we are able to cache it, reducing subsequent start up below 2 minutes. 

LTX2 was the only major DiT still compiled as a single whole-model fullgraph, because LTX2Transformer3DModel never wired the _compile_conditions declared on its arch config. That produced enormous, unportable graphs (~8k guards) and long cold compiles. Even with per-block (regional) compilation turned on, the cold warmup died deterministically and the Inductor/AOTAutograd artifacts could not be reused across processes, so every launch paid the full autotune/codegen cost. This PR fixes both: makes the 48 transformer blocks share a single compiled graph, and makes those graphs disk-cache-serializable so a second launch on the same box reloads them.

## Changes
- LTX2Transformer3DModel now picks up _compile_conditions from its arch config, so the 48 transformer blocks get compiled individually instead of the whole model as one giant fullgraph. LTX2 was the last major DiT still doing the latter.
- We made the block forward free of per-instance state so all 48 blocks share one compiled graph, as it was otherwise hitting the Dynamo limit at block 17. Moved that check up into the eager _process_transformer_blocks loop
- Made the graphs safe to cache. AOTAutograd's serializer was being tripped and forcing a fresh compile from the lru_cache on the rotary freq-grid helpers, the functools.cache on _sm90_or_newer, and a dtype mismatch in the RMSNorm fallback
- Turned on the caching in the launch script with the paths to cache to

## Test Plan

Validated on a B200 (sm100), torch 2.12.0+cu130. A script runs the dreamverse worker's initialize() + warmup(), the streams continuation chunks. Two configs: 576×320 and 1920×1088 at 121 frame chunks (NVFP4, FlashAttention 4), both with max-autotune-no-cudagraphs and the persistent cache.

export TORCHINDUCTOR_CACHE_DIR=$PWD/.cache/inductor TRITON_CACHE_DIR=$PWD/.cache/triton
export TORCHINDUCTOR_FX_GRAPH_CACHE=1 TORCHINDUCTOR_AUTOGRAD_CACHE=1

Cold vs. reload warmup: ran the dreamverse worker's initialize() + warmup()  to build the cache from cold, then again in a fresh process pointed at the same cache dirs to verify it loads it from disk.
Warm state: after a single warmup, we streamed chunks and timed each 121 frame 1080p chunk.

## Test Results

Cold vs. reload warmup (persistent Inductor/Triton + FX-graph + AOTAutograd cache):
576x320  SDPA  autotune:  cold 557.5s  -> reload 58.3s  (9.6x)
1080p    FA4   autotune:  cold 716.0s  -> reload 76.3s  (9.4x)
(0 recompile-limit hits, 0 autograd_cache_bypass, 0 failures)

Warm steady-state (1080p, FA4, fully warm continuation chunks):
121-frame 1080p chunk generation ~5.3s median (range 5.24-5.45s), e2e 5.26-5.47s
-> within the 5-7s/chunk target; 0 recompiles on continuation chunks

Residual reload ~76s = Dynamo tracing (uncached on torch 2.12) + model load + first inference