### PR TITLE
[bugfix] reason1: handle BatchEncoding from apply_chat_template

### DIFF
--- a/fastvideo/models/encoders/reason1.py
+++ b/fastvideo/models/encoders/reason1.py
@@ -41,8 +41,15 @@ def _normalize_chat_template_ids(tokenizer_output) -> list[int]:
         input_ids = tokenizer_output
     if hasattr(input_ids, "tolist"):
         input_ids = input_ids.tolist()
-    if (isinstance(input_ids, list) and len(input_ids) == 1
-            and isinstance(input_ids[0], list)):
+    if isinstance(input_ids, list) and input_ids and isinstance(input_ids[0], list):
+        # A nested list is a batch dimension. We tokenize one conversation at a
+        # time, so batch size 1 is the only shape we can unambiguously flatten;
+        # fail loudly on anything else rather than return a nested list that
+        # violates this helper's flat-``list[int]`` contract downstream.
+        if len(input_ids) != 1:
+            raise RuntimeError(
+                f"Unexpected batched chat_template output: batch={len(input_ids)} "
+                f"type={type(tokenizer_output)}")
         input_ids = input_ids[0]
     if not isinstance(input_ids, list):
         raise RuntimeError(

--- a/fastvideo/models/encoders/reason1.py
+++ b/fastvideo/models/encoders/reason1.py
@@ -3,7 +3,7 @@
 
 import os
 from dataclasses import dataclass
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 import torch
 from transformers import AutoProcessor
@@ -21,6 +21,33 @@ from fastvideo.models.encoders.qwen2_5_vl_custom import (
 )
 
 logger = init_logger(__name__)
+
+
+def _normalize_chat_template_ids(tokenizer_output) -> list[int]:
+    """Normalize `apply_chat_template` output to a flat ``list[int]`` of token ids.
+
+    Depending on the transformers version and tokenizer, `apply_chat_template`
+    (with ``tokenize=True``) may return a ``list[int]``, a nested
+    ``list[list[int]]`` (batch dim), a tensor, or a mapping carrying an
+    ``"input_ids"`` field. transformers returns a ``BatchEncoding``, which
+    subclasses ``collections.UserDict`` -- a ``Mapping`` but **not** a ``dict``
+    -- so an ``isinstance(_, dict)`` check silently misses it and the caller
+    would otherwise raise. Match on ``Mapping`` instead: every ``dict`` is a
+    ``Mapping``, so plain-dict and list outputs behave exactly as before.
+    """
+    if isinstance(tokenizer_output, Mapping) and "input_ids" in tokenizer_output:
+        input_ids = tokenizer_output["input_ids"]
+    else:
+        input_ids = tokenizer_output
+    if hasattr(input_ids, "tolist"):
+        input_ids = input_ids.tolist()
+    if (isinstance(input_ids, list) and len(input_ids) == 1
+            and isinstance(input_ids[0], list)):
+        input_ids = input_ids[0]
+    if not isinstance(input_ids, list):
+        raise RuntimeError(
+            f"Unexpected chat_template output type: {type(tokenizer_output)}")
+    return input_ids
 
 
 @dataclass(frozen=True)
@@ -266,21 +293,7 @@ class Reason1TextEncoder(TextEncoder):
                 add_generation_prompt=False,
             )
 
-            if isinstance(tokenizer_output, dict) and "input_ids" in tokenizer_output:
-                input_ids = tokenizer_output["input_ids"]
-                if hasattr(input_ids, "tolist"):
-                    input_ids = input_ids.tolist()
-            else:
-                input_ids = tokenizer_output
-                if hasattr(input_ids, "tolist"):
-                    input_ids = input_ids.tolist()
-                if isinstance(input_ids, list) and len(input_ids) == 1 and isinstance(
-                        input_ids[0], list):
-                    input_ids = input_ids[0]
-                if not isinstance(input_ids, list):
-                    raise RuntimeError(
-                        f"Unexpected chat_template output type: {type(tokenizer_output)}"
-                    )
+            input_ids = _normalize_chat_template_ids(tokenizer_output)
             
             if self.num_embedding_padding_tokens > len(input_ids):
                 pad_len = self.num_embedding_padding_tokens - len(input_ids)

--- a/fastvideo/models/encoders/reason1.py
+++ b/fastvideo/models/encoders/reason1.py
@@ -3,7 +3,7 @@
 
 import os
 from dataclasses import dataclass
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 import torch
 from transformers import AutoProcessor
@@ -21,6 +21,33 @@ from fastvideo.models.encoders.qwen2_5_vl_custom import (
 )
 
 logger = init_logger(__name__)
+
+
+def _normalize_chat_template_ids(tokenizer_output) -> list[int]:
+    """Normalize `apply_chat_template` output to a flat ``list[int]`` of token ids.
+
+    Depending on the transformers version and tokenizer, `apply_chat_template`
+    (with ``tokenize=True``) may return a ``list[int]``, a nested
+    ``list[list[int]]`` (batch dim), a tensor, or a mapping carrying an
+    ``"input_ids"`` field. transformers returns a ``BatchEncoding``, which
+    subclasses ``collections.UserDict`` -- a ``Mapping`` but **not** a ``dict``
+    -- so an ``isinstance(_, dict)`` check silently misses it and the caller
+    would otherwise raise. Match on ``Mapping`` instead: every ``dict`` is a
+    ``Mapping``, so plain-dict and list outputs behave exactly as before.
+    """
+    if isinstance(tokenizer_output, Mapping) and "input_ids" in tokenizer_output:
+        input_ids = tokenizer_output["input_ids"]
+    else:
+        input_ids = tokenizer_output
+    if hasattr(input_ids, "tolist"):
+        input_ids = input_ids.tolist()
+    if (isinstance(input_ids, list) and len(input_ids) == 1
+            and isinstance(input_ids[0], list)):
+        input_ids = input_ids[0]
+    if not isinstance(input_ids, list):
+        raise RuntimeError(
+            f"Unexpected chat_template output type: {type(tokenizer_output)}")
+    return input_ids
 
 
 @dataclass(frozen=True)
@@ -258,18 +285,7 @@ class Reason1TextEncoder(TextEncoder):
                     add_generation_prompt=False,
                 )
 
-            if isinstance(tokenizer_output, dict) and "input_ids" in tokenizer_output:
-                input_ids = tokenizer_output["input_ids"]
-                if hasattr(input_ids, "tolist"):
-                    input_ids = input_ids.tolist()
-            else:
-                input_ids = tokenizer_output
-                if hasattr(input_ids, "tolist"):
-                    input_ids = input_ids.tolist()
-                if isinstance(input_ids, list) and len(input_ids) == 1 and isinstance(input_ids[0], list):
-                    input_ids = input_ids[0]
-                if not isinstance(input_ids, list):
-                    raise RuntimeError(f"Unexpected chat_template output type: {type(tokenizer_output)}")
+            input_ids = _normalize_chat_template_ids(tokenizer_output)
 
             if self.num_embedding_padding_tokens > len(input_ids):
                 pad_len = self.num_embedding_padding_tokens - len(input_ids)

--- a/fastvideo/tests/encoders/test_reason1_chat_template.py
+++ b/fastvideo/tests/encoders/test_reason1_chat_template.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Weight-free regression tests for reason1's chat-template id normalization.
+
+Guards the fix for the Cosmos-Predict2.5 text-encoder crash: `apply_chat_template`
+returns a `BatchEncoding` (a `collections.UserDict`, i.e. a `Mapping` but NOT a
+`dict`), so an `isinstance(_, dict)` check missed it and raised. These cover every
+shape `apply_chat_template` can return, so a future transformers change can't
+silently reintroduce the crash.
+"""
+
+from collections import UserDict
+
+import pytest
+
+from fastvideo.models.encoders.reason1 import _normalize_chat_template_ids
+
+IDS = [10, 11, 12]
+
+
+class _FakeTensor:
+    """Stand-in for a torch tensor: exposes ``.tolist()`` like real output does."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def tolist(self):
+        return self._value
+
+
+class _BatchEncodingLike(UserDict):
+    """Mirrors ``transformers.BatchEncoding`` (``class BatchEncoding(UserDict)``):
+    a Mapping that is deliberately NOT a ``dict`` subclass."""
+
+
+@pytest.mark.parametrize(
+    "tokenizer_output",
+    [
+        IDS,                                  # list[int]  (legacy list path)
+        [IDS],                                # nested list[list[int]] (batch dim)
+        _FakeTensor(IDS),                     # tensor
+        _FakeTensor([IDS]),                   # batched tensor
+        {"input_ids": IDS},                   # plain dict, flat
+        {"input_ids": [IDS]},                 # plain dict, batched
+        _BatchEncodingLike({"input_ids": IDS}),            # BatchEncoding, flat
+        _BatchEncodingLike({"input_ids": [IDS]}),          # BatchEncoding, batched
+        _BatchEncodingLike({"input_ids": _FakeTensor([IDS])}),  # the crash case
+    ],
+)
+def test_normalizes_every_shape_to_flat_ids(tokenizer_output):
+    assert _normalize_chat_template_ids(tokenizer_output) == IDS
+
+
+def test_batch_encoding_is_not_a_dict_but_is_handled():
+    # Documents the root cause: the old `isinstance(_, dict)` guard was False here.
+    be = _BatchEncodingLike({"input_ids": IDS})
+    assert not isinstance(be, dict)
+    assert _normalize_chat_template_ids(be) == IDS
+
+
+def test_unexpected_type_raises():
+    with pytest.raises(RuntimeError, match="Unexpected chat_template output type"):
+        _normalize_chat_template_ids(object())
+
+
+def test_real_batch_encoding_if_available():
+    # Belt-and-suspenders: exercise the actual transformers BatchEncoding when present.
+    pytest.importorskip("transformers")
+    from transformers.tokenization_utils_base import BatchEncoding
+    assert not isinstance(BatchEncoding(), dict)  # the property the fix relies on
+    assert _normalize_chat_template_ids(BatchEncoding({"input_ids": IDS})) == IDS

--- a/fastvideo/tests/encoders/test_reason1_chat_template.py
+++ b/fastvideo/tests/encoders/test_reason1_chat_template.py
@@ -62,6 +62,21 @@ def test_unexpected_type_raises():
         _normalize_chat_template_ids(object())
 
 
+@pytest.mark.parametrize(
+    "batched",
+    [
+        [[10, 11], [12, 13]],                          # nested list, batch 2
+        {"input_ids": [[10, 11], [12, 13]]},           # mapping w/ batched ids
+        _BatchEncodingLike({"input_ids": _FakeTensor([[10, 11], [12, 13]])}),
+    ],
+)
+def test_batch_gt_one_raises_instead_of_returning_nested(batched):
+    # The helper only unwraps batch size 1; a real batch must fail loudly rather
+    # than silently return a nested list that breaks downstream padding.
+    with pytest.raises(RuntimeError, match="Unexpected batched chat_template output"):
+        _normalize_chat_template_ids(batched)
+
+
 def test_real_batch_encoding_if_available():
     # Belt-and-suspenders: exercise the actual transformers BatchEncoding when present.
     pytest.importorskip("transformers")


### PR DESCRIPTION
# [bugfix] reason1: handle BatchEncoding from apply_chat_template

## Problem

Cosmos-Predict2.5 2B inference crashes at model load, in the text encoder, before any
denoising:

```
File "fastvideo/models/encoders/reason1.py", line 281, in compute_text_embeddings
    raise RuntimeError(
RuntimeError: Unexpected chat_template output type: <class 'transformers.tokenization_utils_base.BatchEncoding'>
```

`Reason1TextEncoder.compute_text_embeddings` calls `tokenizer.apply_chat_template(
tokenize=True, ...)`, whose output it normalizes to a flat `list[int]` of token ids.
The handler branched on `isinstance(tokenizer_output, dict)` — but transformers returns
a **`BatchEncoding`**, which is defined as `class BatchEncoding(UserDict)`. `UserDict`
is **not** a subclass of `dict`, so `isinstance(batch_encoding, dict)` is `False`; the
dict branch was skipped and the value fell through to the `raise`.

This reproduces on `examples/inference/basic/basic_cosmos2_5_t2w.py` with transformers
4.57.3 (current pin range). The code path is unchanged since #1352 — earlier transformers
returned a plain list here, so the crash surfaces as newer transformers standardize on
`BatchEncoding`.

## Fix

Match on `collections.abc.Mapping` instead of `dict`, and lift the normalization into a
small, tested helper `_normalize_chat_template_ids`.

`Mapping` is a **superset** of `dict` (every `dict` is a registered `Mapping`), so:

- plain-`dict` and `list`/tensor outputs behave **exactly as before** — nothing that
  matched previously stops matching;
- `BatchEncoding`/`UserDict` (Mapping-but-not-dict) is now handled;
- the `"input_ids" in tokenizer_output` guard still gates the branch, so a Mapping
  without tokens falls through unchanged.

The helper also unifies the `tolist()` / batch-dim-unwrap / validate steps that were
previously duplicated across the two branches (the old `dict` branch skipped the
unwrap/validate — the unified path is strictly more correct, since downstream requires
a flat list).

## Tests

New weight-free, CPU-only `fastvideo/tests/encoders/test_reason1_chat_template.py`,
parametrized over every shape `apply_chat_template` can return — `list[int]`, nested
`list[list[int]]`, tensor, batched tensor, plain `dict` (flat + batched), and
`BatchEncoding` (flat, batched, tensor) — all asserting the same flat id list. Includes
a case documenting that `BatchEncoding` is not a `dict`, and an `importorskip` check
against the real `transformers.BatchEncoding` when installed.

```
pytest fastvideo/tests/encoders/test_reason1_chat_template.py
```

## Validation

Verified end-to-end on an NVIDIA DGX Spark (GB10 / sm_121) on current `main`. Before
the fix, `basic_cosmos2_5_t2w.py` aborts in ~46 s at text encoding with the
`RuntimeError` above. With the fix it clears text encoding and completes the full
pipeline:

- text encoding 16.5 s → denoising 1622 s (35 steps, guidance 7) → decode 43.8 s
- end-to-end 1683.6 s (~28 min), denoise-bound (~96%)
- output: 77 × 704 × 1280 video, exit 0

## Scope / blast radius

`reason1.py` is Cosmos's Qwen2.5-VL text encoder, so this path only feeds Cosmos
pipelines. No shared tokenizer utility is touched.
