### PR TITLE
[docs]: document automatic Docker image builds

### DIFF
--- a/docs/contributing/ci_architecture.md
+++ b/docs/contributing/ci_architecture.md
@@ -268,15 +268,17 @@ The docs job:
 
 ### Docker Images
 
-`.github/workflows/infra-build-image.yml` is a manual `workflow_dispatch`
-workflow. Maintainers choose which image families to build. The
-`fastvideo-dev` matrix builds Python 3.12 images for CUDA 12.6 and CUDA 13 on
-native `amd64` and `arm64` runners, then publishes one multi-platform manifest
-per CUDA version. CUDA 12.6 owns the `py3.12-latest` and global `latest` tags,
-as well as the explicit `py3.12-cuda12.6.3-latest` alias. CUDA 13 is published
-under the explicit `py3.12-cuda13.0.0-latest` tag. This publication policy does
-not change the unparameterized `docker/Dockerfile` build defaults, which remain
-CUDA 13 and `cu130`.
+`.github/workflows/infra-build-image.yml` supports manual `workflow_dispatch`
+runs and automatically rebuilds the CUDA matrix when `docker/Dockerfile`
+changes on `main` in the canonical repository. Manual runs let maintainers
+choose which image families to build. The `fastvideo-dev` matrix builds Python
+3.12 images for CUDA 12.6 and CUDA 13 on native `amd64` and `arm64` runners,
+then publishes one multi-platform manifest per CUDA version. CUDA 12.6 owns the
+`py3.12-latest` and global `latest` tags, as well as the explicit
+`py3.12-cuda12.6.3-latest` alias. CUDA 13 is published under the explicit
+`py3.12-cuda13.0.0-latest` tag. This publication policy does not change the
+unparameterized `docker/Dockerfile` build defaults, which remain CUDA 13 and
+`cu130`.
 
 The optional Dreamverse matrix builds backend and UI images for CUDA 12.6 and
 CUDA 13 on `amd64`. Dreamverse remains `amd64`-only because its FA4 dependency
@@ -316,7 +318,7 @@ The reusable implementation lives in
 | `fastvideo/tests/modal/ssim_test.py` | Modal functions and partitioning for SSIM |
 | `.buildkite/performance-benchmarks/tests/*.json` | Performance benchmark configs and thresholds |
 | `.github/workflows/infra-docs.yml` | Docs build and GitHub Pages deploy |
-| `.github/workflows/infra-build-image.yml` | Manual Docker image builds |
+| `.github/workflows/infra-build-image.yml` | Automatic CUDA and manual Docker image builds |
 | `.github/workflows/publish-fastvideo.yml` | FastVideo PyPI publishing |
 | `.github/workflows/publish-kernel.yml` | FastVideo kernel PyPI publishing |
 | `.github/workflows/publish-comfyui.yml` | ComfyUI registry publishing |

--- a/docs/contributing/ci_architecture.md
+++ b/docs/contributing/ci_architecture.md
@@ -318,7 +318,7 @@ The reusable implementation lives in
 | `fastvideo/tests/modal/ssim_test.py` | Modal functions and partitioning for SSIM |
 | `.buildkite/performance-benchmarks/tests/*.json` | Performance benchmark configs and thresholds |
 | `.github/workflows/infra-docs.yml` | Docs build and GitHub Pages deploy |
-| `.github/workflows/infra-build-image.yml` | Automatic CUDA and manual Docker image builds |
+| `.github/workflows/infra-build-image.yml` | Automatic CUDA matrix and manual Docker image builds |
 | `.github/workflows/publish-fastvideo.yml` | FastVideo PyPI publishing |
 | `.github/workflows/publish-kernel.yml` | FastVideo kernel PyPI publishing |
 | `.github/workflows/publish-comfyui.yml` | ComfyUI registry publishing |


### PR DESCRIPTION
## Summary

- document automatic CUDA image rebuilds when `docker/Dockerfile` changes on `main` in the canonical repository
- clarify that manual dispatch remains available for selecting image families

## Tests

- `pre-commit run --files docs/contributing/ci_architecture.md`
- `git diff HEAD^ --check`
