### PR TITLE
[ci] Run docs only for trusted PR branches

### DIFF
--- a/.github/workflows/infra-docs.yml
+++ b/.github/workflows/infra-docs.yml
@@ -11,7 +11,9 @@ on:
       - 'requirements-mkdocs.txt'
       - 'scripts/check_docs_links.py'
       - '.github/workflows/infra-docs.yml'
-  pull_request:
+  # Run the trusted base-branch workflow so fork PRs can be skipped without
+  # waiting for maintainer approval.
+  pull_request_target:
     branches: [ main ]
     paths:
       - 'docs/**'
@@ -24,21 +26,19 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
 
 jobs:
   build:
+    # MkDocs executes repository code; only trusted same-repository PRs run it.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -52,6 +52,7 @@ jobs:
         run: uv pip install --system -r requirements-mkdocs.txt
 
       - name: Setup Pages
+        if: github.event_name == 'push'
         uses: actions/configure-pages@v4
 
       - name: Build documentation
@@ -61,17 +62,22 @@ jobs:
         run: python scripts/check_docs_links.py
 
       - name: Upload artifact
+        if: github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./site
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
+    concurrency: pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'push'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/docs/contributing/ci_architecture.md
+++ b/docs/contributing/ci_architecture.md
@@ -255,9 +255,10 @@ If you add a new CI test category:
 
 ### Documentation
 
-`.github/workflows/infra-docs.yml` builds documentation for PRs that touch
-`docs/**`, `mkdocs.yml`, `requirements-mkdocs.txt`, or the workflow itself. On
-pushes to `main`, it also deploys the built site to GitHub Pages.
+`.github/workflows/infra-docs.yml` builds documentation for same-repository PRs
+that touch `docs/**`, `mkdocs.yml`, `requirements-mkdocs.txt`, or the workflow
+itself. Fork PRs skip this executable build instead of waiting for maintainer
+approval. On pushes to `main`, it also deploys the built site to GitHub Pages.
 
 The docs job:
 


### PR DESCRIPTION
## Summary

- run the documentation PR workflow from the trusted base-branch definition
- execute MkDocs only for branches in `hao-ai-lab/FastVideo`; fork PRs skip before runner allocation or checkout
- restrict Pages/OIDC permissions, artifact upload, and deployment concurrency to `main` pushes

## Why

Fork documentation runs currently stop at GitHub's `action_required` gate. The Full Suite cheap-check gate can then wait up to 25 minutes before failing open. Skipping executable docs builds for forks removes that delay without running fork-controlled MkDocs hooks, configuration, dependencies, or repository code under `pull_request_target`.

## Security boundary

- the same-repository condition is evaluated at the job boundary before a runner starts
- the exact PR head is checked out only after `head.repo.full_name == github.repository`
- workflow-wide permissions are reduced to `contents: read`, and checkout credentials are not persisted
- Pages write/OIDC permissions and `pages` concurrency exist only on the main-push deployment job
- fork documentation changes remain covered by pre-commit, but the executable MkDocs build is deferred until merge

## Test evidence

- `pre-commit run --files .github/workflows/infra-docs.yml docs/contributing/ci_architecture.md`
- `git diff --check`
- Ruby YAML parse
- static assertions for the fork guard, push-only deployment, and deploy-only permissions/concurrency
- independent read-only audit: no functional or security blockers after documenting the fork exception

No local pytest was run; this workflow-only change has no pytest surface.
