### PR TITLE
[ci]: skip unused Buildkite submodule checkout

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,8 @@
 env:
   IMAGE_VERSION: "py3.12-latest"
   BUILDKITE_CLEAN_CHECKOUT: true
+  # Buildkite only launches Modal; remote jobs initialize their own submodules.
+  BUILDKITE_GIT_SUBMODULES: false
 
 notify:
   - github_commit_status:


### PR DESCRIPTION
## Summary

- skip unused Cutlass, ThunderKittens, and VBench initialization on Buildkite agents before Modal launch
- preserve clean checkouts and exact fork PR refs; Modal GPU jobs continue to initialize their own submodules before install, build, or test

## Tests

- `bk pipeline validate --file .buildkite/pipeline.yml`
- `pre-commit run --files .buildkite/pipeline.yml`
- Ruby YAML boolean assertion and `git diff --check`

No local pytest, GPU, dlcluster, or paid Modal job was run; this is a Buildkite checkout-policy-only change.
