### PR TITLE
[ci]: prevent direct tests from minting suite gates

### DIFF
--- a/.github/workflows/ci-aggregate-status.yml
+++ b/.github/workflows/ci-aggregate-status.yml
@@ -43,7 +43,15 @@ jobs:
               s => FULL_SUITE_PREFIXES.some(p => s.context.startsWith(p))
             );
 
+            // Direct reruns may repair a failed suite, never create a gate for
+            // a suite that did not run.
+            const failedAggregate = context => data.statuses.some(
+              s => s.context === context && s.state === 'failure'
+            );
+
             if (
+              failedAggregate('fastcheck-passed')
+              &&
               fastcheck.length > 0
               && fastcheck.every(s => s.state === 'success')
             ) {
@@ -62,6 +70,8 @@ jobs:
             }
 
             if (
+              failedAggregate('full-suite-passed')
+              &&
               fullSuite.length > 0
               && fullSuite.every(s => s.state === 'success')
             ) {

--- a/docs/contributing/ci_architecture.md
+++ b/docs/contributing/ci_architecture.md
@@ -164,8 +164,9 @@ Valid direct test names:
 
 When a direct test completes successfully, Buildkite posts
 `direct-test-completed`. `.github/workflows/ci-aggregate-status.yml` then reads
-the latest Buildkite statuses for the commit and updates `fastcheck-passed` or
-`full-suite-passed` if all jobs in that group are green.
+the latest Buildkite statuses for the commit and repairs an already-failed
+`fastcheck-passed` or `full-suite-passed` status if all jobs in that group are
+now green. A direct test never creates an aggregate for a tier that did not run.
 
 Skipped path-filtered jobs have no status entry and do not block the aggregate.
 

--- a/docs/contributing/pull_requests.md
+++ b/docs/contributing/pull_requests.md
@@ -92,8 +92,9 @@ All supported `/test` names and their `TEST_TYPE` mappings are listed in
 [CI/CD Architecture](ci_architecture.md#slash-commands).
 
 When a direct test succeeds, the aggregate `fastcheck-passed` or
-`full-suite-passed` status is refreshed automatically if all jobs in that tier
-are now green.
+`full-suite-passed` status is refreshed automatically if that tier previously
+failed and all its jobs are now green. A targeted test cannot replace an
+initial Fastcheck or Full Suite run.
 
 ## Troubleshooting
 

--- a/fastvideo/tests/contract/test_ci_aggregate_status.py
+++ b/fastvideo/tests/contract/test_ci_aggregate_status.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Keep direct CI reruns from manufacturing aggregate suite gates."""
+
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci-aggregate-status.yml"
+
+
+def test_direct_reruns_only_repair_failed_aggregates():
+    source = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "s.context === context && s.state === 'failure'" in source
+    assert source.count("failedAggregate(") == 2
+    assert "failedAggregate('fastcheck-passed')" in source
+    assert "failedAggregate('full-suite-passed')" in source


### PR DESCRIPTION
## Summary
- require an existing failed aggregate before a direct test can repair `fastcheck-passed` or `full-suite-passed`
- prevent a targeted test from manufacturing a suite gate when the tier never ran
- document the repair-only behavior and keep one source-contract regression

PR #1614 exposed the bug: direct SSIM build 4501 alone caused the workflow to report “All 1 full suite tests passed” and create `full-suite-passed` without a Full Suite.

## Tests
- `pre-commit run --files .github/workflows/ci-aggregate-status.yml docs/contributing/ci_architecture.md docs/contributing/pull_requests.md fastvideo/tests/contract/test_ci_aggregate_status.py`
- direct source-contract invocation
- Ruby YAML parse
- Python compilation
- `git diff --check`

No local pytest or paid job was run.