### PR TITLE
[ci]: extend Full Suite training lane timeouts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -402,7 +402,7 @@ steps:
                 - "pyproject.toml"
                 - "docker/Dockerfile"
               config:
-                command: "timeout 15m .buildkite/scripts/pr_test.sh"
+                command: "timeout 25m .buildkite/scripts/pr_test.sh"
                 label: ":test_tube: Training Tests"
                 env:
                   - TEST_TYPE=training

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -413,7 +413,7 @@ steps:
                 - "pyproject.toml"
                 - "docker/Dockerfile"
               config:
-                command: "timeout 15m .buildkite/scripts/pr_test.sh"
+                command: "timeout 25m .buildkite/scripts/pr_test.sh"
                 label: ":test_tube: Distillation DMD Tests"
                 env:
                   - TEST_TYPE=distillation_dmd


### PR DESCRIPTION
## Summary
- extend the Full Suite Training wrapper from 15 to 25 minutes
- extend the Distillation DMD wrapper from 15 to 25 minutes
- retain both Modal functions' 15-minute execution ceilings

Builds 4470 and 4496 show L40S capacity plus normal setup consuming the outer envelope before either lane can return a result. LoRA already uses the same 25-minute wrapper after #1589.

## Tests
- official Buildkite pipeline schema validation
- pre-commit
- Ruby YAML parse
- `git diff --check`

No local pytest or GPU job was run for this two-scalar CI change.