### PR TITLE
Make LTX-2 RMSNorm out-of-place so torch_tensorrt + Ulysses SP compiles

### DIFF
--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -64,6 +64,32 @@ def _is_ltx2_refine_stage() -> bool:
     return forward_batch.extra.get("ltx2_fp4_stage_profile") == "refine"
 
 
+def _functional_rms_norm(
+    x: torch.Tensor,
+    eps: float,
+    weight: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Out-of-place RMSNorm equivalent to ``torch.nn.functional.rms_norm``.
+
+    ``F.rms_norm`` / ``nn.RMSNorm`` decompose under AOTAutograd into an
+    in-place ``variance.add_(eps)`` (an ``aten.copy_`` into the computed
+    ``mean``). AOTAutograd's ``assert_functional_graph`` requires every
+    ``copy_`` destination to be a graph input, so this trips when the DiT is
+    compiled through the ``torch.compile(backend="torch_tensorrt")`` path
+    (Dynamo -> AOTAutograd functionalization -> torch-tensorrt), breaking
+    TensorRT + sequence-parallel (Ulysses) export. Computing ``variance + eps``
+    out-of-place keeps the graph functional. Numerically matches
+    ``F.rms_norm`` (fp32 accumulation, dtype restored to the input)."""
+    input_dtype = x.dtype
+    hidden = x.to(torch.float32)
+    variance = hidden.pow(2).mean(-1, keepdim=True)
+    hidden = hidden * torch.rsqrt(variance + eps)
+    out = hidden.to(input_dtype)
+    if weight is not None:
+        out = out * weight
+    return out
+
+
 def _rms_norm_dispatch(
     x: torch.Tensor,
     eps: float,
@@ -77,8 +103,7 @@ def _rms_norm_dispatch(
     # rms_norm to autocast's float32 cast policy, which under our
     # autocast(bfloat16) forward returns float32 instead. Restore the input
     # dtype to match the official numerics (and torch <= 2.11 behavior).
-    return torch.nn.functional.rms_norm(
-        x, (x.shape[-1], ), weight=weight, eps=eps).to(x.dtype)
+    return _functional_rms_norm(x, eps, weight)
 
 
 class StageAwareRMSNorm(nn.RMSNorm):
@@ -103,7 +128,7 @@ class StageAwareRMSNorm(nn.RMSNorm):
         # norm now returns float32 where torch <= 2.11 returned bfloat16.
         # Restore the input dtype so autocast-blind consumers downstream
         # (e.g. the flash-attention custom op) don't receive upcast q/k.
-        return super().forward(x).to(x.dtype)
+        return _functional_rms_norm(x, self.eps, self.weight)
 
 
 def _supports_prequantized_input(linear: ReplicatedLinear) -> bool:

--- a/fastvideo/models/dits/ltx2.py
+++ b/fastvideo/models/dits/ltx2.py
@@ -86,8 +86,10 @@ def _functional_rms_norm(
     hidden = hidden * torch.rsqrt(variance + eps)
     out = hidden.to(input_dtype)
     if weight is not None:
+        # A weight dtype differing from x (e.g. fp32 params under autocast)
+        # would promote the output; keep the input-dtype guarantee.
         out = out * weight
-    return out
+    return out.to(input_dtype)
 
 
 def _rms_norm_dispatch(


### PR DESCRIPTION
### Problem
Compiling the LTX-2 DiT through `torch.compile(dit, backend="torch_tensorrt")` under sequence parallelism (Ulysses) fails at compile time:

```
torch._dynamo.exc.BackendCompilerFailed: backend='torch_tensorrt' raised:
AssertionError: n=copy__13, n.args[0]=mean_13, placeholders={arg0_1 … arg79_1}
```

### Root cause
`torch.nn.functional.rms_norm` / `nn.RMSNorm` (used by `StageAwareRMSNorm` and `_rms_norm_dispatch`) decompose under AOTAutograd into an **in-place `variance.add_(eps)`** — an `aten.copy_` whose destination is the computed `mean`:

```
mean_1  = aten.mean.dim(pow, [2], True)       # variance
add_10  = aten.add.Tensor(mean_1, 1e-6)
copy__1 = aten.copy_.default(mean_1, add_10)  # copy_ into a non-input -> assert
```

AOTAutograd's `assert_functional_graph` requires every `copy_`/`set_` destination to be a graph input (placeholder). The `torch.compile(backend="torch_tensorrt")` path routes Dynamo → AOTAutograd functionalization → torch-tensorrt, so the assert fires before TRT sees the graph. (`torch_tensorrt.dynamo.compile(exported_program)` is unaffected — it consumes an already-functionalized graph.) This blocks **TensorRT-DiT + Ulysses sequence parallelism**.

### Fix
Compute `variance + eps` **out-of-place** via a small functional RMSNorm helper (`_functional_rms_norm`), used on the non-refine path in both `_rms_norm_dispatch` and `StageAwareRMSNorm.forward`. The refine-stage QuACK path is untouched. Numerically equivalent to `F.rms_norm` (fp32 accumulation, input dtype restored).

### Verification
torch 2.12.1 + torch-tensorrt 2.12.1 (Blackwell sm120), tiny LTX-2 DiT, `sp=2`:
- **Before:** `torch.compile(backend="torch_tensorrt")` raises the assert for video-only, audio+cross-modal, and `cross_attention_adaln=True` (LTX-2.3) configs.
- **After:** all three **compile + run a TRT forward** with no assert.
- Numerics vs original `F.rms_norm` (fp32, same seed): maxdiff ~1.3e-5, rel ~3e-7, `allclose(1e-5)=True`.