### PR TITLE
[ci]: opt in to fork-PR head checkout after actions/checkout guard change

### DIFF
--- a/.github/workflows/ci-precommit.yml
+++ b/.github/workflows/ci-precommit.yml
@@ -27,14 +27,25 @@ jobs:
         ref: ${{ inputs.ref || '' }}
     # For PR events, lint the PR head — but keep the hook definitions from
     # the base branch so an untrusted PR cannot alter what gets executed.
-    - name: Save trusted hook config
+    # The gate scripts are saved too: the self-test step below executes them,
+    # so it must run the base-branch copies, not the PR head's.
+    - name: Save trusted hook config and gate scripts
       if: github.event_name == 'pull_request_target'
-      run: cp .pre-commit-config.yaml "$RUNNER_TEMP/trusted-pre-commit-config.yaml"
-    - uses: actions/checkout@v4
+      run: |
+        cp .pre-commit-config.yaml "$RUNNER_TEMP/trusted-pre-commit-config.yaml"
+        cp -a .github/scripts "$RUNNER_TEMP/trusted-scripts"
+        echo "GATE_SCRIPTS_DIR=$RUNNER_TEMP/trusted-scripts" >> "$GITHUB_ENV"
+    # allow-unsafe-pr-checkout acknowledges checkout's pull_request_target
+    # guard: the head is data for the trusted hooks to lint; nothing from it
+    # is executed (config and gate scripts are pinned to the base branch
+    # above) and credentials are not persisted. SHA-pinned to v4.4.0 because
+    # actionlint's action schema does not know the new input yet.
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       if: github.event_name == 'pull_request_target'
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
+        allow-unsafe-pr-checkout: true
     - name: Restore trusted hook config
       if: github.event_name == 'pull_request_target'
       run: cp "$RUNNER_TEMP/trusted-pre-commit-config.yaml" .pre-commit-config.yaml
@@ -48,5 +59,7 @@ jobs:
       with:
         extra_args: --all-files --hook-stage manual
     # After pre-commit so a self-test failure cannot mask lint failures.
+    # GATE_SCRIPTS_DIR points at the base-branch copy on fork PRs (set above);
+    # push / workflow_call runs use the checked-out tree directly.
     - name: Full-suite gate self-test
-      run: bash .github/scripts/test_gate_full_suite.sh
+      run: bash "${GATE_SCRIPTS_DIR:-.github/scripts}/test_gate_full_suite.sh"


### PR DESCRIPTION
## Problem

Every fork PR's pre-commit lane started failing today at the checkout step (e.g. #1602, and 3 other fork PRs today — same-repo PRs are unaffected):

> Refusing to check out fork pull request code from a 'pull_request_target' workflow. ... To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

The floating `actions/checkout@v4` tag moved to a release (v4.4.0) that adds this guard, breaking the fork-PR lint flow that #1555 deliberately built on `pull_request_target`.

## Solution

- Set `allow-unsafe-pr-checkout: true` on the PR-head checkout. The workflow was already designed for this event: hook config is pinned to the base branch and credentials are not persisted, so the head is lint data, not executed code.
- Make that claim fully true: the full-suite gate self-test previously ran `.github/scripts/test_gate_full_suite.sh` from the PR head — untrusted code executing in the trusted context, exactly the "pwn request" vector the guard warns about. The gate scripts are now saved to `RUNNER_TEMP` alongside the trusted hook config and the self-test runs those base-branch copies on fork PRs. push/`workflow_call` runs still use the checked-out tree.
- The head-checkout step is SHA-pinned to checkout v4.4.0 because actionlint's bundled action schema (through v1.7.12) doesn't know the new input and fails the lint lane on the floating `v4` tag.

## Test evidence

- `pre-commit run --files .github/workflows/ci-precommit.yml` passes (actionlint included).
- Gate self-test passes when run from a relocated copy, as CI will: all 14 `ok:` cases, exit 0.
- Note: this PR's own pre-commit run still uses the workflow from main (that's how `pull_request_target` works) and passes because it's a same-repo branch. Fork PRs pick up the fix once this merges; #1602's lane needs a retrigger (new push or close/reopen) since reruns reuse the old workflow snapshot.