### PR TITLE
[bugfix]: fix stale imports in LTX-2.3 gradio local demo

### DIFF
--- a/examples/inference/gradio/local/gradio_local_demo_ltx2_3/README.md
+++ b/examples/inference/gradio/local/gradio_local_demo_ltx2_3/README.md
@@ -6,10 +6,6 @@ original single-file version to make each concern independently reviewable.
 The folder name matches the sibling `gradio_local_demo*.py` demos in this
 directory so both flat and packaged demos read consistently.
 
-> **Status: draft.** This package is structurally in place but will not run
-> against the current upstream `fastvideo` package. See *Blocking prereqs*
-> below.
-
 ## Layout
 
 | File | Purpose |
@@ -38,27 +34,21 @@ python -m gradio_local_demo_ltx2_3 --port 7860
 GPU requirement: a single FP4-capable GPU (B200 or comparable) for the
 "real-time 1080p" speed claim. Lower tiers will still run but slower.
 
-## Blocking prereqs (why this draft PR cannot be merged yet)
+## Upstream surfaces the demo relies on
 
-The upstream `fastvideo` package is missing three pieces that the demo
-currently depends on verbatim. Each needs its own upstreaming PR before this
-demo can actually boot:
+Everything the demo needs ships in the upstream `fastvideo` package:
 
-1. **`fastvideo.layers.quantization.fp4_config.FP4Config`** — the demo sets
-   `pipeline_config.dit_config.quant_config = FP4Config()` in `app.py`.
-   Upstream only ships `absmax_fp8.py` and `base_config.py` under
-   `fastvideo/layers/quantization/`.
-2. **LTX-2.3 refine / image-conditioning kwargs on `VideoGenerator`** —
-   `ltx2_refine_enabled`, `ltx2_refine_upsampler_path`, `ltx2_refine_lora_path`,
-   `ltx2_refine_num_inference_steps`, `ltx2_refine_guidance_scale`,
-   `ltx2_refine_add_noise`, `ltx2_images`, `ltx2_image_crf`. Upstream
-   `fastvideo/fastvideo_args.py` currently wires only `ltx2_vae_tiling`.
-   The backing stages (`ltx2_refine.py`, `ltx2_i2v_conditioning.py`) are
-   also missing from `fastvideo/pipelines/stages/`.
-3. **`fastvideo.configs.sample.base.SamplingParam`** — the import path used
-   by this demo. Upstream moved sampling params to
-   `fastvideo.api.sampling_param`. A re-export shim at the old path, or an
-   import update here once the other two prereqs land, will resolve it.
+- **`fastvideo.layers.quantization.nvfp4_config.NVFP4Config`** — the demo sets
+  `pipeline_config.dit_config.quant_config = NVFP4Config()` in `app.py` (same
+  pattern as `examples/inference/basic/basic_ltx2_distilled_fast_profile.py`).
+- **LTX-2.3 refine kwargs on `VideoGenerator`** — `ltx2_refine_enabled`,
+  `ltx2_refine_upsampler_path`, `ltx2_refine_lora_path`,
+  `ltx2_refine_num_inference_steps`, `ltx2_refine_guidance_scale`,
+  `ltx2_refine_add_noise`, and `ltx2_vae_tiling` are wired in
+  `fastvideo/fastvideo_args.py`, backed by
+  `fastvideo/pipelines/basic/ltx2/stages/ltx2_refine.py`.
+- **`SamplingParam`** — imported from the public `fastvideo` package root
+  (`fastvideo.api.sampling_param` under the hood).
 
 ## Environment variables
 

--- a/examples/inference/gradio/local/gradio_local_demo_ltx2_3/app.py
+++ b/examples/inference/gradio/local/gradio_local_demo_ltx2_3/app.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import gradio as gr
 
+from fastvideo import SamplingParam
 from fastvideo.configs.pipelines.base import PipelineConfig
-from fastvideo.configs.sample.base import SamplingParam
 from fastvideo.entrypoints.video_generator import VideoGenerator
-from fastvideo.layers.quantization.fp4_config import FP4Config
+from fastvideo.layers.quantization.nvfp4_config import NVFP4Config
 from fastvideo.utils import maybe_download_model
 
 from .config import (
@@ -44,7 +44,7 @@ def main():
         resolved_model_path = Path(model_root)
 
         pipeline_config = PipelineConfig.from_pretrained(str(resolved_model_path))
-        pipeline_config.dit_config.quant_config = FP4Config()
+        pipeline_config.dit_config.quant_config = NVFP4Config()
         refine_upsampler_path = resolve_refine_upsampler_path(resolved_model_path)
         print(f"Using refine upsampler: {refine_upsampler_path}")
 

--- a/examples/inference/gradio/local/gradio_local_demo_ltx2_3/config.py
+++ b/examples/inference/gradio/local/gradio_local_demo_ltx2_3/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import torch
 import torch._inductor.config
 
-from fastvideo.configs.sample.base import SamplingParam
+from fastvideo import SamplingParam
 
 LOCAL_DEMO_DIR = Path(__file__).resolve().parent
 CLASSIFIER_DIR = Path(

--- a/examples/inference/gradio/local/gradio_local_demo_ltx2_3/ui.py
+++ b/examples/inference/gradio/local/gradio_local_demo_ltx2_3/ui.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import gradio as gr
 
-from fastvideo.configs.sample.base import SamplingParam
+from fastvideo import SamplingParam
 from fastvideo.entrypoints.video_generator import VideoGenerator
 
 from .config import (


### PR DESCRIPTION
## Problem

The LTX-2.3 gradio local demo (`examples/inference/gradio/local/gradio_local_demo_ltx2_3/`) fails at import on current main:

- `app.py`, `config.py`, `ui.py` import `SamplingParam` from `fastvideo.configs.sample.base`, a module that no longer exists.
- `app.py` imports `FP4Config` from `fastvideo.layers.quantization.fp4_config`, which was renamed — the class is now `NVFP4Config` in `fastvideo/layers/quantization/nvfp4_config.py`.

The demo is also published to the docs site by `docs/generate_examples.py`, so the broken code is user-visible there.

## Solution

Mirror the already-migrated sibling example `examples/inference/basic/basic_ltx2_distilled_fast_profile.py`:

- `from fastvideo import SamplingParam` (public re-export) in all three files.
- `from fastvideo.layers.quantization.nvfp4_config import NVFP4Config` and `NVFP4Config()` in `app.py` (default `layer_profile="refine"` matches this demo, which runs with `ltx2_refine_enabled=True`).

No behavior change beyond restoring importability.

## Test evidence

- Static import check: every `from fastvideo...` import in the demo now resolves to an existing module/symbol on main (script asserts module file exists and symbol is present; passes).
- `pre-commit run --files <the 3 files>`: all content hooks report `(no files to check)` — `examples/.*` is deliberately excluded in `.pre-commit-config.yaml`; filename check passed.
- GPU run not performed (docs-role machine has no CUDA GPU); the fix is import-path-only and mirrors the sibling example's working pattern.