### PR TITLE
[docs]: unify community links on the README Slack invite

### DIFF
--- a/docs/getting_started/installation/gpu.md
+++ b/docs/getting_started/installation/gpu.md
@@ -134,4 +134,4 @@ If you're planning to contribute to FastVideo please see the following page:
 
 If you encounter any issues during installation, please open an issue on our [GitHub repository](https://github.com/hao-ai-lab/FastVideo).
 
-You can also join our [Slack community](https://join.slack.com/t/fastvideo/shared_invite/zt-38u6p1jqe-yDI1QJOCEnbtkLoaI5bjZQ) for additional support.
+You can also join our [Slack community](https://join.slack.com/t/fastvideo/shared_invite/zt-3f4lao1uq-u~Ipx6Lt4J27AlD2y~IdLQ) for additional support.

--- a/docs/getting_started/installation/mps.md
+++ b/docs/getting_started/installation/mps.md
@@ -100,4 +100,4 @@ If you're planning to contribute to FastVideo please see the following page:
 
 If you encounter any issues during installation, please open an issue on our [GitHub repository](https://github.com/hao-ai-lab/FastVideo).
 
-You can also join our [Slack community](https://join.slack.com/t/fastvideo/shared_invite/zt-38u6p1jqe-yDI1QJOCEnbtkLoaI5bjZQ) for additional support.
+You can also join our [Slack community](https://join.slack.com/t/fastvideo/shared_invite/zt-3f4lao1uq-u~Ipx6Lt4J27AlD2y~IdLQ) for additional support.

--- a/docs/getting_started/installation/spark.md
+++ b/docs/getting_started/installation/spark.md
@@ -134,7 +134,7 @@ uv pip install "https://github.com/mjun0812/flash-attention-prebuild-wheels/rele
 
 If you hit other issues, please open an issue on our
 [GitHub repository](https://github.com/hao-ai-lab/FastVideo). You can also join
-our [Slack community](https://join.slack.com/t/fastvideo/shared_invite/zt-38u6p1jqe-yDI1QJOCEnbtkLoaI5bjZQ)
+our [Slack community](https://join.slack.com/t/fastvideo/shared_invite/zt-3f4lao1uq-u~Ipx6Lt4J27AlD2y~IdLQ)
 for additional support.
 
 ## Development Environment Setup

--- a/docs/inference/add_pipeline.md
+++ b/docs/inference/add_pipeline.md
@@ -11,7 +11,7 @@ This guide explains how to implement a custom diffusion pipeline in FastVideo, l
 4. **Register Your Pipeline** - Make it discoverable by the framework
 5. **Configure Your Pipeline** - (Coming soon)
 
-Need help? Join our [Slack community](https://join.slack.com/t/fastvideo/shared_invite/zt-38u6p1jqe-yDI1QJOCEnbtkLoaI5bjZQ).
+Need help? Join our [Slack community](https://join.slack.com/t/fastvideo/shared_invite/zt-3f4lao1uq-u~Ipx6Lt4J27AlD2y~IdLQ).
 
 ## Step 1: Pipeline Modules
 

--- a/docs/inference/inference_quick_start.md
+++ b/docs/inference/inference_quick_start.md
@@ -134,5 +134,4 @@ If the generated video doesn't match your prompt:
 - Learn about [Advanced Inference Configurations](configuration.md)
 - Learn about using [Optimizations](optimizations.md)
 - See [Examples](examples/examples_inference_index.md) for more usage scenarios
-- Join our [Community Discord](https://discord.gg/JA7cksDz86).
-- Join our [Community Slack](https://join.slack.com/t/fastvideo/shared_invite/zt-38u6p1jqe-yDI1QJOCEnbtkLoaI5bjZQ).
+- Join our [Community Slack](https://join.slack.com/t/fastvideo/shared_invite/zt-3f4lao1uq-u~Ipx6Lt4J27AlD2y~IdLQ).


### PR DESCRIPTION
## Problem

Five docs pages (the three installation guides, `add_pipeline.md`, and the inference quickstart) carry a different Slack invite (`zt-38u6p1jqe-...`) than the README (`zt-3f4lao1uq-...`). Slack invites expire, so one of these is likely dead for new users. The inference quickstart also still links a Discord server the README no longer references.

## Solution

- Point all five pages at the README's invite — the most recently maintained community surface. (Liveness could not be verified programmatically: Slack's edge returns identical HTTP 403 bot-protection pages for both URLs, so this standardizes on the invite already shown to every visitor of the repo front page.)
- Drop the stray Discord bullet from the quickstart's Next Steps.

If the README invite is itself expired, that needs a fresh invite from a workspace admin — this PR just removes the two-invites inconsistency.

## Test evidence

- `grep -r 'join.slack' docs README.md` now yields a single invite ID across the repo.
- `pre-commit run --files <5 files>`: codespell + PyMarkdown pass.