### PR TITLE
[docs]: batched docs cleanup (landing page, links, requirements, nav)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ FastVideo has the following features:
   - [Sparse distillation](https://hao-ai-lab.github.io/blogs/fastvideo_post_training/) to achieve >50x denoising speedup
   - Scalable training with FSDP2, sequence parallelism, and selective activation checkpointing.
   - Causal distillation through Self-Forcing
-  - See this [page](https://hao-ai-lab.github.io/FastVideo/training/overview/) for full list of supported models and recipes.
+  - See this [page](https://hao-ai-lab.github.io/FastVideo/training/overview/) for the supported training workflows, and the [support matrix](https://hao-ai-lab.github.io/FastVideo/inference/support_matrix/) for supported models.
 - State-of-the-art performance optimizations for inference
   - Sequence Parallelism for distributed inference
   - Multiple state-of-the-art attention backends

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -54,8 +54,10 @@ UV_TORCH_BACKEND=cu126 uv pip install -e .
 uv pip install flash-attn --no-build-isolation -v
 ```
 
-## Hardware Requirements
+## Requirements
 
+- **Python**: 3.10-3.12 is the tested and recommended range (the commands
+  above pin 3.12)
 - **NVIDIA GPUs**: CUDA 12.6+ with compute capability 7.0+
 - **Apple Silicon**: macOS 14.0+ with M1/M2/M3/M4 chips
 - **CPU**: x86_64 architecture (for CPU-only inference)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 </div>
 
 <div style="text-align: center;">
-<strong>FastVideo is a unified inference and post-training framework for accelerated video generation.</strong>
+<strong>FastVideo is a unified post-training and real-time inference framework for accelerated video generation.</strong>
 </div>
 
 <div style="text-align: center;">
@@ -25,14 +25,23 @@ FastVideo is an inference and post-training framework for diffusion models. It f
 
 FastVideo has the following features:
 
+- End-to-end post-training support for bidirectional and autoregressive models
+  - Full finetuning and LoRA [finetuning](training/finetune.md) for state-of-the-art open video DiTs
+  - [Data preprocessing pipeline](training/data_preprocess.md) for video, image, and text data
+  - [Distribution Matching Distillation (DMD2)](distillation/dmd.md) stepwise distillation
+  - Sparse attention with [Video Sparse Attention](attention/vsa/index.md)
+  - [Sparse distillation](https://hao-ai-lab.github.io/blogs/fastvideo_post_training/) to achieve >50x denoising speedup
+  - [Attn-QAT training](training/attn_qat.md) for quantization-aware post-training
+  - Causal distillation through Self-Forcing
+  - Scalable training with FSDP2, sequence parallelism, and selective activation checkpointing
+  - See the [training overview](training/overview.md) for the full training workflow
 - State-of-the-art performance optimizations for inference
-  - [Sliding Tile Attention](attention/sta/index.md)
-  - [Sage Attention](https://arxiv.org/abs/2410.02367)
-- E2E post-training support
-  - Data preprocessing pipeline for video data
-  - [Sparse distillation](https://hao-ai-lab.github.io/blogs/fastvideo_post_training/) for Wan2.1 and Wan2.2 using [Video Sparse Attention](https://arxiv.org/pdf/2505.13389) and [Distribution Matching Distillation](https://tianweiy.github.io/dmd2/)
-  - Support full finetuning and LoRA finetuning for state-of-the-art open video DiTs.
-  - Scalable training with FSDP2, sequence parallelism, and selective activation checkpointing, with near linear scaling to 64 GPUs.
+  - Sequence parallelism for distributed inference
+  - Multiple state-of-the-art [attention backends](attention/index.md)
+  - User-friendly [CLI](inference/cli.md) and Python API
+  - See the [support matrix](inference/support_matrix.md) for supported models and [optimizations](inference/optimizations.md) for the full list
+- Realtime video generation and editing
+  - [Dreamverse](https://github.com/hao-ai-lab/FastVideo/tree/main/apps/dreamverse): stream and "vibe direct" video in realtime ([live demo](https://dreamverse.fastvideo.org/))
 
 ## Documentation
 

--- a/docs/inference/inference_quick_start.md
+++ b/docs/inference/inference_quick_start.md
@@ -4,10 +4,11 @@ This page contains step-by-step instructions to get you quickly started with vid
 
 ## Requirements
 
-- **OS**: Linux (Tested on Ubuntu 22.04+)
+- **OS**: Linux (tested on Ubuntu 22.04+), or macOS on Apple silicon via the
+  [MPS installation guide](../getting_started/installation/mps.md)
 - **Python**: 3.10-3.12
-- **CUDA**: 12.6 or 13.0
-- **GPU**: At least one NVIDIA GPU
+- **CUDA**: 12.6 or 13.0 (NVIDIA GPUs)
+- **GPU**: At least one NVIDIA GPU, or an Apple silicon chip with MPS
 
 ## Installation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -163,8 +163,11 @@ nav:
     - CLI: inference/cli.md
     - Add Pipeline: inference/add_pipeline.md
     - Examples:
+      - Examples Index: inference/examples/examples_inference_index.md
       - Basic: inference/examples/basic.md
       - Optimizations: inference/examples/optimizations.md
+      - LTX-2.3: inference/examples/ltx2_3.md
+      - LTX-2.3 Gradio Demo: inference/examples/gradio_local_demo_ltx2_3.md
       - STA Mask Search (Archived): inference/examples/sta_mask_search.md
   - Training:
     - Overview: training/overview.md


### PR DESCRIPTION
Batch of nit-class, pure-factual docs fixes (per the batched-PR policy: grouped for one review session; no behavior changes). Each item below is independent; itemized for line-by-line review. Source audit: docs-role first-boot audit vs main @ `8d89f30d`.

## Items

- [ ] **Landing page Key Features refresh** (`docs/index.md`) — [audit HIGH-3] Key Features led with Sliding Tile Attention (archived to `sta_do_not_delete`; the support matrix itself says VSA is strictly better on `main`) and omitted VSA/DMD2/QAD/self-forcing/Dreamverse. Rewritten to mirror the README's current feature set with links to each docs page (all 10 link targets verified present); tagline aligned to the README's; unsourced "near linear scaling to 64 GPUs" claim dropped.
- [ ] **Quickstart OS requirements** (`docs/inference/inference_quick_start.md`) — [audit MED-5] Requirements said Linux-only while the repo ships a maintained [MPS install guide](docs/getting_started/installation/mps.md); now lists macOS/Apple-silicon alongside Linux. (Windows intentionally not added: no install doc backs it.)
- [ ] **Python range on the installation hub** (`docs/getting_started/installation.md`) — the hub's requirements block never stated a Python range even though `gpu.md` and the quickstart both document 3.10-3.12. Now states 3.10-3.12 as the **tested and recommended** range — deliberately not a support ceiling, since `pyproject.toml` declares `requires-python = ">=3.10"` and the lockfile resolves 3.13+ (maintainer review infra/r37; also corrects this PR's earlier framing of #1490, whose actual failure was `OSError: Disk quota exceeded`, not wheel incompatibility).
- [ ] **README training pointer accuracy** (`README.md`) — [audit MED-4] the Key Features bullet promised a "full list of supported models and recipes" at `training/overview`, which contains no model list; now points at the training workflows there and the support matrix for models.
- [ ] **Sidebar nav for generated example pages** (`mkdocs.yml`) — [audit MED-8] the inference Examples nav listed 3 pages including an archived one, while the LTX-2.3 example pages that `docs/generate_examples.py` emits were invisible. Added: Examples Index, LTX-2.3, LTX-2.3 Gradio Demo. All six nav targets verified to be produced by a fresh `generate_examples.py` run.

## Landed separately

- **Slack invite unification + Discord removal** [audit MED-6] shipped via #1643 (merged by the author while this batch was being assembled); this PR was rebased onto that merge, so those hunks no longer appear here.

## Not in this batch (and why)

- **#1435 (Wan-VACE)**: the honest fix is a support-matrix note; that surface is owned by the in-flight #1641, so the note landed there (avoids two PRs editing the same file).
- **#1254 docs slice (per-model attention-backend matrix)**: substantive, not nit-class — backend support is currently declared per-layer and interleaves at runtime (that is the bug reported); publishing a per-model matrix now would codify incorrect behavior as documentation. Deferred until the code-side normalization (implementor-tracked) lands.

Supersedes #1642 (closed).

## Test evidence

- `pre-commit run --files <changed files>`: codespell + PyMarkdown pass.
- Landing-page internal links: existence-checked (10/10).
- Nav additions: `generate_examples.py` run confirms every referenced page is emitted.