### PR TITLE
[misc]: add LTX-2 fine-tuning example recipes

### DIFF
--- a/docs/training/train_infra.md
+++ b/docs/training/train_infra.md
@@ -231,6 +231,10 @@ switches those layers to `ATTN_QAT_INFER`.
 On GB200, set `callbacks.validation.attn_qat_infer: false` to keep validation on
 the train-time QAT backend; the inference kernel is sm120-only.
 
+User-adaptable LTX-2 fine-tuning recipes (full, LoRA, and NVFP4 QAT) live in
+`examples/train/configs/fine_tuning/ltx2/`, alongside the other model
+families under `examples/train/configs/fine_tuning/`.
+
 ---
 
 ## Training Methods

--- a/examples/train/configs/fine_tuning/ltx2/nvfp4_qat_t2v.yaml
+++ b/examples/train/configs/fine_tuning/ltx2/nvfp4_qat_t2v.yaml
@@ -1,0 +1,131 @@
+# LTX-2 T2V NVFP4 quantization-aware fine-tune (QAT).
+#
+# Same recipe as fine_tuning/ltx2/t2v.yaml, with the deployment-matched
+# NVFP4 quantization from the validated
+# examples/train/configs/overfit_ltx2_t2v_nvfp4_qat.yaml run: the curated
+# attention/FFN linear set used by LTX-2 NVFP4 deployment runs its
+# forward through real NVFP4 GEMMs (flashinfer cutlass) with a
+# straight-through-estimator backward into the dense fp32 master weights.
+# No extra parameters or buffers are added, so FSDP sharding,
+# checkpointing, and export are identical to dense training. Video
+# attention uses ATTN_QAT_TRAIN for its quantized forward and STE
+# backward, then ATTN_QAT_INFER during validation. Head-dim-64 audio
+# attention and masked text attention remain dense.
+#
+# Validation requires an sm_120 GPU with the attn_qat_infer extension.
+#
+# Prerequisites: preprocess your dataset into the trainer's latent format
+# (see docs/training/data_preprocess.md;
+# fastvideo/pipelines/preprocess/preprocess_ltx2_overfit.py is a minimal
+# LTX-2 reference to adapt). Data paths, step counts, and learning rate
+# below are placeholders you must adapt to your workload.
+#
+# Run on multi-GPU sm_120 hardware:
+#   NUM_GPUS=4 bash examples/train/run.sh \
+#     examples/train/configs/fine_tuning/ltx2/nvfp4_qat_t2v.yaml
+#
+# GB200 can train and validate with ATTN_QAT_TRAIN, but cannot load the
+# sm_120-only inference kernel. Disable only the validation-time swap:
+#   NUM_GPUS=4 bash examples/train/run.sh \
+#     examples/train/configs/fine_tuning/ltx2/nvfp4_qat_t2v.yaml \
+#     --callbacks.validation.attn_qat_infer false
+
+models:
+  student:
+    _target_: fastvideo.train.models.ltx2.LTX2Model
+    # Validation settings below (8 steps, guidance 1.0) assume this
+    # distilled checkpoint.
+    init_from: FastVideo/LTX2-Distilled-Diffusers
+    trainable: true
+    enable_gradient_checkpointing_type: full
+    attention_backend: ATTN_QAT_TRAIN
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    # The 13B video branch needs sharding; 4-way HSDP shard matches the
+    # validated LTX-2 runs. Scale num_gpus/hsdp_shard_dim together.
+    num_gpus: 4
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 4
+
+  data:
+    # REQUIRED: path to your preprocessed dataset.
+    data_path: data/your_dataset_preprocessed
+    dataloader_num_workers: 4
+    train_batch_size: 1
+    # LTX2Model requires 0.0: CFG dropout would zero post-connector
+    # embeddings, which is not the model's unconditional input.
+    training_cfg_rate: 0.0
+    seed: 42
+    # Must match your preprocessed resolution/length.
+    # num_latent_t = (num_frames - 1) / 8 + 1.
+    num_latent_t: 11
+    num_height: 480
+    num_width: 832
+    num_frames: 81
+
+  optimizer:
+    # Carried from the validated LTX-2 QAT overfit run as a starting
+    # point; tune for your dataset size and batch configuration.
+    learning_rate: 5.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    # Workload-dependent: set from your dataset size and target epochs.
+    max_train_steps: 2000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/ltx2_t2v_nvfp4_qat_finetune
+    # A full training-state checkpoint is ~150GB for the 13B trainable
+    # video branch — size the interval and total limit to your storage.
+    training_state_checkpointing_steps: 500
+    checkpoints_total_limit: 2
+    resume_from_checkpoint: latest
+
+  tracker:
+    trackers: [wandb]
+    project_name: fastvideo_ltx2
+    run_name: ltx2_t2v_nvfp4_qat_finetune
+
+  model:
+    # LTX2Model.predict_noise converts the DiT's x0 output to velocity,
+    # so the default noise-minus-clean target reproduces the official
+    # unweighted masked-MSE (mask is all-ones for plain T2V).
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.ltx2.ltx2_pipeline.LTX2Pipeline
+    # REQUIRED: prompts to sample during training.
+    dataset_file: data/your_dataset_preprocessed/validation_prompts.json
+    every_steps: 250
+    # 8-step single-pass sampling matches the distilled checkpoint
+    # (validated in the LTX-2 overfit runs).
+    sampling_steps: [8]
+    guidance_scale: 1.0
+    num_frames: 81
+    # Validation reuses the live transformer and temporarily replaces its
+    # ATTN_QAT_TRAIN implementations with the sm120 inference kernel.
+    # Set false on GB200 (see header).
+    attn_qat_infer: true
+
+# quant_config selects NVFP4 QAT for the same curated linear prefixes as
+# LTX-2 NVFP4 deployment. They fake-quantize through real FP4 GEMMs with
+# an STE backward. The string resolves to NVFP4QATTrainConfig at parse.
+pipeline:
+  dit_config:
+    quant_config: nvfp4_qat_train

--- a/examples/train/configs/fine_tuning/ltx2/t2v.yaml
+++ b/examples/train/configs/fine_tuning/ltx2/t2v.yaml
@@ -1,0 +1,110 @@
+# LTX-2 T2V full fine-tune.
+#
+# Starting point for fine-tuning LTX-2 on your own dataset with the
+# modular trainer. Model wiring (checkpoint, CFG rate, output
+# preconditioning, sharding) follows the validated
+# examples/train/configs/overfit_ltx2_t2v.yaml run; data paths, step
+# counts, and learning rate are placeholders you must adapt — the right
+# values depend on your dataset and are marked below.
+#
+# Prerequisites: preprocess your dataset into the trainer's latent format
+# (see docs/training/data_preprocess.md;
+# fastvideo/pipelines/preprocess/preprocess_ltx2_overfit.py is a minimal
+# LTX-2 reference to adapt).
+#
+# Run:
+#   NUM_GPUS=4 bash examples/train/run.sh \
+#     examples/train/configs/fine_tuning/ltx2/t2v.yaml
+
+models:
+  student:
+    _target_: fastvideo.train.models.ltx2.LTX2Model
+    # Validation settings below (8 steps, guidance 1.0) assume this
+    # distilled checkpoint.
+    init_from: FastVideo/LTX2-Distilled-Diffusers
+    trainable: true
+    enable_gradient_checkpointing_type: full
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    # The 13B video branch needs sharding; 4-way HSDP shard matches the
+    # validated LTX-2 runs. Scale num_gpus/hsdp_shard_dim together.
+    num_gpus: 4
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 4
+
+  data:
+    # REQUIRED: path to your preprocessed dataset.
+    data_path: data/your_dataset_preprocessed
+    dataloader_num_workers: 4
+    train_batch_size: 1
+    # LTX2Model requires 0.0: CFG dropout would zero post-connector
+    # embeddings, which is not the model's unconditional input.
+    training_cfg_rate: 0.0
+    seed: 42
+    # Must match your preprocessed resolution/length.
+    # num_latent_t = (num_frames - 1) / 8 + 1.
+    num_latent_t: 11
+    num_height: 480
+    num_width: 832
+    num_frames: 81
+
+  optimizer:
+    # Carried from the validated LTX-2 overfit run as a starting point;
+    # tune for your dataset size and batch configuration.
+    learning_rate: 5.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    # Workload-dependent: set from your dataset size and target epochs.
+    max_train_steps: 2000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/ltx2_t2v_finetune
+    # A full training-state checkpoint is ~150GB for the 13B trainable
+    # video branch — size the interval and total limit to your storage.
+    training_state_checkpointing_steps: 500
+    checkpoints_total_limit: 2
+    resume_from_checkpoint: latest
+
+  tracker:
+    trackers: [wandb]
+    project_name: fastvideo_ltx2
+    run_name: ltx2_t2v_finetune
+
+  model:
+    # LTX2Model.predict_noise converts the DiT's x0 output to velocity,
+    # so the default noise-minus-clean target reproduces the official
+    # unweighted masked-MSE (mask is all-ones for plain T2V).
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.ltx2.ltx2_pipeline.LTX2Pipeline
+    # REQUIRED: prompts to sample during training.
+    dataset_file: data/your_dataset_preprocessed/validation_prompts.json
+    every_steps: 250
+    # 8-step single-pass sampling matches the distilled checkpoint
+    # (validated in the LTX-2 overfit runs).
+    sampling_steps: [8]
+    guidance_scale: 1.0
+    num_frames: 81
+
+# Required so the LTX2T2VConfig pipeline config is resolved from
+# init_from (without a `pipeline:` key the loader falls back to a
+# generic PipelineConfig and the LTX-2 DiT cannot be constructed).
+pipeline: {}

--- a/examples/train/configs/fine_tuning/ltx2/t2v_lora.yaml
+++ b/examples/train/configs/fine_tuning/ltx2/t2v_lora.yaml
@@ -1,0 +1,114 @@
+# LTX-2 T2V LoRA fine-tune.
+#
+# Same recipe as fine_tuning/ltx2/t2v.yaml, but only LoRA adapters on the
+# attention projections train — the base weights stay frozen, so
+# training-state checkpoints are adapter-sized instead of ~150GB.
+# See that file's header for prerequisites and placeholder notes.
+#
+# Run:
+#   NUM_GPUS=4 bash examples/train/run.sh \
+#     examples/train/configs/fine_tuning/ltx2/t2v_lora.yaml
+
+models:
+  student:
+    _target_: fastvideo.train.models.ltx2.LTX2Model
+    # Validation settings below (8 steps, guidance 1.0) assume this
+    # distilled checkpoint.
+    init_from: FastVideo/LTX2-Distilled-Diffusers
+    trainable: true
+    enable_gradient_checkpointing_type: full
+    lora:
+      enable: true
+      # rank/alpha and the attention-projection target set follow the
+      # Wan/Hunyuan LoRA recipes; targets match by substring against
+      # module names (LTX-2 blocks name theirs to_q/to_k/to_v/to_out).
+      rank: 16
+      alpha: 32
+      target_modules:
+        - to_q
+        - to_k
+        - to_v
+        - to_out
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    # The 13B video branch needs sharding even with frozen base weights;
+    # 4-way HSDP shard matches the validated LTX-2 runs.
+    num_gpus: 4
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 4
+
+  data:
+    # REQUIRED: path to your preprocessed dataset.
+    data_path: data/your_dataset_preprocessed
+    dataloader_num_workers: 4
+    train_batch_size: 1
+    # LTX2Model requires 0.0: CFG dropout would zero post-connector
+    # embeddings, which is not the model's unconditional input.
+    training_cfg_rate: 0.0
+    seed: 42
+    # Must match your preprocessed resolution/length.
+    # num_latent_t = (num_frames - 1) / 8 + 1.
+    num_latent_t: 11
+    num_height: 480
+    num_width: 832
+    num_frames: 81
+
+  optimizer:
+    # LoRA-only training usually tolerates a higher LR than full
+    # fine-tuning (the Wan/Hunyuan LoRA recipes use 1.0e-4); tune for
+    # your dataset.
+    learning_rate: 1.0e-4
+    betas: [0.9, 0.999]
+    weight_decay: 0.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    # Workload-dependent: set from your dataset size and target epochs.
+    max_train_steps: 2000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/ltx2_t2v_lora_finetune
+    training_state_checkpointing_steps: 500
+    checkpoints_total_limit: 2
+    resume_from_checkpoint: latest
+
+  tracker:
+    trackers: [wandb]
+    project_name: fastvideo_ltx2
+    run_name: ltx2_t2v_lora_finetune
+
+  model:
+    # LTX2Model.predict_noise converts the DiT's x0 output to velocity,
+    # so the default noise-minus-clean target reproduces the official
+    # unweighted masked-MSE (mask is all-ones for plain T2V).
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.ltx2.ltx2_pipeline.LTX2Pipeline
+    # REQUIRED: prompts to sample during training.
+    dataset_file: data/your_dataset_preprocessed/validation_prompts.json
+    every_steps: 250
+    # 8-step single-pass sampling matches the distilled checkpoint
+    # (validated in the LTX-2 overfit runs).
+    sampling_steps: [8]
+    guidance_scale: 1.0
+    num_frames: 81
+
+# Required so the LTX2T2VConfig pipeline config is resolved from
+# init_from (without a `pipeline:` key the loader falls back to a
+# generic PipelineConfig and the LTX-2 DiT cannot be constructed).
+pipeline: {}


### PR DESCRIPTION
## Problem

`examples/train/configs/fine_tuning/` has recipes for cosmos, hunyuan, longcat, and wan — but nothing for LTX-2, even though the modular trainer has shipped LTX-2 support (#1624), LoRA plumbing, and NVFP4 linear+attention QAT (#1626). Users coming from the overfit smoke configs have no production-oriented starting point.

## Solution

Add `examples/train/configs/fine_tuning/ltx2/` with three user-adaptable recipes (batched per surface):

- **`t2v.yaml`** — plain full fine-tune. Model wiring (checkpoint, `training_cfg_rate: 0.0` requirement, `precondition_outputs: false`, 4-way HSDP shard for the 13B video branch) carried from the validated `overfit_ltx2_t2v.yaml`; dataset path, step count, and LR are clearly-commented placeholders — workload-dependent values are marked as such rather than presented as tuned.
- **`t2v_lora.yaml`** — LoRA variant; rank/alpha and the `to_q/to_k/to_v/to_out` target set follow the existing Wan/Hunyuan LoRA recipes and `fastvideo/train/utils/lora.py`'s documented example.
- **`nvfp4_qat_t2v.yaml`** — deployment-matched NVFP4 QAT, derived from #1626's merged `overfit_ltx2_t2v_nvfp4_qat.yaml`: same wiring (`attention_backend: ATTN_QAT_TRAIN`, `quant_config: nvfp4_qat_train`, validation-time `ATTN_QAT_INFER` swap) including the sm_120 requirement and the GB200 `--callbacks.validation.attn_qat_infer false` note.
- `docs/training/train_infra.md`: one cross-link sentence pointing at the new directory from the existing LTX-2 QAT recipe paragraph.

The 8-step / guidance 1.0 validation settings reuse what the LTX-2 overfit runs established for the distilled checkpoint, with attribution in comments. No new hyperparameters are invented.

## Test evidence

- All three configs parse through the train entrypoint's loader (`fastvideo.train.utils.config.load_run_config`), resolving the expected knobs:
```
PARSED .../t2v.yaml: target=fastvideo.train.models.ltx2.LTX2Model lora=off attn=None quant=None steps=2000
PARSED .../t2v_lora.yaml: target=fastvideo.train.models.ltx2.LTX2Model lora=on attn=None quant=None steps=2000
PARSED .../nvfp4_qat_t2v.yaml: target=fastvideo.train.models.ltx2.LTX2Model lora=off attn=ATTN_QAT_TRAIN quant=nvfp4_qat_train steps=2000
```
- `pytest fastvideo/tests/train/utils/test_config.py -q` → 22 passed (same env).
- `pre-commit` green on all four files.
- Not train-tested end-to-end on GPU: the LoRA recipe is parse-verified and mirrors the shipped Wan/Hunyuan LoRA wiring; the QAT recipe is config-identical to #1626's validated overfit run apart from the production placeholders.

## Blast radius

Examples + docs only — no library code, no test code, no shared-forward changes.

## Context

- #1626 (merged NVFP4 QAT recipe this derives from), #1624 (LTX-2 trainer support)
- Closes the LTX-2 production-recipe gap (every other trained family ships fine-tuning recipes under `examples/train/configs/fine_tuning/`; LTX-2 shipped none)
