### PR TITLE
[bugfix]: registry most-specific match + QAD weights file path

### DIFF
--- a/examples/inference/optimizations/FastWan_QAD_TAEHV.py
+++ b/examples/inference/optimizations/FastWan_QAD_TAEHV.py
@@ -46,9 +46,9 @@ OUTPUT_PATH = "video_samples"
 # guidance 1.0). Loaded on top of the base Wan2.1 pipeline; pass
 # ``--distilled_model ''`` to run the base weights instead.
 DEFAULT_DISTILLED_MODEL = "FastVideo/FastWan-QAD-1.3B"
-DISTILLED_WEIGHTS_FILE = (
-    "generator_inference_transformer/diffusion_pytorch_model.safetensors"
-)
+# File layout of FastVideo/FastWan-QAD-1.3B: the distilled transformer lives
+# in the standard diffusers ``transformer/`` subfolder.
+DISTILLED_WEIGHTS_FILE = "transformer/diffusion_pytorch_model.safetensors"
 
 # TAEHV checkpoint for Wan2.1. Clone https://github.com/madebyollin/taehv to get
 # ``taew2_1.pth`` (Wan 2.1 / Wan 2.2-14B / Qwen-Image all use this VAE).

--- a/fastvideo/registry.py
+++ b/fastvideo/registry.py
@@ -185,6 +185,14 @@ def get_model_short_name(model_id: str) -> str:
     return model_id
 
 
+def _pattern_specificity(model_id: str, path_lower: str) -> int:
+    """Length of the longest registered HF path (short name) for ``model_id``
+    that appears in ``path_lower``, or 0 when none does."""
+    return max((len(short) for registered_path, mapped_id in _MODEL_HF_PATH_TO_NAME.items()
+                if mapped_id == model_id and (short := get_model_short_name(registered_path.lower())) in path_lower),
+               default=0)
+
+
 def _get_config_info(
     model_path: str,
     *,
@@ -222,12 +230,25 @@ def _get_config_info(
 
     if matched_model_names:
         if len(matched_model_names) > 1:
-            logger.warning(
-                "Multiple models matched for path '%s': %s. Using the first matched: '%s'.",
-                model_path,
-                matched_model_names,
-                matched_model_names[0],
-            )
+            # Most specific entry wins: rank matches by the longest registered
+            # HF path found in the query path, so a broad family detector
+            # (e.g. LTX-2 base firing on the shared pipeline class name) never
+            # shadows a dedicated entry (e.g. LTX-2.3 distilled). Warn only
+            # when matches are equally specific (genuine ambiguity); ties keep
+            # registration order.
+            path_lower = model_path.lower()
+            scores = [_pattern_specificity(name, path_lower) for name in matched_model_names]
+            best_score = max(scores)
+            matched_model_names = [
+                name for name, score in zip(matched_model_names, scores, strict=False) if score == best_score
+            ]
+            if len(matched_model_names) > 1:
+                logger.warning(
+                    "Multiple models matched for path '%s': %s. Using the first matched: '%s'.",
+                    model_path,
+                    matched_model_names,
+                    matched_model_names[0],
+                )
         model_id = matched_model_names[0]
         return _CONFIG_REGISTRY.get(model_id)
 

--- a/tests/local_tests/ltx2/test_ltx2_registry.py
+++ b/tests/local_tests/ltx2/test_ltx2_registry.py
@@ -96,3 +96,50 @@ def test_ltx2_ambiguous_local_path_resolves_via_detector(
     _write_minimal_diffusers_repo(model_dir, "LTX2Pipeline")
     resolved_cls = get_pipeline_config_cls_from_name(str(model_dir))
     assert resolved_cls is LTX2T2VConfig
+
+
+def _record_registry_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple]:
+    from fastvideo import registry
+
+    warnings: list[tuple] = []
+    monkeypatch.setattr(
+        registry.logger, "warning",
+        lambda *args, **kwargs: warnings.append(args))
+    return warnings
+
+
+def test_ltx23_distilled_local_path_prefers_most_specific_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The LTX-2 base detector also fires on the shared "LTX2Pipeline"
+    # class name, but the LTX-2.3 distilled entry has the longest
+    # registered HF path matching this directory, so it must win
+    # silently (no ambiguity warning).
+    from fastvideo.registry import get_default_preset
+
+    warnings = _record_registry_warnings(monkeypatch)
+    model_dir = tmp_path / "LTX-2.3-Distilled-Diffusers-ckpt"
+    _write_minimal_diffusers_repo(model_dir, "LTX2Pipeline")
+
+    assert get_default_preset(str(model_dir)) == "ltx2_distilled"
+    assert warnings == []
+
+
+def test_ltx2_equally_specific_local_path_still_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # No registered HF path appears in this directory name, so the
+    # distilled (path match) and base (pipeline-name match) entries are
+    # equally specific: genuine ambiguity keeps the warning, and
+    # registration order breaks the tie.
+    from fastvideo.registry import get_default_preset
+
+    warnings = _record_registry_warnings(monkeypatch)
+    model_dir = tmp_path / "ltx2-distilled"
+    _write_minimal_diffusers_repo(model_dir, "LTX2Pipeline")
+
+    assert get_default_preset(str(model_dir)) == "ltx2_distilled"
+    assert len(warnings) == 1
+    assert "Multiple models matched" in warnings[0][0]


### PR DESCRIPTION
## Problem

Two related model-resolution bugs:

1. **Registry ambiguous multi-match — LTX-2.3 paths resolved to the WRONG entry.** The detector loop in `_get_config_info` ORs `detector(model_path)` with `detector(pipeline_name)`; every LTX-2 variant shares the pipeline class name `LTX2Pipeline`, so the LTX-2 base entry's negative predicates trivially pass on that string and the base entry co-matched every `LTX-2.3-Distilled` path. Production log:
`WARNING [registry.py:225] Multiple models matched for path '...LTX-2.3-Distilled-Diffusers...': ['0', '2']. Using the first matched: '0'.`
This was not cosmetic: first-match-wins handed LTX-2.3 paths the base entry's config/preset. Any LTX-2.3 run made before this fix carried that resolution.

2. **FastWan QAD + TAEHV example 404s.** `FastWan_QAD_TAEHV.py` downloads `generator_inference_transformer/diffusion_pytorch_model.safetensors` from `FastVideo/FastWan-QAD-1.3B`, but the repo uses the standard diffusers `transformer/` subfolder (matching its FP8 sibling repo). Verified against the HuggingFace API: the old path returns **404**, the corrected `transformer/diffusion_pytorch_model.safetensors` returns **302** (exists); all three referenced repo ids return **200**.

## Solution

- `fastvideo/registry.py`: when multiple detectors match, the **most specific entry wins** — matches are ranked by the longest registered HF path (short name) found in the query path; the ambiguity warning now fires only for equally-specific matches (genuine ambiguity), with registration order as the tiebreak. Fixed inside `_get_config_info` so every consumer (`get_model_info`, `get_default_preset`, `get_pipeline_config_cls_from_name`, `get_model_family`, `get_preset_selection`, `get_sampling_param_cls_for_name`) benefits. No registry entries reordered or renamed; single-match behavior unchanged.
- `examples/inference/optimizations/FastWan_QAD_TAEHV.py`: weights path corrected to the repo's actual layout.

## Behavior change (intended)

LTX-2.3-Distilled paths now resolve to the LTX-2.3 entry (specificity 27 vs 5 in the production repro) instead of the base LTX-2 entry, silently. Equal-specificity collisions still warn.

## Test evidence

- Two CPU-only regression tests added beside the existing LTX-2 registry tests (`tests/local_tests/ltx2/test_ltx2_registry.py`): LTX-2.3 local path resolves to the distilled variant with zero warnings; an equally-specific tie still warns. Local tmp-dir repos, no network.
- Resolution logic verified against a standalone simulation of the exact production path (entry `'0'` → `'2'`, no warning).
- pre-commit green (yapf, ruff, codespell, mypy) on all three files.

## Blast radius

Inference and training pipeline resolution both route through `_get_config_info` — behavior changes ONLY for paths that previously multi-matched (which warned loudly); single-match resolution is byte-identical. The example fix is example-only.