### PR TITLE
[bugfix]: copy text encoder outputs out of CUDAGraph static buffers

### DIFF
--- a/fastvideo/pipelines/stages/text_encoding.py
+++ b/fastvideo/pipelines/stages/text_encoding.py
@@ -315,14 +315,19 @@ class TextEncodingStage(PipelineStage):
                 prompt_embeds = postprocess_func(outputs)
             except Exception:
                 prompt_embeds, attention_mask = postprocess_func(outputs, attention_mask)
+            # copy=True: when the text encoder is torch.compile'd with
+            # mode="reduce-overhead"/"max-autotune" (CUDAGraphs), its output
+            # tensors are backed by the graph's static buffer pool and are
+            # overwritten by the next encode call (e.g. the negative prompt).
+            # Retaining them past this call (batch.prompt_embeds is consumed
+            # at denoising time) then raises "accessing tensor output of
+            # CUDAGraphs that has been overwritten by a subsequent run", so
+            # copy them out of graph-owned storage here, at the single point
+            # where encoder outputs escape the compiled region.
             if is_ltx2 and getattr(outputs, "hidden_states", None):
-                audio_embed = outputs.hidden_states[0].to(device=target_device)
-                if dtype is not None:
-                    audio_embed = audio_embed.to(dtype=dtype)
+                audio_embed = outputs.hidden_states[0].to(device=target_device, dtype=dtype, copy=True)
                 audio_embeds_list.append(audio_embed)
-            prompt_embeds = prompt_embeds.to(device=target_device)
-            if dtype is not None:
-                prompt_embeds = prompt_embeds.to(dtype=dtype)
+            prompt_embeds = prompt_embeds.to(device=target_device, dtype=dtype, copy=True)
             embeds_list.append(prompt_embeds)
             if return_attention_mask:
                 attn_masks_list.append(attention_mask.to(device=target_device))

--- a/fastvideo/tests/stages/test_text_encoding.py
+++ b/fastvideo/tests/stages/test_text_encoding.py
@@ -327,3 +327,67 @@ def test_encode_text_explicit_device_overrides_hf_passthrough_marker():
 
     assert stage.text_encoders[0].last_input_device == torch.device("meta")
     assert output[0].device.type == "meta"
+
+
+class StaticBufferTextEncoder(torch.nn.Module):
+    """Mimics a text encoder compiled with torch.compile
+    mode="reduce-overhead"/"max-autotune" (CUDAGraphs): every forward returns
+    tensors backed by the same static storage, which the next invocation
+    overwrites in place."""
+
+    def __init__(self, text_len=4, hidden_size=8):
+        super().__init__()
+        self.register_buffer("static_out",
+                             torch.zeros(1, text_len, hidden_size))
+        self.register_buffer("static_audio",
+                             torch.zeros(1, text_len, hidden_size))
+
+    def forward(self, input_ids, attention_mask, output_hidden_states=False):
+        # A CUDAGraph replay rewrites the static output buffers in place.
+        self.static_out += 1.0
+        self.static_audio += 2.0
+        hidden_states = (self.static_audio, ) if output_hidden_states else None
+        return types.SimpleNamespace(last_hidden_state=self.static_out,
+                                     hidden_states=hidden_states)
+
+
+def identity_postprocess(outputs: BaseEncoderOutput) -> torch.Tensor:
+    return outputs.last_hidden_state
+
+
+def test_encode_text_output_does_not_alias_encoder_static_buffers():
+    # Regression: with a CUDAGraph-compiled text encoder, the raw forward
+    # outputs are graph-owned static buffers (for the LTX-2 Gemma encoder the
+    # escaping tensors are produced by the connector's final rms_norm). The
+    # CFG negative-prompt encode replays the graph and overwrites them, so
+    # consuming the positive prompt's embeds at denoising time raised
+    # "accessing tensor output of CUDAGraphs that has been overwritten by a
+    # subsequent run". encode_text must copy every embedding it retains out
+    # of encoder-owned storage.
+    fastvideo_args, hidden = make_args(num_encoders=1, text_len=4, hidden_size=8)
+    fastvideo_args.pipeline_config.dit_config.prefix = "ltx2"
+    fastvideo_args.pipeline_config.postprocess_text_funcs = (identity_postprocess, )
+    cfg = fastvideo_args.pipeline_config.text_encoder_configs[0].arch_config
+    cfg.output_hidden_states = True
+
+    encoder = StaticBufferTextEncoder(text_len=4, hidden_size=hidden)
+    stage = TextEncodingStage(text_encoders=[encoder],
+                              tokenizers=[FakeTokenizer()])
+
+    embeds = stage.encode_text("a cat", fastvideo_args, encoder_index=[0],
+                               device="cpu")
+    prompt_embeds = embeds[0]
+    audio_embeds = stage._last_audio_embeds[0]
+
+    # The retained tensors must not alias the encoder's reused output storage.
+    assert prompt_embeds.data_ptr() != encoder.static_out.data_ptr()
+    assert audio_embeds.data_ptr() != encoder.static_audio.data_ptr()
+
+    # And their values must survive a subsequent encode (the negative prompt)
+    # that overwrites the encoder's static buffers in place.
+    expected_prompt = prompt_embeds.clone()
+    expected_audio = audio_embeds.clone()
+    stage.encode_text("bad quality", fastvideo_args, encoder_index=[0],
+                      device="cpu")
+    torch.testing.assert_close(prompt_embeds, expected_prompt)
+    torch.testing.assert_close(audio_embeds, expected_audio)


### PR DESCRIPTION
## Problem

With a text encoder compiled under `torch.compile mode="reduce-overhead"` or `mode="max-autotune"` (both enable CUDAGraphs), generation crashes at denoising time:

`accessing tensor output of CUDAGraphs that has been overwritten by a subsequent run`

(first observed via the LTX-2 Gemma encoder's trailing `rms_norm` output, `fastvideo/models/encoders/gemma.py:353`). Root cause: the compiled encoder's output tensors are backed by the CUDAGraph static buffer pool. `TextEncodingStage.encode_text` retained them via `.to(device)`/`.to(dtype)` — **aliasing no-ops when device/dtype already match** — and stashed them in `batch.prompt_embeds` (and the LTX-2 audio embeds). The CFG negative-prompt encode then replays the same graph and overwrites the positive prompt's buffers long before denoising consumes them. This blocks the entire CUDAGraphs compile-mode family for any pipeline whose text encoder is compiled.

## Solution

Copy at the single escape point: `prompt_embeds` and the LTX-2 `audio_embed` are now retained with `.to(device=..., dtype=..., copy=True)` (dtype `None` preserves dtype), forcing fresh storage out of graph-owned memory — one small copy per encode, covering **every** compiled text encoder (Gemma, T5, Qwen, ...), not just the site where the error surfaced. An in-graph clone inside the encoder cannot fix this: under fullgraph capture its result is still pool-backed.

Interim workaround for deployments pinned to older builds: disable text-encoder compilation and keep `reduce-overhead` on the DiT only.

## Test evidence

- New CPU regression in `fastvideo/tests/stages/test_text_encoding.py`: a fake encoder returns the same registered buffers every call and mutates them in place (mimicking graph replays); the test pins (1) retained embeds' `data_ptr()` differs from the encoder's static buffers, and (2) embed values survive a second encode that overwrites those buffers — the exact negative-prompt scenario. No CUDAGraphs needed to pin the aliasing property.
- pre-commit green (yapf, ruff, codespell, mypy).

## Blast radius

Shared inference path (`TextEncodingStage` serves all pipelines; training touches it only via validation-callback pipelines). Numerics: exact — the change is a storage copy; values are byte-identical.