### PR TITLE
[misc]: add LTX-2.3 fine-tuning example recipes

### DIFF
--- a/examples/train/configs/fine_tuning/ltx2_3/nvfp4_qat_t2v.yaml
+++ b/examples/train/configs/fine_tuning/ltx2_3/nvfp4_qat_t2v.yaml
@@ -1,0 +1,142 @@
+# LTX-2.3 T2V NVFP4 quantization-aware fine-tune (QAT).
+#
+# Same recipe as fine_tuning/ltx2_3/t2v.yaml, with the deployment-matched
+# NVFP4 quantization wiring carried from the validated LTX-2.0 QAT run
+# (examples/train/configs/overfit_ltx2_t2v_nvfp4_qat.yaml): the curated
+# attention/FFN linear set runs its forward through real NVFP4 GEMMs
+# (flashinfer cutlass) with a straight-through-estimator backward into
+# the dense fp32 master weights. No extra parameters or buffers are
+# added, so FSDP sharding, checkpointing, and export are identical to
+# dense training. Video attention uses ATTN_QAT_TRAIN for its quantized
+# forward and STE backward, then ATTN_QAT_INFER during validation.
+# Head-dim-64 audio attention and masked text attention remain dense.
+#
+# LTX-2.3 applicability: the curated linear prefix set
+# (fastvideo/layers/quantization/nvfp4_config.py) targets
+# ltx2.blocks.{0..47}.* — LTX-2.3 uses the same LTX-2 transformer class,
+# module naming, and 48-block depth, so the same 576 linears attach.
+# CAVEAT: the set was curated against LTX-2.0 NVFP4 deployment, and
+# LTX-2.3 QAT training has no validated overfit run yet. The 2.3
+# gated-attention to_gate_logits projections are not in the set and
+# remain dense.
+#
+# Validation requires an sm_120 GPU with the attn_qat_infer extension.
+#
+# Prerequisites: preprocess your dataset into the trainer's latent format
+# (see docs/training/data_preprocess.md;
+# fastvideo/pipelines/preprocess/preprocess_ltx2_overfit.py is a minimal
+# LTX-2 reference to adapt — set
+# LTX2_OVERFIT_MODEL=FastVideo/LTX-2.3-Distilled-Diffusers). Data paths,
+# step counts, and learning rate below are placeholders you must adapt
+# to your workload.
+#
+# Run on multi-GPU sm_120 hardware:
+#   NUM_GPUS=4 bash examples/train/run.sh \
+#     examples/train/configs/fine_tuning/ltx2_3/nvfp4_qat_t2v.yaml
+#
+# GB200 can train and validate with ATTN_QAT_TRAIN, but cannot load the
+# sm_120-only inference kernel. Disable only the validation-time swap:
+#   NUM_GPUS=4 bash examples/train/run.sh \
+#     examples/train/configs/fine_tuning/ltx2_3/nvfp4_qat_t2v.yaml \
+#     --callbacks.validation.attn_qat_infer false
+
+models:
+  student:
+    _target_: fastvideo.train.models.ltx2.LTX2Model
+    # Validation settings below (8 steps, guidance 1.0) assume this
+    # distilled checkpoint.
+    init_from: FastVideo/LTX-2.3-Distilled-Diffusers
+    trainable: true
+    enable_gradient_checkpointing_type: full
+    attention_backend: ATTN_QAT_TRAIN
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    # The 13B video branch needs sharding; 4-way HSDP shard matches the
+    # validated LTX-2.3 runs. Scale num_gpus/hsdp_shard_dim together.
+    num_gpus: 4
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 4
+
+  data:
+    # REQUIRED: path to your preprocessed dataset.
+    data_path: data/your_dataset_preprocessed
+    dataloader_num_workers: 4
+    train_batch_size: 1
+    # LTX2Model requires 0.0: CFG dropout would zero post-connector
+    # embeddings, which is not the model's unconditional input.
+    training_cfg_rate: 0.0
+    seed: 42
+    # Must match your preprocessed resolution/length.
+    # num_latent_t = (num_frames - 1) / 8 + 1.
+    num_latent_t: 11
+    num_height: 480
+    num_width: 832
+    num_frames: 81
+
+  optimizer:
+    # Carried from the validated LTX-2.0 QAT overfit run as a starting
+    # point; tune for your dataset size and batch configuration.
+    learning_rate: 5.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    # Workload-dependent: set from your dataset size and target epochs.
+    max_train_steps: 2000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/ltx2_3_t2v_nvfp4_qat_finetune
+    # A full training-state checkpoint is ~150GB for the 13B trainable
+    # video branch — size the interval and total limit to your storage.
+    training_state_checkpointing_steps: 500
+    checkpoints_total_limit: 2
+    resume_from_checkpoint: latest
+
+  tracker:
+    trackers: [wandb]
+    project_name: fastvideo_ltx2
+    run_name: ltx2_3_t2v_nvfp4_qat_finetune
+
+  model:
+    # LTX2Model.predict_noise converts the DiT's x0 output to velocity,
+    # so the default noise-minus-clean target reproduces the official
+    # unweighted masked-MSE (mask is all-ones for plain T2V).
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.ltx2.ltx2_pipeline.LTX2Pipeline
+    # REQUIRED: prompts to sample during training.
+    dataset_file: data/your_dataset_preprocessed/validation_prompts.json
+    every_steps: 250
+    # 8-step single-pass sampling matches the distilled checkpoint
+    # (validated in the LTX-2.3 overfit runs).
+    sampling_steps: [8]
+    guidance_scale: 1.0
+    num_frames: 81
+    # Validation reuses the live transformer and temporarily replaces its
+    # ATTN_QAT_TRAIN implementations with the sm120 inference kernel.
+    # Set false on GB200 (see header).
+    attn_qat_infer: true
+
+# quant_config selects NVFP4 QAT for the same curated linear prefixes as
+# LTX-2 NVFP4 deployment (see the LTX-2.3 applicability note in the
+# header). They fake-quantize through real FP4 GEMMs with an STE
+# backward. The string resolves to NVFP4QATTrainConfig at parse.
+pipeline:
+  dit_config:
+    quant_config: nvfp4_qat_train

--- a/examples/train/configs/fine_tuning/ltx2_3/t2v.yaml
+++ b/examples/train/configs/fine_tuning/ltx2_3/t2v.yaml
@@ -1,0 +1,112 @@
+# LTX-2.3 T2V full fine-tune.
+#
+# Starting point for fine-tuning LTX-2.3 (gated attention, cross-attn
+# AdaLN, 4096-d post-connector text embeddings, no in-DiT caption
+# projection) on your own dataset with the modular trainer. Model wiring
+# (checkpoint, CFG rate, output preconditioning, sharding) follows the
+# validated examples/train/configs/overfit_ltx2_3_t2v.yaml run; data
+# paths, step counts, and learning rate are placeholders you must
+# adapt — the right values depend on your dataset and are marked below.
+#
+# Prerequisites: preprocess your dataset into the trainer's latent format
+# (see docs/training/data_preprocess.md;
+# fastvideo/pipelines/preprocess/preprocess_ltx2_overfit.py is a minimal
+# LTX-2 reference to adapt — set
+# LTX2_OVERFIT_MODEL=FastVideo/LTX-2.3-Distilled-Diffusers).
+#
+# Run:
+#   NUM_GPUS=4 bash examples/train/run.sh \
+#     examples/train/configs/fine_tuning/ltx2_3/t2v.yaml
+
+models:
+  student:
+    _target_: fastvideo.train.models.ltx2.LTX2Model
+    # Validation settings below (8 steps, guidance 1.0) assume this
+    # distilled checkpoint.
+    init_from: FastVideo/LTX-2.3-Distilled-Diffusers
+    trainable: true
+    enable_gradient_checkpointing_type: full
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    # The 13B video branch needs sharding; 4-way HSDP shard matches the
+    # validated LTX-2.3 runs. Scale num_gpus/hsdp_shard_dim together.
+    num_gpus: 4
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 4
+
+  data:
+    # REQUIRED: path to your preprocessed dataset.
+    data_path: data/your_dataset_preprocessed
+    dataloader_num_workers: 4
+    train_batch_size: 1
+    # LTX2Model requires 0.0: CFG dropout would zero post-connector
+    # embeddings, which is not the model's unconditional input.
+    training_cfg_rate: 0.0
+    seed: 42
+    # Must match your preprocessed resolution/length.
+    # num_latent_t = (num_frames - 1) / 8 + 1.
+    num_latent_t: 11
+    num_height: 480
+    num_width: 832
+    num_frames: 81
+
+  optimizer:
+    # Carried from the validated LTX-2.3 overfit run as a starting point;
+    # tune for your dataset size and batch configuration.
+    learning_rate: 5.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    # Workload-dependent: set from your dataset size and target epochs.
+    max_train_steps: 2000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/ltx2_3_t2v_finetune
+    # A full training-state checkpoint is ~150GB for the 13B trainable
+    # video branch — size the interval and total limit to your storage.
+    training_state_checkpointing_steps: 500
+    checkpoints_total_limit: 2
+    resume_from_checkpoint: latest
+
+  tracker:
+    trackers: [wandb]
+    project_name: fastvideo_ltx2
+    run_name: ltx2_3_t2v_finetune
+
+  model:
+    # LTX2Model.predict_noise converts the DiT's x0 output to velocity,
+    # so the default noise-minus-clean target reproduces the official
+    # unweighted masked-MSE (mask is all-ones for plain T2V).
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.ltx2.ltx2_pipeline.LTX2Pipeline
+    # REQUIRED: prompts to sample during training.
+    dataset_file: data/your_dataset_preprocessed/validation_prompts.json
+    every_steps: 250
+    # 8-step single-pass sampling matches the distilled checkpoint
+    # (validated in the LTX-2.3 overfit runs).
+    sampling_steps: [8]
+    guidance_scale: 1.0
+    num_frames: 81
+
+# Required so the LTX2T2VConfig pipeline config is resolved from
+# init_from (without a `pipeline:` key the loader falls back to a
+# generic PipelineConfig and the LTX-2 DiT cannot be constructed).
+pipeline: {}

--- a/examples/train/configs/fine_tuning/ltx2_3/t2v_lora.yaml
+++ b/examples/train/configs/fine_tuning/ltx2_3/t2v_lora.yaml
@@ -1,0 +1,116 @@
+# LTX-2.3 T2V LoRA fine-tune.
+#
+# Same recipe as fine_tuning/ltx2_3/t2v.yaml, but only LoRA adapters on
+# the attention projections train — the base weights stay frozen, so
+# training-state checkpoints are adapter-sized instead of ~150GB.
+# See that file's header for prerequisites and placeholder notes.
+#
+# Run:
+#   NUM_GPUS=4 bash examples/train/run.sh \
+#     examples/train/configs/fine_tuning/ltx2_3/t2v_lora.yaml
+
+models:
+  student:
+    _target_: fastvideo.train.models.ltx2.LTX2Model
+    # Validation settings below (8 steps, guidance 1.0) assume this
+    # distilled checkpoint.
+    init_from: FastVideo/LTX-2.3-Distilled-Diffusers
+    trainable: true
+    enable_gradient_checkpointing_type: full
+    lora:
+      enable: true
+      # rank/alpha and the attention-projection target set follow the
+      # Wan/Hunyuan LoRA recipes; targets match by substring against
+      # module names (LTX-2.3 blocks name theirs to_q/to_k/to_v/to_out;
+      # the 2.3 gated-attention to_gate_logits projection is not
+      # targeted).
+      rank: 16
+      alpha: 32
+      target_modules:
+        - to_q
+        - to_k
+        - to_v
+        - to_out
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    # The 13B video branch needs sharding even with frozen base weights;
+    # 4-way HSDP shard matches the validated LTX-2.3 runs.
+    num_gpus: 4
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 4
+
+  data:
+    # REQUIRED: path to your preprocessed dataset.
+    data_path: data/your_dataset_preprocessed
+    dataloader_num_workers: 4
+    train_batch_size: 1
+    # LTX2Model requires 0.0: CFG dropout would zero post-connector
+    # embeddings, which is not the model's unconditional input.
+    training_cfg_rate: 0.0
+    seed: 42
+    # Must match your preprocessed resolution/length.
+    # num_latent_t = (num_frames - 1) / 8 + 1.
+    num_latent_t: 11
+    num_height: 480
+    num_width: 832
+    num_frames: 81
+
+  optimizer:
+    # LoRA-only training usually tolerates a higher LR than full
+    # fine-tuning (the Wan/Hunyuan LoRA recipes use 1.0e-4); tune for
+    # your dataset.
+    learning_rate: 1.0e-4
+    betas: [0.9, 0.999]
+    weight_decay: 0.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    # Workload-dependent: set from your dataset size and target epochs.
+    max_train_steps: 2000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/ltx2_3_t2v_lora_finetune
+    training_state_checkpointing_steps: 500
+    checkpoints_total_limit: 2
+    resume_from_checkpoint: latest
+
+  tracker:
+    trackers: [wandb]
+    project_name: fastvideo_ltx2
+    run_name: ltx2_3_t2v_lora_finetune
+
+  model:
+    # LTX2Model.predict_noise converts the DiT's x0 output to velocity,
+    # so the default noise-minus-clean target reproduces the official
+    # unweighted masked-MSE (mask is all-ones for plain T2V).
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.ltx2.ltx2_pipeline.LTX2Pipeline
+    # REQUIRED: prompts to sample during training.
+    dataset_file: data/your_dataset_preprocessed/validation_prompts.json
+    every_steps: 250
+    # 8-step single-pass sampling matches the distilled checkpoint
+    # (validated in the LTX-2.3 overfit runs).
+    sampling_steps: [8]
+    guidance_scale: 1.0
+    num_frames: 81
+
+# Required so the LTX2T2VConfig pipeline config is resolved from
+# init_from (without a `pipeline:` key the loader falls back to a
+# generic PipelineConfig and the LTX-2 DiT cannot be constructed).
+pipeline: {}

--- a/fastvideo/models/loader/fsdp_load.py
+++ b/fastvideo/models/loader/fsdp_load.py
@@ -38,8 +38,14 @@ def _maybe_quantize_model(model: nn.Module) -> None:
     The walk returns on the first quantized layer found so unquantized callers
     pay only an ``isinstance`` check per module. Both imports are deferred so
     this is a no-op on hosts without the relevant backends.
+
+    QAT-*train* linears (``nvfp4_qat_train``) need no weight conversion — the
+    master weight stays full precision — but their attachment is otherwise
+    silent, so the same walk emits a one-line receipt with the count of
+    linears that actually carry the QAT method.
     """
     # Defer imports: these modules pull in heavy symbols at module-load time.
+    from fastvideo.layers.linear import LinearBase
     from fastvideo.layers.quantization.nvfp4_config import (
         NVFP4QuantizeMethod,
         convert_model_to_nvfp4,
@@ -48,11 +54,15 @@ def _maybe_quantize_model(model: nn.Module) -> None:
         NVFP4QATQuantizeMethod,
         convert_model_to_fp4,
     )
+    from fastvideo.layers.quantization.nvfp4_qat_train_config import (
+        NVFP4QATTrainQuantizeMethod, )
     from fastvideo.layers.quantization.fp8_config import (
         FP8QuantizeMethod,
         convert_model_to_fp8,
     )
 
+    qat_train_attached = 0
+    qat_train_skipped = 0
     for mod in model.modules():
         qm = getattr(mod, "quant_method", None)
         if isinstance(qm, NVFP4QuantizeMethod):
@@ -67,6 +77,16 @@ def _maybe_quantize_model(model: nn.Module) -> None:
             logger.info("Converting loaded model weights for FP8 linear layers")
             convert_model_to_fp8(model)
             return
+        # QAT-train configs are mutually exclusive with the inference schemes
+        # above (one quant_config per model), so when they're active the loop
+        # always runs to completion and the counts below are model-wide.
+        if isinstance(qm, NVFP4QATTrainQuantizeMethod):
+            qat_train_attached += 1
+        elif isinstance(mod, LinearBase):
+            qat_train_skipped += 1
+    if qat_train_attached:
+        logger.info("NVFP4 QAT: attached %d linears (%d skipped by prefix filter)", qat_train_attached,
+                    qat_train_skipped)
 
 
 # TODO(PY): move this to utils elsewhere

--- a/fastvideo/tests/ops/quantization/test_nvfp4_qat_receipt.py
+++ b/fastvideo/tests/ops/quantization/test_nvfp4_qat_receipt.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only test for the NVFP4 QAT attachment receipt.
+
+``_maybe_quantize_model`` is the single post-load walk over the model,
+so it is where the definitive "how many linears carry the QAT-train
+method" count exists. This test builds a tiny module tree — one linear
+whose prefix matches the QAT target set, one that doesn't — and asserts
+the receipt reports the counts derived from that walk.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import torch.nn as nn
+
+from fastvideo.layers.linear import ReplicatedLinear
+from fastvideo.layers.quantization.nvfp4_qat_train_config import (
+    NVFP4QATTrainConfig, )
+from fastvideo.models.loader.fsdp_load import _maybe_quantize_model
+
+
+# ``fastvideo.logger.init_logger`` sets ``propagate=False`` on its
+# loggers, so the standard ``caplog`` fixture cannot observe them.
+# Attach a temporary handler directly to the target logger instead
+# (same pattern as fastvideo/tests/train/callbacks/test_callback.py).
+@contextmanager
+def _capture_logger(name: str, level: int = logging.INFO) -> Iterator[list[logging.LogRecord]]:
+    logger = logging.getLogger(name)
+    records: list[logging.LogRecord] = []
+
+    class _Handler(logging.Handler):
+
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Handler(level=level)
+    prev_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
+
+
+def _model(quant_config: NVFP4QATTrainConfig | None) -> nn.Module:
+    model = nn.Module()
+    # Prefix in DEFAULT_FP4_LAYERS -> gets the QAT-train method attached.
+    model.matched = ReplicatedLinear(16, 16, quant_config=quant_config, prefix="blocks.0.attn1.to_k")
+    # Prefix outside the target set -> UnquantizedLinearMethod fallback.
+    model.unmatched = ReplicatedLinear(16, 16, quant_config=quant_config, prefix="blocks.0.proj_mlp")
+    return model
+
+
+def test_qat_train_receipt_reports_attached_and_skipped_counts() -> None:
+    model = _model(NVFP4QATTrainConfig())
+    with _capture_logger("fastvideo.models.loader.fsdp_load") as records:
+        _maybe_quantize_model(model)
+    messages = [r.getMessage() for r in records]
+    assert "NVFP4 QAT: attached 1 linears (1 skipped by prefix filter)" in messages
+
+
+def test_no_receipt_without_qat_train_layers() -> None:
+    model = _model(quant_config=None)
+    with _capture_logger("fastvideo.models.loader.fsdp_load") as records:
+        _maybe_quantize_model(model)
+    assert not any("NVFP4 QAT" in r.getMessage() for r in records)

--- a/fastvideo/tests/train/utils/test_finetune_config_construction.py
+++ b/fastvideo/tests/train/utils/test_finetune_config_construction.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only construction check for every shipped fine-tuning recipe.
+
+Parametrizes over ``examples/train/configs/fine_tuning/**/*.yaml`` and
+asserts each loads through :func:`load_run_config` with a resolved
+pipeline config and an importable-shaped student target — the
+construction proof (parse-green is not construct-green) and a
+regression net for every family's recipes.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fastvideo.train.utils.config import load_run_config
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_RECIPE_DIR = _REPO_ROOT / "examples" / "train" / "configs" / "fine_tuning"
+
+_RECIPES = sorted(_RECIPE_DIR.glob("**/*.yaml"))
+
+
+def _recipe_id(path: Path) -> str:
+    return str(path.relative_to(_RECIPE_DIR))
+
+
+@pytest.mark.parametrize("recipe", _RECIPES, ids=_recipe_id)
+def test_fine_tuning_recipe_constructs(recipe: Path) -> None:
+    cfg = load_run_config(str(recipe))
+
+    assert cfg.training.pipeline_config is not None, (
+        f"{_recipe_id(recipe)} did not resolve a pipeline config; "
+        "check its `pipeline:` key and init_from registry match")
+
+    target = cfg.models["student"]["_target_"]
+    assert isinstance(target, str) and target and "." in target, (
+        f"{_recipe_id(recipe)} student _target_ is not importable-shaped: "
+        f"{target!r}")
+
+
+def test_recipe_glob_found_recipes() -> None:
+    # Guard against the glob silently matching nothing after a move.
+    assert len(_RECIPES) >= 20


### PR DESCRIPTION
## Problem

`examples/train/configs/fine_tuning/ltx2/` covers LTX-2.0; LTX-2.3 — the current flagship checkpoint — has no fine-tuning recipes. Contributors wanting to fine-tune or run NVFP4 QAT on 2.3 have only the overfit dev config to reverse-engineer.

## Solution

New `examples/train/configs/fine_tuning/ltx2_3/` (underscore naming matches `examples/inference/ltx2_3/`) with the three counterparts adapted to `FastVideo/LTX-2.3-Distilled-Diffusers`: `t2v.yaml`, `t2v_lora.yaml`, `nvfp4_qat_t2v.yaml`.

Adaptation was reconciled against three sources of truth (the LTX-2.3 registry preset, the `overfit_ltx2_3_t2v.yaml` dev config, and the `ltx2_3_t2v_finetune_min.yaml` test fixture) — all three agree: same resolution set (480×832, 81 frames, `num_latent_t: 11`), validation at 8 steps / guidance 1.0 (the 30-step / CFG-3.0 sampling change applies only to the 2.3 *base* checkpoint, not distilled), `training_cfg_rate: 0.0`, `precondition_outputs: false`, `pipeline: {}`, same `LTX2Model` target (2.3 arch flags come from the checkpoint's config).

**NVFP4 QAT targeting verified, not assumed**: the curated linear-prefix set applies cleanly to 2.3 — same transformer class and module naming, and the checkpoint's transformer config confirms `num_layers: 48`, so the same 576 linears attach. Two caveats stated in the recipe header: the set was curated against LTX-2.0 deployment and 2.3 QAT has no validated overfit run yet; 2.3's gated-attention `to_gate_logits` projections are outside the set and remain dense.

**Note: the LTX-2.3 QAD checkpoint does not exist yet.** These recipes land first so contributors can run QAT themselves; a trained/validated 2.3 QAD checkpoint follows separately.

## Test evidence

- New `fastvideo/tests/train/utils/test_finetune_config_construction.py`: parametrizes over **every** yaml under `examples/train/configs/fine_tuning/` (20 recipes) and asserts each constructs through `load_run_config` with a resolved `pipeline_config` — construction-level proof in the CI unit lane for these three recipes AND a permanent regression net for all families (a recipe missing its `pipeline:` key previously parsed green and crashed at model construction).
- pre-commit green (example yamls and tests are deliberately excluded from the Python hooks; filename checks pass).

## Blast radius

Examples + one CPU test. No library code.