### PR TITLE
Add PromptRL training support

### DIFF
--- a/examples/inference/promptrl/promptrl_wan_inference.py
+++ b/examples/inference/promptrl/promptrl_wan_inference.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRL inference: refine a prompt, then generate with the Wan LoRA.
+
+Explicit two-stage flow (VideoGenerator behavior is unchanged — the
+refiner is applied by the caller, not inside the generator):
+
+1. ``PromptRefiner.from_bundle(bundle).refine(prompt)`` loads the
+   PromptRL refiner adapter and returns the refined prompt (falling
+   back to the original when the completion misses <answer>...</answer>).
+2. The exported Wan LoRA loads through the existing generator
+   configuration (``ComponentConfig.lora_path``).
+3. ``VideoGenerator.generate(...)`` runs the typed request API.
+
+Usage::
+
+    python examples/inference/promptrl/promptrl_wan_inference.py \
+        --bundle outputs/wan2.1_promptrl_joint/bundle \
+        --prompt "a cat riding a skateboard" \
+        --output outputs/promptrl/skateboard.mp4
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from fastvideo import VideoGenerator
+from fastvideo.api import (
+    EngineConfig,
+    GenerationRequest,
+    GeneratorConfig,
+    OutputConfig,
+    ParallelismConfig,
+    PipelineSelection,
+    SamplingConfig,
+)
+from fastvideo.api.schema import ComponentConfig
+from fastvideo.train.methods.rl.promptrl import PromptRefiner
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="PromptRL Wan inference")
+    parser.add_argument("--bundle", required=True, help="PromptRL bundle directory")
+    parser.add_argument("--model-path", default=None,
+                        help="Wan base model; defaults to the bundle manifest value")
+    parser.add_argument("--prompt", default="a cat riding a skateboard")
+    parser.add_argument("--negative-prompt", default="")
+    parser.add_argument("--output", default="outputs/promptrl/promptrl_wan.mp4")
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--width", type=int, default=832)
+    parser.add_argument("--num-frames", type=int, default=77)
+    parser.add_argument("--steps", type=int, default=50)
+    parser.add_argument("--guidance-scale", type=float, default=6.0)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--refiner-seed", type=int, default=0)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    # 1. Refine the prompt with the bundled PromptRL refiner.
+    refiner = PromptRefiner.from_bundle(args.bundle, device="cuda")
+    model_path = args.model_path or refiner.manifest.base_generator_model
+    refinement = refiner.refine(args.prompt, seed=args.refiner_seed)
+    print(f"[promptrl] original : {refinement.original_prompt}")
+    print(f"[promptrl] refined  : {refinement.refined_prompt} "
+          f"(format_valid={refinement.format_valid})")
+
+    # 2. Load the exported Wan LoRA through the existing generator config.
+    generator_lora = os.path.join(args.bundle, "generator", "promptrl_generator_lora.safetensors")
+    lora_path = generator_lora if os.path.isfile(generator_lora) else None
+    if lora_path is None:
+        print("[promptrl] no generator LoRA in bundle; running the base Wan model")
+    generator = VideoGenerator.from_config(
+        GeneratorConfig(
+            model_path=model_path,
+            engine=EngineConfig(
+                num_gpus=1,
+                parallelism=ParallelismConfig(tp_size=1, sp_size=1),
+                use_fsdp_inference=False,
+            ),
+            pipeline=PipelineSelection(
+                workload_type="t2v",
+                components=ComponentConfig(lora_path=lora_path),
+            ),
+        ))
+    try:
+        # 3. Typed request API with the refined prompt.
+        generator.generate(
+            GenerationRequest(
+                prompt=refinement.refined_prompt,
+                negative_prompt=args.negative_prompt,
+                sampling=SamplingConfig(
+                    height=args.height,
+                    width=args.width,
+                    num_frames=args.num_frames,
+                    num_inference_steps=args.steps,
+                    guidance_scale=args.guidance_scale,
+                    seed=args.seed,
+                ),
+                output=OutputConfig(
+                    output_path=str(output),
+                    save_video=True,
+                    return_frames=False,
+                ),
+            ))
+    finally:
+        generator.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/train/configs/rl/wan/README_promptrl.md
+++ b/examples/train/configs/rl/wan/README_promptrl.md
@@ -1,0 +1,112 @@
+# PromptRL for Wan video generation
+
+PromptRL trains a **prompt-refiner LoRA** (Qwen2.5-VL-3B-Instruct) and —
+in the joint milestone — a **Wan LoRA** with shared group-relative
+rewards.  The canonical target is Wan2.1 T2V 1.3B at 480×832 / 77
+frames on eight 80GB training GPUs, with VideoScore2 running as a
+pluggable reward service on a ninth GPU.
+
+## Milestones
+
+1. **Prompt-only** (`promptrl_prompt_only.yaml`): train the refiner LoRA
+   while Wan stays frozen.  Rollout/transition storage is skipped.
+2. **Joint** (`promptrl_joint.yaml`): train independent LoRA adapters
+   for the refiner and Wan.  Shared advantages are detached before both
+   policy losses, so no gradients cross between the models.  The refiner
+   initializes from the prompt-only adapter
+   (`models.refiner.init_adapter_from`); Wan's LoRA initializes at zero.
+
+## Group layout per step
+
+One original prompt is replicated across the eight training ranks; each
+rank produces one independently seeded candidate:
+
+| Ranks | Role               | Generation prompt        | Format reward |
+|-------|--------------------|--------------------------|---------------|
+| 0–1   | retained originals | original prompt          | 1             |
+| 2–7   | refined            | sampled refiner output*  | 1 if valid    |
+
+\* Malformed refinements (missing `<answer>...</answer>`) receive format
+reward 0 and fall back to the original prompt for video generation; the
+completion is preserved so it still receives its negative LM signal.
+Every rank executes the refiner forward/backward path — retained
+originals use zero refiner advantage — so distributed collectives stay
+aligned.
+
+Videos are scored against the **original** prompt (never the refined
+one).  The composite reward `format + VideoScore2` is normalized within
+each `(group, reward_tag)`; zero-variance groups yield zero advantages.
+
+## Reward service
+
+The trainer depends only on the reward-provider contract
+(`score(samples) -> results`).  The built-in service collects each complete
+group and evaluates every video with the official VideoScore2 procedure:
+2 FPS video sampling, the published three-dimension prompt, temperature-0.7
+generation, and confidence-weighted scores from the generated `1`–`5` token
+logits. A fixed seed makes repeated requests reproducible, and completed
+request IDs are cached for idempotent retries:
+
+```bash
+# reward host (ninth GPU)
+CUDA_VISIBLE_DEVICES=0 python -m fastvideo.train.methods.rl.promptrl.rewards.serve \
+    --model-id TIGER-Lab/VideoScore2 --port 8100
+
+# training host (eight GPUs)
+torchrun --nproc_per_node=8 -m fastvideo.train.entrypoint.train \
+    --config examples/train/configs/rl/wan/promptrl_prompt_only.yaml
+```
+
+Endpoints: `GET /healthz`, `POST /v1/rewards:score` (multipart).  Any
+timeout, duplicate/missing sample, non-finite score, or cardinality
+mismatch fails the step consistently on every rank — zero rewards are
+never substituted.  Videos transfer over HTTP only; no shared
+filesystem is required.
+
+## Prompt dataset
+
+Raw JSONL or Parquet (not preprocessed):
+
+```json
+{"id": "p1", "prompt": "a cat riding a skateboard", "reward_tag": "animals"}
+```
+
+`prompt` is required; `id` and `reward_tag` are optional.
+
+## Bundles and inference
+
+The `promptrl_export` callback writes an inference bundle at train end
+(`manifest.json`, `refiner/` PEFT adapter, `generator/` Wan LoRA
+safetensors + prompt template/version, refiner sampling config, base
+model identifiers, compatible FastVideo version).  Generate with the
+typed API:
+
+```bash
+python examples/inference/promptrl/promptrl_wan_inference.py \
+    --bundle outputs/wan2.1_promptrl_joint/bundle \
+    --prompt "a cat riding a skateboard"
+```
+
+## Observability
+
+Per-step metrics include group reward statistics, VideoScore2
+components, refinement validity, refined-vs-original reward gap,
+LM loss/KL/completion length, Wan policy loss/KL/ratio/clip fraction,
+rollout/reward/backward latency, and peak GPU memory.  Only group
+leaders log prompt samples or videos.
+
+## Notes
+
+- Distributed layout: `sp_size=1`, `hsdp_shard_dim=8`; Wan uses HSDP
+  while the refiner is replicated with DDP-synchronized LoRA gradients.
+- Wan rollouts use 20 flow-matching steps; only the last 8 are
+  stochastic SDE transitions whose states/old log-probs are stored and
+  recomputed (microbatch 1) in the joint loss.
+- Reference policies are adapter-disabled forward contexts (PEFT
+  `disable_adapter` for the refiner, `disable_lora` for Wan) — no
+  duplicate frozen model copies.
+- Checkpointing covers both adapters, both optimizers/schedulers, and
+  all RNG states; prompt iteration is a deterministic function of the
+  step index, so resume continues the exact prompt stream.
+- Out of scope for v1: FLUX/image reproduction, full-parameter
+  training, automatic prompt refinement inside `VideoGenerator`.

--- a/examples/train/configs/rl/wan/build_promptrl_vbench_dataset.py
+++ b/examples/train/configs/rl/wan/build_promptrl_vbench_dataset.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Build the PromptRL training prompt pool from the pinned VBench suite."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+DEFAULT_VBENCH_ROOT = Path(
+    "fastvideo/third_party/eval/vbench/prompts")
+DEFAULT_SOURCES = ("all_dimension.txt", "all_category.txt")
+
+
+def build_rows(vbench_root: Path) -> list[dict[str, str]]:
+    """Return deterministic, de-duplicated VBench prompt records."""
+    prompts: dict[str, str] = {}
+    for source_name in DEFAULT_SOURCES:
+        source_path = vbench_root / source_name
+        if not source_path.is_file():
+            raise FileNotFoundError(
+                f"VBench prompt source not found: {source_path}. "
+                "Initialize the pinned VBench git submodule first.")
+        for raw_prompt in source_path.read_text(encoding="utf-8").splitlines():
+            prompt = raw_prompt.strip()
+            if prompt:
+                prompts.setdefault(prompt, source_name)
+
+    return [{
+        "id": f"vbench-{index:04d}",
+        "prompt": prompt,
+        "reward_tag": "videoscore2",
+        "source": source,
+    } for index, (prompt, source) in enumerate(prompts.items())]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--vbench-root",
+                        type=Path,
+                        default=DEFAULT_VBENCH_ROOT)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    rows = build_rows(args.vbench_root)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print(f"PROMPTRL_DATASET_READY rows={len(rows)} path={args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/train/configs/rl/wan/promptrl_joint.yaml
+++ b/examples/train/configs/rl/wan/promptrl_joint.yaml
@@ -1,0 +1,140 @@
+# PromptRL milestone 2 (joint): train independent LoRA adapters for the
+# refiner and Wan with shared group-relative rewards.  Gradients never
+# cross between the two models (advantages are detached).
+#
+# Start from the prompt-only milestone: the refiner initializes from the
+# prompt-only adapter (init_adapter_from below), Wan's LoRA initializes
+# at zero (lora_B is zero-initialized).
+#
+# Layout is identical to the prompt-only run: 8 training GPUs + the
+# VideoScore2 reward service on a ninth GPU.
+
+models:
+  student:
+    _target_: fastvideo.train.models.wan.WanPromptRLModel
+    init_from: Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+    trainable: true
+    lora:
+      enable: true
+      rank: 16
+      alpha: 32
+      target_modules: [to_q, to_k, to_v, to_out]
+  refiner:
+    _target_: fastvideo.train.roles.qwen_refiner.QwenPromptRefinerRole
+    init_from: Qwen/Qwen2.5-VL-3B-Instruct
+    trainable: true
+    # Prompt-only refiner checkpoint (PEFT adapter directory from the
+    # milestone-1 bundle export).
+    init_adapter_from: outputs/wan2.1_promptrl_prompt_only/bundle/refiner
+    lora:
+      enable: true
+      rank: 16
+      alpha: 32
+      target_modules: [q_proj, k_proj, v_proj, o_proj]
+
+method:
+  _target_: fastvideo.train.methods.rl.promptrl.PromptRLMethod
+  mode: joint
+  group_size: 8
+  retained_originals: 2
+  format_reward_weight: 1.0
+  video_reward_weight: 1.0
+  refiner_kl_beta: 0.01
+  student_kl_beta: 0.01
+  ppo_clip: 0.0001
+
+  rollout:
+    num_steps: 20
+    sde_steps: 8
+    noise_scale: 0.8
+    loss_microbatch_size: 1
+    flow_shift: inherit
+
+  data:
+    data_path: data/promptrl_prompts.jsonl
+    prompt_key: prompt
+    id_key: id
+    reward_tag_key: reward_tag
+
+  reward:
+    endpoint_url: http://127.0.0.1:8100
+    timeout_sec: 300
+    retries: 2
+    fps: 16
+
+  refiner:
+    max_new_tokens: 256
+    temperature: 1.0
+    top_p: 1.0
+    template_version: v1
+
+  refiner_optimizer:
+    learning_rate: 1.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.01
+    max_grad_norm: 1.0
+    lr_scheduler: constant
+
+  generator_optimizer:
+    learning_rate: 1.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.01
+    max_grad_norm: 1.0
+    lr_scheduler: constant
+
+  validation:
+    every_steps: 50
+    num_steps: 20
+    num_prompts: 8
+    batch_size: 8
+    log_samples: true
+    seed: 42
+
+training:
+  distributed:
+    num_gpus: 8
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 8
+
+  data:
+    data_path: ""
+    train_batch_size: 1
+    dataloader_num_workers: 0
+    training_cfg_rate: 0.0
+    seed: 42
+    num_latent_t: 20
+    num_height: 480
+    num_width: 832
+    num_frames: 77
+
+  optimizer:
+    learning_rate: 1.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.01
+    lr_scheduler: constant
+
+  loop:
+    max_train_steps: 1000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/wan2.1_promptrl_joint
+    training_state_checkpointing_steps: 50
+    checkpoints_total_limit: 4
+
+  tracker:
+    project_name: promptrl_wan
+    run_name: wan2.1_promptrl_joint
+
+  model:
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  promptrl_export:
+    output_dir: outputs/wan2.1_promptrl_joint/bundle
+    every_steps: 0
+
+pipeline:
+  flow_shift: 8

--- a/examples/train/configs/rl/wan/promptrl_prompt_only.yaml
+++ b/examples/train/configs/rl/wan/promptrl_prompt_only.yaml
@@ -1,0 +1,148 @@
+# PromptRL milestone 1 (prompt-only): train the Qwen prompt-refiner LoRA
+# while Wan2.1 T2V 1.3B stays frozen.
+#
+# Canonical layout: 8 training GPUs (sp_size=1, hsdp_shard_dim=8; the
+# 3B refiner is replicated with synchronized LoRA gradients via DDP) and
+# a ninth GPU running the VideoScore2 reward service:
+#
+#   # reward host (ninth GPU):
+#   CUDA_VISIBLE_DEVICES=0 python -m \
+#       fastvideo.train.methods.rl.promptrl.rewards.serve --port 8100
+#
+#   # training host (eight GPUs):
+#   torchrun --nproc_per_node=8 -m fastvideo.train.entrypoint.train \
+#       --config examples/train/configs/rl/wan/promptrl_prompt_only.yaml
+#
+# The student's LoRA block is present (but never updated in prompt-only
+# mode) so the joint milestone starts from an identical models section.
+
+models:
+  student:
+    _target_: fastvideo.train.models.wan.WanPromptRLModel
+    init_from: Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+    trainable: true
+    lora:
+      enable: true
+      rank: 16
+      alpha: 32
+      target_modules: [to_q, to_k, to_v, to_out]
+  refiner:
+    _target_: fastvideo.train.roles.qwen_refiner.QwenPromptRefinerRole
+    init_from: Qwen/Qwen2.5-VL-3B-Instruct
+    trainable: true
+    lora:
+      enable: true
+      rank: 16
+      alpha: 32
+      target_modules: [q_proj, k_proj, v_proj, o_proj]
+
+method:
+  _target_: fastvideo.train.methods.rl.promptrl.PromptRLMethod
+  mode: prompt_only
+  group_size: 8
+  retained_originals: 2
+  format_reward_weight: 1.0
+  video_reward_weight: 1.0
+  refiner_kl_beta: 0.01
+  student_kl_beta: 0.01
+  ppo_clip: 0.0001
+
+  rollout:
+    num_steps: 20
+    sde_steps: 8
+    noise_scale: 0.8
+    loss_microbatch_size: 1
+    flow_shift: inherit
+
+  data:
+    # Raw prompt dataset: JSONL or Parquet with required `prompt` field
+    # and optional `id` / `reward_tag` fields.
+    data_path: data/promptrl_prompts.jsonl
+    prompt_key: prompt
+    id_key: id
+    reward_tag_key: reward_tag
+
+  reward:
+    endpoint_url: http://127.0.0.1:8100
+    timeout_sec: 300
+    retries: 2
+    fps: 16
+
+  refiner:
+    max_new_tokens: 256
+    temperature: 1.0
+    top_p: 1.0
+    template_version: v1
+
+  refiner_optimizer:
+    learning_rate: 1.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.01
+    max_grad_norm: 1.0
+    lr_scheduler: constant
+
+  generator_optimizer:
+    learning_rate: 1.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.01
+    max_grad_norm: 1.0
+    lr_scheduler: constant
+
+  validation:
+    every_steps: 50
+    num_steps: 20
+    num_prompts: 8
+    batch_size: 8
+    log_samples: true
+    seed: 42
+
+training:
+  distributed:
+    num_gpus: 8
+    sp_size: 1
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 8
+
+  data:
+    data_path: ""  # prompts come from method.data.data_path
+    train_batch_size: 1
+    dataloader_num_workers: 0
+    training_cfg_rate: 0.0
+    seed: 42
+    num_latent_t: 20
+    num_height: 480
+    num_width: 832
+    num_frames: 77
+
+  optimizer:
+    # Unused by PromptRL (per-role optimizer blocks live under method);
+    # kept at defaults for config-schema completeness.
+    learning_rate: 1.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.01
+    lr_scheduler: constant
+
+  loop:
+    max_train_steps: 1000
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: outputs/wan2.1_promptrl_prompt_only
+    training_state_checkpointing_steps: 50
+    checkpoints_total_limit: 4
+
+  tracker:
+    project_name: promptrl_wan
+    run_name: wan2.1_promptrl_prompt_only
+
+  model:
+    enable_gradient_checkpointing_type: full
+
+callbacks:
+  promptrl_export:
+    output_dir: outputs/wan2.1_promptrl_prompt_only/bundle
+    every_steps: 0  # export once at train end
+
+pipeline:
+  flow_shift: 8

--- a/examples/train/configs/rl/wan/promptrl_vbench_prompts.jsonl
+++ b/examples/train/configs/rl/wan/promptrl_vbench_prompts.jsonl
@@ -1,0 +1,1742 @@
+{"id": "vbench-0000", "prompt": "In a still frame, a stop sign", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0001", "prompt": "a toilet, frozen in time", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0002", "prompt": "a laptop, frozen in time", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0003", "prompt": "A tranquil tableau of alley", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0004", "prompt": "A tranquil tableau of bar", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0005", "prompt": "A tranquil tableau of barn", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0006", "prompt": "A tranquil tableau of bathroom", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0007", "prompt": "A tranquil tableau of bedroom", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0008", "prompt": "A tranquil tableau of cliff", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0009", "prompt": "In a still frame, courtyard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0010", "prompt": "In a still frame, gas station", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0011", "prompt": "A tranquil tableau of house", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0012", "prompt": "indoor gymnasium, frozen in time", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0013", "prompt": "A tranquil tableau of indoor library", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0014", "prompt": "A tranquil tableau of kitchen", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0015", "prompt": "A tranquil tableau of palace", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0016", "prompt": "In a still frame, parking lot", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0017", "prompt": "In a still frame, phone booth", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0018", "prompt": "A tranquil tableau of restaurant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0019", "prompt": "A tranquil tableau of tower", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0020", "prompt": "A tranquil tableau of a bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0021", "prompt": "A tranquil tableau of an apple", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0022", "prompt": "A tranquil tableau of a bench", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0023", "prompt": "A tranquil tableau of a bed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0024", "prompt": "A tranquil tableau of a chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0025", "prompt": "A tranquil tableau of a cup", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0026", "prompt": "A tranquil tableau of a dining table", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0027", "prompt": "In a still frame, a pear", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0028", "prompt": "A tranquil tableau of a bunch of grapes", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0029", "prompt": "A tranquil tableau of a bowl on the kitchen counter", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0030", "prompt": "A tranquil tableau of a beautiful, handcrafted ceramic bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0031", "prompt": "A tranquil tableau of an antique bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0032", "prompt": "A tranquil tableau of an exquisite mahogany dining table", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0033", "prompt": "A tranquil tableau of a wooden bench in the park", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0034", "prompt": "A tranquil tableau of a beautiful wrought-iron bench surrounded by blooming flowers", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0035", "prompt": "In a still frame, a park bench with a view of the lake", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0036", "prompt": "A tranquil tableau of a vintage rocking chair was placed on the porch", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0037", "prompt": "A tranquil tableau of the jail cell was small and dimly lit, with cold, steel bars", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0038", "prompt": "A tranquil tableau of the phone booth was tucked away in a quiet alley", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0039", "prompt": "a dilapidated phone booth stood as a relic of a bygone era on the sidewalk, frozen in time", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0040", "prompt": "A tranquil tableau of the old red barn stood weathered and iconic against the backdrop of the countryside", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0041", "prompt": "A tranquil tableau of a picturesque barn was painted a warm shade of red and nestled in a picturesque meadow", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0042", "prompt": "In a still frame, within the desolate desert, an oasis unfolded, characterized by the stoic presence of palm trees and a motionless, glassy pool of water", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0043", "prompt": "In a still frame, the Parthenon's majestic Doric columns stand in serene solitude atop the Acropolis, framed by the tranquil Athenian landscape", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0044", "prompt": "In a still frame, the Temple of Hephaestus, with its timeless Doric grace, stands stoically against the backdrop of a quiet Athens", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0045", "prompt": "In a still frame, the ornate Victorian streetlamp stands solemnly, adorned with intricate ironwork and stained glass panels", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0046", "prompt": "A tranquil tableau of the Stonehenge presented itself as an enigmatic puzzle, each colossal stone meticulously placed against the backdrop of tranquility", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0047", "prompt": "In a still frame, in the vast desert, an oasis nestled among dunes, featuring tall palm trees and an air of serenity", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0048", "prompt": "static view on a desert scene with an oasis, palm trees, and a clear, calm pool of water", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0049", "prompt": "A tranquil tableau of an ornate Victorian streetlamp standing on a cobblestone street corner, illuminating the empty night", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0050", "prompt": "A tranquil tableau of a tranquil lakeside cabin nestled among tall pines, its reflection mirrored perfectly in the calm water", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0051", "prompt": "In a still frame, a vintage gas lantern, adorned with intricate details, gracing a historic cobblestone square", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0052", "prompt": "In a still frame, a tranquil Japanese tea ceremony room, with tatami mats, a delicate tea set, and a bonsai tree in the corner", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0053", "prompt": "A tranquil tableau of the Parthenon stands resolute in its classical elegance, a timeless symbol of Athens' cultural legacy", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0054", "prompt": "A tranquil tableau of in the heart of Plaka, the neoclassical architecture of the old city harmonizes with the ancient ruins", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0055", "prompt": "A tranquil tableau of in the desolate beauty of the American Southwest, Chaco Canyon's ancient ruins whispered tales of an enigmatic civilization that once thrived amidst the arid landscapes", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0056", "prompt": "A tranquil tableau of at the edge of the Arabian Desert, the ancient city of Petra beckoned with its enigmatic rock-carved façades", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0057", "prompt": "In a still frame, amidst the cobblestone streets, an Art Nouveau lamppost stood tall", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0058", "prompt": "A tranquil tableau of in the quaint village square, a traditional wrought-iron streetlamp featured delicate filigree patterns and amber-hued glass panels", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0059", "prompt": "A tranquil tableau of the lampposts were adorned with Art Deco motifs, their geometric shapes and frosted glass creating a sense of vintage glamour", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0060", "prompt": "In a still frame, in the picturesque square, a Gothic-style lamppost adorned with intricate stone carvings added a touch of medieval charm to the setting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0061", "prompt": "In a still frame, in the heart of the old city, a row of ornate lantern-style streetlamps bathed the narrow alleyway in a warm, welcoming light", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0062", "prompt": "A tranquil tableau of in the heart of the Utah desert, a massive sandstone arch spanned the horizon", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0063", "prompt": "A tranquil tableau of in the Arizona desert, a massive stone bridge arched across a rugged canyon", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0064", "prompt": "A tranquil tableau of in the corner of the minimalist tea room, a bonsai tree added a touch of nature's beauty to the otherwise simple and elegant space", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0065", "prompt": "In a still frame, amidst the hushed ambiance of the traditional tea room, a meticulously arranged tea set awaited, with porcelain cups, a bamboo whisk", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0066", "prompt": "In a still frame, nestled in the Zen garden, a rustic teahouse featured tatami seating and a traditional charcoal brazier", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0067", "prompt": "A tranquil tableau of a country estate's library featured elegant wooden shelves", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0068", "prompt": "A tranquil tableau of beneath the shade of a solitary oak tree, an old wooden park bench sat patiently", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0069", "prompt": "A tranquil tableau of beside a tranquil pond, a weeping willow tree draped its branches gracefully over the water's surface, creating a serene tableau of reflection and calm", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0070", "prompt": "A tranquil tableau of in the Zen garden, a perfectly raked gravel path led to a serene rock garden", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0071", "prompt": "In a still frame, a tranquil pond was fringed by weeping cherry trees, their blossoms drifting lazily onto the glassy surface", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0072", "prompt": "In a still frame, within the historic library's reading room, rows of antique leather chairs and mahogany tables offered a serene haven for literary contemplation", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0073", "prompt": "A tranquil tableau of a peaceful orchid garden showcased a variety of delicate blooms", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0074", "prompt": "A tranquil tableau of in the serene courtyard, a centuries-old stone well stood as a symbol of a bygone era, its mossy stones bearing witness to the passage of time", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0075", "prompt": "a bird and a cat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0076", "prompt": "a cat and a dog", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0077", "prompt": "a dog and a horse", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0078", "prompt": "a horse and a sheep", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0079", "prompt": "a sheep and a cow", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0080", "prompt": "a cow and an elephant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0081", "prompt": "an elephant and a bear", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0082", "prompt": "a bear and a zebra", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0083", "prompt": "a zebra and a giraffe", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0084", "prompt": "a giraffe and a bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0085", "prompt": "a chair and a couch", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0086", "prompt": "a couch and a potted plant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0087", "prompt": "a potted plant and a tv", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0088", "prompt": "a tv and a laptop", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0089", "prompt": "a laptop and a remote", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0090", "prompt": "a remote and a keyboard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0091", "prompt": "a keyboard and a cell phone", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0092", "prompt": "a cell phone and a book", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0093", "prompt": "a book and a clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0094", "prompt": "a clock and a backpack", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0095", "prompt": "a backpack and an umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0096", "prompt": "an umbrella and a handbag", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0097", "prompt": "a handbag and a tie", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0098", "prompt": "a tie and a suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0099", "prompt": "a suitcase and a vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0100", "prompt": "a vase and scissors", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0101", "prompt": "scissors and a teddy bear", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0102", "prompt": "a teddy bear and a frisbee", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0103", "prompt": "a frisbee and skis", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0104", "prompt": "skis and a snowboard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0105", "prompt": "a snowboard and a sports ball", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0106", "prompt": "a sports ball and a kite", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0107", "prompt": "a kite and a baseball bat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0108", "prompt": "a baseball bat and a baseball glove", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0109", "prompt": "a baseball glove and a skateboard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0110", "prompt": "a skateboard and a surfboard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0111", "prompt": "a surfboard and a tennis racket", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0112", "prompt": "a tennis racket and a bottle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0113", "prompt": "a bottle and a chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0114", "prompt": "an airplane and a train", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0115", "prompt": "a train and a boat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0116", "prompt": "a boat and an airplane", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0117", "prompt": "a bicycle and a car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0118", "prompt": "a car and a motorcycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0119", "prompt": "a motorcycle and a bus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0120", "prompt": "a bus and a traffic light", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0121", "prompt": "a traffic light and a fire hydrant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0122", "prompt": "a fire hydrant and a stop sign", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0123", "prompt": "a stop sign and a parking meter", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0124", "prompt": "a parking meter and a truck", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0125", "prompt": "a truck and a bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0126", "prompt": "a toilet and a hair drier", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0127", "prompt": "a hair drier and a toothbrush", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0128", "prompt": "a toothbrush and a sink", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0129", "prompt": "a sink and a toilet", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0130", "prompt": "a wine glass and a chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0131", "prompt": "a cup and a couch", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0132", "prompt": "a fork and a potted plant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0133", "prompt": "a knife and a tv", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0134", "prompt": "a spoon and a laptop", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0135", "prompt": "a bowl and a remote", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0136", "prompt": "a banana and a keyboard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0137", "prompt": "an apple and a cell phone", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0138", "prompt": "a sandwich and a book", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0139", "prompt": "an orange and a clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0140", "prompt": "broccoli and a backpack", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0141", "prompt": "a carrot and an umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0142", "prompt": "a hot dog and a handbag", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0143", "prompt": "a pizza and a tie", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0144", "prompt": "a donut and a suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0145", "prompt": "a cake and a vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0146", "prompt": "an oven and scissors", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0147", "prompt": "a toaster and a teddy bear", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0148", "prompt": "a microwave and a frisbee", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0149", "prompt": "a refrigerator and skis", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0150", "prompt": "a bicycle and an airplane", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0151", "prompt": "a car and a train", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0152", "prompt": "a motorcycle and a boat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0153", "prompt": "a person and a toilet", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0154", "prompt": "a person and a hair drier", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0155", "prompt": "a person and a toothbrush", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0156", "prompt": "a person and a sink", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0157", "prompt": "A person is riding a bike", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0158", "prompt": "A person is marching", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0159", "prompt": "A person is roller skating", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0160", "prompt": "A person is tasting beer", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0161", "prompt": "A person is clapping", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0162", "prompt": "A person is drawing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0163", "prompt": "A person is petting animal (not cat)", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0164", "prompt": "A person is eating watermelon", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0165", "prompt": "A person is playing harp", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0166", "prompt": "A person is wrestling", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0167", "prompt": "A person is riding scooter", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0168", "prompt": "A person is sweeping floor", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0169", "prompt": "A person is skateboarding", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0170", "prompt": "A person is dunking basketball", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0171", "prompt": "A person is playing flute", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0172", "prompt": "A person is stretching leg", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0173", "prompt": "A person is tying tie", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0174", "prompt": "A person is skydiving", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0175", "prompt": "A person is shooting goal (soccer)", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0176", "prompt": "A person is playing piano", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0177", "prompt": "A person is finger snapping", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0178", "prompt": "A person is canoeing or kayaking", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0179", "prompt": "A person is laughing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0180", "prompt": "A person is digging", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0181", "prompt": "A person is clay pottery making", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0182", "prompt": "A person is shooting basketball", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0183", "prompt": "A person is bending back", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0184", "prompt": "A person is shaking hands", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0185", "prompt": "A person is bandaging", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0186", "prompt": "A person is push up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0187", "prompt": "A person is catching or throwing frisbee", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0188", "prompt": "A person is playing trumpet", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0189", "prompt": "A person is flying kite", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0190", "prompt": "A person is filling eyebrows", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0191", "prompt": "A person is shuffling cards", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0192", "prompt": "A person is folding clothes", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0193", "prompt": "A person is smoking", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0194", "prompt": "A person is tai chi", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0195", "prompt": "A person is squat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0196", "prompt": "A person is playing controller", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0197", "prompt": "A person is throwing axe", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0198", "prompt": "A person is giving or receiving award", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0199", "prompt": "A person is air drumming", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0200", "prompt": "A person is taking a shower", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0201", "prompt": "A person is planting trees", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0202", "prompt": "A person is sharpening knives", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0203", "prompt": "A person is robot dancing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0204", "prompt": "A person is rock climbing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0205", "prompt": "A person is hula hooping", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0206", "prompt": "A person is writing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0207", "prompt": "A person is bungee jumping", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0208", "prompt": "A person is pushing cart", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0209", "prompt": "A person is cleaning windows", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0210", "prompt": "A person is cutting watermelon", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0211", "prompt": "A person is cheerleading", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0212", "prompt": "A person is washing hands", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0213", "prompt": "A person is ironing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0214", "prompt": "A person is cutting nails", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0215", "prompt": "A person is hugging", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0216", "prompt": "A person is trimming or shaving beard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0217", "prompt": "A person is jogging", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0218", "prompt": "A person is making bed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0219", "prompt": "A person is washing dishes", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0220", "prompt": "A person is grooming dog", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0221", "prompt": "A person is doing laundry", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0222", "prompt": "A person is knitting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0223", "prompt": "A person is reading book", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0224", "prompt": "A person is baby waking up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0225", "prompt": "A person is massaging legs", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0226", "prompt": "A person is brushing teeth", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0227", "prompt": "A person is crawling baby", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0228", "prompt": "A person is motorcycling", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0229", "prompt": "A person is driving car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0230", "prompt": "A person is sticking tongue out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0231", "prompt": "A person is shaking head", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0232", "prompt": "A person is sword fighting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0233", "prompt": "A person is doing aerobics", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0234", "prompt": "A person is strumming guitar", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0235", "prompt": "A person is riding or walking with horse", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0236", "prompt": "A person is archery", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0237", "prompt": "A person is catching or throwing baseball", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0238", "prompt": "A person is playing chess", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0239", "prompt": "A person is rock scissors paper", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0240", "prompt": "A person is using computer", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0241", "prompt": "A person is arranging flowers", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0242", "prompt": "A person is bending metal", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0243", "prompt": "A person is ice skating", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0244", "prompt": "A person is climbing a rope", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0245", "prompt": "A person is crying", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0246", "prompt": "A person is dancing ballet", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0247", "prompt": "A person is getting a haircut", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0248", "prompt": "A person is running on treadmill", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0249", "prompt": "A person is kissing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0250", "prompt": "A person is counting money", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0251", "prompt": "A person is barbequing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0252", "prompt": "A person is peeling apples", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0253", "prompt": "A person is milking cow", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0254", "prompt": "A person is shining shoes", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0255", "prompt": "A person is making snowman", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0256", "prompt": "A person is sailing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0257", "prompt": "a person swimming in ocean", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0258", "prompt": "a person giving a presentation to a room full of colleagues", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0259", "prompt": "a person washing the dishes", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0260", "prompt": "a person eating a burger", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0261", "prompt": "a person walking in the snowstorm", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0262", "prompt": "a person drinking coffee in a cafe", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0263", "prompt": "a person playing guitar", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0264", "prompt": "a bicycle leaning against a tree", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0265", "prompt": "a bicycle gliding through a snowy field", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0266", "prompt": "a bicycle slowing down to stop", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0267", "prompt": "a bicycle accelerating to gain speed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0268", "prompt": "a car stuck in traffic during rush hour", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0269", "prompt": "a car turning a corner", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0270", "prompt": "a car slowing down to stop", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0271", "prompt": "a car accelerating to gain speed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0272", "prompt": "a motorcycle cruising along a coastal highway", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0273", "prompt": "a motorcycle turning a corner", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0274", "prompt": "a motorcycle slowing down to stop", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0275", "prompt": "a motorcycle gliding through a snowy field", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0276", "prompt": "a motorcycle accelerating to gain speed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0277", "prompt": "an airplane soaring through a clear blue sky", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0278", "prompt": "an airplane taking off", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0279", "prompt": "an airplane landing smoothly on a runway", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0280", "prompt": "an airplane accelerating to gain speed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0281", "prompt": "a bus turning a corner", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0282", "prompt": "a bus stuck in traffic during rush hour", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0283", "prompt": "a bus accelerating to gain speed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0284", "prompt": "a train speeding down the tracks", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0285", "prompt": "a train crossing over a tall bridge", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0286", "prompt": "a train accelerating to gain speed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0287", "prompt": "a truck turning a corner", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0288", "prompt": "a truck anchored in a tranquil bay", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0289", "prompt": "a truck stuck in traffic during rush hour", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0290", "prompt": "a truck slowing down to stop", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0291", "prompt": "a truck accelerating to gain speed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0292", "prompt": "a boat sailing smoothly on a calm lake", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0293", "prompt": "a boat slowing down to stop", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0294", "prompt": "a boat accelerating to gain speed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0295", "prompt": "a bird soaring gracefully in the sky", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0296", "prompt": "a bird building a nest from twigs and leaves", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0297", "prompt": "a bird flying over a snowy forest", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0298", "prompt": "a cat grooming itself meticulously with its tongue", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0299", "prompt": "a cat playing in park", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0300", "prompt": "a cat drinking water", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0301", "prompt": "a cat running happily", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0302", "prompt": "a dog enjoying a peaceful walk", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0303", "prompt": "a dog playing in park", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0304", "prompt": "a dog drinking water", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0305", "prompt": "a dog running happily", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0306", "prompt": "a horse bending down to drink water from a river", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0307", "prompt": "a horse galloping across an open field", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0308", "prompt": "a horse taking a peaceful walk", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0309", "prompt": "a horse running to join a herd of its kind", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0310", "prompt": "a sheep bending down to drink water from a river", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0311", "prompt": "a sheep taking a peaceful walk", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0312", "prompt": "a sheep running to join a herd of its kind", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0313", "prompt": "a cow bending down to drink water from a river", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0314", "prompt": "a cow chewing cud while resting in a tranquil barn", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0315", "prompt": "a cow running to join a herd of its kind", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0316", "prompt": "an elephant spraying itself with water using its trunk to cool down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0317", "prompt": "an elephant taking a peaceful walk", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0318", "prompt": "an elephant running to join a herd of its kind", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0319", "prompt": "a bear catching a salmon in its powerful jaws", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0320", "prompt": "a bear sniffing the air for scents of food", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0321", "prompt": "a bear climbing a tree", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0322", "prompt": "a bear hunting for prey", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0323", "prompt": "a zebra bending down to drink water from a river", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0324", "prompt": "a zebra running to join a herd of its kind", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0325", "prompt": "a zebra taking a peaceful walk", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0326", "prompt": "a giraffe bending down to drink water from a river", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0327", "prompt": "a giraffe taking a peaceful walk", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0328", "prompt": "a giraffe running to join a herd of its kind", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0329", "prompt": "a person", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0330", "prompt": "a bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0331", "prompt": "a car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0332", "prompt": "a motorcycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0333", "prompt": "an airplane", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0334", "prompt": "a bus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0335", "prompt": "a train", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0336", "prompt": "a truck", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0337", "prompt": "a boat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0338", "prompt": "a traffic light", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0339", "prompt": "a fire hydrant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0340", "prompt": "a stop sign", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0341", "prompt": "a parking meter", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0342", "prompt": "a bench", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0343", "prompt": "a bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0344", "prompt": "a cat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0345", "prompt": "a dog", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0346", "prompt": "a horse", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0347", "prompt": "a sheep", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0348", "prompt": "a cow", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0349", "prompt": "an elephant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0350", "prompt": "a bear", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0351", "prompt": "a zebra", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0352", "prompt": "a giraffe", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0353", "prompt": "a backpack", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0354", "prompt": "an umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0355", "prompt": "a handbag", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0356", "prompt": "a tie", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0357", "prompt": "a suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0358", "prompt": "a frisbee", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0359", "prompt": "skis", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0360", "prompt": "a snowboard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0361", "prompt": "a sports ball", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0362", "prompt": "a kite", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0363", "prompt": "a baseball bat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0364", "prompt": "a baseball glove", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0365", "prompt": "a skateboard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0366", "prompt": "a surfboard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0367", "prompt": "a tennis racket", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0368", "prompt": "a bottle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0369", "prompt": "a wine glass", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0370", "prompt": "a cup", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0371", "prompt": "a fork", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0372", "prompt": "a knife", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0373", "prompt": "a spoon", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0374", "prompt": "a bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0375", "prompt": "a banana", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0376", "prompt": "an apple", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0377", "prompt": "a sandwich", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0378", "prompt": "an orange", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0379", "prompt": "broccoli", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0380", "prompt": "a carrot", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0381", "prompt": "a hot dog", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0382", "prompt": "a pizza", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0383", "prompt": "a donut", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0384", "prompt": "a cake", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0385", "prompt": "a chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0386", "prompt": "a couch", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0387", "prompt": "a potted plant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0388", "prompt": "a bed", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0389", "prompt": "a dining table", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0390", "prompt": "a toilet", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0391", "prompt": "a tv", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0392", "prompt": "a laptop", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0393", "prompt": "a remote", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0394", "prompt": "a keyboard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0395", "prompt": "a cell phone", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0396", "prompt": "a microwave", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0397", "prompt": "an oven", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0398", "prompt": "a toaster", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0399", "prompt": "a sink", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0400", "prompt": "a refrigerator", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0401", "prompt": "a book", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0402", "prompt": "a clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0403", "prompt": "a vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0404", "prompt": "scissors", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0405", "prompt": "a teddy bear", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0406", "prompt": "a hair drier", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0407", "prompt": "a toothbrush", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0408", "prompt": "a red bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0409", "prompt": "a green bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0410", "prompt": "a blue bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0411", "prompt": "a yellow bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0412", "prompt": "an orange bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0413", "prompt": "a purple bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0414", "prompt": "a pink bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0415", "prompt": "a black bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0416", "prompt": "a white bicycle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0417", "prompt": "a red car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0418", "prompt": "a green car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0419", "prompt": "a blue car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0420", "prompt": "a yellow car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0421", "prompt": "an orange car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0422", "prompt": "a purple car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0423", "prompt": "a pink car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0424", "prompt": "a black car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0425", "prompt": "a white car", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0426", "prompt": "a red bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0427", "prompt": "a green bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0428", "prompt": "a blue bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0429", "prompt": "a yellow bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0430", "prompt": "an orange bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0431", "prompt": "a purple bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0432", "prompt": "a pink bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0433", "prompt": "a black bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0434", "prompt": "a white bird", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0435", "prompt": "a black cat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0436", "prompt": "a white cat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0437", "prompt": "an orange cat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0438", "prompt": "a yellow cat", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0439", "prompt": "a red umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0440", "prompt": "a green umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0441", "prompt": "a blue umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0442", "prompt": "a yellow umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0443", "prompt": "an orange umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0444", "prompt": "a purple umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0445", "prompt": "a pink umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0446", "prompt": "a black umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0447", "prompt": "a white umbrella", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0448", "prompt": "a red suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0449", "prompt": "a green suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0450", "prompt": "a blue suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0451", "prompt": "a yellow suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0452", "prompt": "an orange suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0453", "prompt": "a purple suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0454", "prompt": "a pink suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0455", "prompt": "a black suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0456", "prompt": "a white suitcase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0457", "prompt": "a red bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0458", "prompt": "a green bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0459", "prompt": "a blue bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0460", "prompt": "a yellow bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0461", "prompt": "an orange bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0462", "prompt": "a purple bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0463", "prompt": "a pink bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0464", "prompt": "a black bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0465", "prompt": "a white bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0466", "prompt": "a red chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0467", "prompt": "a green chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0468", "prompt": "a blue chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0469", "prompt": "a yellow chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0470", "prompt": "an orange chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0471", "prompt": "a purple chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0472", "prompt": "a pink chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0473", "prompt": "a black chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0474", "prompt": "a white chair", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0475", "prompt": "a red clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0476", "prompt": "a green clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0477", "prompt": "a blue clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0478", "prompt": "a yellow clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0479", "prompt": "an orange clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0480", "prompt": "a purple clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0481", "prompt": "a pink clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0482", "prompt": "a black clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0483", "prompt": "a white clock", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0484", "prompt": "a red vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0485", "prompt": "a green vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0486", "prompt": "a blue vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0487", "prompt": "a yellow vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0488", "prompt": "an orange vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0489", "prompt": "a purple vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0490", "prompt": "a pink vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0491", "prompt": "a black vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0492", "prompt": "a white vase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0493", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0494", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0495", "prompt": "A beautiful coastal beach in spring, waves lapping on sand by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0496", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0497", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0498", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0499", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0500", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0501", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0502", "prompt": "The bund Shanghai, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0503", "prompt": "The bund Shanghai, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0504", "prompt": "The bund Shanghai by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0505", "prompt": "The bund Shanghai, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0506", "prompt": "The bund Shanghai, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0507", "prompt": "The bund Shanghai, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0508", "prompt": "The bund Shanghai, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0509", "prompt": "The bund Shanghai, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0510", "prompt": "The bund Shanghai, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0511", "prompt": "a shark is swimming in the ocean, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0512", "prompt": "a shark is swimming in the ocean, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0513", "prompt": "a shark is swimming in the ocean by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0514", "prompt": "a shark is swimming in the ocean, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0515", "prompt": "a shark is swimming in the ocean, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0516", "prompt": "a shark is swimming in the ocean, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0517", "prompt": "a shark is swimming in the ocean, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0518", "prompt": "a shark is swimming in the ocean, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0519", "prompt": "a shark is swimming in the ocean, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0520", "prompt": "A panda drinking coffee in a cafe in Paris, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0521", "prompt": "A panda drinking coffee in a cafe in Paris, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0522", "prompt": "A panda drinking coffee in a cafe in Paris by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0523", "prompt": "A panda drinking coffee in a cafe in Paris, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0524", "prompt": "A panda drinking coffee in a cafe in Paris, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0525", "prompt": "A panda drinking coffee in a cafe in Paris, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0526", "prompt": "A panda drinking coffee in a cafe in Paris, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0527", "prompt": "A panda drinking coffee in a cafe in Paris, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0528", "prompt": "A panda drinking coffee in a cafe in Paris, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0529", "prompt": "A cute happy Corgi playing in park, sunset, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0530", "prompt": "A cute happy Corgi playing in park, sunset, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0531", "prompt": "A cute happy Corgi playing in park, sunset by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0532", "prompt": "A cute happy Corgi playing in park, sunset, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0533", "prompt": "A cute happy Corgi playing in park, sunset, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0534", "prompt": "A cute happy Corgi playing in park, sunset, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0535", "prompt": "A cute happy Corgi playing in park, sunset, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0536", "prompt": "A cute happy Corgi playing in park, sunset, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0537", "prompt": "A cute happy Corgi playing in park, sunset, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0538", "prompt": "Gwen Stacy reading a book, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0539", "prompt": "Gwen Stacy reading a book, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0540", "prompt": "Gwen Stacy reading a book by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0541", "prompt": "Gwen Stacy reading a book, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0542", "prompt": "Gwen Stacy reading a book, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0543", "prompt": "Gwen Stacy reading a book, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0544", "prompt": "Gwen Stacy reading a book, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0545", "prompt": "Gwen Stacy reading a book, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0546", "prompt": "Gwen Stacy reading a book, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0547", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0548", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0549", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0550", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0551", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0552", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0553", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0554", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0555", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0556", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0557", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0558", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0559", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0560", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0561", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0562", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0563", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0564", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0565", "prompt": "An astronaut flying in space, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0566", "prompt": "An astronaut flying in space, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0567", "prompt": "An astronaut flying in space by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0568", "prompt": "An astronaut flying in space, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0569", "prompt": "An astronaut flying in space, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0570", "prompt": "An astronaut flying in space, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0571", "prompt": "An astronaut flying in space, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0572", "prompt": "An astronaut flying in space, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0573", "prompt": "An astronaut flying in space, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0574", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0575", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, oil painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0576", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks by Hokusai, in the style of Ukiyo", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0577", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, black and white", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0578", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, pixel art", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0579", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, in cyberpunk style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0580", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, animated style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0581", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, watercolor painting", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0582", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, surrealism style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0583", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0584", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0585", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0586", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0587", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0588", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0589", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0590", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0591", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0592", "prompt": "A beautiful coastal beach in spring, waves lapping on sand, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0593", "prompt": "The bund Shanghai, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0594", "prompt": "The bund Shanghai, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0595", "prompt": "The bund Shanghai, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0596", "prompt": "The bund Shanghai, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0597", "prompt": "The bund Shanghai, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0598", "prompt": "The bund Shanghai, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0599", "prompt": "The bund Shanghai, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0600", "prompt": "The bund Shanghai, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0601", "prompt": "The bund Shanghai, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0602", "prompt": "The bund Shanghai, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0603", "prompt": "a shark is swimming in the ocean, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0604", "prompt": "a shark is swimming in the ocean, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0605", "prompt": "a shark is swimming in the ocean, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0606", "prompt": "a shark is swimming in the ocean, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0607", "prompt": "a shark is swimming in the ocean, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0608", "prompt": "a shark is swimming in the ocean, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0609", "prompt": "a shark is swimming in the ocean, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0610", "prompt": "a shark is swimming in the ocean, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0611", "prompt": "a shark is swimming in the ocean, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0612", "prompt": "a shark is swimming in the ocean, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0613", "prompt": "A panda drinking coffee in a cafe in Paris, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0614", "prompt": "A panda drinking coffee in a cafe in Paris, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0615", "prompt": "A panda drinking coffee in a cafe in Paris, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0616", "prompt": "A panda drinking coffee in a cafe in Paris, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0617", "prompt": "A panda drinking coffee in a cafe in Paris, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0618", "prompt": "A panda drinking coffee in a cafe in Paris, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0619", "prompt": "A panda drinking coffee in a cafe in Paris, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0620", "prompt": "A panda drinking coffee in a cafe in Paris, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0621", "prompt": "A panda drinking coffee in a cafe in Paris, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0622", "prompt": "A panda drinking coffee in a cafe in Paris, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0623", "prompt": "A cute happy Corgi playing in park, sunset, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0624", "prompt": "A cute happy Corgi playing in park, sunset, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0625", "prompt": "A cute happy Corgi playing in park, sunset, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0626", "prompt": "A cute happy Corgi playing in park, sunset, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0627", "prompt": "A cute happy Corgi playing in park, sunset, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0628", "prompt": "A cute happy Corgi playing in park, sunset, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0629", "prompt": "A cute happy Corgi playing in park, sunset, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0630", "prompt": "A cute happy Corgi playing in park, sunset, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0631", "prompt": "A cute happy Corgi playing in park, sunset, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0632", "prompt": "A cute happy Corgi playing in park, sunset, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0633", "prompt": "Gwen Stacy reading a book, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0634", "prompt": "Gwen Stacy reading a book, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0635", "prompt": "Gwen Stacy reading a book, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0636", "prompt": "Gwen Stacy reading a book, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0637", "prompt": "Gwen Stacy reading a book, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0638", "prompt": "Gwen Stacy reading a book, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0639", "prompt": "Gwen Stacy reading a book, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0640", "prompt": "Gwen Stacy reading a book, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0641", "prompt": "Gwen Stacy reading a book, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0642", "prompt": "Gwen Stacy reading a book, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0643", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0644", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0645", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0646", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0647", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0648", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0649", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0650", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0651", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0652", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0653", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0654", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0655", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0656", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0657", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0658", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0659", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0660", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0661", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0662", "prompt": "A couple in formal evening wear going home get caught in a heavy downpour with umbrellas, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0663", "prompt": "An astronaut flying in space, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0664", "prompt": "An astronaut flying in space, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0665", "prompt": "An astronaut flying in space, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0666", "prompt": "An astronaut flying in space, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0667", "prompt": "An astronaut flying in space, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0668", "prompt": "An astronaut flying in space, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0669", "prompt": "An astronaut flying in space, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0670", "prompt": "An astronaut flying in space, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0671", "prompt": "An astronaut flying in space, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0672", "prompt": "An astronaut flying in space, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0673", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, in super slow motion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0674", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, zoom in", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0675", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, zoom out", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0676", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, pan left", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0677", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, pan right", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0678", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, tilt up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0679", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, tilt down", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0680", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, with an intense shaking effect", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0681", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, featuring a steady and smooth perspective", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0682", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks, racking focus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0683", "prompt": "Close up of grapes on a rotating table.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0684", "prompt": "Turtle swimming in ocean.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0685", "prompt": "A storm trooper vacuuming the beach.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0686", "prompt": "A panda standing on a surfboard in the ocean in sunset.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0687", "prompt": "An astronaut feeding ducks on a sunny afternoon, reflection from the water.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0688", "prompt": "Two pandas discussing an academic paper.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0689", "prompt": "Sunset time lapse at the beach with moving clouds and colors in the sky.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0690", "prompt": "A fat rabbit wearing a purple robe walking through a fantasy landscape.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0691", "prompt": "A koala bear playing piano in the forest.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0692", "prompt": "An astronaut flying in space.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0693", "prompt": "Fireworks.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0694", "prompt": "An animated painting of fluffy white clouds moving in sky.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0695", "prompt": "Flying through fantasy landscapes.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0696", "prompt": "A bigfoot walking in the snowstorm.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0697", "prompt": "A squirrel eating a burger.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0698", "prompt": "A cat wearing sunglasses and working as a lifeguard at a pool.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0699", "prompt": "Snow rocky mountains peaks canyon. snow blanketed rocky mountains surround and shadow deep canyons. the canyons twist and bend through the high elevated mountain peaks.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0700", "prompt": "Splash of turquoise water in extreme slow motion, alpha channel included.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0701", "prompt": "an ice cream is melting on the table.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0702", "prompt": "a drone flying over a snowy forest.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0703", "prompt": "a shark is swimming in the ocean.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0704", "prompt": "Aerial panoramic video from a drone of a fantasy land.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0705", "prompt": "a teddy bear is swimming in the ocean.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0706", "prompt": "time lapse of sunrise on mars.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0707", "prompt": "golden fish swimming in the ocean.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0708", "prompt": "An artist brush painting on a canvas close up.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0709", "prompt": "A drone view of celebration with Christmas tree and fireworks, starry sky - background.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0710", "prompt": "happy dog wearing a yellow turtleneck, studio, portrait, facing camera, dark background", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0711", "prompt": "Origami dancers in white paper, 3D render, on white background, studio shot, dancing modern dance.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0712", "prompt": "Campfire at night in a snowy forest with starry sky in the background.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0713", "prompt": "a fantasy landscape", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0714", "prompt": "A 3D model of a 1800s victorian house.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0715", "prompt": "this is how I do makeup in the morning.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0716", "prompt": "A raccoon that looks like a turtle, digital art.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0717", "prompt": "Robot dancing in Times Square.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0718", "prompt": "Busy freeway at night.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0719", "prompt": "Balloon full of water exploding in extreme slow motion.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0720", "prompt": "An astronaut is riding a horse in the space in a photorealistic style.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0721", "prompt": "Macro slo-mo. Slow motion cropped closeup of roasted coffee beans falling into an empty bowl.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0722", "prompt": "Sewing machine, old sewing machine working.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0723", "prompt": "Motion colour drop in water, ink swirling in water, colourful ink in water, abstraction fancy dream cloud of ink.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0724", "prompt": "Few big purple plums rotating on the turntable. water drops appear on the skin during rotation. isolated on the white background. close-up. macro.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0725", "prompt": "Vampire makeup face of beautiful girl, red contact lenses.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0726", "prompt": "Ashtray full of butts on table, smoke flowing on black background, close-up", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0727", "prompt": "Pacific coast, carmel by the sea ocean and waves.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0728", "prompt": "A teddy bear is playing drum kit in NYC Times Square.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0729", "prompt": "A corgi is playing drum kit.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0730", "prompt": "An Iron man is playing the electronic guitar, high electronic guitar.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0731", "prompt": "A raccoon is playing the electronic guitar.", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0732", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background by Vincent van Gogh", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0733", "prompt": "A corgi's head depicted as an explosion of a nebula", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0734", "prompt": "A fantasy landscape", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0735", "prompt": "A future where humans have achieved teleportation technology", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0736", "prompt": "A jellyfish floating through the ocean, with bioluminescent tentacles", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0737", "prompt": "A Mars rover moving on Mars", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0738", "prompt": "A panda drinking coffee in a cafe in Paris", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0739", "prompt": "A space shuttle launching into orbit, with flames and smoke billowing out from the engines", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0740", "prompt": "A steam train moving on a mountainside", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0741", "prompt": "A super cool giant robot in Cyberpunk Beijing", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0742", "prompt": "A tropical beach at sunrise, with palm trees and crystal-clear water in the foreground", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0743", "prompt": "Cinematic shot of Van Gogh's selfie, Van Gogh style", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0744", "prompt": "Gwen Stacy reading a book", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0745", "prompt": "Iron Man flying in the sky", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0746", "prompt": "Yoda playing guitar on the stage", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0747", "prompt": "A beautiful coastal beach in spring, waves lapping on sand by Vincent van Gogh", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0748", "prompt": "A boat sailing leisurely along the Seine River with the Eiffel Tower in background", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0749", "prompt": "A car moving slowly on an empty street, rainy evening", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0750", "prompt": "A cat eating food out of a bowl", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0751", "prompt": "A cat wearing sunglasses at a pool", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0752", "prompt": "A confused panda in calculus class", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0753", "prompt": "A cute fluffy panda eating Chinese food in a restaurant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0754", "prompt": "A cute happy Corgi playing in park, sunset", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0755", "prompt": "A cute raccoon playing guitar in a boat on the ocean", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0756", "prompt": "A happy fuzzy panda playing guitar nearby a campfire, snow mountain in the background", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0757", "prompt": "A lightning striking atop of eiffel tower, dark clouds in the sky", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0758", "prompt": "A modern art museum, with colorful paintings", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0759", "prompt": "A panda cooking in the kitchen", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0760", "prompt": "A panda playing on a swing set", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0761", "prompt": "A polar bear is playing guitar", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0762", "prompt": "A raccoon dressed in suit playing the trumpet, stage background", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0763", "prompt": "A robot DJ is playing the turntable, in heavy raining futuristic tokyo rooftop cyberpunk night, sci-fi, fantasy", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0764", "prompt": "A shark swimming in clear Caribbean ocean", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0765", "prompt": "A super robot protecting city", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0766", "prompt": "A teddy bear washing the dishes", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0767", "prompt": "An epic tornado attacking above a glowing city at night, the tornado is made of smoke", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0768", "prompt": "An oil painting of a couple in formal evening wear going home get caught in a heavy downpour with umbrellas", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0769", "prompt": "Clown fish swimming through the coral reef", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0770", "prompt": "Hyper-realistic spaceship landing on Mars", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0771", "prompt": "The bund Shanghai, vibrant color", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0772", "prompt": "Vincent van Gogh is painting in the room", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0773", "prompt": "Yellow flowers swing in the wind", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0774", "prompt": "alley", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0775", "prompt": "amusement park", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0776", "prompt": "aquarium", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0777", "prompt": "arch", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0778", "prompt": "art gallery", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0779", "prompt": "bathroom", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0780", "prompt": "bakery shop", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0781", "prompt": "ballroom", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0782", "prompt": "bar", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0783", "prompt": "barn", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0784", "prompt": "basement", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0785", "prompt": "beach", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0786", "prompt": "bedroom", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0787", "prompt": "bridge", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0788", "prompt": "botanical garden", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0789", "prompt": "cafeteria", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0790", "prompt": "campsite", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0791", "prompt": "campus", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0792", "prompt": "carrousel", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0793", "prompt": "castle", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0794", "prompt": "cemetery", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0795", "prompt": "classroom", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0796", "prompt": "cliff", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0797", "prompt": "crosswalk", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0798", "prompt": "construction site", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0799", "prompt": "corridor", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0800", "prompt": "courtyard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0801", "prompt": "desert", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0802", "prompt": "downtown", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0803", "prompt": "driveway", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0804", "prompt": "farm", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0805", "prompt": "food court", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0806", "prompt": "football field", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0807", "prompt": "forest road", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0808", "prompt": "fountain", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0809", "prompt": "gas station", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0810", "prompt": "glacier", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0811", "prompt": "golf course", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0812", "prompt": "indoor gymnasium", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0813", "prompt": "harbor", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0814", "prompt": "highway", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0815", "prompt": "hospital", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0816", "prompt": "house", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0817", "prompt": "iceberg", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0818", "prompt": "industrial area", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0819", "prompt": "jail cell", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0820", "prompt": "junkyard", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0821", "prompt": "kitchen", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0822", "prompt": "indoor library", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0823", "prompt": "lighthouse", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0824", "prompt": "laboratory", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0825", "prompt": "mansion", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0826", "prompt": "marsh", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0827", "prompt": "mountain", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0828", "prompt": "indoor movie theater", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0829", "prompt": "indoor museum", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0830", "prompt": "music studio", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0831", "prompt": "nursery", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0832", "prompt": "ocean", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0833", "prompt": "office", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0834", "prompt": "palace", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0835", "prompt": "parking lot", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0836", "prompt": "pharmacy", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0837", "prompt": "phone booth", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0838", "prompt": "raceway", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0839", "prompt": "restaurant", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0840", "prompt": "river", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0841", "prompt": "science museum", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0842", "prompt": "shower", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0843", "prompt": "ski slope", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0844", "prompt": "sky", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0845", "prompt": "skyscraper", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0846", "prompt": "baseball stadium", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0847", "prompt": "staircase", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0848", "prompt": "street", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0849", "prompt": "supermarket", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0850", "prompt": "indoor swimming pool", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0851", "prompt": "tower", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0852", "prompt": "outdoor track", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0853", "prompt": "train railway", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0854", "prompt": "train station platform", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0855", "prompt": "underwater coral reef", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0856", "prompt": "valley", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0857", "prompt": "volcano", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0858", "prompt": "waterfall", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0859", "prompt": "windmill", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0860", "prompt": "a bicycle on the left of a car, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0861", "prompt": "a car on the right of a motorcycle, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0862", "prompt": "a motorcycle on the left of a bus, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0863", "prompt": "a bus on the right of a traffic light, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0864", "prompt": "a traffic light on the left of a fire hydrant, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0865", "prompt": "a fire hydrant on the right of a stop sign, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0866", "prompt": "a stop sign on the left of a parking meter, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0867", "prompt": "a parking meter on the right of a bench, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0868", "prompt": "a bench on the left of a truck, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0869", "prompt": "a truck on the right of a bicycle, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0870", "prompt": "a bird on the left of a cat, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0871", "prompt": "a cat on the right of a dog, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0872", "prompt": "a dog on the left of a horse, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0873", "prompt": "a horse on the right of a sheep, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0874", "prompt": "a sheep on the left of a cow, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0875", "prompt": "a cow on the right of an elephant, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0876", "prompt": "an elephant on the left of a bear, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0877", "prompt": "a bear on the right of a zebra, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0878", "prompt": "a zebra on the left of a giraffe, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0879", "prompt": "a giraffe on the right of a bird, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0880", "prompt": "a bottle on the left of a wine glass, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0881", "prompt": "a wine glass on the right of a cup, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0882", "prompt": "a cup on the left of a fork, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0883", "prompt": "a fork on the right of a knife, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0884", "prompt": "a knife on the left of a spoon, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0885", "prompt": "a spoon on the right of a bowl, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0886", "prompt": "a bowl on the left of a bottle, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0887", "prompt": "a potted plant on the left of a remote, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0888", "prompt": "a remote on the right of a clock, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0889", "prompt": "a clock on the left of a vase, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0890", "prompt": "a vase on the right of scissors, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0891", "prompt": "scissors on the left of a teddy bear, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0892", "prompt": "a teddy bear on the right of a potted plant, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0893", "prompt": "a frisbee on the left of a sports ball, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0894", "prompt": "a sports ball on the right of a baseball bat, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0895", "prompt": "a baseball bat on the left of a baseball glove, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0896", "prompt": "a baseball glove on the right of a tennis racket, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0897", "prompt": "a tennis racket on the left of a frisbee, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0898", "prompt": "a toilet on the left of a hair drier, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0899", "prompt": "a hair drier on the right of a toothbrush, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0900", "prompt": "a toothbrush on the left of a sink, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0901", "prompt": "a sink on the right of a toilet, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0902", "prompt": "a chair on the left of a couch, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0903", "prompt": "a couch on the right of a bed, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0904", "prompt": "a bed on the left of a tv, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0905", "prompt": "a tv on the right of a dining table, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0906", "prompt": "a dining table on the left of a chair, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0907", "prompt": "an airplane on the left of a train, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0908", "prompt": "a train on the right of a boat, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0909", "prompt": "a boat on the left of an airplane, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0910", "prompt": "an oven on the top of a toaster, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0911", "prompt": "an oven on the bottom of a toaster, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0912", "prompt": "a toaster on the top of a microwave, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0913", "prompt": "a toaster on the bottom of a microwave, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0914", "prompt": "a microwave on the top of an oven, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0915", "prompt": "a microwave on the bottom of an oven, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0916", "prompt": "a banana on the top of an apple, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0917", "prompt": "a banana on the bottom of an apple, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0918", "prompt": "an apple on the top of a sandwich, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0919", "prompt": "an apple on the bottom of a sandwich, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0920", "prompt": "a sandwich on the top of an orange, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0921", "prompt": "a sandwich on the bottom of an orange, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0922", "prompt": "an orange on the top of a carrot, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0923", "prompt": "an orange on the bottom of a carrot, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0924", "prompt": "a carrot on the top of a hot dog, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0925", "prompt": "a carrot on the bottom of a hot dog, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0926", "prompt": "a hot dog on the top of a pizza, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0927", "prompt": "a hot dog on the bottom of a pizza, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0928", "prompt": "a pizza on the top of a donut, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0929", "prompt": "a pizza on the bottom of a donut, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0930", "prompt": "a donut on the top of broccoli, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0931", "prompt": "a donut on the bottom of broccoli, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0932", "prompt": "broccoli on the top of a banana, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0933", "prompt": "broccoli on the bottom of a banana, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0934", "prompt": "skis on the top of a snowboard, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0935", "prompt": "skis on the bottom of a snowboard, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0936", "prompt": "a snowboard on the top of a kite, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0937", "prompt": "a snowboard on the bottom of a kite, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0938", "prompt": "a kite on the top of a skateboard, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0939", "prompt": "a kite on the bottom of a skateboard, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0940", "prompt": "a skateboard on the top of a surfboard, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0941", "prompt": "a skateboard on the bottom of a surfboard, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0942", "prompt": "a surfboard on the top of skis, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0943", "prompt": "a surfboard on the bottom of skis, front view", "reward_tag": "videoscore2", "source": "all_dimension.txt"}
+{"id": "vbench-0944", "prompt": "a black dog wearing halloween costume", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0945", "prompt": "spider making a web", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0946", "prompt": "bat eating fruits while hanging", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0947", "prompt": "a snake crawling on a wooden flooring", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0948", "prompt": "a close up video of a dragonfly", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0949", "prompt": "macro shot of ladybug on green leaf plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0950", "prompt": "chameleon eating ant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0951", "prompt": "a bee feeding on nectars", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0952", "prompt": "bird nests on a tree captured with moving camera", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0953", "prompt": "a squirrel eating nuts", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0954", "prompt": "close up video of snail", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0955", "prompt": "top view of a hermit crab crawling on a wooden surface", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0956", "prompt": "cat licking another cat", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0957", "prompt": "red dragonfly perched on green leaf", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0958", "prompt": "close up view of a brown caterpillar crawling on green leaf", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0959", "prompt": "ants eating dead spider", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0960", "prompt": "an eagle on a tree branch", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0961", "prompt": "a frog eating an ant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0962", "prompt": "white rabbit near the fence", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0963", "prompt": "a gorilla eating a carrot", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0964", "prompt": "close up of wolf", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0965", "prompt": "a meerkat looking around", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0966", "prompt": "a hyena in a zoo", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0967", "prompt": "lemur eating grass leaves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0968", "prompt": "an owl being trained by a man", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0969", "prompt": "a lizard on a bamboo", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0970", "prompt": "brown chicken hunting for its food", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0971", "prompt": "video of parrots perched on bird stand", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0972", "prompt": "underwater footage of an octopus in a coral reef", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0973", "prompt": "a cute pomeranian dog playing with a soccer ball", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0974", "prompt": "white fox on rock", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0975", "prompt": "close up footage of a horse figurine", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0976", "prompt": "giraffe feeding on a tree in a savannah", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0977", "prompt": "curious cat sitting and looking around", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0978", "prompt": "hummingbird hawk moth flying near pink flowers", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0979", "prompt": "close up of a scorpion on a rock", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0980", "prompt": "close up on fish in net", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0981", "prompt": "koala eating leaves from a branch", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0982", "prompt": "a pod of dolphins swirling in the sea catching forage fish", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0983", "prompt": "low angle view of a hawk perched on a tree branch", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0984", "prompt": "a lion standing on wild grass", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0985", "prompt": "deer grazing in the field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0986", "prompt": "elephant herd in a savanna", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0987", "prompt": "close up on lobster under water", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0988", "prompt": "hedgehog crossing road in forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0989", "prompt": "a sheep eating yellow flowers from behind a wire fence", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0990", "prompt": "twin sisters and a turtle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0991", "prompt": "a pig wallowing in mud", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0992", "prompt": "flock of goose eating on the lake water", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0993", "prompt": "cow in a field irritated with flies", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0994", "prompt": "a close up shot of a fly", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0995", "prompt": "cheetah lying on the grass", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0996", "prompt": "close up of a lemur", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0997", "prompt": "close up shot of a kangaroo itching in the sand", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0998", "prompt": "a tortoise covered with algae", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-0999", "prompt": "turkey in cage", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1000", "prompt": "a great blue heron bird in the lakeside", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1001", "prompt": "crab with shell in aquarium", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1002", "prompt": "a seagull walking on shore", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1003", "prompt": "an american crocodile", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1004", "prompt": "a tiger walking inside a cage", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1005", "prompt": "alligator in the nature", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1006", "prompt": "a raccoon climbing a tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1007", "prompt": "wild rabbit in a green meadow", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1008", "prompt": "group of ring tailed lemurs", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1009", "prompt": "a clouded leopard on a tree branch", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1010", "prompt": "duck grooming its feathers", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1011", "prompt": "an african penguin walking on a beach", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1012", "prompt": "a video of a peacock", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1013", "prompt": "close up shot of a wild bear", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1014", "prompt": "baby rhino plays with mom", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1015", "prompt": "porcupine climbs tree branches", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1016", "prompt": "close up of a natterjack toad on a rock", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1017", "prompt": "a sleeping orangutan", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1018", "prompt": "mother whale swimming with babies", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1019", "prompt": "a bear wearing red jersey", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1020", "prompt": "pink jellyfish swimming underwater in a blue sea", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1021", "prompt": "beautiful clown fish swimming", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1022", "prompt": "animation of disposable objects shaped as a whale", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1023", "prompt": "paper cut out of a pair of hands a whale and a heart", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1024", "prompt": "vertical video of camel roaming in the field during daytime", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1025", "prompt": "a still video of mosquito biting human", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1026", "prompt": "a curious sloth hanging from a tree branch", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1027", "prompt": "a plastic flamingo bird stumbles from the wind", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1028", "prompt": "a wolf in its natural habitat", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1029", "prompt": "a monkey sitting in the stone and scratching his head", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1030", "prompt": "bat hanging upside down", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1031", "prompt": "a red panda eating leaves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1032", "prompt": "snake on ground", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1033", "prompt": "a harbour seal swimming near the shore", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1034", "prompt": "shark swimming in the sea", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1035", "prompt": "otter on branch while eating", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1036", "prompt": "goat standing over a rock", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1037", "prompt": "a troop of monkey on top of a mountain", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1038", "prompt": "a zebra eating grass on the field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1039", "prompt": "a colorful butterfly perching on a bud", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1040", "prompt": "a snail crawling on a leaf", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1041", "prompt": "zookeeper showering a baby elephant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1042", "prompt": "a beetle emerging from the sand", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1043", "prompt": "a nine banded armadillo searching for food", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1044", "prompt": "an apartment building with balcony", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1045", "prompt": "asian garden and medieval castle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1046", "prompt": "illuminated tower in berlin", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1047", "prompt": "a wooden house overseeing the lake", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1048", "prompt": "a crowd of people in a plaza in front of a government building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1049", "prompt": "a church interior", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1050", "prompt": "jewish friends posing with hanukkah menorah in a cabin house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1051", "prompt": "a destroyed building after a missile attack in ukraine", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1052", "prompt": "abandoned building in the woods", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1053", "prompt": "drone video of an abandoned school building in pripyat ukraine", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1054", "prompt": "elegant university building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1055", "prompt": "architecture and designs of buildings in central london", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1056", "prompt": "a pancake tower with chocolate syrup and strawberries on top", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1057", "prompt": "an ancient white building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1058", "prompt": "friends hanging out at a coffee house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1059", "prompt": "house front door with christmas decorations", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1060", "prompt": "city night dark building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1061", "prompt": "a bird house hanging on a tree branch", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1062", "prompt": "sacred sculpture in a temple", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1063", "prompt": "high angle shot of a clock tower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1064", "prompt": "modern wooden house interior", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1065", "prompt": "the interior of an abandoned building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1066", "prompt": "opera house overlooking sea", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1067", "prompt": "a concrete structure near the green trees", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1068", "prompt": "dome like building in scotland", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1069", "prompt": "low angle shot of a building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1070", "prompt": "tower on hill", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1071", "prompt": "a miniature house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1072", "prompt": "eiffel tower from the seine river", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1073", "prompt": "low angle footage of an apartment building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1074", "prompt": "island with pier and antique building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1075", "prompt": "asian historic architecture", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1076", "prompt": "drone footage of a beautiful mansion", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1077", "prompt": "mosque in the middle east", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1078", "prompt": "building a tent and hammock in the forest camping site", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1079", "prompt": "top view of a high rise building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1080", "prompt": "house covered in snow", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1081", "prompt": "skyscraper at night", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1082", "prompt": "house in village", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1083", "prompt": "a casino with people outside the building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1084", "prompt": "silhouette of a building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1085", "prompt": "a woman climbing a tree house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1086", "prompt": "drone view of house near lake during golden hour", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1087", "prompt": "an under construction concrete house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1088", "prompt": "a watch tower by the sea", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1089", "prompt": "exterior view of arabic style building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1090", "prompt": "video of a hotel building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1091", "prompt": "red paper lantern decorations hanging outside a building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1092", "prompt": "house on seashore", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1093", "prompt": "aerial footage of the palace of culture and science building in warsaw poland", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1094", "prompt": "aerial video of stuttgart tv tower in germany", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1095", "prompt": "aerial view of the highway and building in a city", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1096", "prompt": "drone shot of a skyscraper san francisco california usa", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1097", "prompt": "waterfall and house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1098", "prompt": "view of the sky through a building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1099", "prompt": "drone footage of a house on top of the mountain", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1100", "prompt": "abandoned house in the nature", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1101", "prompt": "clouds hovering over a mansion", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1102", "prompt": "light house on the ocean", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1103", "prompt": "buddhist temple at sunrise", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1104", "prompt": "people walking by a graveyard near a mosque at sunset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1105", "prompt": "view of lifeguard tower on the beach", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1106", "prompt": "scenic view of a house in the mountains", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1107", "prompt": "the landscape in front of a government building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1108", "prompt": "aerial footage of a building and its surrounding landscape in winter", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1109", "prompt": "time lapse of a cloudy sky behind a transmission tower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1110", "prompt": "blue ocean near the brown castle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1111", "prompt": "fog over temple", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1112", "prompt": "house in countryside top view", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1113", "prompt": "building under construction", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1114", "prompt": "turkish flag waving on old tower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1115", "prompt": "the georgian building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1116", "prompt": "close up shot of a steel structure", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1117", "prompt": "the atrium and interior design of a multi floor building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1118", "prompt": "city view reflected on a glass building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1119", "prompt": "aerial view of a luxurious house with pool", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1120", "prompt": "an unpaved road leading to the house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1121", "prompt": "drone footage of a lookout tower in mountain landscape", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1122", "prompt": "wind turbines on hill behind building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1123", "prompt": "time lapse footage of the sun light in front of a small house porch", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1124", "prompt": "a building built with lots of stairways", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1125", "prompt": "overcast over house on seashore", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1126", "prompt": "the view of the sydney opera house from the other side of the harbor", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1127", "prompt": "candle on a jar and a house figurine on a surface", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1128", "prompt": "video of a farm and house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1129", "prompt": "a dilapidated building made of bricks", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1130", "prompt": "a view of a unique building from a moving vehicle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1131", "prompt": "aerial footage of a tall building in cambodia", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1132", "prompt": "push in shot of a huge house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1133", "prompt": "a beach house built over a seawall protected from the sea waves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1134", "prompt": "exotic house surrounded by trees", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1135", "prompt": "drone video of a house surrounded by tropical vegetation", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1136", "prompt": "drone footage of a building beside a pond", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1137", "prompt": "observation tower on hill in forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1138", "prompt": "a tree house in the woods", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1139", "prompt": "a video of vessel structure during daytime", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1140", "prompt": "fire in front of illuminated building at night", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1141", "prompt": "a footage of a wooden house on a wheat field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1142", "prompt": "tilt shot of a solar panel below a light tower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1143", "prompt": "water tower on the desert", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1144", "prompt": "freshly baked finger looking cookies", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1145", "prompt": "video of fake blood in wine glass", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1146", "prompt": "halloween food art", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1147", "prompt": "a person slicing a vegetable", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1148", "prompt": "a serving of pumpkin dish in a plate", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1149", "prompt": "close up view of green leafy vegetable", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1150", "prompt": "a birthday cake in the plate", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1151", "prompt": "video of a slice papaya fruit", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1152", "prompt": "a muffin with a burning candle and a love sign by a ceramic mug", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1153", "prompt": "a jack o lantern designed cookie", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1154", "prompt": "baked bread with chocolate", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1155", "prompt": "a broccoli soup on wooden table", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1156", "prompt": "a freshly brewed coffee on a pink mug", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1157", "prompt": "grabbing sourdough neapolitan style pizza slices", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1158", "prompt": "person cooking mushrooms in frying pan", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1159", "prompt": "rice grains placed on a reusable cloth bag", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1160", "prompt": "slices of kiwi fruit", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1161", "prompt": "grilling a steak on a pan grill", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1162", "prompt": "close up of bread popping out of a toaster", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1163", "prompt": "man eating noodle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1164", "prompt": "preparing a cocktail drink", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1165", "prompt": "close up pasta with bacon on plate", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1166", "prompt": "milk and cinnamon rolls", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1167", "prompt": "boy getting a dumpling using chopsticks", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1168", "prompt": "a mother preparing food with her kids", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1169", "prompt": "man using his phone while eating", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1170", "prompt": "fresh salmon salad on a plate", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1171", "prompt": "cutting cucumbers into long thin slices as ingredient for sushi roll", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1172", "prompt": "a steaming cup of tea by the window", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1173", "prompt": "a glass filled with beer", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1174", "prompt": "a kid eating popcorn while watching tv", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1175", "prompt": "close up shot of fried fish on the plate", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1176", "prompt": "a man eating a donut", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1177", "prompt": "person making a vegetarian dish", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1178", "prompt": "spreading cheese on bagel", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1179", "prompt": "close up view of a man drinking red wine", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1180", "prompt": "a couple having breakfast in a restaurant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1181", "prompt": "a student eating her sandwich", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1182", "prompt": "girl peeling a banana", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1183", "prompt": "red rice in a small bowl", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1184", "prompt": "pancake with blueberry on the top", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1185", "prompt": "green apple fruit on white wooden table", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1186", "prompt": "a man eating a taco by the bar", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1187", "prompt": "making of a burrito", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1188", "prompt": "squeezing lemon into salad", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1189", "prompt": "a chef cutting sushi rolls", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1190", "prompt": "video of a delicious dessert", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1191", "prompt": "deep frying a crab on a wok in high fire", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1192", "prompt": "close up video of a orange juice", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1193", "prompt": "video of a cooked chicken breast", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1194", "prompt": "woman holding a pineapple", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1195", "prompt": "a woman eating a bar of chocolate", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1196", "prompt": "decorating christmas cookie", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1197", "prompt": "squeezing a slice of fruit", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1198", "prompt": "tuna sashimi on a plate", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1199", "prompt": "a strawberry fruit mixed in an alcoholic drink", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1200", "prompt": "preparing hot dogs in a grill", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1201", "prompt": "a woman cutting a tomato", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1202", "prompt": "an orange fruit cut in half", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1203", "prompt": "a coconut fruit with drinking straw", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1204", "prompt": "woman holding a dragon fruit", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1205", "prompt": "a woman pouring hot beverage on a cup", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1206", "prompt": "waffles with whipped cream and fruit", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1207", "prompt": "focus shot of an insect at the bottom of a fruit", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1208", "prompt": "preparing a healthy broccoli dish", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1209", "prompt": "man eating snack at picnic", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1210", "prompt": "close up video of a grilled shrimp skewer", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1211", "prompt": "a woman mixing a smoothie drinks", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1212", "prompt": "close up video of woman having a bite of jelly", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1213", "prompt": "businessman drinking whiskey at the bar counter of a hotel lounge", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1214", "prompt": "cutting an onion with a knife over a wooden chopping board", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1215", "prompt": "fresh lemonade in bottles", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1216", "prompt": "grilling a meat on a charcoal grill", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1217", "prompt": "people enjoying asian cuisine", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1218", "prompt": "close up footage of a hot dish on a clay pot", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1219", "prompt": "pork ribs dish", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1220", "prompt": "waffle with strawberry and syrup for breakfast", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1221", "prompt": "tofu dish with rose garnish", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1222", "prompt": "uncooked pork meat", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1223", "prompt": "egg yolk being dumped over gourmet dish", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1224", "prompt": "tasty brunch dish close up", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1225", "prompt": "little boy pretending to eat the watermelon", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1226", "prompt": "slicing roasted beef", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1227", "prompt": "close up of a chef adding teriyaki sauce to a dish", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1228", "prompt": "flat lay mexican dish", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1229", "prompt": "a person placing an octopus dish on a marble surface", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1230", "prompt": "close up of tea leaves brewing in a glass kettle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1231", "prompt": "adding fresh herbs to soup dish", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1232", "prompt": "a scoop of roasted coffee beans", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1233", "prompt": "fresh dim sum set up on a bamboo steam tray for cooking", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1234", "prompt": "a girl putting ketchup on food at the kitchen", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1235", "prompt": "cooking on electric stove", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1236", "prompt": "a woman with a slice of a pie", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1237", "prompt": "grapes and wine on a wooden board", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1238", "prompt": "man taking picture of his food", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1239", "prompt": "hamburger and fries on restaurant table", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1240", "prompt": "close up video of japanese food", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1241", "prompt": "a cracker sandwich with cheese filling for snack", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1242", "prompt": "barista preparing matcha tea", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1243", "prompt": "close up of onion rings being deep fried", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1244", "prompt": "people carving a pumpkin", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1245", "prompt": "people sitting on a sofa", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1246", "prompt": "a man with a muertos face painting", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1247", "prompt": "man walking in the dark", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1248", "prompt": "men in front of their computer editing photos", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1249", "prompt": "men loading christmas tree on tow truck", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1250", "prompt": "woman washing the dishes", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1251", "prompt": "woman adding honey to the cinnamon rolls", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1252", "prompt": "two women kissing and smiling", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1253", "prompt": "three women looking at watercolor paintings", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1254", "prompt": "a family wearing paper bag masks", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1255", "prompt": "a family posing for the camera", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1256", "prompt": "a boy covering a rose flower with a dome glass", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1257", "prompt": "boy sitting on grass petting a dog", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1258", "prompt": "a girl in her tennis sportswear", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1259", "prompt": "a girl coloring the cardboard", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1260", "prompt": "silhouette of the couple during sunset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1261", "prompt": "couple dancing with body paint", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1262", "prompt": "a child playing with water", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1263", "prompt": "a woman with her child sitting on a couch in the living room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1264", "prompt": "a group of friend place doing hand gestures of agreement", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1265", "prompt": "friends having a group selfie", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1266", "prompt": "friends talking while on the basketball court", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1267", "prompt": "group of people protesting", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1268", "prompt": "a group of campers with a cute dog", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1269", "prompt": "a group of photographers taking pictures at the north western gardens in llandudno north wales", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1270", "prompt": "a group of students laughing and talking", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1271", "prompt": "a group of martial artist warming up", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1272", "prompt": "a person playing golf", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1273", "prompt": "a person walking on a wet wooden bridge", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1274", "prompt": "person doing a leg exercise", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1275", "prompt": "ice hockey athlete on rink", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1276", "prompt": "a young athlete training in swimming", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1277", "prompt": "chess player dusting a chessboard", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1278", "prompt": "baseball player holding his bat", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1279", "prompt": "a bearded man putting a vinyl record on a vinyl player", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1280", "prompt": "an orchestra finishes a performance", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1281", "prompt": "people applauding the performance of the kids", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1282", "prompt": "band performance at the recording studio", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1283", "prompt": "father and his children playing jenga game", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1284", "prompt": "people playing a board game", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1285", "prompt": "man playing a video game", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1286", "prompt": "a man video recording the movie in theater", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1287", "prompt": "man and a woman eating while watching a movie", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1288", "prompt": "movie crew talking together", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1289", "prompt": "a director explaining the movie scene", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1290", "prompt": "man and woman listening to music on car", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1291", "prompt": "man playing music", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1292", "prompt": "couple dancing slow dance with sun glare", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1293", "prompt": "a ballerina practicing in the dance studio", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1294", "prompt": "father and son holding hands", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1295", "prompt": "father and daughter talking together", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1296", "prompt": "a mother and her kids engaged in a video call", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1297", "prompt": "mother and daughter reading a book together", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1298", "prompt": "a mother teaching her daughter playing a violin", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1299", "prompt": "kid in a halloween costume", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1300", "prompt": "a happy kid playing the ukulele", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1301", "prompt": "a chef slicing a cucumber", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1302", "prompt": "chef wearing his gloves properly", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1303", "prompt": "brother and sister using hammock", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1304", "prompt": "girl applying sunblock to her brother", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1305", "prompt": "a girl pushing the chair while her sister is on the chair", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1306", "prompt": "colleagues talking in office building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1307", "prompt": "fighter practice kicking", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1308", "prompt": "a woman fighter in her cosplay costume", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1309", "prompt": "an engineer holding blueprints while talking with her colleague", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1310", "prompt": "a young woman looking at vr controllers with her friend", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1311", "prompt": "workmates teasing a colleague in the work", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1312", "prompt": "a male police officer talking on the radio", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1313", "prompt": "teacher holding a marker while talking", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1314", "prompt": "teacher writing on her notebook", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1315", "prompt": "a young student attending her online classes", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1316", "prompt": "a student showing his classmates his wand", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1317", "prompt": "a male vendor selling fruits", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1318", "prompt": "a shirtless male climber", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1319", "prompt": "a sound engineer listening to music", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1320", "prompt": "female talking to a psychiatrist in a therapy session", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1321", "prompt": "young female activist posing with flag", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1322", "prompt": "a man in a hoodie and woman with a red bandana talking to each other and smiling", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1323", "prompt": "a medium close up of women wearing kimonos", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1324", "prompt": "a male interviewer listening to a person talking", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1325", "prompt": "a social worker having a conversation with the foster parents", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1326", "prompt": "a farm worker harvesting onions", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1327", "prompt": "worker packing street food", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1328", "prompt": "worker and client at barber shop", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1329", "prompt": "elderly man lifting kettlebell", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1330", "prompt": "mom assisting son in riding a bicycle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1331", "prompt": "dad watching her daughter eat", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1332", "prompt": "young guy with vr headset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1333", "prompt": "pregnant woman exercising with trainer", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1334", "prompt": "a fortune teller talking to a client", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1335", "prompt": "wizard doing a ritual on a woman", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1336", "prompt": "a footage of an actor on a movie scene", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1337", "prompt": "a man holding a best actor trophy", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1338", "prompt": "a singer of a music band", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1339", "prompt": "a young singer performing on stage", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1340", "prompt": "young dancer practicing at home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1341", "prompt": "seller showing room to a couple", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1342", "prompt": "cab driver talking to passenger", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1343", "prompt": "a policeman talking to the car driver", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1344", "prompt": "kids celebrating halloween at home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1345", "prompt": "little boy helping mother in kitchen", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1346", "prompt": "video of a indoor green plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1347", "prompt": "a girl arranges a christmas garland hanging by the kitchen cabinet", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1348", "prompt": "candle burning in dark room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1349", "prompt": "couple having fun and goofing around the bedroom", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1350", "prompt": "girls jumping up and down in the bedroom", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1351", "prompt": "woman and man in pajamas working from home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1352", "prompt": "a muslim family sitting and talking in the living room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1353", "prompt": "family enjoying snack time while sitting in the living room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1354", "prompt": "woman holding an animal puppet and a little girl playing together at the living room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1355", "prompt": "kids playing in the indoor tent", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1356", "prompt": "young people celebrating new year at the office", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1357", "prompt": "a woman writing on the sticky note in the office", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1358", "prompt": "a woman exercising at home over a yoga mat", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1359", "prompt": "girls preparing easter decorations at home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1360", "prompt": "dog on floor in room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1361", "prompt": "turning on a fluorescent light inside a room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1362", "prompt": "colleagues talking to each other near the office windows", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1363", "prompt": "a woman recording herself while exercising at home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1364", "prompt": "music room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1365", "prompt": "different kind of tools kept in a utility room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1366", "prompt": "sofa beds and other furniture", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1367", "prompt": "a girl finding her brother reading a book in the bedroom", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1368", "prompt": "an elegant ceramic plant pot and hanging plant on indoor", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1369", "prompt": "furniture inside a bedroom", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1370", "prompt": "interior design of the bar section", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1371", "prompt": "living room with party decoration", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1372", "prompt": "firewood burning in dark room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1373", "prompt": "a young woman playing the ukulele at home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1374", "prompt": "woman painting at home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1375", "prompt": "a woman in a locker room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1376", "prompt": "video of a bathroom interior", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1377", "prompt": "the interior design of a jewish synagogue", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1378", "prompt": "a woman in protective suit disinfecting the kitchen", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1379", "prompt": "modern minimalist home interior", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1380", "prompt": "modern interior design of a coffee shop", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1381", "prompt": "person arranging minimalist furniture", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1382", "prompt": "aerial shot of interior of the warehouse", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1383", "prompt": "a room of a manufacturing facility", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1384", "prompt": "interior of catholic", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1385", "prompt": "interior design of a restaurant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1386", "prompt": "a female model in a changing room looking herself in mirror", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1387", "prompt": "men walking in the office hallway", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1388", "prompt": "people sitting in a conference room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1389", "prompt": "the interior design of a shopping mall", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1390", "prompt": "chandeliers in room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1391", "prompt": "lucerne railway station interior", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1392", "prompt": "a female fencer posing in a foggy room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1393", "prompt": "a toolbox and a paint roller beside a huge package in a room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1394", "prompt": "bedroom in hotel", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1395", "prompt": "a woman lying in the operating room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1396", "prompt": "a chef holding and checking kitchen utensils", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1397", "prompt": "a couple singing in the shower room together", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1398", "prompt": "a woman cleaning mess in the living room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1399", "prompt": "an empty meeting room with natural light", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1400", "prompt": "person dancing in a dark room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1401", "prompt": "close up on blood in hospital room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1402", "prompt": "a couple resting on their home floor", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1403", "prompt": "a young female staff at courier office", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1404", "prompt": "a man entering the gym locker room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1405", "prompt": "a bored man sitting by the tv at home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1406", "prompt": "woman dancing in indoor garden", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1407", "prompt": "rubble in the interior of an abandoned house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1408", "prompt": "indoor farm in a greenhouse", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1409", "prompt": "man doing handstand in indoor garden", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1410", "prompt": "an abandoned indoor swimming pool", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1411", "prompt": "home decorations on top of a cabinet", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1412", "prompt": "graffiti art on the interior walls of an abandoned mansion", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1413", "prompt": "indoor wall climbing activity", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1414", "prompt": "sunlight inside a room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1415", "prompt": "teenage girl roller skating at indoor rink", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1416", "prompt": "home deco with lighted", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1417", "prompt": "baby in the shower room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1418", "prompt": "men enjoying office christmas party", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1419", "prompt": "a bedroom with a brick wall", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1420", "prompt": "actors prepping in the dressing room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1421", "prompt": "kids playing at an indoor playground", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1422", "prompt": "a person sanitizing an office space using smoke machine", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1423", "prompt": "mother and daughter choosing clothes at home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1424", "prompt": "a woman sitting by the indoor fire pit", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1425", "prompt": "man standing on the corner of the room while looking around", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1426", "prompt": "person assembling furniture", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1427", "prompt": "a family stacking cardboard boxes in a room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1428", "prompt": "family having fun in the dining room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1429", "prompt": "person disinfecting a room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1430", "prompt": "a woman washing strawberries in the kitchen sink", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1431", "prompt": "modern office waiting room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1432", "prompt": "close up view of a person slicing with a kitchen knife", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1433", "prompt": "boiling coffee on a stove in the kitchen", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1434", "prompt": "modern equipment used in a home studio", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1435", "prompt": "interior of a recording studio", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1436", "prompt": "people working in a call center office", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1437", "prompt": "band performing at a home concert", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1438", "prompt": "a group of people watching a concert in a room", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1439", "prompt": "people packing their furniture", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1440", "prompt": "young employees in office holding a certificate", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1441", "prompt": "a criminal inside a dark room handcuffed in a table", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1442", "prompt": "couple browsing and looking for furniture in the store", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1443", "prompt": "workspace at home", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1444", "prompt": "close up view of a plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1445", "prompt": "close up shot of a burning plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1446", "prompt": "plucking leaves from plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1447", "prompt": "a plant on gold pot with glass lid", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1448", "prompt": "a branch of a tree and a plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1449", "prompt": "a leafless tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1450", "prompt": "close up shot of fern leaf", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1451", "prompt": "close up video of strawberry plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1452", "prompt": "plant with blooming flowers", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1453", "prompt": "close up video of flower petals", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1454", "prompt": "watering yellow plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1455", "prompt": "beautiful flower decoration", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1456", "prompt": "cannabis flower in a jar", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1457", "prompt": "a footage of the tree leaves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1458", "prompt": "a red leaf plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1459", "prompt": "close up view of a white christmas tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1460", "prompt": "snow pouring on a tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1461", "prompt": "close up shot of white flowers on the tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1462", "prompt": "leaves in the trees daytime", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1463", "prompt": "a dead tree lying on a grass field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1464", "prompt": "tree branches in a flowing river", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1465", "prompt": "purple flowers with leaves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1466", "prompt": "a coconut tree by the house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1467", "prompt": "close up on flower in winter", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1468", "prompt": "bamboo leaves backlit by the sun", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1469", "prompt": "close up video of a wet flower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1470", "prompt": "a man putting a flower in a box", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1471", "prompt": "dropping flower petals on a wooden bowl", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1472", "prompt": "a close up shot of gypsophila flower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1473", "prompt": "variety of succulent plants on a garden", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1474", "prompt": "variety of trees and plants in a botanical garden", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1475", "prompt": "forest of deciduous trees", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1476", "prompt": "a stack of dried leaves burning in a forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1477", "prompt": "tall forest trees on a misty morning", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1478", "prompt": "close up view of dewdrops on a leaf", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1479", "prompt": "close up view of white petaled flower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1480", "prompt": "removing a pineapple leaf", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1481", "prompt": "a dragonfly perched on a leaf", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1482", "prompt": "butterfly pollinating flower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1483", "prompt": "person visiting and checking a corn plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1484", "prompt": "woman picking beans from a plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1485", "prompt": "woman plucking mint leaves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1486", "prompt": "single tree in the middle of farmland", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1487", "prompt": "a plant on a soil", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1488", "prompt": "drone footage of a tree on farm field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1489", "prompt": "a tractor harvesting lavender flower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1490", "prompt": "people putting christmas ornaments on a christmas tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1491", "prompt": "jack o lantern hanging on a tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1492", "prompt": "tree with halloween decoration", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1493", "prompt": "flower field near the waterfall", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1494", "prompt": "truck carrying the tree logs", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1495", "prompt": "raindrops falling on leaves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1496", "prompt": "shot of a palm tree swaying with the wind", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1497", "prompt": "squirrels on a tree branch", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1498", "prompt": "person holding a flower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1499", "prompt": "a fallen tree trunk", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1500", "prompt": "tree with golden leaves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1501", "prompt": "cherry tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1502", "prompt": "wind blows through leaves of the tree in autumn", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1503", "prompt": "a leaf on a glass", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1504", "prompt": "the long trunks of tall trees in the forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1505", "prompt": "trees in the forest during sunny day", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1506", "prompt": "close up video of tree bark", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1507", "prompt": "reflection of tree branches", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1508", "prompt": "trunks of many trees in the forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1509", "prompt": "tree leaves providing shades from the sun", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1510", "prompt": "leaves swaying in the wind", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1511", "prompt": "low angle shot of baobab tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1512", "prompt": "bare trees in forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1513", "prompt": "a plant surrounded by fallen leaves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1514", "prompt": "a couple preparing food and pruning a plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1515", "prompt": "a man cutting a tree bark", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1516", "prompt": "oranges on a tree branch", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1517", "prompt": "plant connected on the stones", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1518", "prompt": "video of a sawmill machine cutting tree log", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1519", "prompt": "women drying flower petals", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1520", "prompt": "macro view of an agave plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1521", "prompt": "a video of a person tying a plant on a string", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1522", "prompt": "green moss in forest nature", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1523", "prompt": "coconut tree near sea under blue sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1524", "prompt": "the canopy of a coconut tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1525", "prompt": "a man leaning on a tree at the beach", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1526", "prompt": "a full grown plant on a pot", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1527", "prompt": "candle wax dripping on flower petals", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1528", "prompt": "close up of leaves in autumn", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1529", "prompt": "a woman opening a book with a flower inside", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1530", "prompt": "a man holding leaves looking at the camera", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1531", "prompt": "a shadow of a swaying plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1532", "prompt": "a tree and concrete structure under a blue and cloudy sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1533", "prompt": "trimming excess leaves on a potted plant", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1534", "prompt": "the changing color of the tree leaves during autumn season", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1535", "prompt": "a gooseberry tree swayed by the wind", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1536", "prompt": "forest trees and a medieval castle at sunset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1537", "prompt": "woman cut down tree", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1538", "prompt": "an old oak tree in a park across the street from a hotel", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1539", "prompt": "wild flowers growing in a forest ground", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1540", "prompt": "a mossy fountain and green plants in a botanical garden", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1541", "prompt": "mansion with beautiful garden", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1542", "prompt": "ants on a dragon fruit flower", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1543", "prompt": "scenery of desert landscape", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1544", "prompt": "landscape agriculture farm tractor", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1545", "prompt": "burning slash piles in the forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1546", "prompt": "graveyard at sunset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1547", "prompt": "view of a jack o lantern with pumpkins in a smoky garden", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1548", "prompt": "sun view through a spider web", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1549", "prompt": "view of the sea from an abandoned building", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1550", "prompt": "close up view of a full moon", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1551", "prompt": "close up view of lighted candles", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1552", "prompt": "close up view of swaying white flowers and leaves", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1553", "prompt": "scenery of a relaxing beach", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1554", "prompt": "selective focus video of grass during sunny day", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1555", "prompt": "aerial view of brown dry landscape", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1556", "prompt": "fireworks display in the sky at night", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1557", "prompt": "a bonfire near river", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1558", "prompt": "mountain view", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1559", "prompt": "waterfalls in between mountain", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1560", "prompt": "a picturesque view of nature", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1561", "prompt": "exotic view of a riverfront city", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1562", "prompt": "tall trees in the forest under the clear sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1563", "prompt": "snow on branches in forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1564", "prompt": "stream in the nature", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1565", "prompt": "an airplane flying above the sea of clouds", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1566", "prompt": "scenic video of sunset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1567", "prompt": "view of houses with bush fence under a blue and cloudy sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1568", "prompt": "scenic view from wooden pathway", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1569", "prompt": "scenic view of a tropical beach", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1570", "prompt": "drone footage of waves crashing on beach shore", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1571", "prompt": "a scenic view of the golden hour at norway", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1572", "prompt": "time lapse video of foggy mountain forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1573", "prompt": "brown mountain during fall season", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1574", "prompt": "video of ocean during daytime", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1575", "prompt": "boat sailing in the ocean", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1576", "prompt": "top view of yachts", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1577", "prompt": "beautiful scenery of flowing waterfalls and river", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1578", "prompt": "wild ducks paddling on the lake surface", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1579", "prompt": "a relaxing scenery of beach view under cloudy sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1580", "prompt": "natural rock formations on beach under cloudy sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1581", "prompt": "a palm tree against blue sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1582", "prompt": "video of sailboat on a lake during sunset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1583", "prompt": "aerial view of snow piles", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1584", "prompt": "time lapse of a sunset sky in the countryside", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1585", "prompt": "aerial footage of a statue", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1586", "prompt": "time lapse video of a farm during sunset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1587", "prompt": "clouds formation in the sky at sunset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1588", "prompt": "aerial shot of a village", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1589", "prompt": "drone shot of a beautiful sunrise at the mountains", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1590", "prompt": "time lapse video of foggy morning during sunrise", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1591", "prompt": "sun shining between tree leaves at sunrise", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1592", "prompt": "video of lake during dawn", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1593", "prompt": "vehicles traveling on roadway under cloudy sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1594", "prompt": "view of golden domed church", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1595", "prompt": "a monument under the blue sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1596", "prompt": "firecrackers in the sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1597", "prompt": "view of fruit signage in the farm", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1598", "prompt": "a dark clouds over shadowing the full moon", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1599", "prompt": "view of the amazon river", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1600", "prompt": "a big river swamp in a dense forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1601", "prompt": "a blooming cherry blossom tree under a blue sky with white clouds", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1602", "prompt": "a river waterfall cascading down the plunge basin", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1603", "prompt": "flooded landscape with palm trees", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1604", "prompt": "a blurry waterfall background", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1605", "prompt": "waterfall in the mountains", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1606", "prompt": "aerial footage of a city at night", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1607", "prompt": "pond by small waterfall in forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1608", "prompt": "aerial view of farmlands at the bay of lake", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1609", "prompt": "rice terraces in the countryside", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1610", "prompt": "a highway built across an agricultural area in the countryside", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1611", "prompt": "gloomy morning in the countryside", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1612", "prompt": "drone shot of an abandoned coliseum on a snowy mountain top", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1613", "prompt": "boat sailing in the middle of ocean", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1614", "prompt": "drone shot of the grass field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1615", "prompt": "natural landscape of mountain and sea with islets developed into a community", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1616", "prompt": "aerial view of zaporizhia in ukraine", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1617", "prompt": "aerial footage of a herd", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1618", "prompt": "an aerial footage of a red sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1619", "prompt": "grass and plants growing in the remains of an abandoned house", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1620", "prompt": "view from hill on city", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1621", "prompt": "aerial view on orthodox church", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1622", "prompt": "aerial view of bay in croatia", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1623", "prompt": "a footage of a frozen river", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1624", "prompt": "overlooking view of a city at daylight", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1625", "prompt": "view outside the cemetery", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1626", "prompt": "clear sky with moon over meadow", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1627", "prompt": "clouds over railway", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1628", "prompt": "aerial footage of moving vehicles on the road at night", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1629", "prompt": "aerial view of town and park", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1630", "prompt": "top view of skyscrapers", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1631", "prompt": "top view of the empire state building in manhattan", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1632", "prompt": "top view of the central park in new york city", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1633", "prompt": "sheep running in a grass field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1634", "prompt": "clear sky over factory", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1635", "prompt": "smoke and fire in birds eye view", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1636", "prompt": "view of a pathway with snow melting on its side", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1637", "prompt": "ferry under bridge on river near city in malaysia", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1638", "prompt": "mountain slopes covered in green vegetation", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1639", "prompt": "panoramic view of a town surrounded by snow covered mountains", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1640", "prompt": "aerial view of a palace", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1641", "prompt": "top view of vehicles driving on the intersection", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1642", "prompt": "a graveyard by a church in a mountain landscape", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1643", "prompt": "a modern railway station in malaysia use for public transportation", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1644", "prompt": "drone footage of amsterdam metro station", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1645", "prompt": "train arriving at a station", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1646", "prompt": "red vehicle driving on field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1647", "prompt": "close up view of flashing emergency vehicle lighting", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1648", "prompt": "vehicle with fertilizer on field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1649", "prompt": "drone footage of motorcycles driving on country road between agricultural fields", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1650", "prompt": "a road in the woods under fog", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1651", "prompt": "footage of a car driving through a wheat field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1652", "prompt": "vehicle stops for an ambulance passing through city traffic", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1653", "prompt": "emergency vehicle parked outside the casino", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1654", "prompt": "zombies attacking a woman and a boy inside a car", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1655", "prompt": "woman seating inside the car while chewing", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1656", "prompt": "video of passengers riding a double decker bus during night", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1657", "prompt": "traffic in london street at night", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1658", "prompt": "elderly couple checking engine of automobile", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1659", "prompt": "a green vintage automobile with an open hood parked in a parking area", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1660", "prompt": "close up of a prototype automobile with exposed engine on the back seat of the car", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1661", "prompt": "aerial view of road in forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1662", "prompt": "train departing from station", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1663", "prompt": "aerial view of a train passing by a bridge", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1664", "prompt": "video of a train tracks", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1665", "prompt": "video footage of a subway", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1666", "prompt": "video of blinking traffic lights", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1667", "prompt": "couple walking out on the subway", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1668", "prompt": "time lapse of a subway tunnel", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1669", "prompt": "monitor board inside the subway", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1670", "prompt": "metro train at night", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1671", "prompt": "zoom in video of a tram passing by city", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1672", "prompt": "young man using laptop in the tram", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1673", "prompt": "man reading a book at bus stop", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1674", "prompt": "close up shot of a moving taxi", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1675", "prompt": "night travel in london street on a public bus", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1676", "prompt": "red bus in a rainy city", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1677", "prompt": "flow of traffic in the city", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1678", "prompt": "close up shot of a yellow taxi turning left", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1679", "prompt": "two women calling for a taxi", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1680", "prompt": "drone view of an illuminated bridge across a river", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1681", "prompt": "policeman in police car talking on radio", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1682", "prompt": "airplane taking off at night", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1683", "prompt": "view through window in airplane", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1684", "prompt": "an airplane in the sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1685", "prompt": "helicopter landing on the street", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1686", "prompt": "a pilot getting out of a helicopter", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1687", "prompt": "a helicopter flying under blue sky", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1688", "prompt": "boat sailing in the middle of the ocean", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1689", "prompt": "girl playing with a toy boat", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1690", "prompt": "silhouette of a boat on sea during golden hour", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1691", "prompt": "a boat travelling around the lake", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1692", "prompt": "road on mountain ridge", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1693", "prompt": "ship sailing on danube river", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1694", "prompt": "slow motion video of a ship water trail in the sea", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1695", "prompt": "drone footage of a wreck ship on shore", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1696", "prompt": "a white yacht traveling on a river and passing under the bridge", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1697", "prompt": "female teenagers drinking champagne in the yacht", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1698", "prompt": "video of yacht sailing in the ocean", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1699", "prompt": "red combine harvester on road on field", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1700", "prompt": "a woman sitting on a bicycle while using a mobile phone", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1701", "prompt": "a woman sitting on a motorcycle looking around", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1702", "prompt": "three teenagers fixing a bicycle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1703", "prompt": "a woman in a halloween costume posing on a motorcycle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1704", "prompt": "a parked motorcycle on a foggy roadside", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1705", "prompt": "cable car near sea shore", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1706", "prompt": "a truck travelling in the road", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1707", "prompt": "footage of the road without any traffic", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1708", "prompt": "a road sign", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1709", "prompt": "love padlocks on a bridge", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1710", "prompt": "camera moving at highway construction site", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1711", "prompt": "vehicles driving on highway", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1712", "prompt": "a motorbike on highway at timelapse mode", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1713", "prompt": "point of view of a car driving through a tunnel", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1714", "prompt": "time lapse of heavy traffic on an avenue", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1715", "prompt": "ferry boat on city canal", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1716", "prompt": "black vintage car in museum", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1717", "prompt": "a zigzag road across a forest", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1718", "prompt": "people crossing the road", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1719", "prompt": "video of a kayak boat in a river", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1720", "prompt": "a person paddling a wooden boat in a lake", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1721", "prompt": "a car charging in the parking area", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1722", "prompt": "cars parked on the road", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1723", "prompt": "footage of the street with people and vehicle passing by in the rain", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1724", "prompt": "traffic on busy city street", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1725", "prompt": "a woman getting out of the car to walk with their dog", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1726", "prompt": "yacht sailing through the ocean", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1727", "prompt": "people in queue to military ship", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1728", "prompt": "man wearing motorcycle helmet looking at the camera", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1729", "prompt": "empty seats in the bus", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1730", "prompt": "empty boat on the water", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1731", "prompt": "cargo train traveling on the mountainside", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1732", "prompt": "cruise ship in harbor", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1733", "prompt": "counting down at traffic lights", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1734", "prompt": "pressing the car ignition", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1735", "prompt": "fire truck driving on the road", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1736", "prompt": "a footage of a broken bicycle", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1737", "prompt": "drone footage of an ambulance on the road", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1738", "prompt": "slow motion footage of a racing car", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1739", "prompt": "ship sailing on sea against sunset", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1740", "prompt": "big cargo ship passing on the shore", "reward_tag": "videoscore2", "source": "all_category.txt"}
+{"id": "vbench-1741", "prompt": "back view of man and woman walking on unpaved road", "reward_tag": "videoscore2", "source": "all_category.txt"}

--- a/examples/train/configs/rl/wan/run_promptrl_slurm.sbatch
+++ b/examples/train/configs/rl/wan/run_promptrl_slurm.sbatch
@@ -1,0 +1,160 @@
+#!/bin/bash
+#SBATCH --job-name=promptrl-wan
+#SBATCH --partition=all
+#SBATCH --nodes=3
+#SBATCH --ntasks=3
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:4
+#SBATCH --exclusive
+#SBATCH --time=14-00:00:00
+#SBATCH --chdir=.
+#SBATCH --output=slurm-%j.out
+#SBATCH --error=slurm-%j.err
+
+set -euo pipefail
+
+export PATH="${PATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
+
+work_root="${PROMPTRL_WORK_ROOT:-${SLURM_SUBMIT_DIR:-${PWD}}}"
+export HOME="${PROMPTRL_HOME:-${work_root}}"
+
+source_dir="${PROMPTRL_SOURCE_DIR:-${work_root}/promptrl/staging/source}"
+run_dir="${PROMPTRL_RUN_DIR:-${work_root}/promptrl_runs/wan21_prompt_only}"
+container_image="${PROMPTRL_CONTAINER_IMAGE:-ghcr.io#hao-ai-lab/fastvideo/fastvideo-dev:py3.12-cuda13.0.0-latest}"
+reward_port="${PROMPTRL_REWARD_PORT:-8100}"
+max_train_steps="${PROMPTRL_MAX_TRAIN_STEPS:-1000}"
+master_port="${PROMPTRL_MASTER_PORT:-29500}"
+prompt_data="/workspace/FastVideo/examples/train/configs/rl/wan/promptrl_vbench_prompts.jsonl"
+
+mkdir -p "${run_dir}" "${run_dir}/wandb" "${run_dir}/hf-cache"
+mapfile -t nodes < <(scontrol show hostnames "${SLURM_JOB_NODELIST}")
+if [[ "${#nodes[@]}" -ne 3 ]]; then
+  echo "Expected exactly three allocated nodes, got ${#nodes[@]}" >&2
+  exit 1
+fi
+
+reward_node="${nodes[0]}"
+train_node_0="${nodes[1]}"
+train_node_1="${nodes[2]}"
+train_nodes="${train_node_0},${train_node_1}"
+reward_endpoint="http://${reward_node}:${reward_port}"
+mounts="${source_dir}:/workspace/FastVideo,${run_dir}:/workspace/run"
+
+# A user-provisioned mode-600 file may contain WANDB_API_KEY and optional
+# WANDB_ENTITY. If it is absent, preserve all logs in W&B offline format so
+# they can be synchronized later without delaying the queued GPU allocation.
+wandb_env="${HOME}/.config/fastvideo/wandb.env"
+if [[ -r "${wandb_env}" ]]; then
+  # shellcheck disable=SC1090
+  source "${wandb_env}"
+  export WANDB_MODE="${WANDB_MODE:-online}"
+else
+  export WANDB_MODE=offline
+fi
+
+export HF_HOME="${run_dir}/hf-cache"
+export TOKENIZERS_PARALLELISM=false
+export WANDB_DIR="${run_dir}/wandb"
+export WANDB_PROJECT=promptrl_wan
+export WANDB_RUN_ID=wan21-promptrl-prompt-only
+export WANDB_RESUME=allow
+
+echo "PROMPTRL_SLURM_LAYOUT reward=${reward_node} train=${train_nodes}"
+echo "PROMPTRL_TRACKING_MODE mode=${WANDB_MODE}"
+
+srun \
+  --export=ALL \
+  --overlap \
+  --nodes=1 \
+  --ntasks=1 \
+  --nodelist="${reward_node}" \
+  --gres=gpu:1 \
+  --container-image="${container_image}" \
+  --container-mounts="${mounts}" \
+  --container-workdir=/workspace/FastVideo \
+  --container-writable \
+  --container-env=HF_HOME,TOKENIZERS_PARALLELISM \
+  bash -lc '
+    set -euo pipefail
+    source /opt/venv/bin/activate
+    /root/.local/bin/uv pip install qwen-vl-utils python-multipart
+    python -c "import torch; assert torch.cuda.get_device_capability(0) == (10, 0); assert torch.ones(1, device=\"cuda\").item() == 1"
+    python -m fastvideo.train.methods.rl.promptrl.rewards.serve \
+      --host 0.0.0.0 \
+      --port "'"${reward_port}"'" \
+      > /workspace/run/reward-service.log 2>&1
+  ' &
+reward_step_pid=$!
+
+cleanup() {
+  kill "${reward_step_pid}" 2>/dev/null || true
+  wait "${reward_step_pid}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 180); do
+  if curl --fail --silent --show-error \
+    "${reward_endpoint}/healthz" >/dev/null; then
+    break
+  fi
+  if ! kill -0 "${reward_step_pid}" 2>/dev/null; then
+    tail -n 200 "${run_dir}/reward-service.log" 2>/dev/null || true
+    exit 1
+  fi
+  sleep 5
+done
+curl --fail --silent --show-error "${reward_endpoint}/healthz" >/dev/null
+echo "PROMPTRL_REWARD_SERVICE_READY endpoint=${reward_endpoint}"
+
+export PROMPTRL_REWARD_ENDPOINT="${reward_endpoint}"
+export PROMPTRL_MASTER_ADDR="${train_node_0}"
+export PROMPTRL_MASTER_PORT="${master_port}"
+export PROMPTRL_MAX_TRAIN_STEPS="${max_train_steps}"
+
+srun \
+  --export=ALL \
+  --overlap \
+  --nodes=2 \
+  --ntasks=2 \
+  --ntasks-per-node=1 \
+  --nodelist="${train_nodes}" \
+  --gres=gpu:4 \
+  --container-image="${container_image}" \
+  --container-mounts="${mounts}" \
+  --container-workdir=/workspace/FastVideo \
+  --container-writable \
+  --container-env=HF_HOME,TOKENIZERS_PARALLELISM,WANDB_API_KEY,WANDB_ENTITY,WANDB_MODE,WANDB_DIR,WANDB_PROJECT,WANDB_RUN_ID,WANDB_RESUME,PROMPTRL_REWARD_ENDPOINT,PROMPTRL_MASTER_ADDR,PROMPTRL_MASTER_PORT,PROMPTRL_MAX_TRAIN_STEPS \
+  bash -lc '
+    set -euo pipefail
+    source /opt/venv/bin/activate
+    /root/.local/bin/uv pip install qwen-vl-utils python-multipart
+    python -c "import torch; assert torch.cuda.get_device_capability(0) == (10, 0); assert torch.ones(1, device=\"cuda\").item() == 1"
+
+    resume_args=()
+    if compgen -G "/workspace/run/output/checkpoint-*/dcp" >/dev/null; then
+      resume_args=(--training.checkpoint.resume_from_checkpoint latest)
+    fi
+
+    torchrun \
+      --nnodes=2 \
+      --nproc-per-node=4 \
+      --node-rank="${SLURM_PROCID}" \
+      --master-addr="${PROMPTRL_MASTER_ADDR}" \
+      --master-port="${PROMPTRL_MASTER_PORT}" \
+      -m fastvideo.train.entrypoint.train \
+      --config examples/train/configs/rl/wan/promptrl_prompt_only.yaml \
+      --method.data.data_path "'"${prompt_data}"'" \
+      --method.reward.endpoint_url "${PROMPTRL_REWARD_ENDPOINT}" \
+      --method.validation.every_steps 0 \
+      --training.loop.max_train_steps "${PROMPTRL_MAX_TRAIN_STEPS}" \
+      --training.checkpoint.output_dir /workspace/run/output \
+      --training.checkpoint.training_state_checkpointing_steps 10 \
+      --training.checkpoint.checkpoints_total_limit 4 \
+      --training.tracker.trackers "[wandb]" \
+      --training.tracker.project_name promptrl_wan \
+      --training.tracker.run_name wan2.1_promptrl_prompt_only \
+      --callbacks.promptrl_export.output_dir /workspace/run/output/bundle \
+      "${resume_args[@]}"
+  '
+
+echo "PROMPTRL_TRAINING_OK steps=${max_train_steps}"

--- a/examples/train/configs/rl/wan/run_promptrl_training.sh
+++ b/examples/train/configs/rl/wan/run_promptrl_training.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${WANDB_API_KEY:?WANDB_API_KEY must be provided through a secret}"
+
+run_dir="${PROMPTRL_RUN_DIR:-/root/data/promptrl_runs/wan21_prompt_only}"
+max_train_steps="${PROMPTRL_MAX_TRAIN_STEPS:-1000}"
+reward_port="${PROMPTRL_REWARD_PORT:-8100}"
+reward_log="${run_dir}/reward-service.log"
+prompt_data="${PROMPTRL_PROMPT_DATA:-examples/train/configs/rl/wan/promptrl_vbench_prompts.jsonl}"
+
+mkdir -p "${run_dir}"
+
+if [[ ! -f "${prompt_data}" ]]; then
+  echo "Prompt dataset not found: ${prompt_data}" >&2
+  exit 1
+fi
+
+CUDA_VISIBLE_DEVICES=0 python -m \
+  fastvideo.train.methods.rl.promptrl.rewards.serve \
+  --port "${reward_port}" >"${reward_log}" 2>&1 &
+reward_pid=$!
+
+cleanup() {
+  kill "${reward_pid}" 2>/dev/null || true
+  wait "${reward_pid}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 120); do
+  if curl --fail --silent --show-error \
+    "http://127.0.0.1:${reward_port}/healthz" >/dev/null; then
+    break
+  fi
+  if ! kill -0 "${reward_pid}" 2>/dev/null; then
+    tail -n 200 "${reward_log}"
+    exit 1
+  fi
+  sleep 5
+done
+
+curl --fail --silent --show-error \
+  "http://127.0.0.1:${reward_port}/healthz" >/dev/null
+echo "PROMPTRL_REWARD_SERVICE_READY"
+
+torchrun --standalone --nproc-per-node=8 -m \
+  fastvideo.train.entrypoint.train \
+  --config examples/train/configs/rl/wan/promptrl_prompt_only.yaml \
+  --method.data.data_path "${prompt_data}" \
+  --method.reward.endpoint_url "http://127.0.0.1:${reward_port}" \
+  --method.validation.every_steps 0 \
+  --training.loop.max_train_steps "${max_train_steps}" \
+  --training.checkpoint.output_dir "${run_dir}/output" \
+  --training.checkpoint.training_state_checkpointing_steps 1 \
+  --training.checkpoint.checkpoints_total_limit 2 \
+  --training.tracker.trackers "[wandb]" \
+  --training.tracker.project_name promptrl_wan \
+  --training.tracker.run_name wan2.1_promptrl_prompt_only \
+  --callbacks.promptrl_export.output_dir "${run_dir}/output/bundle"
+
+echo "PROMPTRL_TRAINING_OK steps=${max_train_steps}"

--- a/fastvideo/tests/modal/launch_l40s_job.py
+++ b/fastvideo/tests/modal/launch_l40s_job.py
@@ -488,6 +488,22 @@ def run_h100_2(
                         local_patch_b64, commit_volume)
 
 
+@app.function(gpu="H100:8", **COMMON_FUNCTION_KWARGS)
+def run_h100_8(
+    command: str,
+    git_repo: str,
+    git_commit: str,
+    pr_number: str,
+    install_extra: str,
+    build_kernel: bool,
+    env_vars: str,
+    local_patch_b64: str,
+    commit_volume: bool,
+):
+    return _run_gpu_job(command, git_repo, git_commit, pr_number, install_extra, build_kernel, env_vars,
+                        local_patch_b64, commit_volume)
+
+
 def _select_runner(gpu_type: str, num_gpus: int) -> Callable[..., Any]:
     normalized_gpu_type = gpu_type.upper()
     runners = {
@@ -497,6 +513,7 @@ def _select_runner(gpu_type: str, num_gpus: int) -> Callable[..., Any]:
         ("L40S", 8): run_l40s_8,
         ("H100", 1): run_h100_1,
         ("H100", 2): run_h100_2,
+        ("H100", 8): run_h100_8,
     }
     try:
         return runners[(normalized_gpu_type, num_gpus)]
@@ -526,6 +543,13 @@ def main(
     resolved_git_commit = _resolve_git_commit(git_commit)
     resolved_pr_number = _resolve_pull_request(pr_number)
     runner = _select_runner(normalized_gpu_type, num_gpus)
+    named_secrets = [
+        modal.Secret.from_name(name.strip())
+        for name in os.environ.get("FASTVIDEO_MODAL_SECRETS", "").split(",")
+        if name.strip()
+    ]
+    if named_secrets:
+        runner = runner.with_options(secrets=[local_secrets, *named_secrets])
 
     print(f"Launching {normalized_gpu_type}:{num_gpus} job")
     print(f"Command: {command}")

--- a/fastvideo/train/AGENTS.md
+++ b/fastvideo/train/AGENTS.md
@@ -16,10 +16,15 @@ train/
 │   ├── knowledge_distillation/  #   KDMethod, KDCausalMethod
 │   ├── consistency_model/       #   Consistency-model training methods
 │   └── rl/                      #   RL methods, sampling helpers, rewards
+│       └── promptrl/            #   PromptRL: refiner GRPO + Wan flow-policy
 ├── models/
 │   ├── base.py             #   ModelBase / CausalModelBase wrappers
 │   ├── wan/, hunyuan/, cosmos/  # Per-family training wrappers
-├── callbacks/              # callback.py base + ema, grad_clip, validation
+├── roles/
+│   ├── base.py             #   TrainRoleBase (diffusion + non-diffusion roles)
+│   └── qwen_refiner.py     #   QwenPromptRefinerRole (PEFT LoRA LM role)
+├── callbacks/              # callback.py base + ema, grad_clip, validation,
+│                           #   promptrl_export
 └── utils/
     ├── training_config.py  #   Hierarchical YAML config dataclasses
     ├── builder.py          #   Build trainer from config
@@ -51,6 +56,18 @@ Trainer = Method × Model × [Callback...] × Config
    reimplement.
 3. Expose `trainable_parameters()` so the optimizer factory can group them.
 4. Register in `utils/builder.py` if the trainer dispatches by name.
+
+## Training Roles
+
+`roles/base.py::TrainRoleBase` is the lightweight contract every
+training role satisfies: `checkpoint_modules()`, `trainable_parameters()`,
+lifecycle hooks (`init_preprocessors`, `on_train_start`), and device
+metadata. `ModelBase` inherits it for diffusion roles; non-diffusion
+roles (e.g. `roles/qwen_refiner.py`, a PEFT-LoRA language model)
+implement it directly. The builder, DCP checkpointing
+(`TrainingMethod.checkpoint_state`), gradient clipping, and optimizer
+plumbing all operate on `TrainRoleBase`, so mixed diffusion + LM
+methods (PromptRL) compose the same way diffusion-only methods do.
 
 ## Adding a New Method
 

--- a/fastvideo/train/callbacks/__init__.py
+++ b/fastvideo/train/callbacks/__init__.py
@@ -8,6 +8,8 @@ from fastvideo.train.callbacks.ema import (
     EMACallback, )
 from fastvideo.train.callbacks.grad_clip import (
     GradNormClipCallback, )
+from fastvideo.train.callbacks.promptrl_export import (
+    PromptRLBundleExportCallback, )
 from fastvideo.train.callbacks.validation import (
     ValidationCallback, )
 
@@ -16,5 +18,6 @@ __all__ = [
     "CallbackDict",
     "EMACallback",
     "GradNormClipCallback",
+    "PromptRLBundleExportCallback",
     "ValidationCallback",
 ]

--- a/fastvideo/train/callbacks/callback.py
+++ b/fastvideo/train/callbacks/callback.py
@@ -24,6 +24,7 @@ _BUILTIN_CALLBACKS: dict[str, str] = {
     "grad_clip": "fastvideo.train.callbacks.grad_clip.GradNormClipCallback",
     "validation": "fastvideo.train.callbacks.validation.ValidationCallback",
     "ema": "fastvideo.train.callbacks.ema.EMACallback",
+    "promptrl_export": "fastvideo.train.callbacks.promptrl_export.PromptRLBundleExportCallback",
 }
 
 

--- a/fastvideo/train/callbacks/promptrl_export.py
+++ b/fastvideo/train/callbacks/promptrl_export.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRL inference-bundle export callback.
+
+Exports a PromptRL bundle (manifest + refiner PEFT adapter + generator
+LoRA safetensors) from the live roles at train end, and optionally at a
+step cadence for long runs.  Only rank 0 writes; LoRA weights are
+replicated across ranks so the rank-0 copy is complete.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastvideo.logger import init_logger
+from fastvideo.train.callbacks.callback import Callback
+
+logger = init_logger(__name__)
+
+
+class PromptRLBundleExportCallback(Callback):
+    """Write PromptRL inference bundles from a PromptRLMethod."""
+
+    def __init__(
+        self,
+        *,
+        output_dir: str,
+        every_steps: int = 0,
+    ) -> None:
+        if not output_dir:
+            raise ValueError("callbacks.promptrl_export.output_dir must be set")
+        self._output_dir = str(output_dir)
+        self._every_steps = max(0, int(every_steps))
+
+    # ------------------------------------------------------------------
+
+    def _is_rank0(self) -> bool:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized():
+            return dist.get_rank() == 0
+        return True
+
+    def _export(self, method: Any, *, suffix: str = "") -> None:
+        export = getattr(method, "export_bundle", None)
+        if export is None:
+            logger.warning("promptrl_export callback attached to %s which has no "
+                           "export_bundle(); skipping", type(method).__name__)
+            return
+        if not self._is_rank0():
+            return
+        target = os.path.join(self._output_dir + suffix) if suffix else self._output_dir
+        written = export(target)
+        logger.info("Exported PromptRL bundle to %s (%s)", target, sorted(written))
+
+    # ------------------------------------------------------------------
+
+    def on_training_step_end(self, method: Any, loss_dict: dict[str, Any], iteration: int = 0) -> None:
+        if self._every_steps <= 0 or iteration <= 0 or iteration % self._every_steps != 0:
+            return
+        self._export(method, suffix=f"-step-{iteration}")
+
+    def on_train_end(self, method: Any, iteration: int = 0) -> None:
+        self._export(method)

--- a/fastvideo/train/methods/base.py
+++ b/fastvideo/train/methods/base.py
@@ -10,7 +10,7 @@ import torch
 
 from fastvideo import envs
 from fastvideo.logger import init_logger
-from fastvideo.train.models.base import ModelBase
+from fastvideo.train.roles.base import TrainRoleBase
 from fastvideo.train.utils.checkpoint import _RoleModuleContainer
 from fastvideo.training.checkpointing_utils import (
     ModelWrapper,
@@ -47,24 +47,24 @@ class TrainingMethod(torch.nn.Module, ABC):
         self,
         *,
         cfg: Any,
-        role_models: dict[str, ModelBase],
+        role_models: dict[str, TrainRoleBase],
     ) -> None:
         super().__init__()
         self.tracker: Any | None = None
-        self._role_models: dict[str, ModelBase] = dict(role_models)
+        self._role_models: dict[str, TrainRoleBase] = dict(role_models)
 
         self.student = role_models["student"]
         self.training_config = cfg.training
         self.method_config: dict[str, Any] = dict(cfg.method)
         self.validation_config: dict[str, Any] = dict(getattr(cfg, "validation", {}) or {})
 
-        # Build nn.ModuleDict for FSDP / checkpoint visibility.
+        # Build nn.ModuleDict for FSDP / checkpoint visibility.  Roles
+        # expose their modules through ``TrainRoleBase.checkpoint_modules``
+        # so non-diffusion roles (e.g. language models) register the same
+        # way diffusion roles register their transformer.
         self.role_modules = torch.nn.ModuleDict()
         for role, model in role_models.items():
-            mods: dict[str, torch.nn.Module] = {}
-            transformer = getattr(model, "transformer", None)
-            if isinstance(transformer, torch.nn.Module):
-                mods["transformer"] = transformer
+            mods = model.checkpoint_modules() if isinstance(model, TrainRoleBase) else {}
             if mods:
                 self.role_modules[role] = torch.nn.ModuleDict(mods)
 
@@ -126,7 +126,9 @@ class TrainingMethod(torch.nn.Module, ABC):
                 continue
 
             modules: dict[str, torch.nn.Module] = {}
-            if model.transformer is not None:
+            if isinstance(model, TrainRoleBase):
+                modules = model.checkpoint_modules()
+            elif getattr(model, "transformer", None) is not None:
                 modules["transformer"] = model.transformer
 
             container = _RoleModuleContainer(modules)

--- a/fastvideo/train/methods/rl/__init__.py
+++ b/fastvideo/train/methods/rl/__init__.py
@@ -2,5 +2,6 @@
 """RL training methods."""
 
 from fastvideo.train.methods.rl.diffusion_nft import DiffusionNFTMethod
+from fastvideo.train.methods.rl.promptrl.method import PromptRLMethod
 
-__all__ = ["DiffusionNFTMethod"]
+__all__ = ["DiffusionNFTMethod", "PromptRLMethod"]

--- a/fastvideo/train/methods/rl/promptrl/__init__.py
+++ b/fastvideo/train/methods/rl/promptrl/__init__.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRL: prompt-refinement RL for Wan video generation."""
+
+from fastvideo.train.methods.rl.promptrl.advantages import (
+    group_relative_advantages,
+    route_generator_advantages,
+    route_refiner_advantages,
+)
+from fastvideo.train.methods.rl.promptrl.config import (
+    PromptRLMethodConfig,
+    RefinerSamplingConfig,
+    RewardServiceConfig,
+    RoleOptimizerConfig,
+    RolloutConfig,
+)
+from fastvideo.train.methods.rl.promptrl.bundle import (
+    BundleManifest,
+    export_promptrl_bundle,
+    extract_generator_lora,
+    load_bundle_manifest,
+)
+from fastvideo.train.methods.rl.promptrl.inference import (
+    PromptRefiner,
+    RefinementResult,
+)
+from fastvideo.train.methods.rl.promptrl.method import PromptRLMethod
+from fastvideo.train.methods.rl.promptrl.prompts import (
+    GroupAssignment,
+    ParsedCompletion,
+    PromptDataset,
+    PromptRecord,
+    group_assignments,
+    parse_answer_tag,
+    render_refinement_prompt,
+)
+from fastvideo.train.methods.rl.promptrl.rewards import (
+    HttpRewardProvider,
+    RewardProvider,
+    RewardResult,
+    RewardSample,
+    RewardServiceError,
+)
+
+__all__ = [
+    "BundleManifest",
+    "GroupAssignment",
+    "HttpRewardProvider",
+    "ParsedCompletion",
+    "PromptDataset",
+    "PromptRLMethod",
+    "PromptRLMethodConfig",
+    "PromptRecord",
+    "PromptRefiner",
+    "RefinementResult",
+    "RefinerSamplingConfig",
+    "RewardProvider",
+    "RewardResult",
+    "RewardSample",
+    "RewardServiceConfig",
+    "RewardServiceError",
+    "RoleOptimizerConfig",
+    "RolloutConfig",
+    "export_promptrl_bundle",
+    "extract_generator_lora",
+    "group_assignments",
+    "group_relative_advantages",
+    "load_bundle_manifest",
+    "parse_answer_tag",
+    "render_refinement_prompt",
+    "route_generator_advantages",
+    "route_refiner_advantages",
+]

--- a/fastvideo/train/methods/rl/promptrl/advantages.py
+++ b/fastvideo/train/methods/rl/promptrl/advantages.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Group-relative advantage computation for PromptRL.
+
+Composite rewards (format + VideoScore2) are normalized within each
+``(group_id, reward_tag)`` group.  Groups with effectively zero reward
+variance produce zero advantages so they contribute no policy gradient.
+
+Advantage routing:
+
+* The refiner GRPO loss consumes only the *refined* samples'
+  advantages; retained-original ranks receive zero refiner advantage
+  so every rank still runs compatible refiner forward/backward paths
+  and distributed collectives stay aligned.
+* Wan's clipped flow-policy loss consumes *all* samples' advantages.
+
+All advantage tensors are detached before either policy loss so no
+gradient crosses between the refiner and the generator.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+
+#: Group reward standard deviations below this are treated as zero.
+ZERO_VARIANCE_EPS = 1e-8
+
+
+def group_relative_advantages(
+    rewards: torch.Tensor,
+    group_keys: Sequence[str],
+    *,
+    zero_variance_eps: float = ZERO_VARIANCE_EPS,
+) -> torch.Tensor:
+    """Normalize *rewards* within each group.
+
+    Args:
+        rewards: 1-D float tensor, one scalar per sample.
+        group_keys: group label per sample; samples sharing a label are
+            normalized together.  Labels typically combine the original
+            prompt id and the reward tag so different reward tags never
+            share a normalization basin.
+        zero_variance_eps: groups whose (population) standard deviation
+            is below this threshold produce all-zero advantages.
+
+    Returns:
+        Detached float32 advantages with the same shape as *rewards*.
+    """
+    rewards = rewards.detach().float()
+    if rewards.ndim != 1:
+        raise ValueError(f"rewards must be 1-D, got shape {tuple(rewards.shape)}")
+    if len(group_keys) != int(rewards.shape[0]):
+        raise ValueError(f"group_keys length {len(group_keys)} does not match "
+                         f"rewards shape {tuple(rewards.shape)}")
+
+    advantages = torch.zeros_like(rewards)
+    unique_keys = sorted(set(group_keys))
+    for key in unique_keys:
+        indices = [i for i, k in enumerate(group_keys) if k == key]
+        index_tensor = torch.tensor(indices, dtype=torch.long, device=rewards.device)
+        group = rewards[index_tensor]
+        std = group.std(unbiased=False)
+        if not torch.isfinite(std) or float(std) < zero_variance_eps:
+            continue  # effectively zero variance -> zero advantages
+        advantages[index_tensor] = (group - group.mean()) / std
+    return advantages.detach()
+
+
+def route_refiner_advantages(
+    advantages: torch.Tensor,
+    refiner_participation: Sequence[bool],
+) -> torch.Tensor:
+    """Zero out advantages for samples that skip the refiner loss.
+
+    Retained-original ranks get exactly zero refiner advantage while
+    still executing the refiner forward/backward path (required to keep
+    DDP/replicated gradient collectives aligned).
+    """
+    advantages = advantages.detach().float()
+    if len(refiner_participation) != int(advantages.shape[0]):
+        raise ValueError("refiner_participation length does not match advantages")
+    mask = torch.tensor([1.0 if flag else 0.0 for flag in refiner_participation],
+                        dtype=advantages.dtype,
+                        device=advantages.device)
+    return (advantages * mask).detach()
+
+
+def route_generator_advantages(advantages: torch.Tensor) -> torch.Tensor:
+    """Advantages consumed by the Wan flow-policy loss: every sample."""
+    return advantages.detach().float()

--- a/fastvideo/train/methods/rl/promptrl/bundle.py
+++ b/fastvideo/train/methods/rl/promptrl/bundle.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRL bundle exporter.
+
+Produces a self-contained inference bundle::
+
+    <bundle>/
+      manifest.json                         # schema, base models, versions
+      refiner/                              # PEFT adapter + tokenizer
+        adapter_model.safetensors
+        adapter_config.json
+        tokenizer... (saved via save_pretrained)
+      generator/                            # FastVideo Wan LoRA
+        promptrl_generator_lora.safetensors # HF-style Wan layer names
+        lora_config.json                    # rank/alpha/targets + layout
+
+``manifest.json`` records the prompt template/version, refiner sampling
+configuration, base model identifiers, and the compatible FastVideo
+version so :class:`~fastvideo.train.methods.rl.promptrl.inference.PromptRefiner`
+can reconstruct the exact refiner behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import torch
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+BUNDLE_SCHEMA_VERSION = 1
+GENERATOR_LORA_FILENAME = "promptrl_generator_lora.safetensors"
+GENERATOR_KEY_LAYOUT = "fastvideo_hf_v1"
+
+#: FastVideo-training Wan module names -> HF/diffusers Wan layer names.
+#: Inverse of the Wan arch ``param_names_mapping`` for LoRA-wrapped paths.
+_WAN_CUSTOM_TO_HF = {
+    r"^blocks\.(\d+)\.self_attn\.to_q\b(.*)$": r"blocks.\1.attn1.to_q\2",
+    r"^blocks\.(\d+)\.self_attn\.to_k\b(.*)$": r"blocks.\1.attn1.to_k\2",
+    r"^blocks\.(\d+)\.self_attn\.to_v\b(.*)$": r"blocks.\1.attn1.to_v\2",
+    r"^blocks\.(\d+)\.self_attn\.to_out\b(.*)$": r"blocks.\1.attn1.to_out.0\2",
+    r"^blocks\.(\d+)\.cross_attn\.to_q\b(.*)$": r"blocks.\1.attn2.to_q\2",
+    r"^blocks\.(\d+)\.cross_attn\.to_k\b(.*)$": r"blocks.\1.attn2.to_k\2",
+    r"^blocks\.(\d+)\.cross_attn\.to_v\b(.*)$": r"blocks.\1.attn2.to_v\2",
+    r"^blocks\.(\d+)\.cross_attn\.to_out\b(.*)$": r"blocks.\1.attn2.to_out.0\2",
+    r"^blocks\.(\d+)\.ffn\.fc_in\b(.*)$": r"blocks.\1.ffn.net.0.proj\2",
+    r"^blocks\.(\d+)\.ffn\.fc_out\b(.*)$": r"blocks.\1.ffn.net.2\2",
+}
+
+
+@dataclass(slots=True)
+class BundleManifest:
+    """Contents of ``manifest.json``."""
+
+    base_refiner_model: str
+    base_generator_model: str
+    fastvideo_version: str
+    refiner_lora: dict[str, Any]
+    generator_lora: dict[str, Any]
+    prompt_template_version: str
+    refiner_sampling: dict[str, Any]
+    mode: str
+    schema_version: int = BUNDLE_SCHEMA_VERSION
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> BundleManifest:
+        known = {f for f in cls.__dataclass_fields__}  # type: ignore[attr-defined]
+        unknown = sorted(set(raw) - known)
+        if unknown:
+            raise ValueError(f"Unknown manifest keys: {unknown}")
+        return cls(**raw)
+
+
+def training_name_to_hf(name: str) -> str:
+    """Map a training-layout Wan LoRA key to the HF/diffusers layout."""
+    for pattern, replacement in _WAN_CUSTOM_TO_HF.items():
+        if re.match(pattern, name):
+            return re.sub(pattern, replacement, name)
+    logger.warning("No HF mapping for LoRA key %r; exporting as-is", name)
+    return name
+
+
+def extract_generator_lora(transformer: torch.nn.Module) -> dict[str, torch.Tensor]:
+    """Extract LoRA tensors from a training transformer.
+
+    Returns HF-named ``{layer}.lora_A`` / ``{layer}.lora_B`` weights plus
+    scalar ``{layer}.lora_alpha`` entries.
+    """
+    from fastvideo.layers.lora.linear import BaseLayerWithLoRA
+
+    state: dict[str, torch.Tensor] = {}
+    for module_name, module in transformer.named_modules():
+        if not isinstance(module, BaseLayerWithLoRA):
+            continue
+        if module.lora_A is None or module.lora_B is None:
+            continue
+        base_name = training_name_to_hf(module_name)
+        lora_a = module.lora_A
+        lora_b = module.lora_B
+        if hasattr(lora_a, "to_local"):  # DTensor-safe extraction
+            lora_a = lora_a.to_local()
+            lora_b = lora_b.to_local()
+        state[f"{base_name}.lora_A"] = lora_a.detach().float().cpu().contiguous()
+        state[f"{base_name}.lora_B"] = lora_b.detach().float().cpu().contiguous()
+        alpha = float(getattr(module, "lora_alpha", 0) or 0)
+        state[f"{base_name}.lora_alpha"] = torch.tensor(alpha, dtype=torch.float32)
+    if not state:
+        raise ValueError("Transformer contains no LoRA layers to export")
+    return state
+
+
+def export_promptrl_bundle(
+    output_dir: str,
+    *,
+    manifest: BundleManifest,
+    refiner_role: Any = None,
+    refiner_adapter_dir: str | None = None,
+    refiner_tokenizer: Any = None,
+    generator_transformer: torch.nn.Module | None = None,
+) -> dict[str, str]:
+    """Write a PromptRL inference bundle to *output_dir*.
+
+    Exactly one of ``refiner_role`` / ``refiner_adapter_dir`` provides
+    the refiner adapter; ``generator_transformer`` provides the Wan
+    LoRA.  Returns the written artifact paths.
+    """
+    from safetensors.torch import save_file
+
+    os.makedirs(output_dir, exist_ok=True)
+    written: dict[str, str] = {}
+
+    # --- manifest ---
+    manifest_path = os.path.join(output_dir, "manifest.json")
+    with open(manifest_path, "w", encoding="utf-8") as handle:
+        json.dump(manifest.to_dict(), handle, indent=2, sort_keys=True)
+    written["manifest"] = manifest_path
+
+    # --- refiner adapter ---
+    refiner_dir = os.path.join(output_dir, "refiner")
+    if refiner_role is not None:
+        refiner_role.save_adapter(refiner_dir)
+    elif refiner_adapter_dir is not None:
+        if os.path.isdir(refiner_dir):
+            shutil.rmtree(refiner_dir)
+        shutil.copytree(refiner_adapter_dir, refiner_dir)
+    else:
+        raise ValueError("export_promptrl_bundle requires refiner_role or "
+                         "refiner_adapter_dir")
+    if refiner_tokenizer is not None:
+        refiner_tokenizer.save_pretrained(refiner_dir)
+    written["refiner"] = refiner_dir
+
+    # --- generator LoRA ---
+    generator_dir = os.path.join(output_dir, "generator")
+    os.makedirs(generator_dir, exist_ok=True)
+    if generator_transformer is not None:
+        state = extract_generator_lora(generator_transformer)
+        lora_path = os.path.join(generator_dir, GENERATOR_LORA_FILENAME)
+        save_file(state, lora_path)
+        written["generator"] = lora_path
+        config_path = os.path.join(generator_dir, "lora_config.json")
+        with open(config_path, "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "key_layout": GENERATOR_KEY_LAYOUT,
+                    "filename": GENERATOR_LORA_FILENAME,
+                    **manifest.generator_lora,
+                },
+                handle,
+                indent=2,
+                sort_keys=True,
+            )
+        written["generator_config"] = config_path
+    else:
+        logger.info("No generator transformer given; bundle ships refiner-only")
+    return written
+
+
+def load_bundle_manifest(bundle_dir: str) -> BundleManifest:
+    manifest_path = os.path.join(bundle_dir, "manifest.json")
+    if not os.path.isfile(manifest_path):
+        raise FileNotFoundError(f"No manifest.json in bundle {bundle_dir}")
+    with open(manifest_path, encoding="utf-8") as handle:
+        return BundleManifest.from_dict(json.load(handle))

--- a/fastvideo/train/methods/rl/promptrl/config.py
+++ b/fastvideo/train/methods/rl/promptrl/config.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRL method configuration.
+
+Parsed from the ``method:`` mapping of a run YAML.  Defaults follow the
+PromptRL-Wan recipe:
+
+* ``group_size: 8`` ranks per original prompt, ``retained_originals: 2``
+  of which generate from the original prompt.
+* Composite reward = ``format_reward_weight * format`` +
+  ``video_reward_weight * VideoScore2``.
+* KL to the frozen bases: ``refiner_kl_beta`` / ``student_kl_beta``.
+* PPO clip ``1e-4`` for the Wan flow-policy loss (and refiner surrogate).
+* Rollout: 20 flow-matching steps, the last 8 stochastic (SDE) with
+  noise scale 0.8, transition losses recomputed with microbatch 1.
+* Per-role optimizers: LoRA lr 1e-5, AdamW betas (0.9, 0.999), weight
+  decay 0.01, gradient clipping 1.0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+PromptRLMode = Literal["prompt_only", "joint"]
+
+_SUPPORTED_MODE = ("prompt_only", "joint")
+
+
+@dataclass(slots=True)
+class RoleOptimizerConfig:
+    """Per-role optimizer + gradient clipping settings."""
+
+    learning_rate: float = 1e-5
+    betas: tuple[float, float] = (0.9, 0.999)
+    weight_decay: float = 0.01
+    max_grad_norm: float = 1.0
+    lr_scheduler: str = "constant"
+    lr_warmup_steps: int = 0
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any] | None, *, where: str) -> RoleOptimizerConfig:
+        if raw is None:
+            return cls()
+        if not isinstance(raw, dict):
+            raise ValueError(f"{where} must be a mapping, got {type(raw).__name__}")
+        betas_raw = raw.get("betas", (0.9, 0.999))
+        if not isinstance(betas_raw, list | tuple) or len(betas_raw) != 2:
+            raise ValueError(f"{where}.betas must be a 2-element list, got {betas_raw!r}")
+        return cls(
+            learning_rate=float(raw.get("learning_rate", 1e-5)),
+            betas=(float(betas_raw[0]), float(betas_raw[1])),
+            weight_decay=float(raw.get("weight_decay", 0.01)),
+            max_grad_norm=float(raw.get("max_grad_norm", 1.0)),
+            lr_scheduler=str(raw.get("lr_scheduler", "constant") or "constant"),
+            lr_warmup_steps=int(raw.get("lr_warmup_steps", 0) or 0),
+        )
+
+
+@dataclass(slots=True)
+class RolloutConfig:
+    """Wan rollout knobs for PromptRL."""
+
+    num_steps: int = 20
+    sde_steps: int = 8
+    noise_scale: float = 0.8
+    loss_microbatch_size: int = 1
+    flow_shift: float | None = None
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any] | None) -> RolloutConfig:
+        if raw is None:
+            return cls()
+        if not isinstance(raw, dict):
+            raise ValueError(f"method.rollout must be a mapping, got {type(raw).__name__}")
+        flow_shift = raw.get("flow_shift", None)
+        cfg = cls(
+            num_steps=int(raw.get("num_steps", 20) or 20),
+            sde_steps=int(raw.get("sde_steps", 8) or 0),
+            noise_scale=float(raw.get("noise_scale", 0.8)),
+            loss_microbatch_size=int(raw.get("loss_microbatch_size", 1) or 1),
+            flow_shift=(None if flow_shift in (None, "inherit") else float(flow_shift)),
+        )
+        cfg.validate()
+        return cfg
+
+    def validate(self) -> None:
+        if self.num_steps <= 0:
+            raise ValueError(f"method.rollout.num_steps must be positive, got {self.num_steps}")
+        if not 0 <= self.sde_steps <= self.num_steps:
+            raise ValueError("method.rollout.sde_steps must be within "
+                             f"[0, num_steps={self.num_steps}], got {self.sde_steps}")
+        if self.noise_scale <= 0.0:
+            raise ValueError(f"method.rollout.noise_scale must be positive, got {self.noise_scale}")
+        if self.loss_microbatch_size <= 0:
+            raise ValueError("method.rollout.loss_microbatch_size must be positive, "
+                             f"got {self.loss_microbatch_size}")
+
+
+
+@dataclass(slots=True)
+class PromptDataConfig:
+    """Raw prompt dataset settings (JSONL or Parquet).
+
+    Required column/key: ``prompt``.  Optional: ``id``, ``reward_tag``.
+    """
+
+    data_path: str = ""
+    prompt_key: str = "prompt"
+    id_key: str = "id"
+    reward_tag_key: str = "reward_tag"
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any] | None) -> PromptDataConfig:
+        if raw is None:
+            return cls()
+        if not isinstance(raw, dict):
+            raise ValueError(f"method.data must be a mapping, got {type(raw).__name__}")
+        return cls(
+            data_path=str(raw.get("data_path", "") or ""),
+            prompt_key=str(raw.get("prompt_key", "prompt") or "prompt"),
+            id_key=str(raw.get("id_key", "id") or "id"),
+            reward_tag_key=str(raw.get("reward_tag_key", "reward_tag") or "reward_tag"),
+        )
+
+
+@dataclass(slots=True)
+class RewardServiceConfig:
+    """External reward service client settings."""
+
+    endpoint_url: str = "http://127.0.0.1:8100"
+    timeout_sec: float = 300.0
+    retries: int = 2
+    fps: int = 16
+    score_path: str = "/v1/rewards:score"
+    health_path: str = "/healthz"
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any] | None) -> RewardServiceConfig:
+        if raw is None:
+            return cls()
+        if not isinstance(raw, dict):
+            raise ValueError(f"method.reward must be a mapping, got {type(raw).__name__}")
+        cfg = cls(
+            endpoint_url=str(raw.get("endpoint_url", "http://127.0.0.1:8100") or "").rstrip("/"),
+            timeout_sec=float(raw.get("timeout_sec", 300.0)),
+            retries=int(raw.get("retries", 2) or 0),
+            fps=int(raw.get("fps", 16) or 16),
+            score_path=str(raw.get("score_path", "/v1/rewards:score") or "/v1/rewards:score"),
+            health_path=str(raw.get("health_path", "/healthz") or "/healthz"),
+        )
+        if not cfg.endpoint_url:
+            raise ValueError("method.reward.endpoint_url must be a non-empty URL")
+        if cfg.retries < 0:
+            raise ValueError(f"method.reward.retries must be >= 0, got {cfg.retries}")
+        if cfg.timeout_sec <= 0:
+            raise ValueError(f"method.reward.timeout_sec must be positive, got {cfg.timeout_sec}")
+        return cfg
+
+
+@dataclass(slots=True)
+class RefinerSamplingConfig:
+    """Refiner completion sampling settings."""
+
+    max_new_tokens: int = 256
+    temperature: float = 1.0
+    top_p: float = 1.0
+    template_version: str = "v1"
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any] | None) -> RefinerSamplingConfig:
+        if raw is None:
+            return cls()
+        if not isinstance(raw, dict):
+            raise ValueError(f"method.refiner must be a mapping, got {type(raw).__name__}")
+        cfg = cls(
+            max_new_tokens=int(raw.get("max_new_tokens", 256) or 256),
+            temperature=float(raw.get("temperature", 1.0)),
+            top_p=float(raw.get("top_p", 1.0)),
+            template_version=str(raw.get("template_version", "v1") or "v1"),
+        )
+        if cfg.max_new_tokens <= 0:
+            raise ValueError("method.refiner.max_new_tokens must be positive, "
+                             f"got {cfg.max_new_tokens}")
+        if cfg.temperature <= 0:
+            raise ValueError(f"method.refiner.temperature must be positive, got {cfg.temperature}")
+        return cfg
+
+
+
+@dataclass(slots=True)
+class PromptRLMethodConfig:
+    """Top-level ``method:`` block for PromptRL."""
+
+    mode: PromptRLMode = "prompt_only"
+    group_size: int = 8
+    retained_originals: int = 2
+    format_reward_weight: float = 1.0
+    video_reward_weight: float = 1.0
+    refiner_kl_beta: float = 0.01
+    student_kl_beta: float = 0.01
+    ppo_clip: float = 1e-4
+    rollout: RolloutConfig = field(default_factory=RolloutConfig)
+    data: PromptDataConfig = field(default_factory=PromptDataConfig)
+    reward: RewardServiceConfig = field(default_factory=RewardServiceConfig)
+    refiner: RefinerSamplingConfig = field(default_factory=RefinerSamplingConfig)
+    refiner_optimizer: RoleOptimizerConfig = field(default_factory=RoleOptimizerConfig)
+    generator_optimizer: RoleOptimizerConfig = field(default_factory=RoleOptimizerConfig)
+    log_samples: bool = True
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any]) -> PromptRLMethodConfig:
+        if not isinstance(raw, dict):
+            raise ValueError(f"method must be a mapping, got {type(raw).__name__}")
+        cfg = cls(
+            mode=str(raw.get("mode", "prompt_only") or "prompt_only"),  # type: ignore[arg-type]
+            group_size=int(raw.get("group_size", 8)),
+            retained_originals=int(raw.get("retained_originals", 2)),
+            format_reward_weight=float(raw.get("format_reward_weight", 1.0)),
+            video_reward_weight=float(raw.get("video_reward_weight", 1.0)),
+            refiner_kl_beta=float(raw.get("refiner_kl_beta", 0.01)),
+            student_kl_beta=float(raw.get("student_kl_beta", 0.01)),
+            ppo_clip=float(raw.get("ppo_clip", 1e-4)),
+            rollout=RolloutConfig.from_mapping(raw.get("rollout")),
+            data=PromptDataConfig.from_mapping(raw.get("data")),
+            reward=RewardServiceConfig.from_mapping(raw.get("reward")),
+            refiner=RefinerSamplingConfig.from_mapping(raw.get("refiner")),
+            refiner_optimizer=RoleOptimizerConfig.from_mapping(
+                raw.get("refiner_optimizer"), where="method.refiner_optimizer"),
+            generator_optimizer=RoleOptimizerConfig.from_mapping(
+                raw.get("generator_optimizer"), where="method.generator_optimizer"),
+            log_samples=bool(raw.get("log_samples", True)),
+        )
+        cfg.validate()
+        return cfg
+
+    def validate(self) -> None:
+        if self.mode not in _SUPPORTED_MODE:
+            raise ValueError(f"method.mode must be one of {_SUPPORTED_MODE}, got {self.mode!r}")
+        if self.group_size <= 0:
+            raise ValueError(f"method.group_size must be positive, got {self.group_size}")
+        if not 0 < self.retained_originals < self.group_size:
+            raise ValueError("method.retained_originals must be within "
+                             f"(0, group_size={self.group_size}), got {self.retained_originals}")
+        if self.ppo_clip <= 0:
+            raise ValueError(f"method.ppo_clip must be positive, got {self.ppo_clip}")
+        if self.refiner_kl_beta < 0 or self.student_kl_beta < 0:
+            raise ValueError("KL betas must be non-negative")

--- a/fastvideo/train/methods/rl/promptrl/distributed.py
+++ b/fastvideo/train/methods/rl/promptrl/distributed.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Distributed helpers for PromptRL.
+
+One original prompt is replicated across the training ranks of a group;
+each rank produces one independently seeded candidate.  After scoring,
+rewards are gathered across ranks and validated identically on *every*
+rank: any timeout, duplicate/missing sample, non-finite score, or
+cardinality mismatch fails the step consistently everywhere instead of
+substituting a zero reward.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import torch.distributed as dist
+
+from fastvideo.train.methods.rl.promptrl.rewards.provider import RewardResult
+
+
+class RewardConsistencyError(RuntimeError):
+    """Raised on every rank when group reward collection is invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class RewardFailure:
+    """Picklable sentinel for a rank-local reward collection failure."""
+
+    rank: int
+    error_type: str
+    message: str
+
+
+def dist_ready() -> bool:
+    return dist.is_available() and dist.is_initialized()
+
+
+def world_rank() -> int:
+    return int(dist.get_rank()) if dist_ready() else 0
+
+
+def world_size() -> int:
+    return int(dist.get_world_size()) if dist_ready() else 1
+
+
+def all_gather_objects(obj: Any) -> list[Any]:
+    """Gather a picklable object from every rank (rank order)."""
+    if not dist_ready():
+        return [obj]
+    gathered: list[Any] = [None] * world_size()
+    dist.all_gather_object(gathered, obj)
+    return gathered
+
+
+def gather_group_reward_results(
+    local_result: RewardResult,
+    *,
+    group_id: str,
+    expected_group_size: int,
+) -> list[RewardResult]:
+    """Gather one result per rank and validate identically everywhere."""
+    gathered: list[RewardResult] = all_gather_objects(local_result)
+    validate_group_reward_results(
+        gathered,
+        group_id=group_id,
+        expected_group_size=expected_group_size,
+    )
+    return gathered
+
+
+def validate_group_reward_results(
+    gathered: list[RewardResult | RewardFailure],
+    *,
+    group_id: str,
+    expected_group_size: int,
+) -> None:
+    """Validate a full group's results; raise consistently on any problem.
+
+    Every rank runs this on the identical gathered list, so a timeout,
+    duplicate/missing sample, non-finite score, or cardinality mismatch
+    fails the step on *all* ranks instead of substituting a zero reward.
+    """
+    problems: list[str] = []
+    if len(gathered) != expected_group_size:
+        problems.append(f"cardinality: expected {expected_group_size} results, "
+                        f"gathered {len(gathered)}")
+    failures = [r for r in gathered if isinstance(r, RewardFailure)]
+    for failure in failures:
+        problems.append(
+            f"rank {failure.rank} reward failure: {failure.error_type}: {failure.message}")
+    reward_results = [r for r in gathered if isinstance(r, RewardResult)]
+    sample_ids = [r.sample_id for r in reward_results]
+    if len(set(sample_ids)) != len(sample_ids):
+        problems.append(f"duplicate sample ids: {sorted(sample_ids)}")
+    for result in gathered:
+        if isinstance(result, RewardFailure):
+            continue
+        if not isinstance(result, RewardResult):
+            problems.append(f"unexpected gathered object: {type(result).__name__}")
+            continue
+        if not math.isfinite(float(result.score)):
+            problems.append(f"non-finite score for sample {result.sample_id!r}")
+        for key, value in result.details.items():
+            if not math.isfinite(float(value)):
+                problems.append(f"non-finite detail {key!r} for sample "
+                                f"{result.sample_id!r}")
+    if problems:
+        raise RewardConsistencyError(f"PromptRL group {group_id!r} reward validation failed: "
+                                     + "; ".join(problems))

--- a/fastvideo/train/methods/rl/promptrl/inference.py
+++ b/fastvideo/train/methods/rl/promptrl/inference.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRL inference-time prompt refiner.
+
+Loads a PromptRL bundle (``manifest.json`` + ``refiner/`` PEFT adapter)
+and exposes ``refine(prompt)`` returning the original prompt, the
+refined prompt (with fallback to the original on malformed output), the
+raw completion, and the format-valid flag.  This helper intentionally
+stays separate from ``VideoGenerator`` — generation behavior is
+unchanged in v1.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from fastvideo.logger import init_logger
+from fastvideo.train.methods.rl.promptrl.bundle import (
+    BundleManifest,
+    load_bundle_manifest,
+)
+from fastvideo.train.methods.rl.promptrl.prompts import (
+    parse_answer_tag,
+    render_refinement_prompt,
+)
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class RefinementResult:
+    """Output of one prompt refinement."""
+
+    original_prompt: str
+    refined_prompt: str
+    raw_completion: str
+    format_valid: bool
+
+
+class PromptRefiner:
+    """Inference-time prompt refiner loaded from a PromptRL bundle."""
+
+    def __init__(
+        self,
+        *,
+        manifest: BundleManifest,
+        model: torch.nn.Module,
+        tokenizer: Any,
+        device: str | torch.device = "cuda",
+    ) -> None:
+        self.manifest = manifest
+        self.model = model
+        self.tokenizer = tokenizer
+        self.device = torch.device(device)
+        self.model.to(self.device)
+        self.model.eval()
+
+    @classmethod
+    def from_bundle(
+        cls,
+        bundle_dir: str,
+        *,
+        device: str | torch.device = "cuda",
+        torch_dtype: str = "bfloat16",
+        model: torch.nn.Module | None = None,
+        tokenizer: Any = None,
+    ) -> PromptRefiner:
+        """Load the refiner adapter of a PromptRL bundle.
+
+        ``model``/``tokenizer`` may be injected directly (tests); by
+        default the base model named in the manifest is loaded and the
+        ``refiner/`` PEFT adapter applied on top.
+        """
+        manifest = load_bundle_manifest(bundle_dir)
+        refiner_dir = os.path.join(bundle_dir, "refiner")
+        if not os.path.isdir(refiner_dir):
+            raise FileNotFoundError(f"Bundle {bundle_dir} has no refiner/ directory")
+
+        if tokenizer is None:
+            from transformers import AutoTokenizer
+
+            tokenizer_source = (refiner_dir if os.path.exists(
+                os.path.join(refiner_dir, "tokenizer_config.json")) else manifest.base_refiner_model)
+            tokenizer = AutoTokenizer.from_pretrained(tokenizer_source)
+
+        if model is None:
+            import transformers
+            from peft import PeftModel
+
+            dtype = getattr(torch, torch_dtype)
+            model_cls = getattr(transformers, "Qwen2_5_VLForConditionalGeneration", None)
+            if model_cls is None:
+                model_cls = transformers.AutoModelForCausalLM
+            base = model_cls.from_pretrained(manifest.base_refiner_model, torch_dtype=dtype)
+            model = PeftModel.from_pretrained(base, refiner_dir)
+
+        return cls(manifest=manifest, model=model, tokenizer=tokenizer, device=device)
+
+
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def refine(
+        self,
+        prompt: str,
+        *,
+        max_new_tokens: int | None = None,
+        temperature: float | None = None,
+        top_p: float | None = None,
+        seed: int | None = None,
+    ) -> RefinementResult:
+        """Refine *prompt* with the bundled adapter.
+
+        Malformed completions (missing ``<answer>...</answer>``) fall
+        back to the original prompt, mirroring training-time behavior.
+        """
+        sampling = self.manifest.refiner_sampling
+        max_new_tokens = int(max_new_tokens or sampling.get("max_new_tokens", 256))
+        temperature = float(temperature if temperature is not None else sampling.get("temperature", 1.0))
+        top_p = float(top_p if top_p is not None else sampling.get("top_p", 1.0))
+
+        instruction = render_refinement_prompt(
+            prompt, template_version=self.manifest.prompt_template_version)
+        messages = [{"role": "user", "content": instruction}]
+        apply_template = getattr(self.tokenizer, "apply_chat_template", None)
+        if callable(apply_template):
+            rendered = apply_template(messages, tokenize=False, add_generation_prompt=True)
+        else:
+            rendered = instruction + "\n"
+        encoded = self.tokenizer(rendered, return_tensors="pt").to(self.device)
+
+        sample = temperature > 0.0
+        if seed is None:
+            rng_context = contextlib.nullcontext()
+        elif self.device.type == "cuda":
+            rng_context = torch.random.fork_rng(devices=[self.device])
+        else:
+            rng_context = torch.random.fork_rng(devices=[])
+        with rng_context:
+            if seed is not None:
+                torch.manual_seed(int(seed))
+                if self.device.type == "cuda":
+                    torch.cuda.manual_seed_all(int(seed))
+            output = self.model.generate(
+                **encoded,
+                max_new_tokens=max_new_tokens,
+                do_sample=sample,
+                temperature=temperature if sample else None,
+                top_p=top_p if sample else None,
+                pad_token_id=self.tokenizer.pad_token_id or self.tokenizer.eos_token_id,
+            )
+        completion_ids = output[:, encoded["input_ids"].shape[1]:]
+        raw_completion = self.tokenizer.batch_decode(
+            completion_ids, skip_special_tokens=True)[0]
+
+        parsed = parse_answer_tag(raw_completion)
+        refined = parsed.refined_prompt if parsed.format_valid else prompt
+        return RefinementResult(
+            original_prompt=prompt,
+            refined_prompt=refined,
+            raw_completion=raw_completion,
+            format_valid=parsed.format_valid,
+        )

--- a/fastvideo/train/methods/rl/promptrl/method.py
+++ b/fastvideo/train/methods/rl/promptrl/method.py
@@ -1,0 +1,951 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRL training method for Wan video generation.
+
+Two milestones share one implementation:
+
+* ``prompt_only`` — train the Qwen prompt-refiner LoRA while Wan stays
+  frozen.  Rollout/transition storage is skipped and only the refiner
+  optimizer steps.
+* ``joint`` — train independent LoRA adapters for the refiner and Wan
+  with shared group-relative advantages (detached, so no gradients
+  cross between the models).
+
+One original prompt is replicated across the group's ranks; each rank
+produces independently seeded candidates for its assigned group slots.
+Ranks holding retained-original slots generate from the original
+prompt; refined slots use sampled refiner outputs (falling back to the
+original when the completion misses ``<answer>...</answer>``).  Videos
+are scored against the original prompt by the pluggable reward
+provider, rewards are gathered and validated consistently on every
+rank, normalized per ``(group, reward_tag)``, then consumed detached by
+the refiner GRPO loss (refined slots only) and Wan's clipped
+flow-policy loss (all slots).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+from collections.abc import Iterator
+
+import torch
+
+from fastvideo.logger import init_logger
+from fastvideo.train.methods.base import LogScalar, TrainingMethod
+from fastvideo.train.methods.rl.common import RLValidationConfig
+from fastvideo.train.methods.rl.promptrl.advantages import (
+    group_relative_advantages,
+    route_generator_advantages,
+    route_refiner_advantages,
+)
+from fastvideo.train.methods.rl.promptrl.config import (
+    PromptRLMethodConfig,
+    RoleOptimizerConfig,
+)
+from fastvideo.train.methods.rl.promptrl.distributed import (
+    RewardFailure,
+    all_gather_objects,
+    validate_group_reward_results,
+    world_rank,
+    world_size,
+)
+from fastvideo.train.methods.rl.promptrl.prompts import (
+    GroupAssignment,
+    PromptDataset,
+    PromptRecord,
+    group_assignments,
+    parse_answer_tag,
+    render_refinement_prompt,
+)
+from fastvideo.train.methods.rl.promptrl.rewards import (
+    HttpRewardProvider,
+    RewardProvider,
+    RewardResult,
+    RewardSample,
+)
+from fastvideo.train.methods.rl.promptrl.sde import transition_kl_to_reference
+from fastvideo.train.methods.rl.promptrl.video_io import encode_video_bytes
+from fastvideo.train.roles.base import TrainRoleBase
+from fastvideo.train.utils.optimizer import clip_grad_norm_if_needed
+
+logger = init_logger(__name__)
+
+#: Distributed validation of gathered rewards lives in distributed.py;
+#: imported here for re-export to tests.
+
+
+@dataclass(slots=True)
+class _SlotState:
+    """Per-slot rollout state kept on the owning rank."""
+
+    slot: int
+    kind: str
+    refiner_participation: bool
+    instruction: str
+    completion: str
+    refined_prompt: str
+    generation_prompt: str
+    format_valid: bool
+    format_reward: float
+    reward_sample: RewardSample
+    rollout: Any  # WanRolloutResult
+    batch: Any  # TrainingBatch
+    reward_result: RewardResult | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        """Picklable per-slot summary exchanged across ranks."""
+        return {
+            "slot": self.slot,
+            "kind": self.kind,
+            "reward_result": self.reward_result,
+            "format_reward": self.format_reward,
+            "format_valid": self.format_valid,
+            "refined_prompt": self.refined_prompt,
+            "generation_prompt": self.generation_prompt,
+        }
+
+
+class _TickDataloader:
+    """Infinite placeholder dataloader.
+
+    Prompt sampling is a deterministic function of the iteration (see
+    ``_sample_prompt_record``), so resume continues the exact prompt
+    stream without dataloader state; the trainer only needs an iterable
+    to pace steps.
+    """
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        while True:
+            yield {}
+
+
+def _has_lora_layers(module: torch.nn.Module) -> bool:
+    from fastvideo.layers.lora.linear import BaseLayerWithLoRA
+
+    return any(isinstance(m, BaseLayerWithLoRA) for m in module.modules())
+
+
+class PromptRLMethod(TrainingMethod):
+    """PromptRL: refiner GRPO + Wan clipped flow-policy optimization."""
+
+    def __init__(
+        self,
+        *,
+        cfg: Any,
+        role_models: dict[str, TrainRoleBase],
+    ) -> None:
+        super().__init__(cfg=cfg, role_models=role_models)
+        if "refiner" not in role_models:
+            raise ValueError("PromptRLMethod requires role 'refiner'")
+
+        self.refiner = role_models["refiner"]
+        self.config = PromptRLMethodConfig.from_mapping(self.method_config)
+        if not self.student._trainable and self.config.mode == "joint":
+            raise ValueError("PromptRL joint mode requires a trainable student")
+        self._validation_config = RLValidationConfig.from_mapping(
+            self.method_config.get("validation"))
+        self._assignments: list[GroupAssignment] = group_assignments(
+            group_size=self.config.group_size,
+            retained_originals=self.config.retained_originals,
+        )
+        if world_size() > 1 and self.config.group_size % world_size() != 0:
+            raise ValueError(f"method.group_size ({self.config.group_size}) must be "
+                             f"divisible by world size ({world_size()})")
+
+        self.student.init_preprocessors(self.training_config)
+        self.refiner.init_preprocessors(self.training_config)
+
+        self._prompt_dataset: PromptDataset | None = None
+        if self.config.data.data_path:
+            self._prompt_dataset = PromptDataset.load(
+                self.config.data.data_path,
+                prompt_key=self.config.data.prompt_key,
+                id_key=self.config.data.id_key,
+                reward_tag_key=self.config.data.reward_tag_key,
+            )
+
+        self._reward_provider: RewardProvider = HttpRewardProvider(
+            endpoint_url=self.config.reward.endpoint_url,
+            timeout_sec=self.config.reward.timeout_sec,
+            retries=self.config.reward.retries,
+            score_path=self.config.reward.score_path,
+            health_path=self.config.reward.health_path,
+        )
+
+        self._refiner_optimizer: torch.optim.Optimizer | None = None
+        self._refiner_scheduler: Any = None
+        self._generator_optimizer: torch.optim.Optimizer | None = None
+        self._generator_scheduler: Any = None
+        self._init_optimizers()
+
+        # The trainer paces steps through this iterable; prompt sampling
+        # itself is deterministic by iteration.
+        if getattr(self.student, "dataloader", None) is None:
+            self.student.dataloader = _TickDataloader()
+
+    # ------------------------------------------------------------------
+    # Wiring helpers
+    # ------------------------------------------------------------------
+
+    def set_reward_provider(self, provider: RewardProvider) -> None:
+        """Inject a reward provider (tests / alternative scorers)."""
+        self._reward_provider = provider
+
+    def set_prompt_dataset(self, dataset: PromptDataset) -> None:
+        """Inject a prompt dataset (tests / programmatic use)."""
+        self._prompt_dataset = dataset
+
+    def _init_optimizers(self) -> None:
+        self._refiner_optimizer, self._refiner_scheduler = self._build_role_optimizer(
+            self.refiner.trainable_parameters(),
+            self.config.refiner_optimizer,
+            role="refiner",
+        )
+        self._generator_optimizer, self._generator_scheduler = self._build_role_optimizer(
+            self.student.trainable_parameters(),
+            self.config.generator_optimizer,
+            role="student",
+        )
+
+    def _build_role_optimizer(
+        self,
+        params: list[torch.nn.Parameter],
+        cfg: RoleOptimizerConfig,
+        *,
+        role: str,
+    ) -> tuple[torch.optim.Optimizer, Any]:
+        if not params:
+            raise ValueError(f"PromptRL role {role!r} has no trainable parameters")
+        from fastvideo.train.utils.training_config import OptimizerConfig
+        from fastvideo.train.utils.optimizer import build_optimizer_and_scheduler
+
+        shim = OptimizerConfig(
+            learning_rate=cfg.learning_rate,
+            betas=cfg.betas,
+            weight_decay=cfg.weight_decay,
+            lr_scheduler=cfg.lr_scheduler,
+            lr_warmup_steps=cfg.lr_warmup_steps,
+        )
+        return build_optimizer_and_scheduler(
+            params=params,
+            optimizer_config=shim,
+            loop_config=self.training_config.loop,
+            learning_rate=cfg.learning_rate,
+            betas=cfg.betas,
+            scheduler_name=cfg.lr_scheduler,
+        )
+
+
+    # ------------------------------------------------------------------
+    # TrainingMethod plumbing
+    # ------------------------------------------------------------------
+
+    @property
+    def _optimizer_dict(self) -> dict[str, torch.optim.Optimizer]:
+        return {
+            "student": self._generator_optimizer,
+            "refiner": self._refiner_optimizer,
+        }
+
+    @property
+    def _lr_scheduler_dict(self) -> dict[str, Any]:
+        return {
+            "student": self._generator_scheduler,
+            "refiner": self._refiner_scheduler,
+        }
+
+    def get_optimizers(self, iteration: int) -> list[torch.optim.Optimizer]:
+        optimizers = [self._refiner_optimizer]
+        if self.config.mode == "joint":
+            optimizers.append(self._generator_optimizer)
+        return [opt for opt in optimizers if opt is not None]
+
+    def get_lr_schedulers(self, iteration: int) -> list[Any]:
+        schedulers = [self._refiner_scheduler]
+        if self.config.mode == "joint":
+            schedulers.append(self._generator_scheduler)
+        return [sched for sched in schedulers if sched is not None]
+
+    def on_train_start(self) -> None:
+        """Initialize both the diffusion student and prompt refiner roles."""
+        super().on_train_start()
+        self.refiner.on_train_start()
+
+    def manages_optimization(self) -> bool:
+        return True
+
+    def single_train_step(self, batch: dict[str, Any], iteration: int):
+        raise NotImplementedError("PromptRLMethod uses managed_train_step")
+
+    def get_grad_clip_targets(self, iteration: int) -> dict[str, torch.nn.Module]:
+        targets: dict[str, torch.nn.Module] = {}
+        refiner_modules = self.refiner.checkpoint_modules()
+        if "model" in refiner_modules:
+            targets["refiner"] = refiner_modules["model"]
+        transformer = getattr(self.student, "transformer", None)
+        if isinstance(transformer, torch.nn.Module):
+            targets["student"] = transformer
+        return targets
+
+    # ------------------------------------------------------------------
+    # Prompt + seed scheduling
+    # ------------------------------------------------------------------
+
+    def _sample_prompt_record(self, iteration: int) -> PromptRecord:
+        """Deterministic per-iteration prompt shared by the whole group."""
+        if self._prompt_dataset is None:
+            raise RuntimeError("PromptRLMethod has no prompt dataset; set "
+                               "method.data.data_path or call set_prompt_dataset()")
+        from fastvideo.train.methods.rl.common import distributed_k_repeat_indices
+
+        sample = distributed_k_repeat_indices(
+            dataset_length=len(self._prompt_dataset),
+            batch_size=1,
+            repeats_per_prompt=self.config.group_size,
+            world_size=self.config.group_size,
+            rank=0,
+            seed=int(self.training_config.data.seed) + int(iteration),
+        )
+        return self._prompt_dataset[sample.local_indices[0]]
+
+    def _slot_seed(self, iteration: int, slot: int) -> int:
+        """Independently seeded candidate stream for one group slot."""
+        base = int(self.training_config.data.seed)
+        return base + int(iteration) * self.config.group_size + int(slot)
+
+    def _local_slots(self) -> list[int]:
+        """Group slots owned by this rank (round-robin across ranks)."""
+        rank = world_rank()
+        world = world_size()
+        return [slot for slot in range(self.config.group_size) if slot % world == rank]
+
+
+
+    # ------------------------------------------------------------------
+    # Rollout
+    # ------------------------------------------------------------------
+
+    def _rollout_slot(
+        self,
+        record: PromptRecord,
+        slot: int,
+        iteration: int,
+        group_id: str,
+    ) -> _SlotState:
+        """Refine (or retain) the prompt, generate + upload one video."""
+        cfg = self.config
+        assignment = self._assignments[slot]
+        instruction = render_refinement_prompt(
+            record.prompt, template_version=cfg.refiner.template_version)
+
+        # Every slot samples a refiner completion so all ranks execute
+        # compatible refiner paths; retained originals discard it for
+        # generation and receive zero refiner advantage.
+        completion = self.refiner.generate_refinements(
+            [instruction],
+            max_new_tokens=cfg.refiner.max_new_tokens,
+            temperature=cfg.refiner.temperature,
+            top_p=cfg.refiner.top_p,
+            seed=self._slot_seed(iteration, slot),
+        )[0]
+        parsed = parse_answer_tag(completion)
+
+        refined_prompt = ""
+        if assignment.kind == "original":
+            generation_prompt = record.prompt
+            format_reward = 1.0
+        elif parsed.format_valid:
+            generation_prompt = parsed.refined_prompt
+            refined_prompt = parsed.refined_prompt
+            format_reward = 1.0
+        else:
+            # Malformed: fall back to the original prompt for video
+            # generation; the completion is preserved for the LM loss.
+            generation_prompt = record.prompt
+            format_reward = 0.0
+
+        embeds, mask = self.student.encode_prompts([generation_prompt])
+        batch = self.student.build_rollout_batch(
+            embeds, mask, latent_shape=self.student.latent_shape(1))
+        joint = cfg.mode == "joint"
+        rollout = self.student.rollout(
+            batch,
+            batch_size=1,
+            generator=self.cuda_generator,
+            num_steps=cfg.rollout.num_steps,
+            sde_steps=cfg.rollout.sde_steps if joint else 0,
+            noise_scale=cfg.rollout.noise_scale,
+            flow_shift=cfg.rollout.flow_shift,
+            store_transitions=joint,
+        )
+        media = self.student.decode_latents(rollout.latents)
+        video_bytes = encode_video_bytes(media, fps=cfg.reward.fps)
+        reward_sample = RewardSample(
+            group_id=group_id,
+            request_id=group_id,
+            sample_id=f"slot-{slot}",
+            expected_group_size=cfg.group_size,
+            original_prompt=record.prompt,  # always score the original
+            reward_tag=record.reward_tag,
+            fps=cfg.reward.fps,
+            video_bytes=video_bytes,
+        )
+        return _SlotState(
+            slot=slot,
+            kind=assignment.kind,
+            refiner_participation=assignment.refiner_participation,
+            instruction=instruction,
+            completion=completion,
+            refined_prompt=refined_prompt,
+            generation_prompt=generation_prompt,
+            format_valid=parsed.format_valid,
+            format_reward=format_reward,
+            reward_sample=reward_sample,
+            rollout=rollout,
+            batch=batch,
+        )
+
+    # ------------------------------------------------------------------
+    # Managed training step
+    # ------------------------------------------------------------------
+
+    def managed_train_step(
+        self,
+        data_stream: Any,
+        iteration: int,
+    ) -> tuple[dict[str, torch.Tensor], dict[str, Any], dict[str, LogScalar]]:
+        del data_stream
+        cfg = self.config
+        t0 = time.perf_counter()
+        record = self._sample_prompt_record(iteration)
+        group_id = f"step-{int(iteration)}:{record.sample_id}"
+
+        # --- 1. Rollout: refiner + Wan per local slot ---
+        rollout_t0 = time.perf_counter()
+        slot_states: dict[int, _SlotState] = {}
+        for slot in self._local_slots():
+            slot_states[slot] = self._rollout_slot(record, slot, iteration, group_id)
+        rollout_sec = time.perf_counter() - rollout_t0
+
+        # --- 2. Score + gather/validate consistently on every rank ---
+        reward_t0 = time.perf_counter()
+        samples = [slot_states[slot].reward_sample for slot in sorted(slot_states)]
+        local_reward_error: RewardFailure | None = None
+        try:
+            local_results = list(self._reward_provider.score(samples))
+        except Exception as exc:  # noqa: BLE001 - propagated consistently after gather
+            local_reward_error = RewardFailure(
+                rank=world_rank(),
+                error_type=type(exc).__name__,
+                message=str(exc),
+            )
+            local_payloads = [local_reward_error]
+        else:
+            for slot, result in zip(sorted(slot_states), local_results, strict=False):
+                slot_states[slot].reward_result = result
+            local_payloads = [slot_states[slot].to_payload() for slot in sorted(slot_states)]
+        gathered = all_gather_objects(local_payloads)
+        payloads = [payload for rank_payloads in gathered for payload in rank_payloads]
+        reward_failures = [p for p in payloads if isinstance(p, RewardFailure)]
+        if reward_failures:
+            validate_group_reward_results(
+                reward_failures,
+                group_id=group_id,
+                expected_group_size=cfg.group_size,
+            )
+        payloads.sort(key=lambda p: p["slot"])
+        results = [p["reward_result"] for p in payloads]
+        validate_group_reward_results(
+            results,
+            group_id=group_id,
+            expected_group_size=cfg.group_size,
+        )
+        reward_sec = time.perf_counter() - reward_t0
+
+        # --- 3. Composite rewards + detached group-relative advantages ---
+        format_rewards = torch.tensor([p["format_reward"] for p in payloads],
+                                      dtype=torch.float32)
+        video_scores = torch.tensor([r.score for r in results], dtype=torch.float32)
+        composite = (cfg.format_reward_weight * format_rewards +
+                     cfg.video_reward_weight * video_scores)
+        group_keys = [f"{group_id}|{record.reward_tag}"] * len(payloads)
+        advantages = group_relative_advantages(composite, group_keys)
+        refiner_advantages = route_refiner_advantages(
+            advantages, [self._assignments[p["slot"]].refiner_participation for p in payloads])
+        wan_advantages = route_generator_advantages(advantages)
+
+        # --- 4. Losses (advantages detached: no cross-model gradients) ---
+        backward_t0 = time.perf_counter()
+        refiner_loss, refiner_metrics = self._refiner_loss(slot_states, refiner_advantages)
+        refiner_loss.backward()
+
+        wan_loss = torch.zeros((), device=format_rewards.device)
+        wan_metrics: dict[str, LogScalar] = {}
+        if cfg.mode == "joint":
+            wan_loss, wan_metrics = self._wan_loss(slot_states, wan_advantages)
+        backward_sec = time.perf_counter() - backward_t0
+
+        # --- 5. Clip + per-role optimizer steps ---
+        grad_norms = self._clip_grads(iteration)
+        self.optimizers_schedulers_step(iteration)
+        self.optimizers_zero_grad(iteration)
+
+        # --- 6. Metrics ---
+        metrics = self._step_metrics(
+            payloads=payloads,
+            video_scores=video_scores,
+            format_rewards=format_rewards,
+            advantages=advantages,
+            refiner_metrics=refiner_metrics,
+            wan_metrics=wan_metrics,
+            grad_norms=grad_norms,
+            rollout_sec=rollout_sec,
+            reward_sec=reward_sec,
+            backward_sec=backward_sec,
+            step_sec=time.perf_counter() - t0,
+        )
+        total_loss = refiner_loss.detach() + wan_loss.detach()
+        return {"total_loss": total_loss}, {}, metrics
+
+
+    # ------------------------------------------------------------------
+    # Refiner GRPO loss
+    # ------------------------------------------------------------------
+
+    def _refiner_loss(
+        self,
+        slot_states: dict[int, _SlotState],
+        refiner_advantages: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, float | None]]:
+        """Per-token GRPO surrogate + k3 KL to the frozen base refiner.
+
+        Only refined slots carry nonzero advantage; retained-original
+        slots run the same forward/backward with participation weight 0
+        so replicated/DDP gradient collectives stay aligned.
+        """
+        cfg = self.config
+        device = self.refiner.device
+        weighted_losses: list[torch.Tensor] = []
+        weighted_tokens: list[torch.Tensor] = []
+        kl_means: list[torch.Tensor] = []
+        token_counts: list[float] = []
+
+        for slot in sorted(slot_states):
+            state = slot_states[slot]
+            participation = 1.0 if state.refiner_participation else 0.0
+            advantage = refiner_advantages[slot].to(device)
+
+            new_tok, mask = self.refiner.token_logprobs(
+                [state.instruction], [state.completion], requires_grad=True)
+            old_tok = new_tok.detach()
+            ref_tok, _ = self.refiner.token_logprobs(
+                [state.instruction], [state.completion], use_adapter=False)
+
+            ratio = torch.exp(new_tok - old_tok)
+            clipped = torch.clamp(ratio, 1.0 - cfg.ppo_clip, 1.0 + cfg.ppo_clip)
+            surrogate = torch.minimum(ratio * advantage, clipped * advantage)
+            # k3 KL estimator to the adapter-disabled reference policy.
+            ref_gap = ref_tok - new_tok
+            kl_tok = torch.exp(ref_gap) - ref_gap - 1.0
+            token_loss = (-surrogate + cfg.refiner_kl_beta * kl_tok) * mask
+
+            weight = torch.tensor(participation, device=device, dtype=token_loss.dtype)
+            weighted_losses.append((token_loss * weight).sum())
+            weighted_tokens.append((mask * weight).sum())
+            kl_means.append(((kl_tok * mask).sum() / mask.sum().clamp_min(1.0)) * weight)
+            token_counts.append(float(mask.sum().item()) * participation)
+
+        total_tokens = torch.stack(weighted_tokens).sum().clamp_min(1.0)
+        loss = torch.stack(weighted_losses).sum() / total_tokens
+        positive_counts = [c for c in token_counts if c > 0]
+        metrics: dict[str, float | None] = {
+            "loss": float(loss.detach().float().item()),
+            "kl": float(torch.stack(kl_means).sum().detach().item()),
+            "completion_tokens": (sum(positive_counts) / len(positive_counts)
+                                  if positive_counts else None),
+        }
+        return loss, metrics
+
+
+    # ------------------------------------------------------------------
+    # Wan clipped flow-policy loss (joint mode)
+    # ------------------------------------------------------------------
+
+    def _wan_loss(
+        self,
+        slot_states: dict[int, _SlotState],
+        wan_advantages: torch.Tensor,
+    ) -> tuple[torch.Tensor, dict[str, LogScalar]]:
+        """PPO-clipped transition loss + Gaussian KL to frozen-base Wan.
+
+        Consumes *all* slots' advantages.  Transition probabilities are
+        recomputed in microbatches; each microbatch backward
+        accumulates into the Wan LoRA only (reference passes run under
+        the adapter-disabled context with no grad).
+        """
+        cfg = self.config
+        device = self.student.device
+        microbatch = max(1, int(cfg.rollout.loss_microbatch_size))
+        total_slots = max(1, len(slot_states))
+        total_loss = torch.zeros((), device=device)
+        policy_losses: list[float] = []
+        kl_values: list[float] = []
+        ratios: list[float] = []
+        clip_fractions: list[float] = []
+
+        for slot in sorted(slot_states):
+            state = slot_states[slot]
+            advantage = wan_advantages[slot].to(device)
+            transitions = state.rollout.transitions
+            if not transitions:
+                continue
+            sigma_max = (state.rollout.sigmas[1] if len(state.rollout.sigmas) > 1 else 1.0)
+            slot_loss_scale = 1.0 / (total_slots * len(transitions))
+
+            pending: list[tuple[torch.Tensor, Any]] = []
+
+            def backward_pending() -> None:
+                nonlocal pending, total_loss
+                backward = getattr(self.student, "backward", None)
+                for pending_loss, backward_ctx in pending:
+                    if callable(backward):
+                        # Wan activation checkpointing recomputes attention
+                        # during backward. Route through the model's backward
+                        # hook so its timestep/attention ForwardContext is live
+                        # for every independently recomputed transition graph.
+                        backward(
+                            pending_loss,
+                            backward_ctx,
+                            grad_accum_rounds=1,
+                        )
+                    else:
+                        # Model-agnostic fallback for lightweight role plugins.
+                        pending_loss.backward()
+                    total_loss = total_loss + pending_loss.detach()
+                pending = []
+
+            for transition in transitions:
+                new_logp, new_mean = self.student.transition_logprobs(
+                    [transition],
+                    state.batch,
+                    noise_scale=cfg.rollout.noise_scale,
+                    sigma_max=sigma_max,
+                    use_adapter=True,
+                    requires_grad=True,
+                )[0]
+                _, ref_mean = self.student.transition_logprobs(
+                    [transition],
+                    state.batch,
+                    noise_scale=cfg.rollout.noise_scale,
+                    sigma_max=sigma_max,
+                    use_adapter=False,
+                    requires_grad=False,
+                )[0]
+                old_logp = transition.old_log_prob.to(new_logp.device)
+                ratio = torch.exp(new_logp - old_logp)
+                clipped = torch.clamp(ratio, 1.0 - cfg.ppo_clip, 1.0 + cfg.ppo_clip)
+                surrogate = torch.minimum(ratio * advantage, clipped * advantage)
+                kl = transition_kl_to_reference(
+                    new_mean,
+                    ref_mean,
+                    sigma=transition.sigma,
+                    sigma_next=transition.sigma_next,
+                    noise_scale=cfg.rollout.noise_scale,
+                    sigma_max=sigma_max,
+                )
+                transition_loss = (-surrogate.mean() + cfg.student_kl_beta * kl.mean())
+                backward_timestep = torch.full(
+                    (transition.sample.shape[0], ),
+                    float(transition.timestep),
+                    device=device,
+                )
+                backward_ctx = (
+                    backward_timestep,
+                    getattr(state.batch, "attn_metadata", None),
+                )
+                pending.append(
+                    (transition_loss * slot_loss_scale, backward_ctx)
+                )
+
+                policy_losses.append(float((-surrogate.mean()).detach().item()))
+                kl_values.append(float(kl.mean().detach().item()))
+                ratios.append(float(ratio.mean().detach().item()))
+                clip_fractions.append(
+                    float(((ratio - 1.0).abs() > cfg.ppo_clip).float().mean().item()))
+
+                if len(pending) >= microbatch:
+                    backward_pending()
+            if pending:
+                backward_pending()
+
+        metrics: dict[str, LogScalar] = {
+            "loss": sum(policy_losses) / max(1, len(policy_losses)),
+            "kl": sum(kl_values) / max(1, len(kl_values)),
+            "ratio": sum(ratios) / max(1, len(ratios)),
+            "clip_fraction": sum(clip_fractions) / max(1, len(clip_fractions)),
+        }
+        return total_loss, metrics
+
+
+    # ------------------------------------------------------------------
+    # Gradient clipping + metrics
+    # ------------------------------------------------------------------
+
+    def _clip_grads(self, iteration: int) -> dict[str, float]:
+        norms: dict[str, float] = {}
+        targets = self.get_grad_clip_targets(iteration)
+        if "refiner" in targets:
+            norms["refiner"] = clip_grad_norm_if_needed(
+                targets["refiner"], self.config.refiner_optimizer.max_grad_norm)
+        if self.config.mode == "joint" and "student" in targets:
+            norms["student"] = clip_grad_norm_if_needed(
+                targets["student"], self.config.generator_optimizer.max_grad_norm)
+        return norms
+
+    @staticmethod
+    def _peak_memory_mb() -> float:
+        if torch.cuda.is_available():
+            return float(torch.cuda.max_memory_allocated()) / 1e6
+        return 0.0
+
+    def _distributed_mean(self, value: float | None) -> float | None:
+        """Mean of an optional scalar across ranks (None-aware)."""
+        if world_size() <= 1:
+            return value
+        gathered = all_gather_objects(value)
+        present = [float(v) for v in gathered if v is not None]
+        if not present:
+            return None
+        return sum(present) / len(present)
+
+    def _step_metrics(
+        self,
+        *,
+        payloads: list[dict[str, Any]],
+        video_scores: torch.Tensor,
+        format_rewards: torch.Tensor,
+        advantages: torch.Tensor,
+        refiner_metrics: dict[str, float | None],
+        wan_metrics: dict[str, LogScalar],
+        grad_norms: dict[str, float],
+        rollout_sec: float,
+        reward_sec: float,
+        backward_sec: float,
+        step_sec: float,
+    ) -> dict[str, LogScalar]:
+        metrics: dict[str, LogScalar] = {}
+
+        # Group reward statistics.
+        composite = (self.config.format_reward_weight * format_rewards +
+                     self.config.video_reward_weight * video_scores)
+        metrics["reward/group_mean"] = float(composite.mean())
+        metrics["reward/group_std"] = float(composite.std(unbiased=False))
+        metrics["reward/group_min"] = float(composite.min())
+        metrics["reward/group_max"] = float(composite.max())
+        metrics["reward/video_mean"] = float(video_scores.mean())
+        metrics["reward/format_mean"] = float(format_rewards.mean())
+        metrics["reward/advantage_abs_mean"] = float(advantages.abs().mean())
+
+        # VideoScore2 component details.
+        component_names: set[str] = set()
+        for payload in payloads:
+            result = payload.get("reward_result")
+            if result is not None:
+                component_names.update(result.details)
+        for name in sorted(component_names):
+            values = [
+                payload["reward_result"].details[name] for payload in payloads
+                if payload.get("reward_result") is not None
+                and name in payload["reward_result"].details
+            ]
+            if values:
+                metrics[f"reward/{name}"] = sum(values) / len(values)
+
+        # Refinement statistics.
+        refined = [p for p in payloads if p["kind"] == "refined"]
+        originals = [p for p in payloads if p["kind"] == "original"]
+        if refined:
+            metrics["refine/valid_rate"] = (sum(1.0 for p in refined if p["format_valid"]) /
+                                            len(refined))
+        if refined and originals:
+            refined_mean = sum(p["reward_result"].score for p in refined) / len(refined)
+            original_mean = sum(p["reward_result"].score for p in originals) / len(originals)
+            metrics["refine/refined_vs_original_gap"] = refined_mean - original_mean
+
+        # Language-model metrics (produced only on refined-slot ranks;
+        # average across the group so rank-0 logging stays meaningful).
+        lm_loss = self._distributed_mean(refiner_metrics.get("loss"))
+        if lm_loss is not None:
+            metrics["lm/loss"] = lm_loss
+        lm_kl = self._distributed_mean(refiner_metrics.get("kl"))
+        if lm_kl is not None:
+            metrics["lm/kl"] = lm_kl
+        completion_tokens = self._distributed_mean(refiner_metrics.get("completion_tokens"))
+        if completion_tokens is not None:
+            metrics["lm/completion_tokens"] = completion_tokens
+
+        # Wan flow-policy metrics.
+        for key, value in wan_metrics.items():
+            metrics[f"wan/{key}"] = value
+
+        for name, norm in grad_norms.items():
+            metrics[f"grad_norm/{name}"] = norm
+
+        metrics["latency/rollout_sec"] = rollout_sec
+        metrics["latency/reward_sec"] = reward_sec
+        metrics["latency/backward_sec"] = backward_sec
+        metrics["latency/step_sec"] = step_sec
+        metrics["mem/peak_gpu_mb"] = self._peak_memory_mb()
+        return metrics
+
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def on_validation_begin(self, iteration: int = 0) -> dict[str, LogScalar]:
+        """Held-out refined-vs-original evaluation.
+
+        Shards validation prompts across ranks; each sharded prompt is
+        generated once from the original prompt and once from its
+        refinement, then scored against the original prompt.  Videos or
+        prompt samples are only surfaced on group leaders by the
+        tracker/callback layer.
+        """
+        config = self._validation_config
+        if config.every_steps <= 0 or iteration % config.every_steps != 0:
+            return {}
+        if self._prompt_dataset is None:
+            return {}
+
+        from fastvideo.train.methods.rl.common import validation_shard_indices
+
+        rank = world_rank()
+        world = world_size()
+        shard = validation_shard_indices(
+            min(config.num_prompts, len(self._prompt_dataset)),
+            rank=rank,
+            world_size=world,
+        )
+        gaps: list[float] = []
+        original_scores: list[float] = []
+        refined_scores: list[float] = []
+        valid_flags: list[float] = []
+        for prompt_idx, is_real in shard:
+            if not is_real:
+                continue
+            record = self._prompt_dataset[prompt_idx]
+            instruction = render_refinement_prompt(
+                record.prompt, template_version=self.config.refiner.template_version)
+            completion = self.refiner.generate_refinements(
+                [instruction],
+                max_new_tokens=self.config.refiner.max_new_tokens,
+                temperature=self.config.refiner.temperature,
+                top_p=self.config.refiner.top_p,
+                seed=self._slot_seed(iteration, prompt_idx),
+            )[0]
+            parsed = parse_answer_tag(completion)
+            refined_prompt = parsed.refined_prompt if parsed.format_valid else record.prompt
+            valid_flags.append(1.0 if parsed.format_valid else 0.0)
+
+            scores: dict[str, float] = {}
+            for tag, text in (("original", record.prompt), ("refined", refined_prompt)):
+                embeds, mask = self.student.encode_prompts([text])
+                batch = self.student.build_rollout_batch(
+                    embeds, mask, latent_shape=self.student.latent_shape(1))
+                rollout = self.student.rollout(
+                    batch,
+                    batch_size=1,
+                    generator=self.cuda_generator,
+                    num_steps=config.num_steps,
+                    sde_steps=0,
+                    noise_scale=self.config.rollout.noise_scale,
+                    flow_shift=self.config.rollout.flow_shift,
+                    store_transitions=False,
+                )
+                media = self.student.decode_latents(rollout.latents)
+                sample = RewardSample(
+                    group_id=f"val-{iteration}:{record.sample_id}:{tag}",
+                    request_id=f"val-{iteration}:{record.sample_id}:{tag}:{rank}",
+                    sample_id=f"rank-{rank}",
+                    expected_group_size=1,
+                    original_prompt=record.prompt,
+                    reward_tag=record.reward_tag,
+                    fps=self.config.reward.fps,
+                    video_bytes=encode_video_bytes(media, fps=self.config.reward.fps),
+                )
+                scores[tag] = float(self._reward_provider.score([sample])[0].score)
+            original_scores.append(scores["original"])
+            refined_scores.append(scores["refined"])
+            gaps.append(scores["refined"] - scores["original"])
+
+        metrics: dict[str, LogScalar] = {}
+        for key, value in (
+            ("video_original", sum(original_scores) / max(1, len(original_scores))),
+            ("video_refined", sum(refined_scores) / max(1, len(refined_scores))),
+            ("refined_vs_original_gap", sum(gaps) / max(1, len(gaps))),
+            ("refine_valid_rate", sum(valid_flags) / max(1, len(valid_flags))),
+        ):
+            if shard:
+                mean = self._distributed_mean(float(value))
+                if mean is not None:
+                    metrics[f"validation/{key}"] = mean
+        return metrics
+
+
+    # ------------------------------------------------------------------
+    # Bundle export
+    # ------------------------------------------------------------------
+
+    def export_bundle(self, output_dir: str) -> dict[str, str]:
+        """Export a PromptRL inference bundle from the live roles.
+
+        The bundle carries the refiner PEFT adapter, the Wan LoRA (when
+        the student role has one), the prompt template/version, refiner
+        sampling configuration, base model identifiers, and the current
+        FastVideo version.
+        """
+        import fastvideo
+        from fastvideo.train.methods.rl.promptrl.bundle import (
+            BundleManifest,
+            export_promptrl_bundle,
+        )
+
+        refiner_lora = getattr(self.refiner, "_lora_config", None)
+        student_lora = getattr(self.student, "_lora_config", None)
+        manifest = BundleManifest(
+            base_refiner_model=str(getattr(self.refiner, "_init_from", "")),
+            base_generator_model=str(self.training_config.model_path),
+            fastvideo_version=str(getattr(fastvideo, "__version__", "unknown")),
+            refiner_lora=({
+                "rank": refiner_lora.rank,
+                "alpha": refiner_lora.alpha,
+                "target_modules": refiner_lora.target_modules,
+            } if refiner_lora is not None else {}),
+            generator_lora=({
+                "rank": student_lora.rank,
+                "alpha": student_lora.alpha,
+                "target_modules": student_lora.target_modules,
+            } if student_lora is not None else {}),
+            prompt_template_version=self.config.refiner.template_version,
+            refiner_sampling={
+                "max_new_tokens": self.config.refiner.max_new_tokens,
+                "temperature": self.config.refiner.temperature,
+                "top_p": self.config.refiner.top_p,
+            },
+            mode=self.config.mode,
+        )
+        transformer = getattr(self.student, "transformer", None)
+        export_generator = (self.student._trainable and isinstance(transformer, torch.nn.Module)
+                            and _has_lora_layers(transformer))
+        if self.student._trainable and not export_generator:
+            logger.info("Student transformer has no LoRA layers; exporting refiner-only bundle")
+        return export_promptrl_bundle(
+            output_dir,
+            manifest=manifest,
+            refiner_role=self.refiner,
+            refiner_tokenizer=getattr(self.refiner, "tokenizer", None),
+            generator_transformer=transformer if export_generator else None,
+        )

--- a/fastvideo/train/methods/rl/promptrl/prompts.py
+++ b/fastvideo/train/methods/rl/promptrl/prompts.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt dataset + refiner output parsing for PromptRL.
+
+Datasets are raw prompt files (JSONL or Parquet) with a required
+``prompt`` field and optional ``id`` / ``reward_tag`` fields.  Generated
+videos are always scored against the *original* prompt, never the
+refined one.
+
+Refiner completions must contain ``<answer>...</answer>``.  Valid
+refinements and retained originals receive format reward 1; malformed
+refinements receive format reward 0 and fall back to the original
+prompt for video generation (the completion itself is preserved so it
+still receives its negative language-model signal).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+_ANSWER_RE = re.compile(r"<answer>(.*?)</answer>", re.DOTALL)
+
+SampleKind = Literal["original", "refined"]
+
+REFINEMENT_PROMPT_TEMPLATE_V1 = (
+    "You are an expert prompt engineer for text-to-video generation. "
+    "Rewrite the user's prompt to be more detailed, cinematic, and "
+    "visually grounded while preserving its meaning. Respond with the "
+    "rewritten prompt inside <answer>...</answer> tags only.\n"
+    "User prompt: {prompt}")
+
+SUPPORTED_TEMPLATE_VERSIONS = ("v1",)
+
+
+def render_refinement_prompt(prompt: str, *, template_version: str = "v1") -> str:
+    """Render the instruction template used to query the refiner."""
+    if template_version == "v1":
+        return REFINEMENT_PROMPT_TEMPLATE_V1.format(prompt=prompt)
+    raise ValueError(f"Unsupported refiner template_version: {template_version!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedCompletion:
+    """Result of parsing one raw refiner completion."""
+
+    raw: str
+    refined_prompt: str
+    format_valid: bool
+
+
+def parse_answer_tag(completion: str) -> ParsedCompletion:
+    """Extract ``<answer>...</answer>`` from a raw refiner completion.
+
+    A completion is format-valid when it contains exactly one non-empty
+    answer block.  The refined prompt is the stripped answer content.
+    """
+    matches = _ANSWER_RE.findall(completion)
+    if len(matches) != 1:
+        return ParsedCompletion(raw=completion, refined_prompt="", format_valid=False)
+    refined = matches[0].strip()
+    if not refined:
+        return ParsedCompletion(raw=completion, refined_prompt="", format_valid=False)
+    return ParsedCompletion(raw=completion, refined_prompt=refined, format_valid=True)
+
+
+@dataclass(frozen=True, slots=True)
+class PromptRecord:
+    """One original prompt row."""
+
+    prompt: str
+    sample_id: str
+    reward_tag: str
+
+
+@dataclass(frozen=True, slots=True)
+class GroupAssignment:
+    """Per-rank role assignment inside one PromptRL group."""
+
+    rank: int
+    kind: SampleKind
+    # Whether this rank's completion counts toward the refiner loss.
+    refiner_participation: bool
+
+
+def group_assignments(*, group_size: int, retained_originals: int) -> list[GroupAssignment]:
+    """Rank -> role layout for one replicated-prompt group.
+
+    Ranks ``[0, retained_originals)`` are retained originals: they
+    generate video from the original prompt and receive format reward 1,
+    but contribute zero refiner advantage.  Remaining ranks generate
+    from sampled refiner outputs.
+    """
+    if group_size <= 0:
+        raise ValueError(f"group_size must be positive, got {group_size}")
+    if not 0 < retained_originals < group_size:
+        raise ValueError(f"retained_originals must be within (0, {group_size}), "
+                         f"got {retained_originals}")
+    assignments: list[GroupAssignment] = []
+    for rank in range(group_size):
+        retained = rank < retained_originals
+        assignments.append(
+            GroupAssignment(
+                rank=rank,
+                kind="original" if retained else "refined",
+                refiner_participation=not retained,
+            ))
+    return assignments
+
+
+
+class PromptDataset:
+    """In-memory raw prompt dataset loaded from JSONL or Parquet."""
+
+    def __init__(
+        self,
+        records: list[PromptRecord],
+        *,
+        prompt_key: str = "prompt",
+        id_key: str = "id",
+        reward_tag_key: str = "reward_tag",
+    ) -> None:
+        if not records:
+            raise ValueError("PromptDataset requires at least one record")
+        self.records = list(records)
+        self.prompt_key = prompt_key
+        self.id_key = id_key
+        self.reward_tag_key = reward_tag_key
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def __getitem__(self, index: int) -> PromptRecord:
+        return self.records[int(index) % len(self.records)]
+
+    @classmethod
+    def from_rows(
+        cls,
+        rows: list[dict[str, Any]],
+        *,
+        prompt_key: str = "prompt",
+        id_key: str = "id",
+        reward_tag_key: str = "reward_tag",
+    ) -> PromptDataset:
+        records: list[PromptRecord] = []
+        for position, row in enumerate(rows):
+            prompt = row.get(prompt_key)
+            if not isinstance(prompt, str) or not prompt.strip():
+                raise ValueError(f"Prompt row {position} is missing a non-empty "
+                                 f"{prompt_key!r} field")
+            raw_id = row.get(id_key)
+            sample_id = str(raw_id) if raw_id is not None else f"row-{position}"
+            raw_tag = row.get(reward_tag_key)
+            reward_tag = str(raw_tag) if raw_tag is not None else ""
+            records.append(PromptRecord(prompt=prompt.strip(),
+                                        sample_id=sample_id,
+                                        reward_tag=reward_tag))
+        return cls(records, prompt_key=prompt_key, id_key=id_key, reward_tag_key=reward_tag_key)
+
+    @classmethod
+    def load(
+        cls,
+        path: str,
+        *,
+        prompt_key: str = "prompt",
+        id_key: str = "id",
+        reward_tag_key: str = "reward_tag",
+    ) -> PromptDataset:
+        """Load a raw prompt dataset from ``.jsonl``/``.json``/``.parquet``.
+
+        Parquet inputs may be a single file, a directory of parquet
+        files, or a glob pattern.
+        """
+        resolved = Path(path).expanduser()
+        if not resolved.exists():
+            raise FileNotFoundError(f"Prompt dataset not found: {resolved}")
+        suffix = resolved.suffix.lower()
+        if suffix in (".jsonl", ".json"):
+            rows = _load_jsonl(resolved)
+        elif suffix == ".parquet" or resolved.is_dir():
+            rows = _load_parquet(resolved)
+        else:
+            raise ValueError(f"Unsupported prompt dataset format: {resolved} "
+                             "(expected .jsonl/.json/.parquet or a parquet directory)")
+        return cls.from_rows(rows,
+                             prompt_key=prompt_key,
+                             id_key=id_key,
+                             reward_tag_key=reward_tag_key)
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as handle:
+        if path.suffix.lower() == ".json":
+            payload = json.load(handle)
+            if not isinstance(payload, list):
+                raise ValueError(f"Expected a JSON list in {path}")
+            return [dict(row) for row in payload]
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                rows.append(json.loads(stripped))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSON on line {line_number} of {path}: {exc}") from exc
+    return rows
+
+
+def _load_parquet(path: Path) -> list[dict[str, Any]]:
+    import pyarrow.parquet as pq
+
+    files: list[Path]
+    if path.is_dir():
+        files = sorted(path.glob("*.parquet"))
+        if not files:
+            raise FileNotFoundError(f"No .parquet files under {path}")
+    else:
+        files = [path]
+    rows: list[dict[str, Any]] = []
+    for file in files:
+        table = pq.read_table(file)
+        rows.extend(table.to_pylist())
+    return rows

--- a/fastvideo/train/methods/rl/promptrl/rewards/__init__.py
+++ b/fastvideo/train/methods/rl/promptrl/rewards/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRL reward provider contract, HTTP client, and VideoScore2 service."""
+
+from fastvideo.train.methods.rl.promptrl.rewards.provider import (
+    HttpRewardProvider,
+    RewardProvider,
+    RewardResult,
+    RewardSample,
+    RewardServiceError,
+    validate_reward_results,
+)
+from fastvideo.train.methods.rl.promptrl.rewards.service import (
+    COMPONENT_KEYS,
+    RewardGroupCoordinator,
+    RewardRequestError,
+    RewardTimeoutError,
+    RubricVideoScore2Judge,
+    VideoScore2Judge,
+    VideoJudge,
+    create_reward_app,
+    parse_judge_scores,
+    parse_videoscore2_output,
+)
+
+__all__ = [
+    "COMPONENT_KEYS",
+    "HttpRewardProvider",
+    "RewardGroupCoordinator",
+    "RewardProvider",
+    "RewardRequestError",
+    "RewardResult",
+    "RewardSample",
+    "RewardServiceError",
+    "RewardTimeoutError",
+    "RubricVideoScore2Judge",
+    "VideoScore2Judge",
+    "VideoJudge",
+    "create_reward_app",
+    "parse_judge_scores",
+    "parse_videoscore2_output",
+    "validate_reward_results",
+]

--- a/fastvideo/train/methods/rl/promptrl/rewards/provider.py
+++ b/fastvideo/train/methods/rl/promptrl/rewards/provider.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reward provider contract + built-in HTTP client.
+
+The trainer depends only on the :class:`RewardProvider` protocol::
+
+    score(samples: Sequence[RewardSample]) -> Sequence[RewardResult]
+
+``RewardResult`` carries the composite ``score``, per-component
+``details``, the ``sample_id`` and the ``request_id``.  The built-in
+:class:`HttpRewardProvider` uploads videos to an external service
+(e.g. VideoScore2 on a ninth GPU) with bounded retries and strict
+response validation. Any timeout, duplicate/missing sample, non-finite
+score, or cardinality mismatch raises :class:`RewardServiceError`.
+Judge-specific adapters may explicitly neutralize an unscorable output
+for the complete comparison group so it contributes no relative advantage.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+from collections.abc import Sequence
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class RewardServiceError(RuntimeError):
+    """Raised when the reward service fails a step consistently."""
+
+
+@dataclass(frozen=True, slots=True)
+class RewardSample:
+    """One generated video submitted for scoring."""
+
+    group_id: str
+    request_id: str
+    sample_id: str
+    expected_group_size: int
+    original_prompt: str
+    reward_tag: str
+    fps: int
+    video_bytes: bytes
+    video_filename: str = "sample.mp4"
+
+
+@dataclass(frozen=True, slots=True)
+class RewardResult:
+    """Score for one sample returned by a provider."""
+
+    score: float
+    details: dict[str, float]
+    sample_id: str
+    request_id: str
+
+
+@runtime_checkable
+class RewardProvider(Protocol):
+    """Pluggable reward contract used by the PromptRL trainer."""
+
+    def score(self, samples: Sequence[RewardSample]) -> Sequence[RewardResult]:
+        """Score *samples*; exactly one result per input sample."""
+        ...
+
+
+def validate_reward_results(
+    samples: Sequence[RewardSample],
+    results: Sequence[RewardResult],
+) -> None:
+    """Enforce cardinality, identity, and finiteness of *results*.
+
+    Raises :class:`RewardServiceError` on any mismatch so every rank
+    fails the step consistently.
+    """
+    if len(results) != len(samples):
+        raise RewardServiceError(f"Reward cardinality mismatch: sent {len(samples)} "
+                                 f"sample(s), got {len(results)} result(s)")
+    expected_ids = [s.sample_id for s in samples]
+    got_ids = [r.sample_id for r in results]
+    if sorted(got_ids) != sorted(expected_ids):
+        missing = sorted(set(expected_ids) - set(got_ids))
+        duplicate = sorted({g for g in got_ids if got_ids.count(g) > 1})
+        raise RewardServiceError(f"Reward sample id mismatch: missing={missing}, "
+                                 f"duplicates={duplicate}, got={sorted(got_ids)}")
+    for result in results:
+        if not isinstance(result.score, float | int) or not math.isfinite(float(result.score)):
+            raise RewardServiceError(f"Non-finite reward score for sample "
+                                     f"{result.sample_id!r}: {result.score!r}")
+        for key, value in result.details.items():
+            if not math.isfinite(float(value)):
+                raise RewardServiceError(f"Non-finite reward detail {key!r} for sample "
+                                         f"{result.sample_id!r}: {value!r}")
+
+
+@dataclass(slots=True)
+class HttpRewardProvider:
+    """HTTP client for the PromptRL reward service."""
+
+    endpoint_url: str
+    timeout_sec: float = 300.0
+    retries: int = 2
+    score_path: str = "/v1/rewards:score"
+    health_path: str = "/healthz"
+    # Test hook: sleep between retries (seconds).
+    retry_backoff_sec: float = 1.0
+    _session: Any = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        self.endpoint_url = self.endpoint_url.rstrip("/")
+
+    # ------------------------------------------------------------------
+
+    def _client(self) -> Any:
+        if self._session is not None:
+            return self._session
+        # The module-level helpers create an independent Session per request,
+        # avoiding shared mutable Session state across concurrent uploads.
+        import requests
+        return requests
+
+    def health(self) -> bool:
+        try:
+            response = self._client().get(
+                f"{self.endpoint_url}{self.health_path}",
+                timeout=min(self.timeout_sec, 30.0),
+            )
+            return bool(response.status_code == 200)
+        except Exception:
+            return False
+
+    def score(self, samples: Sequence[RewardSample]) -> Sequence[RewardResult]:
+        if not samples:
+            return []
+        last_error: Exception | None = None
+        for attempt in range(self.retries + 1):
+            try:
+                results = self._score_once(samples)
+                validate_reward_results(samples, results)
+                return results
+            except Exception as exc:  # noqa: BLE001 - retried below
+                last_error = exc
+                logger.warning(
+                    "Reward request failed (attempt %d/%d): %s",
+                    attempt + 1,
+                    self.retries + 1,
+                    exc,
+                )
+                if attempt < self.retries and self.retry_backoff_sec > 0:
+                    time.sleep(self.retry_backoff_sec)
+        raise RewardServiceError(f"Reward service failed after "
+                                 f"{self.retries + 1} attempt(s): {last_error}") from last_error
+
+    # ------------------------------------------------------------------
+
+    def _score_once(self, samples: Sequence[RewardSample]) -> list[RewardResult]:
+        # A service-side group does not score until every expected sample
+        # arrives. Submit all samples owned by this rank concurrently so a
+        # rank with multiple group slots cannot block on its first request.
+        # ``executor.map`` preserves input order for deterministic validation.
+        max_workers = min(len(samples), 32)
+        with ThreadPoolExecutor(
+                max_workers=max_workers,
+                thread_name_prefix="promptrl-reward",
+        ) as executor:
+            return list(executor.map(self._score_sample_once, samples))
+
+    def _score_sample_once(self, sample: RewardSample) -> RewardResult:
+        """POST one sample; the service batches the group server-side."""
+        form = {
+            "group_id": sample.group_id,
+            "request_id": sample.request_id,
+            "sample_id": sample.sample_id,
+            "expected_group_size": str(sample.expected_group_size),
+            "original_prompt": sample.original_prompt,
+            "reward_tag": sample.reward_tag,
+            "fps": str(sample.fps),
+        }
+        files = {
+            "video": (sample.video_filename, sample.video_bytes, "video/mp4"),
+        }
+        response = self._client().post(
+            f"{self.endpoint_url}{self.score_path}",
+            data=form,
+            files=files,
+            timeout=self.timeout_sec,
+        )
+        if response.status_code != 200:
+            raise RewardServiceError(f"Reward service returned HTTP {response.status_code}: "
+                                     f"{response.text[:500]}")
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise RewardServiceError(f"Reward service returned non-JSON response: "
+                                     f"{response.text[:500]}") from exc
+        return _parse_reward_payload(payload, sample=sample)
+
+
+def _parse_reward_payload(payload: Any, *, sample: RewardSample) -> RewardResult:
+    if not isinstance(payload, dict):
+        raise RewardServiceError(f"Reward payload must be a JSON object, got "
+                                 f"{type(payload).__name__}")
+    if payload.get("request_id") != sample.request_id:
+        raise RewardServiceError(f"Reward payload request_id mismatch: expected "
+                                 f"{sample.request_id!r}, got {payload.get('request_id')!r}")
+    if payload.get("sample_id") != sample.sample_id:
+        raise RewardServiceError(f"Reward payload sample_id mismatch: expected "
+                                 f"{sample.sample_id!r}, got {payload.get('sample_id')!r}")
+    raw_score = payload.get("score")
+    try:
+        score = float(raw_score)
+    except (TypeError, ValueError) as exc:
+        raise RewardServiceError(f"Reward payload has invalid score: {raw_score!r}") from exc
+    raw_details = payload.get("details", {}) or {}
+    if not isinstance(raw_details, dict):
+        raise RewardServiceError(f"Reward payload details must be an object, got "
+                                 f"{type(raw_details).__name__}")
+    details: dict[str, float] = {}
+    for key, value in raw_details.items():
+        try:
+            details[str(key)] = float(value)
+        except (TypeError, ValueError) as exc:
+            raise RewardServiceError(f"Reward detail {key!r} is not numeric: {value!r}") from exc
+    return RewardResult(
+        score=score,
+        details=details,
+        sample_id=str(payload["sample_id"]),
+        request_id=str(payload["request_id"]),
+    )

--- a/fastvideo/train/methods/rl/promptrl/rewards/serve.py
+++ b/fastvideo/train/methods/rl/promptrl/rewards/serve.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Launch the PromptRL VideoScore2 reward service.
+
+Example (on the reward GPU host)::
+
+    CUDA_VISIBLE_DEVICES=0 python -m \
+        fastvideo.train.methods.rl.promptrl.rewards.serve \
+        --model-id TIGER-Lab/VideoScore2 --port 8100
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="PromptRL reward service")
+    parser.add_argument("--model-id", default="TIGER-Lab/VideoScore2")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8100)
+    parser.add_argument("--max-wait-sec", type=float, default=300.0)
+    parser.add_argument("--max-new-tokens", type=int, default=1024)
+    parser.add_argument("--infer-fps", type=float, default=2.0)
+    parser.add_argument("--temperature", type=float, default=0.7)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    import uvicorn
+
+    from fastvideo.train.methods.rl.promptrl.rewards.service import (
+        VideoScore2Judge,
+        create_reward_app,
+    )
+
+    judge = VideoScore2Judge(
+        args.model_id,
+        max_new_tokens=args.max_new_tokens,
+        infer_fps=args.infer_fps,
+        temperature=args.temperature,
+        seed=args.seed,
+    )
+    app = create_reward_app(judge, max_wait_sec=args.max_wait_sec)
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/fastvideo/train/methods/rl/promptrl/rewards/service.py
+++ b/fastvideo/train/methods/rl/promptrl/rewards/service.py
@@ -1,0 +1,789 @@
+# SPDX-License-Identifier: Apache-2.0
+"""VideoScore2 reward service for PromptRL.
+
+Runs as a pluggable service (canonically on a ninth GPU).  Training
+ranks POST their generated videos to ``/v1/rewards:score`` with group
+metadata; the service collects complete groups, evaluates each video
+with the official VideoScore2 inference procedure, and returns a
+composite score plus visual-quality, text-alignment, and
+physical-consistency details. Completed request IDs are cached so
+client retries are idempotent. Videos transfer over HTTP only — no
+shared filesystem.
+
+Endpoints:
+
+* ``GET /healthz``
+* ``POST /v1/rewards:score`` (multipart form; fields ``group_id``,
+  ``request_id``, ``sample_id``, ``expected_group_size``,
+  ``original_prompt``, ``reward_tag``, ``fps`` + ``video`` file)
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from starlette.concurrency import run_in_threadpool
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+#: Judge payload keys produced per scored sample.
+COMPONENT_KEYS = ("visual_quality", "text_alignment", "physical_consistency")
+
+
+def _read_video_with_pyav(
+    path: str,
+    *,
+    start_pts: float = 0.0,
+    end_pts: float | None = None,
+    pts_unit: str = "sec",
+    output_format: str = "THWC",
+) -> tuple[Any, Any, dict[str, float]]:
+    """PyAV implementation of the removed ``torchvision.io.read_video`` API."""
+    import av
+    import numpy as np
+    import torch
+
+    if pts_unit != "sec":
+        raise ValueError("PromptRL's PyAV video fallback only supports pts_unit='sec'")
+    if output_format not in {"THWC", "TCHW"}:
+        raise ValueError(f"Unsupported video output format: {output_format!r}")
+
+    container = av.open(path)
+    try:
+        stream = container.streams.video[0]
+        video_fps = float(stream.average_rate or stream.base_rate or 0.0)
+        frames = []
+        for frame in container.decode(video=0):
+            timestamp = frame.time
+            if timestamp is not None and timestamp < float(start_pts):
+                continue
+            if end_pts is not None and timestamp is not None and timestamp > float(end_pts):
+                break
+            frames.append(frame.to_ndarray(format="rgb24"))
+    finally:
+        container.close()
+    if not frames:
+        raise RuntimeError(f"No video frames decoded from {path}")
+
+    video = torch.from_numpy(np.stack(frames))
+    if output_format == "TCHW":
+        video = video.permute(0, 3, 1, 2)
+    audio = torch.empty((1, 0), dtype=torch.float32)
+    return video, audio, {"video_fps": video_fps}
+
+
+def _install_torchvision_read_video_fallback() -> None:
+    """Polyfill torchvision >=0.26 for qwen-vl-utils' video reader."""
+    import torchvision.io
+
+    if callable(getattr(torchvision.io, "read_video", None)):
+        return
+    torchvision.io.read_video = _read_video_with_pyav  # type: ignore[attr-defined]
+    logger.warning(
+        "torchvision.io.read_video is unavailable; using the PyAV compatibility decoder",
+    )
+
+
+class RewardRequestError(RuntimeError):
+    """Client-facing request failure carrying an HTTP status code."""
+
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(message)
+        self.status_code = int(status_code)
+
+
+class RewardTimeoutError(RewardRequestError):
+    def __init__(self, message: str) -> None:
+        super().__init__(504, message)
+
+
+@runtime_checkable
+class VideoJudge(Protocol):
+    """Group video scoring backend (e.g. VideoScore2)."""
+
+    def score_batch(
+        self,
+        videos: Sequence[bytes],
+        prompts: Sequence[str],
+        *,
+        fps: int,
+    ) -> list[dict[str, float]]:
+        """Score *videos* against *prompts*.
+
+        Returns one dict per video with ``composite`` plus the
+        :data:`COMPONENT_KEYS` component scores.
+        """
+        ...
+
+
+@dataclass(slots=True)
+class _SubmittedSample:
+    sample_id: str
+    original_prompt: str
+    reward_tag: str
+    fps: int
+    video_bytes: bytes
+
+
+@dataclass(slots=True)
+class _GroupState:
+    expected: int
+    samples: dict[str, _SubmittedSample] = field(default_factory=dict)
+    scoring_started: bool = False
+    payloads: dict[str, dict[str, Any]] | None = None
+    error: BaseException | None = None
+
+
+
+class RewardGroupCoordinator:
+    """Thread-safe group batching + idempotency core (framework-free)."""
+
+    def __init__(
+        self,
+        judge: VideoJudge,
+        *,
+        max_wait_sec: float = 300.0,
+        max_completed_requests: int = 1024,
+    ) -> None:
+        self._judge = judge
+        self._max_wait_sec = float(max_wait_sec)
+        self._max_completed = int(max_completed_requests)
+        self._cond = threading.Condition()
+        self._groups: dict[tuple[str, str], _GroupState] = {}
+        self._completed: OrderedDict[str, dict[str, dict[str, Any]]] = OrderedDict()
+
+    def submit(
+        self,
+        *,
+        group_id: str,
+        request_id: str,
+        sample_id: str,
+        expected_group_size: int,
+        original_prompt: str,
+        reward_tag: str,
+        fps: int,
+        video_bytes: bytes,
+    ) -> dict[str, Any]:
+        """Submit one sample; block until the whole group is scored."""
+        if expected_group_size <= 0:
+            raise RewardRequestError(400, "expected_group_size must be positive")
+        key = (str(group_id), str(request_id))
+        with self._cond:
+            cached = self._completed.get(str(request_id))
+            if cached is not None:
+                payload = cached.get(sample_id)
+                if payload is None:
+                    raise RewardRequestError(
+                        409, f"request_id {request_id!r} completed without "
+                        f"sample_id {sample_id!r}")
+                return payload
+
+            state = self._groups.get(key)
+            if state is None:
+                state = _GroupState(expected=int(expected_group_size))
+                self._groups[key] = state
+            elif state.expected != int(expected_group_size):
+                raise RewardRequestError(400, f"expected_group_size mismatch for group "
+                                         f"{group_id!r}: {state.expected} vs {expected_group_size}")
+            elif state.scoring_started and sample_id not in state.samples:
+                raise RewardRequestError(409, f"group {group_id!r} request {request_id!r} "
+                                         f"is already scoring and sample_id {sample_id!r} "
+                                         "was not part of the submitted group")
+
+            if sample_id not in state.samples:
+                state.samples[sample_id] = _SubmittedSample(
+                    sample_id=sample_id,
+                    original_prompt=original_prompt,
+                    reward_tag=reward_tag,
+                    fps=int(fps),
+                    video_bytes=video_bytes,
+                )
+
+            complete_now = (not state.scoring_started and len(state.samples) == state.expected)
+            if complete_now:
+                state.scoring_started = True
+
+        # Score outside the lock so other groups proceed concurrently.
+        if complete_now:
+            self._score_group(key, state)
+
+        with self._cond:
+            ready = self._cond.wait_for(
+                lambda: state.payloads is not None or state.error is not None,
+                timeout=self._max_wait_sec,
+            )
+            if not ready:
+                raise RewardTimeoutError(f"Timed out after {self._max_wait_sec:.0f}s waiting "
+                                         f"for group {group_id!r} to complete scoring")
+            if state.error is not None:
+                raise RewardRequestError(500, f"Video judge failed for group "
+                                         f"{group_id!r}: {state.error}")
+            assert state.payloads is not None
+            return state.payloads[sample_id]
+
+    # ------------------------------------------------------------------
+
+    def _score_group(self, key: tuple[str, str], state: _GroupState) -> None:
+        group_id, request_id = key
+        try:
+            # Deterministic sample order: sorted by sample_id so every
+            # group scores identically regardless of arrival order.
+            ordered = [state.samples[k] for k in sorted(state.samples)]
+            scores = self._judge.score_batch(
+                [s.video_bytes for s in ordered],
+                [s.original_prompt for s in ordered],
+                fps=ordered[0].fps,
+            )
+            if len(scores) != len(ordered):
+                raise RewardRequestError(500, f"Judge returned {len(scores)} score(s) "
+                                         f"for {len(ordered)} sample(s)")
+            payloads: dict[str, dict[str, Any]] = {}
+            for sample, score_row in zip(ordered, scores, strict=True):
+                composite = float(score_row["composite"])
+                detail_keys = (*COMPONENT_KEYS, "judge_fallback")
+                details = {k: float(score_row[k]) for k in detail_keys if k in score_row}
+                payloads[sample.sample_id] = {
+                    "request_id": request_id,
+                    "sample_id": sample.sample_id,
+                    "score": composite,
+                    "details": details,
+                }
+            with self._cond:
+                state.payloads = payloads
+                self._cache_completed(request_id, payloads)
+                self._groups.pop(key, None)
+                self._cond.notify_all()
+        except BaseException as exc:  # noqa: BLE001 - propagated to waiters
+            logger.warning("Scoring failed for group %s request %s: %s", group_id, request_id, exc)
+            with self._cond:
+                state.error = exc
+                self._groups.pop(key, None)
+                self._cond.notify_all()
+
+    def _cache_completed(self, request_id: str, payloads: dict[str, dict[str, Any]]) -> None:
+        self._completed[request_id] = payloads
+        self._completed.move_to_end(request_id)
+        while len(self._completed) > self._max_completed:
+            self._completed.popitem(last=False)
+
+
+def create_reward_app(
+    judge: VideoJudge,
+    *,
+    max_wait_sec: float = 300.0,
+) -> Any:
+    """Build the FastAPI reward service app around *judge*."""
+    coordinator = RewardGroupCoordinator(judge, max_wait_sec=max_wait_sec)
+    app = FastAPI(title="fastvideo-promptrl-reward", version="1")
+    app.state.coordinator = coordinator
+
+    @app.get("/healthz")
+    def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/v1/rewards:score")
+    async def rewards_score(
+        group_id: str = Form(...),
+        request_id: str = Form(...),
+        sample_id: str = Form(...),
+        expected_group_size: int = Form(...),
+        original_prompt: str = Form(...),
+        reward_tag: str = Form(""),
+        fps: int = Form(16),
+        video: UploadFile = File(...),  # noqa: B008 - FastAPI dependency idiom
+    ) -> dict[str, Any]:
+        video_bytes = await video.read()
+        try:
+            # ``submit`` intentionally waits for all group members and may
+            # execute the synchronous GPU judge. Keep both operations off the
+            # ASGI event loop so the remaining uploads can be accepted.
+            return await run_in_threadpool(
+                coordinator.submit,
+                group_id=group_id,
+                request_id=request_id,
+                sample_id=sample_id,
+                expected_group_size=int(expected_group_size),
+                original_prompt=original_prompt,
+                reward_tag=reward_tag,
+                fps=int(fps),
+                video_bytes=video_bytes,
+            )
+        except RewardRequestError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+    return app
+
+
+_VIDEOSCORE2_QUERY_TEMPLATE = """
+You are an expert for evaluating AI-generated videos from three dimensions:
+(1) visual quality – clarity, smoothness, artifacts;
+(2) text-to-video alignment – fidelity to the prompt;
+(3) physical/common-sense consistency – naturalness and physics plausibility.
+
+Video prompt: {prompt}
+
+Please output in this format:
+visual quality: <v_score>;
+text-to-video alignment: <t_score>,
+physical/common-sense consistency: <p_score>
+""".strip()
+
+_VIDEOSCORE2_LABELS = {
+    "visual_quality": "visual quality:",
+    "text_alignment": "text-to-video alignment:",
+    "physical_consistency": "physical/common-sense consistency:",
+}
+
+_VIDEOSCORE2_LABEL_ALIASES = {
+    "visual_quality": ("visual quality",),
+    "text_alignment": (
+        "text-to-video alignment",
+        "text to video alignment",
+        "text alignment",
+    ),
+    "physical_consistency": (
+        "physical/common-sense consistency",
+        "physical consistency / common-sense",
+        "physical consistency",
+        "common-sense consistency",
+    ),
+}
+
+
+def _videoscore2_score_patterns(label_base: str) -> tuple[str, ...]:
+    """Accepted VideoScore2 score renderings for one dimension label."""
+    import re
+
+    label = re.escape(label_base)
+    value = r"([1-5])(?:\s*/\s*5)?"
+    return (
+        # Requested/final forms: ``Visual Quality: 3`` or
+        # ``Ground-truth scores: Visual Quality 3``. Formatting characters
+        # cover Markdown output such as ``**Visual Quality:** 3``.
+        label + r"[\s*_`-]*[:=]?[\s*_`-]*" + value + r"\b",
+        # Numbered rubric form:
+        # ``(1) visual quality – clarity, smoothness, artifacts: 3``.
+        r"(?:\(\d+\)\s*)?"
+        + label
+        + r"(?:\s*[-–—]\s*[^:\n]+)?\s*:[\s*_`-]*"
+        + value
+        + r"\b",
+        # Narrative forms: ``visual quality is moderate (3/5)`` and
+        # ``visual quality is moderate (score 3)``.
+        label
+        + r"[^\n]{0,500}?\(\s*(?:score(?:\s+of)?\s*[:=]?\s*)?"
+        + value
+        + r"\s*\)",
+        # Narrative forms without parentheses: ``alignment ... score of 4``.
+        label
+        + r"[^\n]{0,500}?\bscore(?:\s+of)?\s*[:=]?\s*"
+        + value
+        + r"\b",
+    )
+
+
+def _videoscore2_aliases(prompt_text: str) -> tuple[str, ...]:
+    normalized = prompt_text.rstrip(":").lower()
+    for component, label in _VIDEOSCORE2_LABELS.items():
+        if normalized == label.rstrip(":").lower():
+            return _VIDEOSCORE2_LABEL_ALIASES[component]
+    return (prompt_text.rstrip(":"),)
+
+
+def _find_score_token_index(
+    prompt_text: str,
+    tokenizer: Any,
+    generated_token_ids: Sequence[int],
+) -> int:
+    """Locate the generated numeric score token after *prompt_text*.
+
+    This follows the official VideoScore2 inference implementation.
+    """
+    import re
+
+    def decode(token_ids: Sequence[int]) -> str:
+        try:
+            return str(
+                tokenizer.decode(
+                    token_ids,
+                    skip_special_tokens=False,
+                    clean_up_tokenization_spaces=False,
+                ))
+        except TypeError:
+            # Lightweight injected tokenizers and older implementations may
+            # not expose the cleanup keyword.
+            return str(
+                tokenizer.decode(
+                    token_ids,
+                    skip_special_tokens=False,
+                ))
+
+    generated_text = decode(generated_token_ids)
+    matches = [
+        match
+        for alias in _videoscore2_aliases(prompt_text)
+        for pattern in _videoscore2_score_patterns(alias)
+        for match in re.finditer(pattern, generated_text, flags=re.IGNORECASE)
+    ]
+    if not matches:
+        return -1
+    match = max(matches, key=lambda candidate: candidate.start())
+    target_end = match.end(1)
+    target = generated_text[:target_end]
+    for index in range(len(generated_token_ids)):
+        partial = decode(generated_token_ids[:index + 1])
+        if partial == target:
+            return index
+        # Transformers 5 tokenizers can decode the newest token together with
+        # punctuation or whitespace, so an exact string boundary is not
+        # guaranteed even though this is the score-producing token. Select the
+        # first token whose decoded prefix contains the complete target.
+        if len(partial) >= target_end and partial[:target_end] == target:
+            return index
+    return -1
+
+
+def _confidence_weighted_score(
+    hard_value: int | None,
+    token_index: int,
+    generation_scores: Sequence[Any],
+    tokenizer: Any,
+) -> float | None:
+    """Compute the official confidence-weighted score over tokens 1–5."""
+    if hard_value is None or token_index < 0 or token_index >= len(generation_scores):
+        return None
+
+    import torch
+
+    logits = generation_scores[token_index][0]
+    values: list[int] = []
+    token_ids: list[int] = []
+    for value in range(1, 6):
+        encoded = tokenizer.encode(str(value), add_special_tokens=False)
+        if len(encoded) == 1:
+            values.append(value)
+            token_ids.append(int(encoded[0]))
+    if not token_ids:
+        return None
+
+    # The official implementation applies log_softmax over the vocabulary,
+    # then renormalizes the five score-token probabilities. The vocabulary
+    # denominator cancels, so a softmax over these five logits is equivalent.
+    probabilities = torch.softmax(
+        logits[token_ids].float(),
+        dim=0,
+    )
+    best_index = int(probabilities.argmax().item())
+    return round(
+        float(values[best_index]) * float(probabilities[best_index].item()),
+        4,
+    )
+
+
+def parse_videoscore2_output(
+    output_text: str,
+    *,
+    generated_token_ids: Sequence[int],
+    generation_scores: Sequence[Any],
+    tokenizer: Any,
+) -> dict[str, float]:
+    """Parse one official VideoScore2 generation into reward components."""
+    import re
+
+    hard_values: dict[str, int | None] = {}
+    for component, label in _VIDEOSCORE2_LABELS.items():
+        # The model sometimes wraps its requested final labels in Markdown,
+        # yielding text such as ``Visual Quality:** 1``. The official regex
+        # accepts only whitespace after the colon, even though this response
+        # is semantically identical. Select the last formatted label so
+        # explanatory headings in the chain of thought cannot shadow the
+        # requested final summary.
+        matches = [
+            match
+            for alias in _VIDEOSCORE2_LABEL_ALIASES[component]
+            for pattern in _videoscore2_score_patterns(alias)
+            for match in re.finditer(
+                pattern,
+                output_text,
+                flags=re.IGNORECASE,
+            )
+        ]
+        hard_values[component] = (
+            int(max(matches, key=lambda candidate: candidate.start()).group(1))
+            if matches
+            else None
+        )
+    parsed: dict[str, float] = {}
+    for component, label in _VIDEOSCORE2_LABELS.items():
+        token_index = _find_score_token_index(
+            label,
+            tokenizer,
+            generated_token_ids,
+        )
+        score = _confidence_weighted_score(
+            hard_values[component],
+            token_index,
+            generation_scores,
+            tokenizer,
+        )
+        if score is None:
+            try:
+                decoded_generation = tokenizer.decode(
+                    generated_token_ids,
+                    skip_special_tokens=False,
+                    clean_up_tokenization_spaces=False,
+                )
+            except TypeError:
+                decoded_generation = tokenizer.decode(
+                    generated_token_ids,
+                    skip_special_tokens=False,
+                )
+            raise RewardRequestError(
+                500,
+                f"VideoScore2 output missing a usable {component} score "
+                f"(hard_value={hard_values[component]!r}, "
+                f"token_index={token_index}): output={output_text[:2000]!r}; "
+                f"decoded_generation={str(decoded_generation)[:2000]!r}",
+            )
+        parsed[component] = score
+    parsed["composite"] = (
+        sum(parsed[key] for key in COMPONENT_KEYS) / len(COMPONENT_KEYS)
+    )
+    return parsed
+
+
+class VideoScore2Judge:
+    """Official VideoScore2 inference wrapped as a group reward judge.
+
+    The upstream procedure evaluates one video at a time at 2 FPS and derives
+    confidence-weighted dimension scores from generation logits. Model loading
+    is lazy so service startup and unit tests do not touch Hugging Face.
+    """
+
+    def __init__(
+        self,
+        model_id: str = "TIGER-Lab/VideoScore2",
+        *,
+        device: str = "cuda",
+        max_new_tokens: int = 1024,
+        infer_fps: float = 2.0,
+        temperature: float = 0.7,
+        seed: int | None = 0,
+        parse_failure_score: float | None = 3.0,
+    ) -> None:
+        self.model_id = model_id
+        self.device = device
+        self.max_new_tokens = int(max_new_tokens)
+        self.infer_fps = float(infer_fps)
+        self.temperature = float(temperature)
+        self.seed = seed
+        self.parse_failure_score = (
+            None if parse_failure_score is None else float(parse_failure_score)
+        )
+        self._model: Any = None
+        self._processor: Any = None
+        self._tokenizer: Any = None
+
+    # ------------------------------------------------------------------
+
+    def _load(self) -> None:
+        if self._model is not None:
+            return
+        import torch
+        import transformers
+        from transformers import AutoProcessor, AutoTokenizer
+
+        # AutoModelForVision2Seq is the class in the official transformers
+        # 4.53.2 example. Transformers 5 renamed it to
+        # AutoModelForImageTextToText, which FastVideo currently uses.
+        model_cls = getattr(transformers, "AutoModelForVision2Seq", None)
+        if model_cls is None:
+            model_cls = transformers.AutoModelForImageTextToText
+        self._processor = AutoProcessor.from_pretrained(
+            self.model_id,
+            trust_remote_code=True,
+        )
+        self._tokenizer = (
+            getattr(self._processor, "tokenizer", None)
+            or AutoTokenizer.from_pretrained(
+                self.model_id,
+                trust_remote_code=True,
+                use_fast=False,
+            )
+        )
+        self._model = model_cls.from_pretrained(
+            self.model_id,
+            trust_remote_code=True,
+            torch_dtype=torch.bfloat16,
+        ).to(self.device)
+        self._model.eval()
+
+    def _score_one(
+        self,
+        video_path: str,
+        prompt: str,
+    ) -> dict[str, float]:
+        import contextlib
+
+        import torch
+
+        _install_torchvision_read_video_fallback()
+        from qwen_vl_utils import process_vision_info
+
+        assert self._model is not None
+        assert self._processor is not None
+        assert self._tokenizer is not None
+
+        messages = [{
+            "role": "user",
+            "content": [{
+                "type": "video",
+                "video": video_path,
+                "fps": self.infer_fps,
+            }, {
+                "type": "text",
+                "text": _VIDEOSCORE2_QUERY_TEMPLATE.format(prompt=prompt),
+            }],
+        }]
+        rendered = self._processor.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        image_inputs, video_inputs = process_vision_info(messages)
+        inputs = self._processor(
+            text=[rendered],
+            images=image_inputs,
+            videos=video_inputs,
+            fps=self.infer_fps,
+            padding=True,
+            return_tensors="pt",
+        ).to(self.device)
+
+        if self.seed is None:
+            rng_context = contextlib.nullcontext()
+        elif torch.device(self.device).type == "cuda":
+            rng_context = torch.random.fork_rng(devices=[torch.device(self.device)])
+        else:
+            rng_context = torch.random.fork_rng(devices=[])
+        with rng_context:
+            if self.seed is not None:
+                torch.manual_seed(int(self.seed))
+                if torch.device(self.device).type == "cuda":
+                    torch.cuda.manual_seed_all(int(self.seed))
+            with torch.no_grad():
+                generated = self._model.generate(
+                    **inputs,
+                    max_new_tokens=self.max_new_tokens,
+                    output_scores=True,
+                    return_dict_in_generate=True,
+                    do_sample=True,
+                    temperature=self.temperature,
+                )
+
+        input_length = int(inputs["input_ids"].shape[1])
+        generated_ids = generated.sequences[0, input_length:].tolist()
+        output_text = self._processor.batch_decode(
+            generated.sequences[:, input_length:],
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )[0]
+        return parse_videoscore2_output(
+            output_text,
+            generated_token_ids=generated_ids,
+            generation_scores=generated.scores,
+            tokenizer=self._tokenizer,
+        )
+
+    def score_batch(
+        self,
+        videos: Sequence[bytes],
+        prompts: Sequence[str],
+        *,
+        fps: int,
+    ) -> list[dict[str, float]]:
+        import tempfile
+        from pathlib import Path
+
+        del fps  # Official VideoScore2 inference samples each video at 2 FPS.
+        if len(videos) != len(prompts):
+            raise RewardRequestError(
+                400,
+                f"Video/prompt cardinality mismatch: {len(videos)} vs {len(prompts)}",
+            )
+        self._load()
+        with tempfile.TemporaryDirectory(prefix="promptrl_reward_") as tmpdir:
+            results: list[dict[str, float]] = []
+            try:
+                for idx, (video_bytes, prompt) in enumerate(zip(videos, prompts, strict=True)):
+                    video_path = Path(tmpdir) / f"video_{idx}.mp4"
+                    video_path.write_bytes(video_bytes)
+                    result = self._score_one(str(video_path), prompt)
+                    result["judge_fallback"] = 0.0
+                    results.append(result)
+            except RewardRequestError as exc:
+                is_parse_failure = (
+                    exc.status_code == 500
+                    and "VideoScore2 output missing a usable" in str(exc)
+                )
+                if not is_parse_failure or self.parse_failure_score is None:
+                    raise
+                # A malformed generation is a judge-side failure, not evidence
+                # that one video is worse. Give the entire comparison group the
+                # same neutral VideoScore2 value so this component contributes
+                # zero group-relative advantage, while format reward can still
+                # train and the long-running job remains healthy.
+                logger.warning(
+                    "VideoScore2 output was unscorable; using neutral score %.2f "
+                    "for all %d samples in the group: %s",
+                    self.parse_failure_score,
+                    len(videos),
+                    exc,
+                )
+                neutral = {
+                    key: self.parse_failure_score
+                    for key in COMPONENT_KEYS
+                }
+                neutral["composite"] = self.parse_failure_score
+                neutral["judge_fallback"] = 1.0
+                results = [dict(neutral) for _ in videos]
+        return results
+
+
+# Backward-compatible name for early PromptRL configs and imports.
+RubricVideoScore2Judge = VideoScore2Judge
+
+
+def parse_judge_scores(output_text: str, *, expected: int) -> list[dict[str, float]]:
+    """Parse the judge JSON array into per-sample score dicts."""
+    import json
+    import re
+
+    match = re.search(r"\[.*\]", output_text, re.DOTALL)
+    if match is None:
+        raise RewardRequestError(500, f"Judge output missing JSON array: {output_text[:200]!r}")
+    try:
+        rows = json.loads(match.group(0))
+    except json.JSONDecodeError as exc:
+        raise RewardRequestError(500, f"Judge output is not valid JSON: {exc}") from exc
+    if not isinstance(rows, list) or len(rows) != expected:
+        raise RewardRequestError(500, f"Judge returned {len(rows) if isinstance(rows, list) else 'non-list'} "
+                                 f"score row(s), expected {expected}")
+    results: list[dict[str, float]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise RewardRequestError(500, f"Judge score row is not an object: {row!r}")
+        try:
+            parsed = {key: float(row[key]) for key in COMPONENT_KEYS}
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RewardRequestError(500, f"Judge score row missing components: {row!r}") from exc
+        parsed["composite"] = sum(parsed[key] for key in COMPONENT_KEYS) / len(COMPONENT_KEYS)
+        results.append(parsed)
+    return results

--- a/fastvideo/train/methods/rl/promptrl/sde.py
+++ b/fastvideo/train/methods/rl/promptrl/sde.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stochastic (SDE) flow-matching transitions with log probabilities.
+
+Adapted from the Flow-GRPO ``sde_step_with_logprob`` patch
+(Apache-2.0), converted to stateless functions over explicit sigma
+pairs so transitions can be recomputed later from stored states:
+
+* ``sde_step_from_model_output`` — rollout-time stochastic step that
+  also returns the transition log probability under the behavior
+  policy.
+* ``transition_log_prob`` — recompute the log probability of a stored
+  transition under a (new or reference) policy.
+* ``transition_kl_to_reference`` — Gaussian KL from the current
+  transition to the frozen-base transition at the same step.
+
+Conventions match ``FlowMatchEulerDiscreteScheduler``:
+``x = (1 - sigma) * x0 + sigma * noise``, Euler step
+``x' = x + (sigma_next - sigma) * model_output`` where ``model_output``
+is the predicted velocity.  Latents may be 5D video tensors
+``[B, C, T, H, W]``; log probs are reduced over all non-batch dims.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(slots=True)
+class SDETransition:
+    """One stored stochastic transition from rollout time."""
+
+    sample: torch.Tensor  # x_t (detached)
+    prev_sample: torch.Tensor  # x_{t+1} actually sampled (detached)
+    timestep: float
+    sigma: float
+    sigma_next: float
+    old_log_prob: torch.Tensor  # [B] behavior-policy log prob (detached)
+
+
+def _std_dev_t(sigma: float, sigma_max: float, noise_scale: float) -> float:
+    denom = 1.0 - (sigma_max if sigma == 1.0 else sigma)
+    denom = max(denom, 1e-6)
+    return math.sqrt(max(sigma, 0.0) / denom) * float(noise_scale)
+
+
+def sde_step_from_model_output(
+    model_output: torch.Tensor,
+    sample: torch.Tensor,
+    *,
+    sigma: float,
+    sigma_next: float,
+    noise_scale: float,
+    sigma_max: float,
+    generator: torch.Generator | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Take one stochastic reverse step; return (prev, log_prob, mean).
+
+    ``log_prob`` is the per-sample transition log probability of the
+    sampled ``prev`` under the Gaussian transition kernel, reduced over
+    all non-batch dimensions.
+    """
+    model_output = model_output.float()
+    sample = sample.float()
+    dt = float(sigma_next) - float(sigma)  # negative
+    std = _std_dev_t(float(sigma), float(sigma_max), noise_scale)
+
+    std_sq = std * std
+    prev_mean = (sample * (1.0 + std_sq / (2.0 * sigma) * dt) +
+                 model_output * (1.0 + std_sq * (1.0 - sigma) / (2.0 * sigma)) * dt)
+
+    noise = torch.randn(
+        prev_mean.shape,
+        device=prev_mean.device,
+        dtype=prev_mean.dtype,
+        generator=generator,
+    )
+    step_std = std * math.sqrt(-dt)
+    prev_sample = prev_mean + step_std * noise
+    log_prob = _gaussian_log_prob(prev_sample.detach(), prev_mean, step_std)
+    return prev_sample, log_prob, prev_mean
+
+
+def transition_log_prob(
+    model_output: torch.Tensor,
+    sample: torch.Tensor,
+    prev_sample: torch.Tensor,
+    *,
+    sigma: float,
+    sigma_next: float,
+    noise_scale: float,
+    sigma_max: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Recompute the log prob of a stored transition.
+
+    Returns ``(log_prob, prev_mean)`` where ``prev_mean`` keeps its
+    gradient (for the policy loss) and ``prev_sample`` is treated as a
+    constant.
+    """
+    model_output = model_output.float()
+    sample = sample.float()
+    prev_sample = prev_sample.float()
+    dt = float(sigma_next) - float(sigma)
+    std = _std_dev_t(float(sigma), float(sigma_max), noise_scale)
+    std_sq = std * std
+    prev_mean = (sample * (1.0 + std_sq / (2.0 * sigma) * dt) +
+                 model_output * (1.0 + std_sq * (1.0 - sigma) / (2.0 * sigma)) * dt)
+    step_std = std * math.sqrt(-dt)
+    log_prob = _gaussian_log_prob(prev_sample, prev_mean, step_std)
+    return log_prob, prev_mean
+
+
+def transition_kl_to_reference(
+    prev_mean: torch.Tensor,
+    ref_prev_mean: torch.Tensor,
+    *,
+    sigma: float,
+    sigma_next: float,
+    noise_scale: float,
+    sigma_max: float,
+) -> torch.Tensor:
+    """Gaussian KL(current || reference) for one transition.
+
+    Both kernels share the same (policy-independent) scale
+    ``step_std = std * sqrt(-dt)``, so the KL reduces to the squared
+    mean gap over ``2 * step_std^2``, summed over non-batch dims.
+    """
+    dt = float(sigma_next) - float(sigma)
+    std = _std_dev_t(float(sigma), float(sigma_max), noise_scale)
+    step_std_sq = max(std * std * (-dt), 1e-12)
+    gap = (prev_mean.float() - ref_prev_mean.detach().float()) ** 2
+    reduce_dims = tuple(range(1, gap.ndim))
+    return (gap.sum(dim=reduce_dims) / (2.0 * step_std_sq))
+
+
+def _gaussian_log_prob(
+    value: torch.Tensor,
+    mean: torch.Tensor,
+    std: float,
+) -> torch.Tensor:
+    """Diagonal-Gaussian log density, mean over non-batch dims.
+
+    Mirrors the Flow-GRPO reduction (mean over pixels/channels), which
+    keeps per-step log probs on a comparable scale across resolutions.
+    """
+    std = max(float(std), 1e-8)
+    log_prob = (-((value.detach() - mean) ** 2) / (2.0 * std * std) - math.log(std) -
+                math.log(math.sqrt(2.0 * math.pi)))
+    return log_prob.mean(dim=tuple(range(1, log_prob.ndim)))

--- a/fastvideo/train/methods/rl/promptrl/video_io.py
+++ b/fastvideo/train/methods/rl/promptrl/video_io.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Video byte encoding for reward uploads."""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import torch
+
+
+def encode_video_bytes(media: torch.Tensor, *, fps: int = 16) -> bytes:
+    """Encode one ``[C, T, H, W]`` float video in [0, 1] to mp4 bytes."""
+    import imageio.v3 as iio
+
+    if media.ndim == 5:
+        if int(media.shape[0]) != 1:
+            raise ValueError(f"expected a single video, got batch {media.shape[0]}")
+        media = media[0]
+    if media.ndim != 4:
+        raise ValueError(f"media must be [C, T, H, W], got {tuple(media.shape)}")
+    video = (media.detach().float().clamp(0, 1) * 255).round().to(torch.uint8)
+    frames: np.ndarray = video.permute(1, 2, 3, 0).cpu().numpy()
+    buffer = io.BytesIO()
+    iio.imwrite(buffer, frames, extension=".mp4", fps=int(fps), codec="libx264")
+    return buffer.getvalue()

--- a/fastvideo/train/models/base.py
+++ b/fastvideo/train/models/base.py
@@ -11,6 +11,7 @@ from fastvideo.attention.selector import coerce_attn_backend
 from fastvideo.distributed import get_local_torch_device
 from fastvideo.models.utils import pred_noise_to_pred_video
 from fastvideo.platforms import AttentionBackendEnum
+from fastvideo.train.roles.base import TrainRoleBase
 
 if TYPE_CHECKING:
     from fastvideo.train.utils.training_config import (
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
     from fastvideo.pipelines import TrainingBatch
 
 
-class ModelBase(ABC):
+class ModelBase(TrainRoleBase, ABC):
     """Per-role model instance.
 
     Every role (student, teacher, critic, …) gets its own ``ModelBase``
@@ -58,6 +59,24 @@ class ModelBase(ABC):
     def device(self) -> torch.device:
         """The local CUDA device for this rank."""
         return get_local_torch_device()
+
+    # ------------------------------------------------------------------
+    # TrainRoleBase plumbing
+    # ------------------------------------------------------------------
+
+    def checkpoint_modules(self) -> dict[str, torch.nn.Module]:
+        """Expose the role transformer for DCP checkpointing/FSDP."""
+        transformer = getattr(self, "transformer", None)
+        if isinstance(transformer, torch.nn.Module):
+            return {"transformer": transformer}
+        return {}
+
+    def trainable_parameters(self) -> list[torch.nn.Parameter]:
+        """Transformer parameters that require gradients."""
+        return [
+            p for module in self.checkpoint_modules().values()
+            for p in module.parameters() if p.requires_grad
+        ]
 
     def _enable_lora_if_configured(
         self,

--- a/fastvideo/train/models/wan/__init__.py
+++ b/fastvideo/train/models/wan/__init__.py
@@ -5,3 +5,5 @@ from fastvideo.train.models.wan.wan import (
     WanModel as WanModel, )
 from fastvideo.train.models.wan.wan_causal import (
     WanCausalModel as WanCausalModel, )
+from fastvideo.train.models.wan.wan_promptrl import (
+    WanPromptRLModel as WanPromptRLModel, )

--- a/fastvideo/train/models/wan/wan_promptrl.py
+++ b/fastvideo/train/models/wan/wan_promptrl.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Wan training role extended for PromptRL.
+
+Adds to :class:`~fastvideo.train.models.wan.wan.WanModel`:
+
+* persistent UMT5 text encoder + tokenizer for online prompt encoding
+  (the refiner produces prompts at train time, so preprocessed text
+  embeddings cannot be used),
+* stochastic rollouts: ``num_steps`` flow-matching steps of which the
+  last ``sde_steps`` are stochastic SDE transitions whose states and
+  behavior-policy log probabilities are stored for the joint loss,
+* transition log-probability recomputation under the current adapter
+  and under the adapter-disabled frozen reference policy,
+* video decoding (inherited ``decode_latents``).
+
+The VAE and text encoder stay frozen and persist for the whole run.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from dataclasses import dataclass, field
+from collections.abc import Iterator
+
+import torch
+
+from fastvideo.distributed import get_sp_group, get_world_group
+from fastvideo.forward_context import set_forward_context
+from fastvideo.logger import init_logger
+from fastvideo.pipelines import TrainingBatch
+from fastvideo.train.methods.rl.promptrl.sde import (
+    SDETransition,
+    sde_step_from_model_output,
+    transition_log_prob,
+)
+from fastvideo.train.models.wan.wan import WanModel
+from fastvideo.train.utils.lora import lora_disabled
+from fastvideo.train.utils.moduleloader import (
+    load_module_from_path,
+    make_inference_args,
+)
+from fastvideo.utils import maybe_download_model
+
+logger = init_logger(__name__)
+
+
+@dataclass(slots=True)
+class WanRolloutResult:
+    """Rollout output: final latents + stored stochastic transitions."""
+
+    latents: torch.Tensor  # [B, T, C, H, W] final denoised latents
+    transitions: list[SDETransition] = field(default_factory=list)
+    sigmas: list[float] = field(default_factory=list)
+    timesteps: list[float] = field(default_factory=list)
+
+
+class WanPromptRLModel(WanModel):
+    """Wan per-role model with PromptRL rollout support."""
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def init_preprocessors(self, training_config) -> None:
+        """Load VAE + persistent UMT5; skip the parquet dataloader.
+
+        PromptRL prompts arrive online from the refiner, so the
+        preprocessed-parquet dataloader built by the base class is not
+        applicable here.
+        """
+        self.vae = load_module_from_path(
+            model_path=str(training_config.model_path),
+            module_type="vae",
+            training_config=training_config,
+        )
+        self.world_group = get_world_group()
+        self.sp_group = get_sp_group()
+        self._init_timestep_mechanics()
+        # Rollouts are conditional-only (no CFG); skip the negative
+        # prompt encoding the base class triggers in on_train_start.
+        self.set_requires_negative_conditioning(False)
+        self._load_prompt_text_encoder(training_config)
+
+    def _load_prompt_text_encoder(self, training_config) -> None:
+        from transformers import AutoTokenizer
+
+        from fastvideo.models.loader.component_loader import TextEncoderLoader
+
+        tc = training_config
+        if tc.pipeline_config is None:
+            raise ValueError("WanPromptRLModel requires training_config.pipeline_config "
+                             "for text encoder settings")
+        model_path = maybe_download_model(str(tc.model_path))
+        inference_args = make_inference_args(tc, model_path=model_path)
+        inference_args.text_encoder_cpu_offload = False
+        loader = TextEncoderLoader()
+        self.text_encoder = loader.load(
+            os.path.join(model_path, "text_encoder"),
+            inference_args,
+        ).to(self.device).eval()
+        self.text_encoder.requires_grad_(False)
+        self.text_tokenizer = AutoTokenizer.from_pretrained(os.path.join(model_path, "tokenizer"))
+        self._text_encoder_config = tc.pipeline_config.text_encoder_configs[0]
+        self._postprocess_text = tc.pipeline_config.postprocess_text_funcs[0]
+        preprocess_funcs = getattr(tc.pipeline_config, "preprocess_text_funcs", None)
+        self._preprocess_text = (preprocess_funcs[0] if preprocess_funcs else None)
+        logger.info("Loaded persistent Wan text encoder for online prompt encoding")
+
+    # ------------------------------------------------------------------
+    # Online prompt encoding
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def encode_prompts(self, prompts: list[str]) -> tuple[torch.Tensor, torch.Tensor]:
+        """Encode raw prompts with the persistent UMT5 encoder.
+
+        Returns ``(encoder_hidden_states, encoder_attention_mask)`` in
+        the training dtype on this rank's device.
+        """
+        device = self.device
+        dtype = self._get_training_dtype()
+        tok_kwargs = dict(self._text_encoder_config.tokenizer_kwargs)
+        texts = [self._preprocess_text(p) if self._preprocess_text is not None else p
+                 for p in prompts]
+        with set_forward_context(current_timestep=0, attn_metadata=None):
+            text_inputs = self.text_tokenizer(texts, **tok_kwargs).to(device)
+            outputs = self.text_encoder(
+                input_ids=text_inputs.input_ids,
+                attention_mask=text_inputs.attention_mask,
+            )
+            outputs.attention_mask = text_inputs["attention_mask"]
+            embeds = self._postprocess_text(outputs).to(device=device, dtype=dtype)
+            mask = text_inputs["attention_mask"].to(device=device, dtype=dtype)
+        return embeds, mask
+
+    # ------------------------------------------------------------------
+    # Rollout batch
+    # ------------------------------------------------------------------
+
+    def latent_shape(self, batch_size: int) -> tuple[int, int, int, int, int]:
+        """``[B, T, C, H, W]`` latent shape from the training config."""
+        tc = self.training_config
+        assert tc is not None
+        vae_config = tc.pipeline_config.vae_config.arch_config  # type: ignore[union-attr]
+        return (
+            int(batch_size),
+            int(tc.data.num_latent_t),
+            int(vae_config.z_dim),
+            int(tc.data.num_height) // int(vae_config.spatial_compression_ratio),
+            int(tc.data.num_width) // int(vae_config.spatial_compression_ratio),
+        )
+
+    def build_rollout_batch(
+        self,
+        encoder_hidden_states: torch.Tensor,
+        encoder_attention_mask: torch.Tensor,
+        *,
+        latent_shape: tuple[int, ...],
+    ) -> TrainingBatch:
+        """Minimal TrainingBatch for rollout/recompute forwards."""
+        batch = TrainingBatch()
+        batch.conditional_dict = {
+            "encoder_hidden_states": encoder_hidden_states,
+            "encoder_attention_mask": encoder_attention_mask,
+        }
+        # raw_latent_shape follows the [B, C, T, H, W] convention used
+        # by _prepare_dit_inputs before its permutation.
+        batch.raw_latent_shape = (latent_shape[0], latent_shape[2], latent_shape[1],
+                                  latent_shape[3], latent_shape[4])
+        batch.timesteps = torch.zeros(latent_shape[0], device=self.device)
+        batch = self._build_attention_metadata(batch)
+        return batch
+
+    # ------------------------------------------------------------------
+    # Adapter-disabled reference context
+    # ------------------------------------------------------------------
+
+    @contextlib.contextmanager
+    def adapter_disabled(self) -> Iterator[None]:
+        """Disable the Wan LoRA adapter (frozen reference policy)."""
+        with lora_disabled(self.transformer):
+            yield
+
+
+    # ------------------------------------------------------------------
+    # Stochastic rollouts
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def rollout(
+        self,
+        batch: TrainingBatch,
+        *,
+        batch_size: int = 1,
+        generator: torch.Generator | None = None,
+        num_steps: int = 20,
+        sde_steps: int = 8,
+        noise_scale: float = 0.8,
+        flow_shift: float | None = None,
+        store_transitions: bool = True,
+    ) -> WanRolloutResult:
+        """Denoise a fresh noise sample with an ODE/SDE hybrid schedule.
+
+        Steps are deterministic Euler except the last ``sde_steps``,
+        which take stochastic SDE transitions.  When
+        ``store_transitions`` is set (joint mode), the stochastic
+        transitions' states and behavior-policy log probs are kept for
+        the flow-policy loss; prompt-only mode skips storage entirely.
+        """
+        import copy
+
+        from fastvideo.models.schedulers.scheduling_flow_match_euler_discrete import (
+            FlowMatchEulerDiscreteScheduler, )
+
+        device = self.device
+        dtype = self._get_training_dtype()
+        shape = self.latent_shape(batch_size)
+        scheduler = copy.deepcopy(self.noise_scheduler)
+        if flow_shift is not None:
+            scheduler = FlowMatchEulerDiscreteScheduler(shift=float(flow_shift))
+        scheduler.set_timesteps(num_inference_steps=int(num_steps), device=device)
+        sigmas = scheduler.sigmas
+        timesteps = scheduler.timesteps
+        sigma_max = float(sigmas[1]) if sigmas.numel() > 1 else float(sigmas[0])
+
+        current = torch.randn(shape, device=device, dtype=dtype, generator=generator)
+        transitions: list[SDETransition] = []
+        sde_start = int(num_steps) - int(sde_steps)
+        for step_idx in range(int(num_steps)):
+            sigma = float(sigmas[step_idx])
+            sigma_next = float(sigmas[step_idx + 1])
+            timestep = timesteps[step_idx].reshape(1).to(device).expand(shape[0])
+            batch.timesteps = timestep
+            model_output = self.predict_noise(
+                current,
+                timestep,
+                batch,
+                conditional=True,
+                attn_kind="dense",
+            )
+            stochastic = store_transitions and step_idx >= sde_start
+            if stochastic:
+                prev_sample, log_prob, _ = sde_step_from_model_output(
+                    model_output,
+                    current,
+                    sigma=sigma,
+                    sigma_next=sigma_next,
+                    noise_scale=noise_scale,
+                    sigma_max=sigma_max,
+                    generator=generator,
+                )
+                transitions.append(
+                    SDETransition(
+                        sample=current.detach().clone(),
+                        prev_sample=prev_sample.detach().clone(),
+                        timestep=float(timesteps[step_idx]),
+                        sigma=sigma,
+                        sigma_next=sigma_next,
+                        old_log_prob=log_prob.detach(),
+                    ))
+                current = prev_sample.to(dtype)
+            else:
+                current = (current.float() +
+                           (sigma_next - sigma) * model_output.float()).to(dtype)
+
+        return WanRolloutResult(
+            latents=current.detach(),
+            transitions=transitions,
+            sigmas=[float(s) for s in sigmas],
+            timesteps=[float(t) for t in timesteps],
+        )
+
+    # ------------------------------------------------------------------
+    # Transition log-probability recomputation
+    # ------------------------------------------------------------------
+
+    def transition_logprobs(
+        self,
+        transitions: list[SDETransition],
+        batch: TrainingBatch,
+        *,
+        noise_scale: float,
+        sigma_max: float,
+        use_adapter: bool = True,
+        requires_grad: bool = False,
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        """Recompute per-transition ``(log_prob, prev_mean)``.
+
+        ``use_adapter=False`` evaluates the frozen reference policy via
+        the adapter-disabled context; ``requires_grad=True`` keeps the
+        computation differentiable for the flow-policy loss.
+        """
+        adapter_context = (contextlib.nullcontext() if use_adapter else self.adapter_disabled())
+        grad_context = torch.enable_grad() if requires_grad else torch.no_grad()
+        results: list[tuple[torch.Tensor, torch.Tensor]] = []
+        with adapter_context, grad_context:
+            for transition in transitions:
+                timestep = torch.full(
+                    (transition.sample.shape[0], ),
+                    float(transition.timestep),
+                    device=self.device,
+                )
+                batch.timesteps = timestep
+                model_output = self.predict_noise(
+                    transition.sample,
+                    timestep,
+                    batch,
+                    conditional=True,
+                    attn_kind="dense",
+                )
+                log_prob, prev_mean = transition_log_prob(
+                    model_output,
+                    transition.sample,
+                    transition.prev_sample,
+                    sigma=transition.sigma,
+                    sigma_next=transition.sigma_next,
+                    noise_scale=noise_scale,
+                    sigma_max=sigma_max,
+                )
+                results.append((log_prob, prev_mean))
+        return results

--- a/fastvideo/train/roles/__init__.py
+++ b/fastvideo/train/roles/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Training-role abstractions and non-diffusion role implementations."""
+
+from fastvideo.train.roles.base import TrainRoleBase
+
+__all__ = ["QwenPromptRefinerRole", "TrainRoleBase"]
+
+
+def __getattr__(name: str):
+    # Lazy: importing the Qwen role pulls in transformers/peft.
+    if name == "QwenPromptRefinerRole":
+        from fastvideo.train.roles.qwen_refiner import QwenPromptRefinerRole
+
+        return QwenPromptRefinerRole
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/fastvideo/train/roles/base.py
+++ b/fastvideo/train/roles/base.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Lightweight training-role abstraction.
+
+``TrainRoleBase`` is the minimal contract every training role must
+satisfy, whether the role wraps a diffusion transformer
+(:class:`~fastvideo.train.models.base.ModelBase`) or a non-diffusion
+model such as a language model prompt refiner.
+
+A role owns:
+
+* its checkpoint-visible modules (``checkpoint_modules``),
+* its trainable parameter set (``trainable_parameters``),
+* lifecycle hooks (``init_preprocessors``, ``on_train_start``),
+* device metadata (``device``).
+
+The builder, checkpointing, gradient clipping, and optimizer plumbing
+all operate on this interface so non-diffusion roles can participate in
+training without pretending to be a diffusion ``ModelBase``.
+"""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import TYPE_CHECKING
+
+import torch
+
+from fastvideo.distributed import get_local_torch_device
+
+if TYPE_CHECKING:
+    from fastvideo.train.utils.training_config import TrainingConfig
+
+
+class TrainRoleBase(ABC):
+    """Minimal per-role training interface.
+
+    Subclasses must set ``_trainable`` and expose the modules that
+    should be visible to DCP checkpointing and FSDP wrapping through
+    :meth:`checkpoint_modules`.
+    """
+
+    _trainable: bool
+
+    # ------------------------------------------------------------------
+    # Device metadata
+    # ------------------------------------------------------------------
+
+    @property
+    def device(self) -> torch.device:
+        """The local training device for this rank."""
+        return get_local_torch_device()
+
+    # ------------------------------------------------------------------
+    # Checkpoint / optimizer plumbing
+    # ------------------------------------------------------------------
+
+    def checkpoint_modules(self) -> dict[str, torch.nn.Module]:
+        """Modules owned by this role, keyed by a stable module name.
+
+        The keys appear in DCP checkpoints as ``roles.<role>.<name>`` and
+        in the method's ``role_modules`` ModuleDict used for FSDP
+        wrapping.  Return an empty dict for roles that hold no modules.
+        """
+        return {}
+
+    def trainable_parameters(self) -> list[torch.nn.Parameter]:
+        """Parameters the role's optimizer should update."""
+        params: list[torch.nn.Parameter] = []
+        for module in self.checkpoint_modules().values():
+            params.extend(p for p in module.parameters() if p.requires_grad)
+        return params
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+
+    def init_preprocessors(  # noqa: B027
+        self,
+        training_config: TrainingConfig,
+    ) -> None:
+        """Load heavyweight resources (VAE, text encoders, dataloaders).
+
+        Called only on roles the method designates as resource-owning.
+        Default is a no-op.
+        """
+
+    def on_train_start(self) -> None:  # noqa: B027
+        """Hook fired once before the first training step."""

--- a/fastvideo/train/roles/qwen_refiner.py
+++ b/fastvideo/train/roles/qwen_refiner.py
@@ -1,0 +1,431 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen prompt-refiner training role for PromptRL.
+
+Wraps ``Qwen/Qwen2.5-VL-3B-Instruct`` (or any compatible causal LM via
+``model_kind="causal_lm"`` for tests) as a non-diffusion
+:class:`~fastvideo.train.roles.base.TrainRoleBase`:
+
+* the base model and vision tower stay frozen,
+* a PEFT LoRA adapter on ``q_proj``/``k_proj``/``v_proj``/``o_proj`` is
+  the only trainable surface,
+* the adapter-disabled model doubles as the frozen reference policy,
+  avoiding a duplicate base-model copy,
+* the role is replicated across ranks; LoRA gradients are synchronized
+  with an optional DDP wrapper (``maybe_wrap_ddp``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Literal
+from collections.abc import Iterator
+
+import torch
+
+from fastvideo.logger import init_logger
+from fastvideo.train.roles.base import TrainRoleBase
+from fastvideo.train.utils.lora import LoraConfig
+
+logger = init_logger(__name__)
+
+REFINER_LORA_TARGET_MODULES = ["q_proj", "k_proj", "v_proj", "o_proj"]
+
+ModelKind = Literal["vlm", "causal_lm"]
+
+
+class QwenPromptRefinerRole(TrainRoleBase):
+    """Language-model role that rewrites prompts for Wan generation."""
+
+    def __init__(
+        self,
+        *,
+        init_from: str,
+        training_config: Any = None,
+        trainable: bool = True,
+        lora: LoraConfig | dict[str, Any] | None = None,
+        model_kind: ModelKind = "vlm",
+        torch_dtype: str = "bfloat16",
+        attn_implementation: str = "sdpa",
+        max_prompt_tokens: int = 1024,
+        init_adapter_from: str | None = None,
+        model: torch.nn.Module | None = None,
+        tokenizer: Any = None,
+        device: str | torch.device | None = None,
+    ) -> None:
+        self._trainable = bool(trainable)
+        self._init_from = str(init_from)
+        self._lora_config = LoraConfig.coerce(lora)
+        self._model_kind = model_kind
+        self._torch_dtype = torch_dtype
+        self._attn_implementation = attn_implementation
+        self._max_prompt_tokens = int(max_prompt_tokens)
+        self._device_override = device
+        self._ddp_model: torch.nn.Module | None = None
+
+        if model is None:
+            model = self._load_model()
+        if tokenizer is None:
+            tokenizer = self._load_tokenizer()
+        self.model = model
+        self.tokenizer = tokenizer
+        self._freeze_base()
+        if self._trainable:
+            self._enable_lora()
+        if init_adapter_from is not None:
+            # Milestone handoff: joint training starts from the
+            # prompt-only refiner checkpoint (Wan's LoRA stays at its
+            # zero initialization).
+            self.load_adapter(init_adapter_from)
+        self.model.to(self.device)
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+
+    def _load_model(self) -> torch.nn.Module:
+        import transformers
+
+        dtype = getattr(torch, self._torch_dtype)
+        if self._model_kind == "vlm":
+            model_cls = getattr(transformers, "Qwen2_5_VLForConditionalGeneration", None)
+            if model_cls is None:
+                raise ImportError("transformers does not provide "
+                                  "Qwen2_5_VLForConditionalGeneration")
+        else:
+            model_cls = transformers.AutoModelForCausalLM
+        logger.info("Loading prompt refiner %s (kind=%s)", self._init_from, self._model_kind)
+        return model_cls.from_pretrained(
+            self._init_from,
+            torch_dtype=dtype,
+            attn_implementation=self._attn_implementation,
+        )
+
+    def _load_tokenizer(self) -> Any:
+        from transformers import AutoTokenizer
+
+        return AutoTokenizer.from_pretrained(self._init_from)
+
+
+    # ------------------------------------------------------------------
+    # TrainRoleBase plumbing
+    # ------------------------------------------------------------------
+
+    @property
+    def device(self) -> torch.device:
+        if self._device_override is not None:
+            return torch.device(self._device_override)
+        return super().device
+
+    def checkpoint_modules(self) -> dict[str, torch.nn.Module]:
+        return {"model": self.model}
+
+    def trainable_parameters(self) -> list[torch.nn.Parameter]:
+        return [p for p in self.model.parameters() if p.requires_grad]
+
+    def on_train_start(self) -> None:
+        self.maybe_wrap_ddp()
+
+    # ------------------------------------------------------------------
+    # Freezing + LoRA
+    # ------------------------------------------------------------------
+
+    def _freeze_base(self) -> None:
+        self.model.requires_grad_(False)
+        # Vision tower stays frozen explicitly (it never receives LoRA).
+        for attr in ("visual", "vision_tower", "vision_model"):
+            tower = getattr(self.model, attr, None)
+            if tower is not None:
+                tower.requires_grad_(False)
+        self.model.eval()
+
+    def _enable_lora(self) -> None:
+        cfg = self._lora_config
+        if cfg is None or not cfg.enable:
+            raise ValueError("QwenPromptRefinerRole requires lora.enable=true with "
+                             "an explicit rank (refiner training is LoRA-only)")
+        from peft import LoraConfig as PeftLoraConfig
+        from peft import get_peft_model
+
+        target_modules = list(cfg.target_modules or REFINER_LORA_TARGET_MODULES)
+        peft_config = PeftLoraConfig(
+            r=int(cfg.rank),  # type: ignore[arg-type]
+            lora_alpha=int(cfg.alpha) if cfg.alpha is not None else int(cfg.rank),  # type: ignore[arg-type]
+            target_modules=target_modules,
+            lora_dropout=0.0,
+            bias="none",
+            task_type="CAUSAL_LM",
+        )
+        self.model = get_peft_model(self.model, peft_config)
+        # Frozen base + frozen vision tower: verify only LoRA trains.
+        trainable = [(n, p.numel()) for n, p in self.model.named_parameters() if p.requires_grad]
+        if not trainable:
+            raise ValueError("Refiner LoRA produced no trainable parameters")
+        non_lora = [n for n, _ in trainable if "lora_" not in n]
+        if non_lora:
+            raise RuntimeError(f"Non-LoRA refiner parameters are trainable: {non_lora[:5]}")
+        logger.info("Refiner LoRA enabled on %d modules (%d trainable params)",
+                    len(trainable), sum(n for _, n in trainable))
+
+    # ------------------------------------------------------------------
+    # Adapter (reference policy) contexts
+    # ------------------------------------------------------------------
+
+    @contextlib.contextmanager
+    def adapter_disabled(self) -> Iterator[None]:
+        """Temporarily disable the LoRA adapter (frozen reference policy)."""
+        disabled = False
+        try:
+            self.model.disable_adapter_layers()
+            disabled = True
+        except AttributeError:
+            pass
+        try:
+            yield
+        finally:
+            if disabled:
+                self.model.enable_adapter_layers()
+
+    def maybe_wrap_ddp(self) -> None:
+        """Wrap the model in DDP for synchronized LoRA gradients.
+
+        No-op when distributed training is inactive, when already
+        wrapped, or on non-CUDA devices (single-process tests).
+        """
+        import torch.distributed as dist
+        from torch.nn.parallel import DistributedDataParallel
+
+        if self._ddp_model is not None:
+            return
+        if not (dist.is_available() and dist.is_initialized()):
+            return
+        if dist.get_world_size() <= 1:
+            return
+        if self.device.type != "cuda":
+            logger.warning("Refiner DDP wrap skipped on non-CUDA device %s", self.device)
+            return
+        # DDP broadcasts parameters from rank 0 at construction, which
+        # also aligns PEFT's RNG-dependent LoRA init across ranks.
+        self._ddp_model = DistributedDataParallel(
+            self.model,
+            device_ids=[self.device.index],
+            output_device=self.device.index,
+            broadcast_buffers=False,
+            find_unused_parameters=False,
+        )
+        logger.info("Wrapped prompt refiner in DDP (rank %d)", dist.get_rank())
+
+    def _forward_model(self) -> torch.nn.Module:
+        return self._ddp_model if self._ddp_model is not None else self.model
+
+    # ------------------------------------------------------------------
+    # Prompt rendering + generation
+    # ------------------------------------------------------------------
+
+    def render_chat(self, instruction: str) -> str:
+        """Render the refiner chat template for one instruction."""
+        messages = [{"role": "user", "content": instruction}]
+        apply_template = getattr(self.tokenizer, "apply_chat_template", None)
+        if callable(apply_template):
+            return str(
+                apply_template(messages, tokenize=False, add_generation_prompt=True))
+        return instruction + "\n"
+
+    @torch.no_grad()
+    def generate_refinements(
+        self,
+        prompts: list[str],
+        *,
+        instructions: list[str] | None = None,
+        max_new_tokens: int = 256,
+        temperature: float = 1.0,
+        top_p: float = 1.0,
+        seed: int | None = None,
+    ) -> list[str]:
+        """Sample one completion per prompt from the current adapter."""
+        if instructions is None:
+            instructions = prompts
+        was_training = self.model.training
+        ddp_model = self._ddp_model
+        was_ddp_training = ddp_model.training if ddp_model is not None else None
+        self.model.eval()
+        if ddp_model is not None:
+            ddp_model.eval()
+        try:
+            rendered = [self.render_chat(text) for text in instructions]
+            encoded = self.tokenizer(
+                rendered,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+                max_length=self._max_prompt_tokens,
+            ).to(self.device)
+            # transformers>=5 dropped the ``generator`` kwarg from
+            # generate(); fork the global RNG for a seeded sample
+            # instead (device-independent across torch versions).
+            if seed is None:
+                rng_context = contextlib.nullcontext()
+            elif self.device.type == "cuda":
+                rng_context = torch.random.fork_rng(devices=[self.device])
+            else:
+                rng_context = torch.random.fork_rng(devices=[])
+            with rng_context:
+                if seed is not None:
+                    torch.manual_seed(int(seed))
+                    if self.device.type == "cuda":
+                        torch.cuda.manual_seed_all(int(seed))
+                output = self.model.generate(
+                    **encoded,
+                    max_new_tokens=int(max_new_tokens),
+                    do_sample=True,
+                    temperature=float(temperature),
+                    top_p=float(top_p),
+                    pad_token_id=self._pad_token_id(),
+                )
+            prompt_length = int(encoded["input_ids"].shape[1])
+            completions = output[:, prompt_length:]
+            return self.tokenizer.batch_decode(completions, skip_special_tokens=True)
+        finally:
+            if ddp_model is not None and was_ddp_training is not None:
+                ddp_model.train(was_ddp_training)
+            self.model.train(was_training)
+
+    # ------------------------------------------------------------------
+    # Sequence log probabilities
+    # ------------------------------------------------------------------
+
+    def sequence_logprobs(
+        self,
+        prompts: list[str],
+        completions: list[str],
+        *,
+        use_adapter: bool = True,
+        requires_grad: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Summed completion log probs per sample.
+
+        Returns ``(sum_logprobs, token_counts)``, each shape ``[B]``.
+        ``use_adapter=False`` evaluates the frozen reference policy via
+        the adapter-disabled context.  With ``requires_grad=True`` the
+        log probs keep gradients for the GRPO loss.
+        """
+        token_logprobs, mask = self.token_logprobs(
+            prompts,
+            completions,
+            use_adapter=use_adapter,
+            requires_grad=requires_grad,
+        )
+        summed = (token_logprobs * mask).sum(dim=-1)
+        counts = mask.sum(dim=-1)
+        return summed, counts
+
+    def token_logprobs(
+        self,
+        prompts: list[str],
+        completions: list[str],
+        *,
+        use_adapter: bool = True,
+        requires_grad: bool = False,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Per-token completion log probs.
+
+        Returns ``(token_logprobs, mask)`` of shapes ``[B, L]`` where
+        padded positions have mask 0 and log prob 0.
+        """
+        if len(prompts) != len(completions):
+            raise ValueError(f"prompts ({len(prompts)}) and completions "
+                             f"({len(completions)}) length mismatch")
+        rendered = [self.render_chat(p) for p in prompts]
+        prompt_ids = self.tokenizer(
+            rendered,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=self._max_prompt_tokens,
+        )["input_ids"]
+        completion_ids = self.tokenizer(
+            completions,
+            add_special_tokens=False,
+            return_tensors="pt",
+            padding=True,
+        )["input_ids"]
+
+        batch_size = len(prompts)
+        input_rows: list[torch.Tensor] = []
+        label_rows: list[torch.Tensor] = []
+        for row in range(batch_size):
+            p_ids = prompt_ids[row][prompt_ids[row] != self._pad_token_id()]
+            c_ids = completion_ids[row][completion_ids[row] != self._pad_token_id()]
+            input_rows.append(torch.cat([p_ids, c_ids], dim=0))
+            labels = torch.full_like(input_rows[-1], -100)
+            labels[p_ids.shape[0]:] = c_ids
+            label_rows.append(labels)
+
+        max_len = max(row.shape[0] for row in input_rows)
+        pad_id = self._pad_token_id()
+        input_ids = torch.full((batch_size, max_len), pad_id, dtype=torch.long)
+        labels = torch.full((batch_size, max_len), -100, dtype=torch.long)
+        attention_mask = torch.zeros((batch_size, max_len), dtype=torch.long)
+        for row in range(batch_size):
+            length = input_rows[row].shape[0]
+            input_ids[row, :length] = input_rows[row]
+            labels[row, :length] = label_rows[row]
+            attention_mask[row, :length] = 1
+        device = self.device
+        input_ids = input_ids.to(device)
+        labels = labels.to(device)
+        attention_mask = attention_mask.to(device)
+
+        context = (contextlib.nullcontext() if use_adapter else self.adapter_disabled())
+        grad_context = (torch.enable_grad() if requires_grad else torch.no_grad())
+        # Reference passes run on the raw model (no DDP reducer needed
+        # under no_grad); current-policy passes go through DDP when
+        # wrapped so LoRA gradients stay synchronized.
+        forward_model = self._forward_model() if use_adapter else self.model
+        with context, grad_context:
+            logits = forward_model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+            ).logits
+            shift_logits = logits[:, :-1, :].float()
+            shift_labels = labels[:, 1:]
+            logprobs = torch.log_softmax(shift_logits, dim=-1)
+            token_logprobs = logprobs.gather(
+                dim=-1, index=shift_labels.clamp_min(0).unsqueeze(-1)).squeeze(-1)
+            mask = (shift_labels != -100).to(token_logprobs.dtype)
+            token_logprobs = token_logprobs * mask
+        return token_logprobs, mask
+
+
+    def _pad_token_id(self) -> int:
+        pad_id = self.tokenizer.pad_token_id
+        if pad_id is None:
+            pad_id = self.tokenizer.eos_token_id
+        if pad_id is None:
+            raise ValueError("Refiner tokenizer needs a pad or eos token")
+        return int(pad_id)
+
+    # ------------------------------------------------------------------
+    # Adapter export
+    # ------------------------------------------------------------------
+
+    def save_adapter(self, output_dir: str) -> None:
+        """Save the PEFT adapter (adapter_model.safetensors + config)."""
+        import os
+
+        os.makedirs(output_dir, exist_ok=True)
+        self.model.save_pretrained(output_dir)
+        logger.info("Saved refiner adapter to %s", output_dir)
+
+    def load_adapter(self, adapter_dir: str) -> None:
+        """Load adapter weights from a PEFT directory into this role."""
+        import os
+
+        from peft import set_peft_model_state_dict
+        from safetensors.torch import load_file
+
+        weights_path = os.path.join(adapter_dir, "adapter_model.safetensors")
+        if not os.path.isfile(weights_path):
+            raise FileNotFoundError(f"No adapter_model.safetensors in {adapter_dir}")
+        set_peft_model_state_dict(self.model, load_file(weights_path))
+        self.model.to(self.device)
+        logger.info("Loaded refiner adapter from %s", adapter_dir)

--- a/fastvideo/train/utils/builder.py
+++ b/fastvideo/train/utils/builder.py
@@ -25,15 +25,15 @@ def build_from_config(cfg: RunConfig, ) -> tuple[TrainingConfig, TrainingMethod,
        and construct it with ``(cfg=cfg, role_models=...)``.
     3. Return ``(training_args, method, dataloader, start_step)``.
     """
-    from fastvideo.train.models.base import ModelBase
+    from fastvideo.train.roles.base import TrainRoleBase
 
     # --- 1. Build role model instances ---
-    role_models: dict[str, ModelBase] = {}
+    role_models: dict[str, TrainRoleBase] = {}
     for role, model_cfg in cfg.models.items():
         model = instantiate(model_cfg, training_config=cfg.training)
-        if not isinstance(model, ModelBase):
+        if not isinstance(model, TrainRoleBase):
             raise TypeError(f"models.{role}._target_ must resolve to a "
-                            f"ModelBase subclass, got {type(model).__name__}")
+                            f"TrainRoleBase subclass, got {type(model).__name__}")
         role_models[role] = model
 
     # --- 2. Build method ---

--- a/fastvideo/train/utils/lora.py
+++ b/fastvideo/train/utils/lora.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import contextlib
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -252,3 +253,22 @@ def enable_lora_training(
         len(replacements),
     )
     return len(replacements)
+
+
+@contextlib.contextmanager
+def lora_disabled(module: torch.nn.Module) -> Iterator[None]:
+    """Temporarily disable every LoRA layer under *module*.
+
+    The adapter-disabled model acts as the frozen reference policy (used
+    by PromptRL's KL terms) without keeping a duplicate base-model copy.
+    The flag is restored on exit, including on exceptions.
+    """
+    layers = [m for m in module.modules() if isinstance(m, BaseLayerWithLoRA)]
+    previous = [m.disable_lora for m in layers]
+    try:
+        for layer in layers:
+            layer.disable_lora = True
+        yield
+    finally:
+        for layer, flag in zip(layers, previous, strict=False):
+            layer.disable_lora = flag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,6 +176,14 @@ prompt-safety = [
     "fasttext",
 ]
 
+# PromptRL prompt-refinement RL training: the refiner role uses
+# qwen-vl-utils for Qwen2.5-VL media handling, and the VideoScore2
+# reward service needs python-multipart for multipart video uploads.
+promptrl = [
+    "qwen-vl-utils",
+    "python-multipart",
+]
+
 prompt-enhancer = [
     "httpx",
 ]

--- a/tests/local_tests/promptrl_ddp_smoke.py
+++ b/tests/local_tests/promptrl_ddp_smoke.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Two-GPU PromptRL refiner DDP smoke test.
+
+Run with:
+
+    torchrun --standalone --nproc-per-node=2 \
+        -m tests.local_tests.promptrl_ddp_smoke
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import torch
+import torch.distributed as dist
+
+from fastvideo.distributed import (
+    cleanup_dist_env_and_memory,
+    maybe_init_distributed_environment_and_model_parallel,
+)
+from fastvideo.train.methods.rl.promptrl.method import PromptRLMethod
+from fastvideo.train.roles.qwen_refiner import QwenPromptRefinerRole
+from fastvideo.train.utils.training_config import (
+    DataConfig,
+    DistributedConfig,
+    TrainingConfig,
+    TrainingLoopConfig,
+)
+from tests.local_tests.promptrl_fixtures import (
+    FakeWanStudent,
+    build_tiny_model,
+    build_tiny_tokenizer,
+)
+
+
+def _build_method(local_rank: int) -> PromptRLMethod:
+    tokenizer = build_tiny_tokenizer()
+    model = build_tiny_model(len(tokenizer), seed=1234)
+    refiner = QwenPromptRefinerRole(
+        init_from="tiny-local",
+        trainable=True,
+        lora={"enable": True, "rank": 4, "alpha": 8},
+        model_kind="causal_lm",
+        torch_dtype="float32",
+        model=model,
+        tokenizer=tokenizer,
+        device=f"cuda:{local_rank}",
+    )
+    cfg = SimpleNamespace(
+        training=TrainingConfig(
+            distributed=DistributedConfig(sp_size=1),
+            data=DataConfig(seed=42),
+            loop=TrainingLoopConfig(max_train_steps=1),
+        ),
+        method={
+            "mode": "prompt_only",
+            "group_size": 2,
+            "retained_originals": 1,
+            "refiner_optimizer": {
+                "learning_rate": 1e-3,
+                "weight_decay": 0.0,
+            },
+            "generator_optimizer": {
+                "learning_rate": 1e-3,
+                "weight_decay": 0.0,
+            },
+        },
+        validation={},
+    )
+    return PromptRLMethod(
+        cfg=cfg,
+        role_models={
+            "student": FakeWanStudent(),
+            "refiner": refiner,
+        },
+    )
+
+
+def main() -> None:
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    maybe_init_distributed_environment_and_model_parallel(
+        tp_size=1,
+        sp_size=1,
+    )
+    try:
+        method = _build_method(local_rank)
+        method.on_train_start()
+        assert method.refiner._ddp_model is not None
+
+        logprobs, _ = method.refiner.sequence_logprobs(
+            ["a cat"],
+            ["<answer> cinematic cat </answer>"],
+            requires_grad=True,
+        )
+        (-logprobs.mean()).backward()
+        gradients = [
+            parameter.grad
+            for parameter in method.refiner.trainable_parameters()
+            if parameter.grad is not None and parameter.grad.abs().sum() > 0
+        ]
+        assert gradients
+        gradient = gradients[0]
+        assert torch.isfinite(gradient).all()
+        gathered = [torch.empty_like(gradient) for _ in range(dist.get_world_size())]
+        dist.all_gather(gathered, gradient)
+        assert all(
+            torch.allclose(gathered[0], candidate, atol=1e-6, rtol=1e-5)
+            for candidate in gathered[1:]
+        )
+        if dist.get_rank() == 0:
+            print({
+                "world_size": dist.get_world_size(),
+                "ddp_wrapped": True,
+                "gradient_norm": float(gradient.float().norm()),
+            })
+    finally:
+        cleanup_dist_env_and_memory()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/local_tests/promptrl_fixtures.py
+++ b/tests/local_tests/promptrl_fixtures.py
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for PromptRL tests: tiny refiner + fake Wan student."""
+
+from __future__ import annotations
+
+import contextlib
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+from fastvideo.train.methods.rl.promptrl.rewards import RewardResult
+from fastvideo.train.methods.rl.promptrl.sde import (
+    SDETransition,
+    sde_step_from_model_output,
+    transition_log_prob,
+)
+from fastvideo.train.roles.base import TrainRoleBase
+from fastvideo.train.roles.qwen_refiner import QwenPromptRefinerRole
+
+
+def build_tiny_tokenizer():
+    from tokenizers import Tokenizer, models, pre_tokenizers
+
+    vocab = {"[PAD]": 0, "[UNK]": 1, "<eos>": 2}
+    words = (
+        ["You", "are", "an", "expert", "prompt", "engineer", "Rewrite", "the", "user", "'s", "to", "be", "more", "detailed", "cinematic", "and", "visually", "grounded", "while", "preserving", "its", "meaning", "Respond", "with", "rewritten", "inside", "<answer>", "</answer>", "tags", "only", ".", "a", "cat", "dog", "runs", "fast", "slow", "cinematic", "lighting", "red", "ball", "jumps", "over", "fence"])
+    vocab.update({w: i + 3 for i, w in enumerate(words)})
+    tokenizer = Tokenizer(models.WordLevel(vocab=vocab, unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = pre_tokenizers.WhitespaceSplit()
+    from transformers import PreTrainedTokenizerFast
+
+    fast = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+        eos_token="<eos>",
+    )
+    fast.chat_template = (
+        "{% for message in messages %}{{ message['content'] }}{% endfor %}")
+    return fast
+
+
+def build_tiny_model(vocab_size: int, *, seed: int = 1234):
+    from transformers import Qwen2Config, Qwen2ForCausalLM
+
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(seed)
+        config = Qwen2Config(
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            vocab_size=vocab_size,
+            max_position_embeddings=256,
+        )
+        model = Qwen2ForCausalLM(config)
+    model.generation_config.pad_token_id = 0
+    model.generation_config.eos_token_id = 2
+    return model
+
+
+def build_tiny_refiner(*, trainable: bool = True, seed: int = 1234) -> QwenPromptRefinerRole:
+    tokenizer = build_tiny_tokenizer()
+    model = build_tiny_model(len(tokenizer), seed=seed)
+    return QwenPromptRefinerRole(
+        init_from="tiny-local",
+        trainable=trainable,
+        lora={"enable": True, "rank": 4, "alpha": 8},
+        model_kind="causal_lm",
+        torch_dtype="float32",
+        model=model,
+        tokenizer=tokenizer,
+        device="cpu",
+    )
+
+
+class TinyVelocityNet(torch.nn.Module):
+    """Frozen base linear + trainable LoRA-style delta on the channel dim."""
+
+    def __init__(self, channels: int, *, seed: int = 99):
+        super().__init__()
+        with torch.random.fork_rng(devices=[]):
+            torch.manual_seed(seed)
+            self.base = torch.nn.Linear(channels, channels)
+        self.base.requires_grad_(False)
+        self.lora_a = torch.nn.Parameter(torch.zeros(channels, channels))
+        self.lora_b = torch.nn.Parameter(torch.zeros(channels, channels))
+        with torch.random.fork_rng(devices=[]):
+            torch.manual_seed(seed + 1)
+            torch.nn.init.kaiming_uniform_(self.lora_a, a=5**0.5)
+        self.delta_enabled = True
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Latents are [B, T, C, H, W]; linears act on the channel dim.
+        moved = x.movedim(2, -1)
+        out = self.base(moved)
+        if self.delta_enabled:
+            out = out + moved @ self.lora_a.T @ self.lora_b.T
+        return out.movedim(-1, 2)
+
+
+class FakeWanStudent(TrainRoleBase):
+    """Duck-typed WanPromptRLModel with a tiny trainable velocity net.
+
+    Latents follow the training convention ``[B, T, C, H, W]``; the
+    velocity net acts on the channel dim.
+    """
+
+    def __init__(self, *, channels: int = 3, latent_t: int = 2, seed: int = 99):
+        self._trainable = True
+        self.channels = channels
+        self.latent_t = latent_t
+        self.transformer = TinyVelocityNet(channels, seed=seed)
+        self.dataloader: Any = None
+        self.encoded_prompts: list[list[str]] = []
+        self._device = torch.device("cpu")
+        self.backward_calls = 0
+
+    # -- TrainRoleBase --
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    def checkpoint_modules(self):
+        return {"transformer": self.transformer}
+
+    def init_preprocessors(self, training_config) -> None:
+        pass
+
+    # -- WanPromptRLModel duck interface --
+
+    def encode_prompts(self, prompts: list[str]):
+        self.encoded_prompts.append(list(prompts))
+        generator = torch.Generator().manual_seed(abs(hash(tuple(prompts))) % (2**31))
+        embeds = torch.randn(len(prompts), 4, 6, generator=generator)
+        mask = torch.ones(len(prompts), 4)
+        return embeds, mask
+
+    def latent_shape(self, batch_size: int):
+        return (int(batch_size), self.latent_t, self.channels, 4, 4)
+
+    def build_rollout_batch(self, embeds, mask, *, latent_shape):
+        return SimpleNamespace(
+            conditional_dict={
+                "encoder_hidden_states": embeds,
+                "encoder_attention_mask": mask,
+            },
+            timesteps=None,
+        )
+
+    def backward(self, loss, ctx, *, grad_accum_rounds):
+        del ctx
+        self.backward_calls += 1
+        (loss / max(1, int(grad_accum_rounds))).backward()
+
+    def predict_noise(self, noisy_latents, timestep, batch, *, conditional, attn_kind="dense"):
+        return self.transformer(noisy_latents.float())
+
+    @contextlib.contextmanager
+    def adapter_disabled(self):
+        previous = self.transformer.delta_enabled
+        self.transformer.delta_enabled = False
+        try:
+            yield
+        finally:
+            self.transformer.delta_enabled = previous
+
+    @torch.no_grad()
+    def rollout(
+        self,
+        batch,
+        *,
+        batch_size=1,
+        generator=None,
+        num_steps=20,
+        sde_steps=8,
+        noise_scale=0.8,
+        flow_shift=None,
+        store_transitions=True,
+    ):
+        shape = self.latent_shape(batch_size)
+        sigmas = torch.linspace(1.0, 0.0, int(num_steps) + 1).tolist()
+        timesteps = [s * 1000.0 for s in sigmas[:-1]]
+        sigma_max = sigmas[1] if len(sigmas) > 1 else sigmas[0]
+        current = torch.randn(shape, generator=generator)
+        transitions: list[SDETransition] = []
+        sde_start = int(num_steps) - int(sde_steps)
+        for step_idx in range(int(num_steps)):
+            model_output = self.predict_noise(current, None, batch, conditional=True)
+            if store_transitions and step_idx >= sde_start:
+                prev, log_prob, _ = sde_step_from_model_output(
+                    model_output,
+                    current,
+                    sigma=sigmas[step_idx],
+                    sigma_next=sigmas[step_idx + 1],
+                    noise_scale=noise_scale,
+                    sigma_max=sigma_max,
+                    generator=generator,
+                )
+                transitions.append(
+                    SDETransition(
+                        sample=current.detach().clone(),
+                        prev_sample=prev.detach().clone(),
+                        timestep=timesteps[step_idx],
+                        sigma=sigmas[step_idx],
+                        sigma_next=sigmas[step_idx + 1],
+                        old_log_prob=log_prob.detach(),
+                    ))
+                current = prev
+            else:
+                current = current + (sigmas[step_idx + 1] - sigmas[step_idx]) * model_output
+        return SimpleNamespace(
+            latents=current.detach(),
+            transitions=transitions,
+            sigmas=sigmas,
+            timesteps=timesteps,
+        )
+
+
+    def transition_logprobs(
+        self,
+        transitions,
+        batch,
+        *,
+        noise_scale,
+        sigma_max,
+        use_adapter=True,
+        requires_grad=False,
+    ):
+        adapter_context = (contextlib.nullcontext() if use_adapter else self.adapter_disabled())
+        grad_context = torch.enable_grad() if requires_grad else torch.no_grad()
+        results = []
+        with adapter_context, grad_context:
+            for transition in transitions:
+                model_output = self.predict_noise(transition.sample, None, batch, conditional=True)
+                log_prob, mean = transition_log_prob(
+                    model_output,
+                    transition.sample,
+                    transition.prev_sample,
+                    sigma=transition.sigma,
+                    sigma_next=transition.sigma_next,
+                    noise_scale=noise_scale,
+                    sigma_max=sigma_max,
+                )
+                results.append((log_prob, mean))
+        return results
+
+    @torch.no_grad()
+    def decode_latents(self, latents):
+        # Fake media [B, C, T, H, W] in [0, 1] with RGB channels.
+        media = torch.sigmoid(latents.float())
+        if media.shape[2] >= 3:
+            return media
+        repeats = (3 + media.shape[2] - 1) // media.shape[2]
+        return media.repeat(1, 1, repeats, 1, 1)[:, :, :3]
+
+
+class FakeRewardProvider:
+    """Deterministic per-slot scores; records scoring prompts."""
+
+    def __init__(self, score_fn=None):
+        self.score_fn = score_fn or (
+            lambda sample: 1.0 + 0.25 * int(sample.sample_id.rsplit("-", 1)[-1]))
+        self.scored: list[tuple[str, str]] = []
+
+    def score(self, samples):
+        results = []
+        for sample in samples:
+            self.scored.append((sample.sample_id, sample.original_prompt))
+            score = float(self.score_fn(sample))
+            results.append(
+                RewardResult(
+                    score=score,
+                    details={
+                        "visual_quality": score,
+                        "text_alignment": score,
+                        "physical_consistency": score,
+                    },
+                    sample_id=sample.sample_id,
+                    request_id=sample.request_id,
+                ))
+        return results

--- a/tests/local_tests/promptrl_real_checkpoint_smoke.py
+++ b/tests/local_tests/promptrl_real_checkpoint_smoke.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One-GPU PromptRL smoke test with the real Wan and Qwen checkpoints.
+
+By default this uses a deterministic local reward judge so the smoke targets
+the complete training path (checkpoint loading, prompt refinement, Wan rollout,
+VAE decode, HTTP reward transport, backward, optimizer step, and bundle
+export). Pass ``--real-videoscore2`` in a two-GPU allocation to put the official
+VideoScore2 judge on the second GPU and validate the complete production path.
+
+Run on a GPU host from the repository root::
+
+    python -m tests.local_tests.promptrl_real_checkpoint_smoke
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+from collections.abc import Sequence
+
+import torch
+
+
+class _DeterministicJudge:
+    """Cheap scorer with non-constant group rewards for GRPO."""
+
+    def score_batch(
+        self,
+        videos: Sequence[bytes],
+        prompts: Sequence[str],
+        *,
+        fps: int,
+    ) -> list[dict[str, float]]:
+        del fps
+        if len(videos) != len(prompts):
+            raise ValueError("video/prompt cardinality mismatch")
+        if any(not video for video in videos):
+            raise ValueError("received an empty encoded video")
+        return [
+            {
+                "composite": float(index + 1),
+                "visual_quality": float(index + 1),
+                "text_alignment": float(index + 1),
+                "physical_consistency": float(index + 1),
+            }
+            for index in range(len(videos))
+        ]
+
+
+def _wait_for_port(port: int, timeout_sec: float = 15.0) -> None:
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        with socket.socket() as sock:
+            sock.settimeout(0.2)
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                return
+        time.sleep(0.05)
+    raise TimeoutError(f"reward service did not listen on port {port}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        default="examples/train/configs/rl/wan/promptrl_prompt_only.yaml",
+    )
+    parser.add_argument("--port", type=int, default=18100)
+    parser.add_argument("--real-videoscore2", action="store_true")
+    parser.add_argument("--judge-model-id", default="TIGER-Lab/VideoScore2")
+    parser.add_argument("--judge-device", default="cuda:1")
+    parser.add_argument(
+        "--mode",
+        choices=("prompt_only", "joint"),
+        default="prompt_only",
+    )
+    parser.add_argument("--work-dir", default="")
+    parser.add_argument("--max-train-steps", type=int, default=1)
+    parser.add_argument("--checkpoint-every", type=int, default=0)
+    parser.add_argument("--resume-from-checkpoint", default="")
+    args = parser.parse_args()
+
+    import uvicorn
+
+    from fastvideo.train.entrypoint.train import run_training_from_config
+    from fastvideo.train.methods.rl.promptrl.rewards.service import (
+        VideoScore2Judge,
+        create_reward_app,
+    )
+
+    judge = (
+        VideoScore2Judge(args.judge_model_id, device=args.judge_device)
+        if args.real_videoscore2
+        else _DeterministicJudge()
+    )
+    server = uvicorn.Server(
+        uvicorn.Config(
+            create_reward_app(judge, max_wait_sec=300.0),
+            host="127.0.0.1",
+            port=args.port,
+            log_level="warning",
+        )
+    )
+    server_thread = threading.Thread(target=server.run, daemon=True)
+    server_thread.start()
+    _wait_for_port(args.port)
+
+    try:
+        work_context = (
+            contextlib.nullcontext(args.work_dir)
+            if args.work_dir
+            else tempfile.TemporaryDirectory(prefix="promptrl_real_smoke_")
+        )
+        with work_context as work_dir:
+            root = Path(work_dir)
+            root.mkdir(parents=True, exist_ok=True)
+            prompts = root / "prompts.jsonl"
+            prompts.write_text(
+                '{"id":"smoke-1","prompt":"a red cube rolling on a table",'
+                '"reward_tag":"smoke"}\n',
+                encoding="utf-8",
+            )
+            output_dir = root / "output"
+            bundle_dir = output_dir / "bundle"
+            reward_timeout = "600" if args.real_videoscore2 else "60"
+            latent_frames = "2" if args.real_videoscore2 else "1"
+            decoded_frames = "5" if args.real_videoscore2 else "1"
+            sde_steps = "1" if args.mode == "joint" else "0"
+            format_reward_weight = "0" if args.mode == "joint" else "1"
+            overrides = [
+                "--method.mode",
+                args.mode,
+                "--method.format_reward_weight",
+                format_reward_weight,
+                "--method.group_size",
+                "2",
+                "--method.retained_originals",
+                "1",
+                "--method.data.data_path",
+                str(prompts),
+                "--method.reward.endpoint_url",
+                f"http://127.0.0.1:{args.port}",
+                "--method.reward.timeout_sec",
+                reward_timeout,
+                "--method.reward.retries",
+                "0",
+                "--method.reward.fps",
+                "4",
+                "--method.rollout.num_steps",
+                "1",
+                "--method.rollout.sde_steps",
+                sde_steps,
+                "--method.refiner.max_new_tokens",
+                "16",
+                "--models.refiner.max_prompt_tokens",
+                "256",
+                "--training.distributed.num_gpus",
+                "1",
+                "--training.distributed.sp_size",
+                "1",
+                "--training.distributed.hsdp_shard_dim",
+                "1",
+                "--training.data.num_latent_t",
+                latent_frames,
+                "--training.data.num_height",
+                "64",
+                "--training.data.num_width",
+                "64",
+                "--training.data.num_frames",
+                decoded_frames,
+                "--training.dit_precision",
+                "bf16",
+                "--training.loop.max_train_steps",
+                str(args.max_train_steps),
+                "--training.checkpoint.output_dir",
+                str(output_dir),
+                "--training.checkpoint.training_state_checkpointing_steps",
+                str(args.checkpoint_every),
+                "--training.tracker.trackers",
+                "[none]",
+                "--method.validation.every_steps",
+                "0",
+                "--callbacks.promptrl_export.output_dir",
+                str(bundle_dir),
+            ]
+            if args.resume_from_checkpoint:
+                overrides.extend([
+                    "--training.checkpoint.resume_from_checkpoint",
+                    args.resume_from_checkpoint,
+                ])
+            run_training_from_config(args.config, overrides=overrides)
+
+            manifest = bundle_dir / "manifest.json"
+            if not manifest.is_file():
+                raise RuntimeError("PromptRL training completed without bundle export")
+            if args.mode == "joint":
+                from safetensors.torch import load_file
+
+                generator_lora = (
+                    bundle_dir
+                    / "generator"
+                    / "promptrl_generator_lora.safetensors"
+                )
+                if not generator_lora.is_file():
+                    raise RuntimeError(
+                        "joint PromptRL smoke did not export generator LoRA"
+                    )
+                state = load_file(str(generator_lora))
+                lora_b = [
+                    tensor
+                    for name, tensor in state.items()
+                    if name.endswith(".lora_B")
+                ]
+                if not lora_b or not any(
+                    bool(torch.count_nonzero(tensor).item())
+                    for tensor in lora_b
+                ):
+                    raise RuntimeError(
+                        "joint PromptRL optimizer step left every Wan LoRA B "
+                        "weight at zero"
+                    )
+            if args.checkpoint_every > 0:
+                checkpoint = (
+                    output_dir
+                    / f"checkpoint-{args.max_train_steps}"
+                    / "dcp"
+                )
+                if not checkpoint.is_dir():
+                    raise RuntimeError(
+                        f"PromptRL smoke did not write expected {checkpoint}"
+                    )
+            judge_name = "videoscore2" if args.real_videoscore2 else "deterministic"
+            print(
+                "PROMPTRL_REAL_CHECKPOINT_SMOKE_OK "
+                f"mode={args.mode} judge={judge_name} "
+                f"steps={args.max_train_steps} "
+                f"resume={args.resume_from_checkpoint or 'none'} "
+                f"manifest={manifest}",
+                flush=True,
+            )
+    finally:
+        server.should_exit = True
+        server_thread.join(timeout=10.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/local_tests/promptrl_videoscore2_smoke.py
+++ b/tests/local_tests/promptrl_videoscore2_smoke.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One-GPU live VideoScore2 inference and parsing smoke."""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+from fastvideo.train.methods.rl.promptrl.rewards.service import (
+    VideoScore2Judge,
+)
+from fastvideo.train.methods.rl.promptrl.video_io import encode_video_bytes
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model-id", default="TIGER-Lab/VideoScore2")
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument(
+        "--adversarial",
+        action="store_true",
+        help="Use a flat yellow video mismatched to the prompt.",
+    )
+    args = parser.parse_args()
+
+    # [B, C, T, H, W], with real temporal variation so the decoder and judge
+    # both exercise a proper short video rather than a still-image edge case.
+    if args.adversarial:
+        video = torch.zeros((1, 3, 5, 64, 64))
+        video[:, 0] = 0.8
+        video[:, 1] = 0.8
+        video[:, 2] = 0.1
+        prompt = "a red cube rolling on a table"
+    else:
+        frames = torch.linspace(0.0, 1.0, 5).view(1, 1, 5, 1, 1)
+        video = frames.expand(1, 3, 5, 64, 64).contiguous()
+        prompt = "a gray screen gradually becoming white"
+    encoded = encode_video_bytes(video, fps=4)
+    judge = VideoScore2Judge(args.model_id, device=args.device)
+    scores = judge.score_batch(
+        [encoded],
+        [prompt],
+        fps=4,
+    )
+    if len(scores) != 1 or not all(
+        key in scores[0]
+        for key in (
+            "composite",
+            "visual_quality",
+            "text_alignment",
+            "physical_consistency",
+        )
+    ):
+        raise RuntimeError(f"unexpected VideoScore2 result: {scores!r}")
+    print(f"PROMPTRL_VIDEOSCORE2_SMOKE_OK scores={scores}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/local_tests/test_promptrl_advantages.py
+++ b/tests/local_tests/test_promptrl_advantages.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Group-relative advantage computation tests."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from fastvideo.train.methods.rl.promptrl.advantages import (
+    group_relative_advantages,
+    route_generator_advantages,
+    route_refiner_advantages,
+)
+
+
+class TestGroupRelativeAdvantages:
+    def test_normalized_within_group(self):
+        rewards = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        keys = ["g"] * 4
+        adv = group_relative_advantages(rewards, keys)
+        assert torch.isclose(adv.mean(), torch.tensor(0.0), atol=1e-6)
+        assert torch.isclose(adv.std(unbiased=False), torch.tensor(1.0), atol=1e-6)
+        assert adv[0] < 0 < adv[-1]
+
+    def test_zero_variance_group_gives_zero_advantages(self):
+        rewards = torch.tensor([2.5, 2.5, 2.5, 2.5])
+        adv = group_relative_advantages(rewards, ["g"] * 4)
+        assert torch.equal(adv, torch.zeros(4))
+
+    def test_reward_tag_grouping_keeps_basins_separate(self):
+        # Same group id prefix, different reward tags: each tag forms its
+        # own normalization basin even when value scales differ.
+        rewards = torch.tensor([0.0, 1.0, 100.0, 200.0])
+        keys = ["g|tagA", "g|tagA", "g|tagB", "g|tagB"]
+        adv = group_relative_advantages(rewards, keys)
+        assert torch.allclose(adv, torch.tensor([-1.0, 1.0, -1.0, 1.0]))
+
+    def test_mixed_zero_and_nonzero_variance_groups(self):
+        rewards = torch.tensor([5.0, 5.0, 1.0, 3.0])
+        keys = ["flat", "flat", "varied", "varied"]
+        adv = group_relative_advantages(rewards, keys)
+        assert adv[0] == 0 and adv[1] == 0
+        assert torch.allclose(adv[2:], torch.tensor([-1.0, 1.0]))
+
+    def test_shape_and_length_validation(self):
+        with pytest.raises(ValueError):
+            group_relative_advantages(torch.zeros(2, 2), ["a", "b"])
+        with pytest.raises(ValueError):
+            group_relative_advantages(torch.zeros(3), ["a"])
+
+    def test_advantages_are_detached(self):
+        rewards = torch.tensor([1.0, 2.0], requires_grad=True)
+        adv = group_relative_advantages(rewards, ["g", "g"])
+        assert not adv.requires_grad
+
+
+class TestAdvantageRouting:
+    def test_refiner_route_zeroes_retained_originals(self):
+        adv = torch.tensor([0.5, -0.5, 1.0, -1.0, 0.25, -0.25, 0.75, -0.75])
+        participation = [False, False] + [True] * 6
+        routed = route_refiner_advantages(adv, participation)
+        assert routed[0] == 0 and routed[1] == 0
+        assert torch.equal(routed[2:], adv[2:])
+        assert not routed.requires_grad
+
+    def test_refiner_route_length_validation(self):
+        with pytest.raises(ValueError):
+            route_refiner_advantages(torch.zeros(3), [True])
+
+    def test_generator_route_consumes_all_samples(self):
+        adv = torch.tensor([1.0, -1.0, 2.0, -2.0])
+        routed = route_generator_advantages(adv)
+        assert torch.equal(routed, adv)
+        assert not routed.requires_grad

--- a/tests/local_tests/test_promptrl_bundle.py
+++ b/tests/local_tests/test_promptrl_bundle.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRL bundle export + PromptRefiner round-trip tests."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+import torch
+
+from fastvideo.train.methods.rl.promptrl.bundle import (
+    BundleManifest,
+    export_promptrl_bundle,
+    extract_generator_lora,
+    load_bundle_manifest,
+    training_name_to_hf,
+)
+from fastvideo.train.methods.rl.promptrl.inference import PromptRefiner
+from tests.local_tests.promptrl_fixtures import (
+    build_tiny_refiner,
+    build_tiny_tokenizer,
+)
+
+
+def _manifest() -> BundleManifest:
+    return BundleManifest(
+        base_refiner_model="Qwen/Qwen2.5-VL-3B-Instruct",
+        base_generator_model="Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+        fastvideo_version="0.2.0",
+        refiner_lora={"rank": 16, "alpha": 32,
+                      "target_modules": ["q_proj", "k_proj", "v_proj", "o_proj"]},
+        generator_lora={"rank": 16, "alpha": 32,
+                        "target_modules": ["to_q", "to_k", "to_v", "to_out"]},
+        prompt_template_version="v1",
+        refiner_sampling={"max_new_tokens": 256, "temperature": 1.0, "top_p": 1.0},
+        mode="joint",
+    )
+
+
+class TestManifest:
+    def test_round_trip(self, tmp_path):
+        manifest = _manifest()
+        bundle_dir = str(tmp_path / "bundle")
+        os.makedirs(bundle_dir)
+        with open(os.path.join(bundle_dir, "manifest.json"), "w") as handle:
+            json.dump(manifest.to_dict(), handle)
+        loaded = load_bundle_manifest(bundle_dir)
+        assert loaded == manifest
+        assert loaded.prompt_template_version == "v1"
+        assert loaded.refiner_lora["target_modules"] == ["q_proj", "k_proj", "v_proj", "o_proj"]
+
+    def test_unknown_keys_rejected(self):
+        with pytest.raises(ValueError, match="Unknown manifest keys"):
+            BundleManifest.from_dict({**_manifest().to_dict(), "surprise": 1})
+
+    def test_missing_manifest(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            load_bundle_manifest(str(tmp_path))
+
+
+class TestGeneratorLoRAExtraction:
+    def _tiny_wan_like_transformer(self) -> torch.nn.Module:
+        from fastvideo.layers.lora.linear import ReplicatedLinear
+        from fastvideo.train.utils.lora import enable_lora_training
+
+        class Block(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.self_attn = torch.nn.ModuleDict({
+                    "to_q": ReplicatedLinear(8, 8),
+                    "to_out": ReplicatedLinear(8, 8),
+                })
+                self.cross_attn = torch.nn.ModuleDict({
+                    "to_v": ReplicatedLinear(8, 8),
+                })
+                self.ffn = torch.nn.ModuleDict({
+                    "fc_in": ReplicatedLinear(8, 8),
+                })
+
+        class FakeWan(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.blocks = torch.nn.ModuleList([Block(), Block()])
+
+        transformer = FakeWan()
+        enable_lora_training(
+            transformer,
+            lora_rank=2,
+            lora_alpha=4,
+            lora_target_modules=["to_q", "to_out", "to_v", "fc_in"],
+        )
+        return transformer
+
+    def test_name_mapping(self):
+        assert (training_name_to_hf("blocks.3.self_attn.to_q.lora_A") ==
+                "blocks.3.attn1.to_q.lora_A")
+        assert (training_name_to_hf("blocks.0.cross_attn.to_out.lora_B") ==
+                "blocks.0.attn2.to_out.0.lora_B")
+        assert (training_name_to_hf("blocks.12.ffn.fc_in.lora_A") ==
+                "blocks.12.ffn.net.0.proj.lora_A")
+
+    def test_extract_and_save(self, tmp_path):
+        from safetensors.torch import load_file
+
+        transformer = self._tiny_wan_like_transformer()
+        state = extract_generator_lora(transformer)
+        # 2 blocks x (to_q + to_out) + 2 cross-attn to_v + 2 ffn fc_in = 8 layers
+        layer_names = {key.rsplit(".", 1)[0] for key in state}
+        assert len(layer_names) == 8
+        assert "blocks.0.attn1.to_q" in layer_names
+        assert "blocks.1.attn2.to_v" in layer_names
+        assert "blocks.1.ffn.net.0.proj" in layer_names
+        for name in layer_names:
+            assert f"{name}.lora_A" in state
+            assert f"{name}.lora_B" in state
+            assert f"{name}.lora_alpha" in state
+            assert state[f"{name}.lora_alpha"].item() == 4.0
+
+        written = export_promptrl_bundle(
+            str(tmp_path / "bundle"),
+            manifest=_manifest(),
+            refiner_adapter_dir=self._save_tiny_adapter(tmp_path),
+            generator_transformer=transformer,
+        )
+        assert os.path.isfile(written["generator"])
+        saved = load_file(written["generator"])
+        assert set(saved) == set(state)
+
+    def _save_tiny_adapter(self, tmp_path) -> str:
+        role = build_tiny_refiner()
+        adapter_dir = str(tmp_path / "tiny_adapter")
+        role.save_adapter(adapter_dir)
+        return adapter_dir
+
+    def test_no_lora_layers_raises(self):
+        with pytest.raises(ValueError, match="no LoRA layers"):
+            extract_generator_lora(torch.nn.Linear(4, 4))
+
+
+class TestPromptRefinerRoundTrip:
+    def test_adapter_round_trip_and_refine(self, tmp_path):
+        role = build_tiny_refiner()
+        # Perturb the adapter so it differs from the zero-init state.
+        with torch.no_grad():
+            for name, param in role.model.named_parameters():
+                if "lora_B" in name:
+                    param.add_(torch.randn_like(param) * 0.05)
+        before = {name: param.detach().clone()
+                  for name, param in role.model.named_parameters() if "lora_" in name}
+
+        written = export_promptrl_bundle(
+            str(tmp_path / "bundle"),
+            manifest=_manifest(),
+            refiner_role=role,
+            refiner_tokenizer=role.tokenizer,
+            generator_transformer=None,
+        )
+        assert os.path.isfile(os.path.join(written["refiner"], "adapter_model.safetensors"))
+        assert os.path.isfile(os.path.join(written["refiner"], "adapter_config.json"))
+        assert os.path.isfile(os.path.join(written["refiner"], "tokenizer_config.json"))
+
+        # Load the bundle with a fresh base model; injected for tests.
+        from tests.local_tests.promptrl_fixtures import build_tiny_model
+
+        from peft import PeftModel
+
+        tokenizer = build_tiny_tokenizer()
+        base = build_tiny_model(len(tokenizer))
+        base = PeftModel.from_pretrained(base, written["refiner"])
+        refiner = PromptRefiner.from_bundle(
+            str(tmp_path / "bundle"),
+            model=base,
+            tokenizer=tokenizer,
+            device="cpu",
+        )
+        after = {name: param.detach().clone()
+                 for name, param in refiner.model.named_parameters() if "lora_" in name}
+        assert set(before) == set(after)
+        for name in before:
+            assert torch.allclose(before[name], after[name], atol=1e-6), name
+
+        result = refiner.refine("a cat", seed=0)
+        assert result.original_prompt == "a cat"
+        assert isinstance(result.raw_completion, str)
+        assert isinstance(result.format_valid, bool)
+        # Fallback contract: invalid format returns the original prompt.
+        if not result.format_valid:
+            assert result.refined_prompt == "a cat"
+
+    def test_refine_fallback_on_malformed(self, tmp_path):
+        role = build_tiny_refiner()
+        written = export_promptrl_bundle(
+            str(tmp_path / "bundle"),
+            manifest=_manifest(),
+            refiner_role=role,
+            refiner_tokenizer=role.tokenizer,
+        )
+        from tests.local_tests.promptrl_fixtures import build_tiny_model
+
+        from peft import PeftModel
+
+        tokenizer = build_tiny_tokenizer()
+        base = PeftModel.from_pretrained(build_tiny_model(len(tokenizer)), written["refiner"])
+        refiner = PromptRefiner.from_bundle(
+            str(tmp_path / "bundle"),
+            model=base,
+            tokenizer=tokenizer,
+            device="cpu",
+        )
+
+        # Force a malformed completion by stubbing generate/decode.
+        refiner.model.generate = lambda **kwargs: torch.tensor([[0] * 5 + [2]])  # type: ignore[method-assign]
+        refiner.tokenizer.batch_decode = lambda ids, **kwargs: ["no tags here"]  # type: ignore[method-assign]
+        result = refiner.refine("a cat")
+        assert not result.format_valid
+        assert result.refined_prompt == "a cat"
+        assert result.raw_completion == "no tags here"

--- a/tests/local_tests/test_promptrl_config.py
+++ b/tests/local_tests/test_promptrl_config.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRLMethodConfig defaults, validation, and example YAML parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from fastvideo.train.methods.rl.promptrl.config import (
+    PromptRLMethodConfig,
+    RoleOptimizerConfig,
+    RolloutConfig,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLES = _REPO_ROOT / "examples" / "train" / "configs" / "rl" / "wan"
+
+
+class TestDefaults:
+    def test_plan_defaults(self):
+        cfg = PromptRLMethodConfig.from_mapping({})
+        assert cfg.mode == "prompt_only"
+        assert cfg.group_size == 8
+        assert cfg.retained_originals == 2
+        assert cfg.format_reward_weight == 1.0
+        assert cfg.video_reward_weight == 1.0
+        assert cfg.refiner_kl_beta == 0.01
+        assert cfg.student_kl_beta == 0.01
+        assert cfg.ppo_clip == pytest.approx(1e-4)
+        # Rollout defaults.
+        assert cfg.rollout.num_steps == 20
+        assert cfg.rollout.sde_steps == 8
+        assert cfg.rollout.noise_scale == pytest.approx(0.8)
+        assert cfg.rollout.loss_microbatch_size == 1
+        # Per-role optimizer defaults.
+        for role_cfg in (cfg.refiner_optimizer, cfg.generator_optimizer):
+            assert role_cfg.learning_rate == pytest.approx(1e-5)
+            assert role_cfg.betas == (0.9, 0.999)
+            assert role_cfg.weight_decay == pytest.approx(0.01)
+            assert role_cfg.max_grad_norm == pytest.approx(1.0)
+        # Reward client defaults.
+        assert cfg.reward.retries == 2
+        assert cfg.reward.timeout_sec == pytest.approx(300.0)
+        assert cfg.reward.fps == 16
+
+    def test_mode_validation(self):
+        with pytest.raises(ValueError, match="mode"):
+            PromptRLMethodConfig.from_mapping({"mode": "everything"})
+
+    def test_group_layout_validation(self):
+        with pytest.raises(ValueError, match="retained_originals"):
+            PromptRLMethodConfig.from_mapping({"group_size": 8, "retained_originals": 8})
+        with pytest.raises(ValueError, match="group_size"):
+            PromptRLMethodConfig.from_mapping({"group_size": 0})
+
+    def test_rollout_validation(self):
+        with pytest.raises(ValueError, match="sde_steps"):
+            RolloutConfig.from_mapping({"num_steps": 4, "sde_steps": 9})
+        with pytest.raises(ValueError, match="noise_scale"):
+            RolloutConfig.from_mapping({"noise_scale": 0.0})
+
+    def test_role_optimizer_betas_validation(self):
+        with pytest.raises(ValueError, match="betas"):
+            RoleOptimizerConfig.from_mapping({"betas": [0.9]}, where="test")
+
+    def test_nested_overrides(self):
+        cfg = PromptRLMethodConfig.from_mapping({
+            "mode": "joint",
+            "rollout": {"num_steps": 30, "sde_steps": 4},
+            "refiner_optimizer": {"learning_rate": 2e-5},
+            "reward": {"endpoint_url": "http://host:9999/", "retries": 5},
+        })
+        assert cfg.mode == "joint"
+        assert cfg.rollout.num_steps == 30
+        assert cfg.rollout.sde_steps == 4
+        assert cfg.refiner_optimizer.learning_rate == pytest.approx(2e-5)
+        assert cfg.reward.endpoint_url == "http://host:9999"  # trailing slash stripped
+        assert cfg.reward.retries == 5
+
+
+class TestExampleYamls:
+    @pytest.mark.parametrize(
+        "filename,expected_mode",
+        [("promptrl_prompt_only.yaml", "prompt_only"), ("promptrl_joint.yaml", "joint")],
+    )
+    def test_example_config_parses(self, filename, expected_mode):
+        path = _EXAMPLES / filename
+        if not path.exists():
+            pytest.skip(f"example config missing: {path}")
+        with open(path, encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle)
+        cfg = PromptRLMethodConfig.from_mapping(raw["method"])
+        assert cfg.mode == expected_mode
+        assert cfg.group_size == 8
+        assert cfg.retained_originals == 2
+        assert cfg.rollout.num_steps == 20
+        assert cfg.rollout.sde_steps == 8
+        # Canonical distributed layout.
+        distributed = raw["training"]["distributed"]
+        assert distributed["sp_size"] == 1
+        assert distributed["hsdp_shard_dim"] == 8
+        # Both roles use LoRA rank 16 / alpha 32.
+        assert raw["models"]["student"]["lora"]["rank"] == 16
+        assert raw["models"]["student"]["lora"]["alpha"] == 32
+        assert raw["models"]["refiner"]["lora"]["rank"] == 16
+        assert raw["models"]["refiner"]["lora"]["alpha"] == 32
+        # 480x832 @ 77 frames target.
+        assert raw["training"]["data"]["num_height"] == 480
+        assert raw["training"]["data"]["num_width"] == 832
+        assert raw["training"]["data"]["num_frames"] == 77
+
+    def test_joint_config_initializes_from_prompt_only(self):
+        path = _EXAMPLES / "promptrl_joint.yaml"
+        if not path.exists():
+            pytest.skip(f"example config missing: {path}")
+        with open(path, encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle)
+        refiner = raw["models"]["refiner"]
+        assert "init_adapter_from" in refiner
+        assert "prompt_only" in refiner["init_adapter_from"]

--- a/tests/local_tests/test_promptrl_method.py
+++ b/tests/local_tests/test_promptrl_method.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PromptRLMethod CPU integration tests with fake flow model + rewards."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from fastvideo.train.methods.rl.promptrl.method import PromptRLMethod
+from fastvideo.train.methods.rl.promptrl.distributed import RewardConsistencyError
+from fastvideo.train.methods.rl.promptrl.prompts import PromptDataset
+from fastvideo.train.utils.training_config import (
+    DataConfig,
+    DistributedConfig,
+    TrainingConfig,
+    TrainingLoopConfig,
+)
+from tests.local_tests.promptrl_fixtures import (
+    FakeRewardProvider,
+    FakeWanStudent,
+    build_tiny_refiner,
+)
+
+
+class FailingRewardProvider:
+    def score(self, samples):
+        del samples
+        raise RuntimeError("rank-local reward timeout")
+
+
+def _make_cfg(method_overrides: dict | None = None) -> SimpleNamespace:
+    method: dict = {
+        "mode": "prompt_only",
+        "group_size": 2,
+        "retained_originals": 1,
+        "rollout": {
+            "num_steps": 4,
+            "sde_steps": 2,
+            "noise_scale": 0.5,
+        },
+        "refiner": {
+            "max_new_tokens": 6,
+            "temperature": 1.0,
+        },
+        "refiner_optimizer": {
+            "learning_rate": 1e-2,
+            "weight_decay": 0.0,
+        },
+        "generator_optimizer": {
+            "learning_rate": 1e-2,
+            "weight_decay": 0.0,
+        },
+    }
+    if method_overrides:
+        method.update(method_overrides)
+    return SimpleNamespace(
+        training=TrainingConfig(
+            distributed=DistributedConfig(),
+            data=DataConfig(seed=42),
+            loop=TrainingLoopConfig(max_train_steps=10),
+        ),
+        method=method,
+        validation={},
+    )
+
+
+def _make_method(
+    mode: str,
+    *,
+    provider: FakeRewardProvider | None = None,
+    refiner_seed: int = 1234,
+    student_seed: int = 99,
+    method_overrides: dict | None = None,
+) -> tuple[PromptRLMethod, FakeWanStudent, FakeRewardProvider]:
+    overrides = {"mode": mode}
+    if method_overrides:
+        overrides.update(method_overrides)
+    cfg = _make_cfg(overrides)
+    student = FakeWanStudent(seed=student_seed)
+    refiner = build_tiny_refiner(seed=refiner_seed)
+    method = PromptRLMethod(cfg=cfg, role_models={"student": student, "refiner": refiner})
+    method.set_prompt_dataset(
+        PromptDataset.from_rows([{
+            "prompt": "a cat",
+            "id": "p1",
+            "reward_tag": "animals",
+        }, {
+            "prompt": "a dog runs",
+            "id": "p2",
+            "reward_tag": "animals",
+        }]))
+    reward_provider = provider or FakeRewardProvider()
+    method.set_reward_provider(reward_provider)
+    method.cuda_generator = torch.Generator().manual_seed(7)
+    return method, student, reward_provider
+
+
+def _params_snapshot(module: torch.nn.Module) -> dict[str, torch.Tensor]:
+    return {name: param.detach().clone() for name, param in module.named_parameters()}
+
+
+def _changed(before: dict[str, torch.Tensor], module: torch.nn.Module, name_substr: str) -> bool:
+    return any(
+        not torch.equal(before[name], param.detach())
+        for name, param in module.named_parameters()
+        if name_substr in name)
+
+
+def test_train_start_initializes_refiner_role(monkeypatch):
+    from fastvideo.train.methods.base import TrainingMethod
+
+    method, _, _ = _make_method("prompt_only")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        TrainingMethod,
+        "on_train_start",
+        lambda self: calls.append("student"),
+    )
+    monkeypatch.setattr(
+        method.refiner,
+        "on_train_start",
+        lambda: calls.append("refiner"),
+    )
+
+    method.on_train_start()
+
+    assert calls == ["student", "refiner"]
+
+
+class TestPromptOnlyStep:
+    def test_one_step_trains_only_refiner(self):
+        method, student, provider = _make_method("prompt_only")
+        refiner_before = _params_snapshot(method.refiner.model)
+        student_before = _params_snapshot(student.transformer)
+
+        loss_map, _, metrics = method.managed_train_step(None, 0)
+
+        assert torch.isfinite(loss_map["total_loss"])
+        # Both group slots scored, always against the original prompt.
+        assert sorted(provider.scored) == [("slot-0", "a cat"), ("slot-1", "a cat")]
+        # Refiner LoRA updated; the whole student stayed frozen.
+        assert _changed(refiner_before, method.refiner.model, "lora_")
+        assert not _changed(student_before, student.transformer, "")
+        # Core observability metrics.
+        for key in ("reward/group_mean", "reward/group_std", "reward/visual_quality",
+                    "refine/valid_rate", "refine/refined_vs_original_gap", "lm/loss",
+                    "lm/kl", "latency/rollout_sec", "latency/reward_sec",
+                    "latency/backward_sec", "mem/peak_gpu_mb"):
+            assert key in metrics, key
+        assert "wan/loss" not in metrics  # prompt-only skips the Wan loss
+
+    def test_valid_refinement_used_for_generation(self):
+        method, student, _ = _make_method("prompt_only")
+        method.refiner.generate_refinements = (  # type: ignore[method-assign]
+            lambda prompts, **kwargs: ["<answer> refined cinematic cat </answer>"])
+        method.managed_train_step(None, 0)
+        # slot-1 (refined) generates from the refined prompt; slot-0
+        # (retained original) from the original.
+        assert student.encoded_prompts[0] == ["a cat"]
+        assert student.encoded_prompts[1] == ["refined cinematic cat"]
+
+    def test_malformed_completion_falls_back_to_original(self):
+        method, student, _ = _make_method("prompt_only")
+        method.refiner.generate_refinements = (  # type: ignore[method-assign]
+            lambda prompts, **kwargs: ["garbage without tags"])
+        method.managed_train_step(None, 0)
+        assert student.encoded_prompts[1] == ["a cat"]
+
+    def test_zero_variance_rewards_produce_no_update(self):
+        constant_provider = FakeRewardProvider(score_fn=lambda sample: 2.0)
+        method, student, _ = _make_method("prompt_only", provider=constant_provider)
+        # Make both slots format-valid so the composite is flat.
+        method.refiner.generate_refinements = (  # type: ignore[method-assign]
+            lambda prompts, **kwargs: ["<answer> x </answer>"])
+        refiner_before = _params_snapshot(method.refiner.model)
+        _, _, metrics = method.managed_train_step(None, 0)
+        assert metrics["reward/group_std"] == pytest.approx(0.0)
+        assert metrics["reward/advantage_abs_mean"] == pytest.approx(0.0)
+        assert not _changed(refiner_before, method.refiner.model, "lora_")
+
+    def test_reward_provider_failure_is_raised_after_gather(self):
+        method, _, _ = _make_method("prompt_only", provider=FailingRewardProvider())
+        with pytest.raises(RewardConsistencyError, match="rank 0 reward failure"):
+            method.managed_train_step(None, 0)
+
+
+class TestJointStep:
+    def test_one_step_trains_both_adapters(self):
+        method, student, provider = _make_method("joint")
+        refiner_before = _params_snapshot(method.refiner.model)
+        student_before = _params_snapshot(student.transformer)
+
+        loss_map, _, metrics = method.managed_train_step(None, 0)
+
+        assert torch.isfinite(loss_map["total_loss"])
+        assert sorted(provider.scored) == [("slot-0", "a cat"), ("slot-1", "a cat")]
+        assert _changed(refiner_before, method.refiner.model, "lora_")
+        assert _changed(student_before, student.transformer, "lora_")
+        assert student.backward_calls > 0
+        # Frozen student base must not move.
+        assert not _changed(student_before, student.transformer, "base.")
+        for key in ("wan/loss", "wan/kl", "wan/ratio", "wan/clip_fraction",
+                    "grad_norm/refiner", "grad_norm/student"):
+            assert key in metrics, key
+
+    def test_joint_rollout_stores_only_sde_transitions(self):
+        method, _, _ = _make_method("joint")
+        captured = {}
+        original_rollout = method.student.rollout
+
+        def spy_rollout(batch, **kwargs):
+            result = original_rollout(batch, **kwargs)
+            captured.setdefault("transitions", []).append(len(result.transitions))
+            return result
+
+        method.student.rollout = spy_rollout  # type: ignore[method-assign]
+        method.managed_train_step(None, 0)
+        # 4-step rollout with sde_steps=2 -> exactly 2 stored transitions.
+        assert captured["transitions"] == [2, 2]
+
+
+
+class TestCheckpointResume:
+    """Exact checkpoint/resume continuation with deterministic rewards."""
+
+    @pytest.fixture()
+    def gloo_world(self, tmp_path, monkeypatch):
+        """Single-rank gloo world + CPU RNG snapshot shims.
+
+        The production RNG snapshot path is CUDA-only; on CPU-only
+        builds we snapshot the CPU generators with the same semantics.
+        """
+        import torch.distributed as dist
+        from fastvideo.train.utils.checkpoint import (
+            CheckpointManager,
+            _resolve_resume_checkpoint,
+        )
+
+        store = dist.FileStore(str(tmp_path / "store"), 1)
+        dist.init_process_group("gloo", store=store, rank=0, world_size=1)
+
+        def cpu_save(self, checkpoint_dir):
+            torch.save(
+                {
+                    "torch_rng": torch.get_rng_state(),
+                    "gen": self.method.cuda_generator.get_state(),
+                },
+                checkpoint_dir / "rng_state_rank0.pt",
+            )
+
+        def cpu_load(self, checkpoint_path):
+            resolved = _resolve_resume_checkpoint(
+                checkpoint_path, output_dir=self.output_dir)
+            if resolved is None:
+                return
+            rng = torch.load(resolved / "rng_state_rank0.pt", weights_only=False)
+            torch.set_rng_state(rng["torch_rng"])
+            self.method.cuda_generator.set_state(rng["gen"])
+
+        monkeypatch.setattr(CheckpointManager, "_save_rng_snapshot", cpu_save)
+        monkeypatch.setattr(CheckpointManager, "load_rng_snapshot", cpu_load)
+        yield
+        dist.destroy_process_group()
+
+    def _checkpoint_manager(self, method, output_dir):
+        from fastvideo.train.utils.checkpoint import (
+            CheckpointConfig,
+            CheckpointManager,
+        )
+
+        return CheckpointManager(
+            method=method,
+            dataloader=method.student.dataloader,
+            output_dir=str(output_dir),
+            config=CheckpointConfig(save_steps=1, keep_last=0),
+            callbacks=None,
+            raw_config=None,
+        )
+
+    def test_exact_continuation(self, tmp_path, gloo_world):
+        method_a, _, _ = _make_method("joint")
+        manager_a = self._checkpoint_manager(method_a, tmp_path / "out")
+
+        method_a.managed_train_step(None, 0)
+        method_a.managed_train_step(None, 1)
+        manager_a.save(2)
+        method_a.managed_train_step(None, 2)
+        expected = {
+            "refiner": _params_snapshot(method_a.refiner.model),
+            "student": _params_snapshot(method_a.student.transformer),
+        }
+
+        # Fresh instance resumes from checkpoint-2 and takes step 2.
+        method_b, _, _ = _make_method("joint")
+        manager_b = self._checkpoint_manager(method_b, tmp_path / "out")
+        method_b.seed_optimizer_state_for_resume()
+        resumed = manager_b.maybe_resume(
+            resume_from_checkpoint=str(tmp_path / "out" / "checkpoint-2"))
+        assert resumed == 2
+        manager_b.load_rng_snapshot(str(tmp_path / "out" / "checkpoint-2"))
+        method_b.managed_train_step(None, 2)
+
+        for name, param in method_b.refiner.model.named_parameters():
+            assert torch.allclose(expected["refiner"][name], param.detach(), atol=1e-7), name
+        for name, param in method_b.student.transformer.named_parameters():
+            assert torch.allclose(expected["student"][name], param.detach(), atol=1e-7), name
+
+    def test_rng_snapshot_restores_rollout_stream(self, tmp_path, gloo_world):
+        """Resume reproduces the exact rollout noise of the live run."""
+        method_a, _, _ = _make_method("prompt_only")
+        manager_a = self._checkpoint_manager(method_a, tmp_path / "out")
+        method_a.managed_train_step(None, 0)
+        manager_a.save(1)
+        # Capture the next noise draw the live run would produce.
+        live_noise = torch.randn(4, generator=method_a.cuda_generator)
+
+        method_b, _, _ = _make_method("prompt_only")
+        manager_b = self._checkpoint_manager(method_b, tmp_path / "out")
+        manager_b.maybe_resume(resume_from_checkpoint=str(tmp_path / "out" / "checkpoint-1"))
+        manager_b.load_rng_snapshot(str(tmp_path / "out" / "checkpoint-1"))
+        resumed_noise = torch.randn(4, generator=method_b.cuda_generator)
+        assert torch.equal(live_noise, resumed_noise)
+
+
+class TestMilestoneHandoff:
+    def test_joint_initializes_from_prompt_only_adapter(self, tmp_path):
+        """Prompt-only refiner checkpoint -> joint run; Wan LoRA at zero."""
+        method_prompt, _, _ = _make_method("prompt_only")
+        method_prompt.managed_train_step(None, 0)
+        written = method_prompt.export_bundle(str(tmp_path / "bundle"))
+        assert "refiner" in written
+
+        # New joint refiner loads the prompt-only adapter at construction.
+        refiner = build_tiny_refiner()
+        refiner.load_adapter(written["refiner"])
+        trained = {name: param.detach().clone()
+                   for name, param in method_prompt.refiner.model.named_parameters()
+                   if "lora_" in name}
+        loaded = {name: param.detach().clone()
+                  for name, param in refiner.model.named_parameters() if "lora_" in name}
+        for name in trained:
+            assert torch.allclose(trained[name], loaded[name], atol=1e-6), name
+
+        # Wan LoRA starts at exact zero (lora_b zero-init).
+        student = FakeWanStudent()
+        assert torch.equal(student.transformer.lora_b, torch.zeros_like(student.transformer.lora_b))

--- a/tests/local_tests/test_promptrl_prompts.py
+++ b/tests/local_tests/test_promptrl_prompts.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Prompt dataset + refiner output parsing tests for PromptRL."""
+
+from __future__ import annotations
+
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from fastvideo.train.methods.rl.promptrl.prompts import (
+    PromptDataset,
+    group_assignments,
+    parse_answer_tag,
+    render_refinement_prompt,
+)
+
+
+class TestParseAnswerTag:
+    def test_valid_completion(self):
+        parsed = parse_answer_tag("Some text <answer> a cinematic cat </answer> trailing")
+        assert parsed.format_valid
+        assert parsed.refined_prompt == "a cinematic cat"
+
+    def test_multiline_answer(self):
+        parsed = parse_answer_tag("<answer>line one\nline two</answer>")
+        assert parsed.format_valid
+        assert parsed.refined_prompt == "line one\nline two"
+
+    def test_missing_tags_is_malformed(self):
+        parsed = parse_answer_tag("no tags at all")
+        assert not parsed.format_valid
+        assert parsed.refined_prompt == ""
+        assert parsed.raw == "no tags at all"
+
+    def test_empty_answer_is_malformed(self):
+        parsed = parse_answer_tag("<answer>   </answer>")
+        assert not parsed.format_valid
+
+    def test_multiple_answer_blocks_are_malformed(self):
+        parsed = parse_answer_tag("<answer>a</answer><answer>b</answer>")
+        assert not parsed.format_valid
+
+
+class TestGroupAssignments:
+    def test_retention_ordering_originals_first(self):
+        assignments = group_assignments(group_size=8, retained_originals=2)
+        kinds = [a.kind for a in assignments]
+        assert kinds == (["original"] * 2 + ["refined"] * 6)
+        participation = [a.refiner_participation for a in assignments]
+        assert participation == [False, False] + [True] * 6
+
+    def test_invalid_layout_rejected(self):
+        with pytest.raises(ValueError):
+            group_assignments(group_size=8, retained_originals=8)
+        with pytest.raises(ValueError):
+            group_assignments(group_size=8, retained_originals=0)
+        with pytest.raises(ValueError):
+            group_assignments(group_size=0, retained_originals=0)
+
+
+class TestPromptDataset:
+    def test_jsonl_round_trip(self, tmp_path):
+        rows = [
+            {"prompt": "a cat", "id": "c1", "reward_tag": "animal"},
+            {"prompt": "a dog", "id": "d1"},
+            {"prompt": "  spaced  "},
+        ]
+        path = tmp_path / "prompts.jsonl"
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+        dataset = PromptDataset.load(str(path))
+        assert len(dataset) == 3
+        assert dataset[0].prompt == "a cat"
+        assert dataset[0].sample_id == "c1"
+        assert dataset[0].reward_tag == "animal"
+        assert dataset[1].reward_tag == ""  # optional field defaults
+        assert dataset[2].sample_id == "row-2"  # positional fallback id
+        assert dataset[2].prompt == "spaced"
+
+    def test_parquet_round_trip(self, tmp_path):
+        table = pa.table({
+            "prompt": ["p1", "p2"],
+            "id": ["1", "2"],
+            "reward_tag": ["t", "t"],
+        })
+        path = tmp_path / "prompts.parquet"
+        pq.write_table(table, path)
+        dataset = PromptDataset.load(str(path))
+        assert len(dataset) == 2
+        assert dataset[1].prompt == "p2"
+        assert dataset[1].reward_tag == "t"
+
+    def test_missing_prompt_field_rejected(self):
+        with pytest.raises(ValueError, match="prompt"):
+            PromptDataset.from_rows([{"text": "wrong key"}])
+
+    def test_empty_prompt_rejected(self):
+        with pytest.raises(ValueError):
+            PromptDataset.from_rows([{"prompt": "   "}])
+
+    def test_custom_keys(self):
+        dataset = PromptDataset.from_rows(
+            [{"caption": "hello", "uid": 7, "tag": "x"}],
+            prompt_key="caption",
+            id_key="uid",
+            reward_tag_key="tag",
+        )
+        record = dataset[0]
+        assert record.prompt == "hello"
+        assert record.sample_id == "7"
+        assert record.reward_tag == "x"
+
+    def test_missing_file_rejected(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            PromptDataset.load(str(tmp_path / "nope.jsonl"))
+
+    def test_render_template_contains_prompt_and_tags(self):
+        rendered = render_refinement_prompt("my prompt", template_version="v1")
+        assert "my prompt" in rendered
+        assert "<answer>" in rendered
+        with pytest.raises(ValueError):
+            render_refinement_prompt("x", template_version="v99")

--- a/tests/local_tests/test_promptrl_refiner.py
+++ b/tests/local_tests/test_promptrl_refiner.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""QwenPromptRefinerRole unit tests with a tiny local causal LM."""
+
+from __future__ import annotations
+
+import torch
+import pytest
+
+from fastvideo.train.roles.qwen_refiner import QwenPromptRefinerRole
+
+
+def _build_tiny_tokenizer():
+    from tokenizers import Tokenizer, models, pre_tokenizers
+
+    vocab = {
+        "[PAD]": 0,
+        "[UNK]": 1,
+        "<eos>": 2,
+    }
+    words = (
+        ["You", "are", "an", "expert", "prompt", "engineer", "Rewrite", "the", "user", "'s", "to", "be", "more", "detailed", "cinematic", "and", "visually", "grounded", "while", "preserving", "its", "meaning", "Respond", "with", "rewritten", "inside", "<answer>", "</answer>", "tags", "only", ".", "a", "cat", "dog", "runs", "fast", "slow", "cinematic", "lighting", "red", "ball", "jumps", "over", "fence"])
+    vocab.update({w: i + 3 for i, w in enumerate(words)})
+    tokenizer = Tokenizer(models.WordLevel(vocab=vocab, unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = pre_tokenizers.WhitespaceSplit()
+    from transformers import PreTrainedTokenizerFast
+
+    fast = PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        unk_token="[UNK]",
+        pad_token="[PAD]",
+        eos_token="<eos>",
+    )
+    fast.chat_template = (
+        "{% for message in messages %}{{ message['content'] }}{% endfor %}")
+    return fast
+
+
+def _build_tiny_model(vocab_size: int):
+    from transformers import Qwen2Config, Qwen2ForCausalLM
+
+    config = Qwen2Config(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        vocab_size=vocab_size,
+        max_position_embeddings=256,
+    )
+    model = Qwen2ForCausalLM(config)
+    model.generation_config.pad_token_id = 0
+    model.generation_config.eos_token_id = 2
+    return model
+
+
+def _build_role(**overrides) -> QwenPromptRefinerRole:
+    tokenizer = _build_tiny_tokenizer()
+    model = _build_tiny_model(len(tokenizer))
+    kwargs = dict(
+        init_from="tiny-local",
+        trainable=True,
+        lora={"enable": True, "rank": 4, "alpha": 8},
+        model_kind="causal_lm",
+        torch_dtype="float32",
+        model=model,
+        tokenizer=tokenizer,
+        device="cpu",
+    )
+    kwargs.update(overrides)
+    return QwenPromptRefinerRole(**kwargs)
+
+
+def test_refiner_role_lora_only_trainable():
+    role = _build_role()
+    trainable = role.trainable_parameters()
+    assert trainable, "expected LoRA parameters to be trainable"
+    for name, param in role.model.named_parameters():
+        if param.requires_grad:
+            assert "lora_" in name, f"non-LoRA parameter trainable: {name}"
+    assert set(role.checkpoint_modules()) == {"model"}
+    assert role.checkpoint_modules()["model"] is role.model
+
+
+def test_refiner_requires_lora_config():
+    tokenizer = _build_tiny_tokenizer()
+    model = _build_tiny_model(len(tokenizer))
+    with pytest.raises(ValueError, match="lora"):
+        QwenPromptRefinerRole(
+            init_from="tiny-local",
+            trainable=True,
+            lora=None,
+            model_kind="causal_lm",
+            model=model,
+            tokenizer=tokenizer,
+            device="cpu",
+        )
+
+
+def test_sequence_logprobs_and_reference_parity():
+    role = _build_role()
+    prompts = ["a cat", "a dog runs"]
+    completions = ["<answer> cinematic cat </answer>", "<answer> dog </answer>"]
+
+    sums, counts = role.sequence_logprobs(prompts, completions)
+    assert sums.shape == (2, )
+    assert counts.tolist() == [4, 3]
+    assert torch.isfinite(sums).all()
+
+    # Zero-init LoRA B: adapter-disabled reference matches the adapter.
+    ref_sums, _ = role.sequence_logprobs(prompts, completions, use_adapter=False)
+    assert torch.allclose(sums, ref_sums, atol=1e-5)
+
+    # Perturb LoRA B: current policy diverges; reference still matches base.
+    with torch.no_grad():
+        for name, param in role.model.named_parameters():
+            if "lora_B" in name:
+                param.add_(torch.randn_like(param) * 0.1)
+    new_sums, _ = role.sequence_logprobs(prompts, completions)
+    new_ref_sums, _ = role.sequence_logprobs(prompts, completions, use_adapter=False)
+    assert not torch.allclose(new_sums, ref_sums, atol=1e-4)
+    assert torch.allclose(new_ref_sums, ref_sums, atol=1e-5)
+
+
+def test_sequence_logprobs_requires_grad():
+    role = _build_role()
+    sums, _ = role.sequence_logprobs(["a cat"], ["<answer> x </answer>"],
+                                     requires_grad=True)
+    assert sums.requires_grad
+    (-sums.mean()).backward()
+    grads = [p.grad for p in role.trainable_parameters()]
+    assert any(g is not None and torch.isfinite(g).all() and g.abs().sum() > 0 for g in grads)
+
+
+def test_generate_refinements_count_and_type():
+    role = _build_role()
+    outputs = role.generate_refinements(
+        ["a cat", "a dog"],
+        max_new_tokens=4,
+        temperature=1.0,
+        top_p=1.0,
+        seed=1234,
+    )
+    assert len(outputs) == 2
+    assert all(isinstance(text, str) for text in outputs)

--- a/tests/local_tests/test_promptrl_reward_service.py
+++ b/tests/local_tests/test_promptrl_reward_service.py
@@ -1,0 +1,719 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reward service batching/idempotency + provider retry/validation tests."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import httpx
+import pytest
+import torch
+from fastapi.testclient import TestClient
+
+from fastvideo.train.methods.rl.promptrl.rewards import (
+    COMPONENT_KEYS,
+    HttpRewardProvider,
+    RewardRequestError,
+    RewardResult,
+    RewardSample,
+    RewardServiceError,
+    create_reward_app,
+    parse_judge_scores,
+    parse_videoscore2_output,
+    validate_reward_results,
+)
+from fastvideo.train.methods.rl.promptrl.rewards.provider import _parse_reward_payload
+from fastvideo.train.methods.rl.promptrl.rewards.service import (
+    _read_video_with_pyav,
+)
+from fastvideo.train.methods.rl.promptrl.video_io import encode_video_bytes
+
+
+class FakeJudge:
+    """Deterministic fake VideoScore2 judge recording its batches."""
+
+    def __init__(self):
+        self.calls: list[tuple[int, tuple[str, ...]]] = []
+        self._lock = threading.Lock()
+
+    def score_batch(self, videos, prompts, *, fps):
+        with self._lock:
+            self.calls.append((len(videos), tuple(prompts)))
+        results = []
+        for idx, prompt in enumerate(prompts):
+            base = 3.0 + 0.1 * idx + (0.5 if "good" in prompt else 0.0)
+            results.append({
+                "visual_quality": base,
+                "text_alignment": base + 0.1,
+                "physical_consistency": base - 0.1,
+                "composite": base,
+            })
+        return results
+
+
+class SlowJudge(FakeJudge):
+    """Fake judge that blocks while a duplicate in-flight submit attaches."""
+
+    def __init__(self):
+        super().__init__()
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def score_batch(self, videos, prompts, *, fps):
+        self.started.set()
+        assert self.release.wait(timeout=5.0)
+        return super().score_batch(videos, prompts, fps=fps)
+
+
+def _sample(sample_id: str, *, group_id="g", request_id="r", expected=2,
+            prompt="a good cat") -> RewardSample:
+    return RewardSample(
+        group_id=group_id,
+        request_id=request_id,
+        sample_id=sample_id,
+        expected_group_size=expected,
+        original_prompt=prompt,
+        reward_tag="tag",
+        fps=16,
+        video_bytes=b"fake-mp4-" + sample_id.encode(),
+    )
+
+
+def _post(client: TestClient, sample: RewardSample):
+    return client.post(
+        "/v1/rewards:score",
+        data={
+            "group_id": sample.group_id,
+            "request_id": sample.request_id,
+            "sample_id": sample.sample_id,
+            "expected_group_size": str(sample.expected_group_size),
+            "original_prompt": sample.original_prompt,
+            "reward_tag": sample.reward_tag,
+            "fps": str(sample.fps),
+        },
+        files={"video": ("sample.mp4", sample.video_bytes, "video/mp4")},
+    )
+
+
+class TestRewardService:
+    def test_healthz(self):
+        app = create_reward_app(FakeJudge())
+        client = TestClient(app)
+        response = client.get("/healthz")
+        assert response.status_code == 200
+        assert response.json()["status"] == "ok"
+
+    def test_group_batched_into_single_judge_call(self):
+        judge = FakeJudge()
+        client = TestClient(create_reward_app(judge))
+        responses: dict[str, dict] = {}
+        errors: list[BaseException] = []
+
+        def worker(sample_id: str):
+            try:
+                responses[sample_id] = _post(client, _sample(sample_id)).json()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(f"slot-{i}", )) for i in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+        assert not errors
+        # The coordinator invokes its group judge exactly once.
+        assert judge.calls == [(2, ("a good cat", "a good cat"))]
+        assert set(responses) == {"slot-0", "slot-1"}
+        for sample_id, payload in responses.items():
+            assert payload["sample_id"] == sample_id
+            assert payload["request_id"] == "r"
+            assert payload["score"] > 0
+            for key in COMPONENT_KEYS:
+                assert key in payload["details"]
+
+    def test_async_server_accepts_group_members_concurrently(self):
+        """A waiting upload must not block the ASGI event loop."""
+        judge = FakeJudge()
+        app = create_reward_app(judge, max_wait_sec=1.0)
+
+        async def exercise():
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                    transport=transport,
+                    base_url="http://reward.test",
+            ) as client:
+
+                async def post(sample_id: str):
+                    sample = _sample(sample_id)
+                    return await client.post(
+                        "/v1/rewards:score",
+                        data={
+                            "group_id": sample.group_id,
+                            "request_id": sample.request_id,
+                            "sample_id": sample.sample_id,
+                            "expected_group_size": str(sample.expected_group_size),
+                            "original_prompt": sample.original_prompt,
+                            "reward_tag": sample.reward_tag,
+                            "fps": str(sample.fps),
+                        },
+                        files={
+                            "video": (
+                                "sample.mp4",
+                                sample.video_bytes,
+                                "video/mp4",
+                            ),
+                        },
+                    )
+
+                return await asyncio.gather(post("slot-0"), post("slot-1"))
+
+        responses = asyncio.run(exercise())
+        assert [response.status_code for response in responses] == [200, 200]
+        assert judge.calls == [(2, ("a good cat", "a good cat"))]
+
+    def test_completed_request_id_is_idempotent(self):
+        judge = FakeJudge()
+        client = TestClient(create_reward_app(judge))
+        first = _post(client, _sample("slot-0", expected=1)).json()
+        # Retry of the completed request returns the cached payload and
+        # never re-invokes the judge.
+        second = _post(client, _sample("slot-0", expected=1)).json()
+        assert first == second
+        assert len(judge.calls) == 1
+
+    def test_duplicate_sample_retry_waits_while_group_is_scoring(self):
+        judge = SlowJudge()
+        client = TestClient(create_reward_app(judge))
+        responses: dict[str, dict] = {}
+        errors: list[BaseException] = []
+
+        def worker(sample_id: str, key: str):
+            try:
+                responses[key] = _post(client, _sample(sample_id)).json()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        originals = [
+            threading.Thread(target=worker, args=("slot-0", "slot-0")),
+            threading.Thread(target=worker, args=("slot-1", "slot-1")),
+        ]
+        for thread in originals:
+            thread.start()
+        assert judge.started.wait(timeout=5.0)
+
+        duplicate = threading.Thread(target=worker, args=("slot-0", "slot-0-retry"))
+        duplicate.start()
+        judge.release.set()
+
+        for thread in [*originals, duplicate]:
+            thread.join(timeout=10.0)
+        assert not errors
+        assert judge.calls == [(2, ("a good cat", "a good cat"))]
+        assert responses["slot-0-retry"] == responses["slot-0"]
+
+    def test_expected_group_size_mismatch_rejected(self):
+        client = TestClient(create_reward_app(FakeJudge()))
+        response = _post(client, _sample("slot-0", expected=0))
+        assert response.status_code == 400
+
+    def test_judge_failure_surfaces_500(self):
+        class BrokenJudge:
+            def score_batch(self, videos, prompts, *, fps):
+                raise RuntimeError("judge exploded")
+
+        client = TestClient(create_reward_app(BrokenJudge()))
+        response = _post(client, _sample("slot-0", expected=1))
+        assert response.status_code == 500
+
+
+def test_pyav_torchvision_read_video_compatibility(tmp_path):
+    frames = torch.linspace(0.0, 1.0, 4).view(1, 1, 4, 1, 1)
+    video = frames.expand(1, 3, 4, 16, 16).contiguous()
+    path = tmp_path / "sample.mp4"
+    path.write_bytes(encode_video_bytes(video, fps=4))
+
+    decoded, audio, info = _read_video_with_pyav(
+        str(path),
+        start_pts=0.0,
+        pts_unit="sec",
+        output_format="TCHW",
+    )
+
+    assert decoded.shape == (4, 3, 16, 16)
+    assert decoded.dtype == torch.uint8
+    assert audio.numel() == 0
+    assert info["video_fps"] == pytest.approx(4.0)
+
+
+class TestJudgeScoreParsing:
+    def test_parse_valid_json_array(self):
+        text = ('Here are the scores: [{"visual_quality": 3, "text_alignment": 4, '
+                '"physical_consistency": 5}] done')
+        rows = parse_judge_scores(text, expected=1)
+        assert rows[0]["visual_quality"] == 3.0
+        assert rows[0]["composite"] == pytest.approx(4.0)
+
+    def test_parse_rejects_missing_array(self):
+        with pytest.raises(RewardRequestError):
+            parse_judge_scores("no json here", expected=1)
+
+    def test_parse_rejects_wrong_cardinality(self):
+        with pytest.raises(RewardRequestError):
+            parse_judge_scores('[{"visual_quality": 1, "text_alignment": 1, '
+                               '"physical_consistency": 1}]', expected=2)
+
+    def test_parse_rejects_missing_components(self):
+        with pytest.raises(RewardRequestError):
+            parse_judge_scores('[{"visual_quality": 3}]', expected=1)
+
+
+class _CharacterTokenizer:
+
+    def encode(self, text, add_special_tokens=False):
+        del add_special_tokens
+        return [ord(character) for character in text]
+
+    def decode(self, token_ids, skip_special_tokens=False):
+        del skip_special_tokens
+        return "".join(chr(int(token_id)) for token_id in token_ids)
+
+
+class _ContextualDecodeTokenizer(_CharacterTokenizer):
+    """Mimic tokenizers that expose punctuation with the newest token."""
+
+    def decode(
+        self,
+        token_ids,
+        skip_special_tokens=False,
+        clean_up_tokenization_spaces=True,
+    ):
+        decoded = super().decode(token_ids, skip_special_tokens=skip_special_tokens)
+        if not clean_up_tokenization_spaces and decoded.endswith(tuple("12345")):
+            return decoded + ";"
+        return decoded
+
+
+class TestOfficialVideoScore2Parsing:
+
+    def test_confidence_weighted_dimension_scores(self):
+        output = (
+            "visual quality: 4; "
+            "text-to-video alignment: 3, "
+            "physical/common-sense consistency: 2"
+        )
+        token_ids = [ord(character) for character in output]
+        generation_scores = []
+        for character in output:
+            logits = torch.full((1, 128), -10.0)
+            for value in range(1, 6):
+                logits[0, ord(str(value))] = 0.0
+            if character in "12345":
+                logits[0, ord(character)] = 10.0
+            generation_scores.append(logits)
+
+        parsed = parse_videoscore2_output(
+            output,
+            generated_token_ids=token_ids,
+            generation_scores=generation_scores,
+            tokenizer=_CharacterTokenizer(),
+        )
+
+        assert parsed["visual_quality"] == pytest.approx(4.0, abs=1e-3)
+        assert parsed["text_alignment"] == pytest.approx(3.0, abs=1e-3)
+        assert parsed["physical_consistency"] == pytest.approx(2.0, abs=1e-3)
+        assert parsed["composite"] == pytest.approx(3.0, abs=1e-3)
+
+    def test_contextual_decode_boundary_maps_to_score_token(self):
+        output = (
+            "visual quality: 4; "
+            "text-to-video alignment: 3, "
+            "physical/common-sense consistency: 2"
+        )
+        token_ids = [ord(character) for character in output]
+        generation_scores = [torch.zeros((1, 128)) for _ in output]
+        for index, character in enumerate(output):
+            if character in "12345":
+                generation_scores[index][0, ord(character)] = 10.0
+
+        parsed = parse_videoscore2_output(
+            output,
+            generated_token_ids=token_ids,
+            generation_scores=generation_scores,
+            tokenizer=_ContextualDecodeTokenizer(),
+        )
+
+        assert parsed["visual_quality"] == pytest.approx(4.0, abs=1e-3)
+        assert parsed["text_alignment"] == pytest.approx(3.0, abs=1e-3)
+        assert parsed["physical_consistency"] == pytest.approx(2.0, abs=1e-3)
+
+    def test_markdown_wrapped_final_labels_are_accepted(self):
+        output = (
+            "Analysis with no numeric summary.\n"
+            "**Visual Quality:** 4;\n"
+            "**Text-to-Video Alignment:** 3,\n"
+            "**Physical/Common-Sense Consistency:** 2"
+        )
+        token_ids = [ord(character) for character in output]
+        generation_scores = [torch.zeros((1, 128)) for _ in output]
+        for index, character in enumerate(output):
+            if character in "12345":
+                generation_scores[index][0, ord(character)] = 10.0
+
+        parsed = parse_videoscore2_output(
+            output,
+            generated_token_ids=token_ids,
+            generation_scores=generation_scores,
+            tokenizer=_CharacterTokenizer(),
+        )
+
+        assert parsed["visual_quality"] == pytest.approx(4.0, abs=1e-3)
+        assert parsed["text_alignment"] == pytest.approx(3.0, abs=1e-3)
+        assert parsed["physical_consistency"] == pytest.approx(2.0, abs=1e-3)
+
+    def test_numbered_rubric_response_is_accepted(self):
+        output = (
+            "(1) visual quality – clarity, smoothness, artifacts: 4\n"
+            "(2) text-to-video alignment – fidelity to the prompt: 3\n"
+            "(3) physical/common-sense consistency – naturalness and "
+            "physics plausibility: 2"
+        )
+        token_ids = [ord(character) for character in output]
+        generation_scores = [torch.zeros((1, 128)) for _ in output]
+        for index, character in enumerate(output):
+            if character in "12345":
+                generation_scores[index][0, ord(character)] = 10.0
+
+        parsed = parse_videoscore2_output(
+            output,
+            generated_token_ids=token_ids,
+            generation_scores=generation_scores,
+            tokenizer=_CharacterTokenizer(),
+        )
+
+        assert parsed["visual_quality"] == pytest.approx(4.0, abs=1e-3)
+        assert parsed["text_alignment"] == pytest.approx(3.0, abs=1e-3)
+        assert parsed["physical_consistency"] == pytest.approx(2.0, abs=1e-3)
+
+    def test_prose_dimension_scores_are_accepted(self):
+        output = (
+            "Visual Quality Analysis:\n"
+            "The overall visual quality is moderate (score 3).\n\n"
+            "Text-to-Video Alignment Analysis:\n"
+            "The text-to-video alignment is strong (score 4).\n\n"
+            "Physical/Common-Sense Consistency Analysis:\n"
+            "The physical/common-sense consistency is weak (score 2)."
+        )
+        token_ids = [ord(character) for character in output]
+        generation_scores = [torch.zeros((1, 128)) for _ in output]
+        for index, character in enumerate(output):
+            if character in "12345":
+                generation_scores[index][0, ord(character)] = 10.0
+
+        parsed = parse_videoscore2_output(
+            output,
+            generated_token_ids=token_ids,
+            generation_scores=generation_scores,
+            tokenizer=_CharacterTokenizer(),
+        )
+
+        assert parsed["visual_quality"] == pytest.approx(3.0, abs=1e-3)
+        assert parsed["text_alignment"] == pytest.approx(4.0, abs=1e-3)
+        assert parsed["physical_consistency"] == pytest.approx(2.0, abs=1e-3)
+
+    def test_fraction_scores_and_short_physical_label_are_accepted(self):
+        output = (
+            "Visual Quality Analysis:\n"
+            "The overall visual quality is moderate (3/5).\n"
+            "Text-to-Video Alignment Analysis:\n"
+            "Overall alignment corresponds to a text-to-video alignment "
+            "score of 4/5.\n"
+            "Physical Consistency Analysis:\n"
+            "Overall Physical Consistency score: 3/5.\n"
+            "Ground-truth scores: Visual Quality 3, "
+            "Text-to-Video Alignment 4, Physical Consistency 3."
+        )
+        token_ids = [ord(character) for character in output]
+        generation_scores = [torch.zeros((1, 128)) for _ in output]
+        for index, character in enumerate(output):
+            if character in "12345":
+                generation_scores[index][0, ord(character)] = 10.0
+
+        parsed = parse_videoscore2_output(
+            output,
+            generated_token_ids=token_ids,
+            generation_scores=generation_scores,
+            tokenizer=_CharacterTokenizer(),
+        )
+
+        assert parsed["visual_quality"] == pytest.approx(3.0, abs=1e-3)
+        assert parsed["text_alignment"] == pytest.approx(4.0, abs=1e-3)
+        assert parsed["physical_consistency"] == pytest.approx(3.0, abs=1e-3)
+
+    def test_missing_official_fields_are_rejected(self):
+        output = "visual quality: 4"
+        token_ids = [ord(character) for character in output]
+        generation_scores = [torch.zeros((1, 128)) for _ in output]
+        with pytest.raises(RewardRequestError, match="missing a usable"):
+            parse_videoscore2_output(
+                output,
+                generated_token_ids=token_ids,
+                generation_scores=generation_scores,
+                tokenizer=_CharacterTokenizer(),
+            )
+
+
+def test_videoscore2_unscorable_generation_neutralizes_entire_group(
+    monkeypatch,
+):
+    from fastvideo.train.methods.rl.promptrl.rewards import VideoScore2Judge
+
+    judge = VideoScore2Judge(device="cpu", parse_failure_score=3.0)
+    monkeypatch.setattr(judge, "_load", lambda: None)
+    calls = 0
+
+    def score_one(path, prompt):
+        nonlocal calls
+        del path, prompt
+        calls += 1
+        if calls == 1:
+            return {
+                "visual_quality": 4.0,
+                "text_alignment": 4.0,
+                "physical_consistency": 4.0,
+                "composite": 4.0,
+            }
+        raise RewardRequestError(
+            500,
+            "VideoScore2 output missing a usable visual_quality score",
+        )
+
+    monkeypatch.setattr(judge, "_score_one", score_one)
+    results = judge.score_batch(
+        [b"video-a", b"video-b"],
+        ["prompt a", "prompt b"],
+        fps=4,
+    )
+
+    assert [result["composite"] for result in results] == [3.0, 3.0]
+    assert [result["judge_fallback"] for result in results] == [1.0, 1.0]
+
+
+class _StubResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class _FlakySession:
+    """requests.Session stand-in: fails N times, then serves ``payload``."""
+
+    def __init__(self, failures: int, payload: dict):
+        self.failures_left = failures
+        self.payload = payload
+        self.attempts = 0
+
+    def post(self, url, data=None, files=None, timeout=None):
+        self.attempts += 1
+        if self.failures_left > 0:
+            self.failures_left -= 1
+            raise ConnectionError("simulated connection drop")
+        return _StubResponse(200, dict(self.payload))
+
+    def get(self, url, timeout=None):
+        return _StubResponse(200, {"status": "ok"})
+
+
+class _ConcurrentGroupSession:
+    """Requires both local group uploads to be in flight together."""
+
+    def __init__(self):
+        self.barrier = threading.Barrier(2, timeout=2.0)
+
+    def post(self, url, data=None, files=None, timeout=None):
+        del url, files, timeout
+        self.barrier.wait()
+        return _StubResponse(
+            200,
+            {
+                "request_id": data["request_id"],
+                "sample_id": data["sample_id"],
+                "score": 4.0,
+                "details": {},
+            },
+        )
+
+
+class TestHttpRewardProvider:
+    def _provider(self, session) -> HttpRewardProvider:
+        provider = HttpRewardProvider(
+            endpoint_url="http://reward.test",
+            timeout_sec=1.0,
+            retries=2,
+            retry_backoff_sec=0.0,
+        )
+        provider._session = session
+        return provider
+
+    def test_retries_then_succeeds(self):
+        payload = {
+            "request_id": "r",
+            "sample_id": "slot-0",
+            "score": 4.2,
+            "details": {"visual_quality": 4.0},
+        }
+        session = _FlakySession(failures=2, payload=payload)
+        provider = self._provider(session)
+        results = provider.score([_sample("slot-0", expected=1)])
+        assert session.attempts == 3  # 2 failures + final success
+        assert results[0].score == 4.2
+
+    def test_exhausted_retries_raise(self):
+        session = _FlakySession(failures=99, payload={})
+        provider = self._provider(session)
+        with pytest.raises(RewardServiceError, match="failed after"):
+            provider.score([_sample("slot-0", expected=1)])
+        assert session.attempts == 3  # retries=2 -> 3 attempts
+
+    def test_invalid_payload_raises(self):
+        session = _FlakySession(failures=0, payload={"request_id": "r"})
+        provider = self._provider(session)
+        with pytest.raises(RewardServiceError):
+            provider.score([_sample("slot-0", expected=1)])
+
+    def test_health(self):
+        provider = self._provider(_FlakySession(0, {}))
+        assert provider.health()
+
+    def test_multiple_local_samples_are_submitted_concurrently(self):
+        provider = self._provider(_ConcurrentGroupSession())
+        results = provider.score([
+            _sample("slot-0"),
+            _sample("slot-1"),
+        ])
+        assert [result.sample_id for result in results] == ["slot-0", "slot-1"]
+
+
+class TestProviderValidation:
+    def _result(self, sample_id, score=1.0, details=None) -> RewardResult:
+        return RewardResult(
+            score=score,
+            details=details or {},
+            sample_id=sample_id,
+            request_id="r",
+        )
+
+    def test_cardinality_mismatch(self):
+        with pytest.raises(RewardServiceError, match="cardinality"):
+            validate_reward_results(
+                [_sample("a"), _sample("b")],
+                [self._result("a")],
+            )
+
+    def test_missing_and_duplicate_samples(self):
+        samples = [_sample("a"), _sample("b")]
+        with pytest.raises(RewardServiceError, match="missing"):
+            validate_reward_results(samples, [self._result("a"), self._result("a")])
+
+    def test_non_finite_score(self):
+        samples = [_sample("a")]
+        with pytest.raises(RewardServiceError, match="Non-finite"):
+            validate_reward_results(samples, [self._result("a", score=float("nan"))])
+
+    def test_non_finite_detail(self):
+        samples = [_sample("a")]
+        with pytest.raises(RewardServiceError, match="Non-finite reward detail"):
+            validate_reward_results(
+                samples, [self._result("a", details={"vq": float("inf")})])
+
+    def test_valid_passes(self):
+        samples = [_sample("a"), _sample("b")]
+        validate_reward_results(samples, [self._result("b"), self._result("a")])
+
+    def test_payload_request_id_mismatch(self):
+        with pytest.raises(RewardServiceError, match="request_id"):
+            _parse_reward_payload(
+                {"request_id": "other", "sample_id": "slot-0", "score": 1.0},
+                sample=_sample("slot-0"),
+            )
+
+
+class TestGroupFailureSynchronization:
+    """Every rank runs identical validation on the gathered results."""
+
+    def _results(self, count: int) -> list[RewardResult]:
+        return [
+            RewardResult(score=float(i), details={}, sample_id=f"slot-{i}", request_id="r")
+            for i in range(count)
+        ]
+
+    def test_cardinality_mismatch_fails(self):
+        from fastvideo.train.methods.rl.promptrl.distributed import (
+            RewardConsistencyError,
+            validate_group_reward_results,
+        )
+
+        with pytest.raises(RewardConsistencyError, match="cardinality"):
+            validate_group_reward_results(
+                self._results(7), group_id="g", expected_group_size=8)
+
+    def test_duplicate_sample_fails(self):
+        from fastvideo.train.methods.rl.promptrl.distributed import (
+            RewardConsistencyError,
+            validate_group_reward_results,
+        )
+
+        results = self._results(8)
+        results[3] = RewardResult(score=1.0, details={}, sample_id="slot-0", request_id="r")
+        with pytest.raises(RewardConsistencyError, match="duplicate"):
+            validate_group_reward_results(
+                results, group_id="g", expected_group_size=8)
+
+    def test_non_finite_score_fails(self):
+        from fastvideo.train.methods.rl.promptrl.distributed import (
+            RewardConsistencyError,
+            validate_group_reward_results,
+        )
+
+        results = self._results(8)
+        results[5] = RewardResult(
+            score=float("nan"), details={}, sample_id="slot-5", request_id="r")
+        with pytest.raises(RewardConsistencyError, match="non-finite"):
+            validate_group_reward_results(
+                results, group_id="g", expected_group_size=8)
+
+    def test_rank_local_reward_failure_fails_all_ranks(self):
+        from fastvideo.train.methods.rl.promptrl.distributed import (
+            RewardConsistencyError,
+            RewardFailure,
+            validate_group_reward_results,
+        )
+
+        results = self._results(7)
+        results.append(
+            RewardFailure(rank=3, error_type="RewardServiceError", message="timeout"))
+        with pytest.raises(RewardConsistencyError, match="rank 3 reward failure"):
+            validate_group_reward_results(
+                results, group_id="g", expected_group_size=8)
+
+    def test_valid_group_passes(self):
+        from fastvideo.train.methods.rl.promptrl.distributed import (
+            validate_group_reward_results,
+        )
+
+        validate_group_reward_results(
+            self._results(8), group_id="g", expected_group_size=8)
+
+    def test_single_process_gather_matches_expectation(self):
+        from fastvideo.train.methods.rl.promptrl.distributed import (
+            gather_group_reward_results,
+        )
+
+        result = self._results(1)[0]
+        gathered = gather_group_reward_results(
+            result, group_id="g", expected_group_size=1)
+        assert gathered == [result]

--- a/tests/local_tests/test_promptrl_roles.py
+++ b/tests/local_tests/test_promptrl_roles.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TrainRoleBase plumbing: construction + checkpoint registration."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import torch
+
+from fastvideo.train.methods.base import TrainingMethod
+from fastvideo.train.roles.base import TrainRoleBase
+from fastvideo.train.utils.training_config import (
+    DataConfig,
+    DistributedConfig,
+    OptimizerConfig,
+    TrainingConfig,
+    TrainingLoopConfig,
+)
+
+
+class _FakeLMRole(TrainRoleBase):
+    """Non-diffusion role registering a plain ``model`` module."""
+
+    def __init__(self, trainable: bool = True) -> None:
+        self._trainable = trainable
+        self.model = torch.nn.Linear(4, 4)
+        if not trainable:
+            self.model.requires_grad_(False)
+
+    def checkpoint_modules(self):
+        return {"model": self.model}
+
+
+class _FakeDiffusionLikeRole(TrainRoleBase):
+    """Diffusion-style role registering a ``transformer`` module."""
+
+    def __init__(self) -> None:
+        self._trainable = True
+        self.transformer = torch.nn.Linear(8, 8)
+        self.device_checked = False
+
+    def checkpoint_modules(self):
+        return {"transformer": self.transformer}
+
+
+class _TinyMethod(TrainingMethod):
+    """Minimal concrete method for role-registration assertions."""
+
+    def single_train_step(self, batch, iteration):
+        raise NotImplementedError
+
+    def get_optimizers(self, iteration):
+        return []
+
+    def get_lr_schedulers(self, iteration):
+        return []
+
+    @property
+    def _optimizer_dict(self):
+        return {}
+
+    @property
+    def _lr_scheduler_dict(self):
+        return {}
+
+
+def _make_cfg():
+    return SimpleNamespace(
+        training=TrainingConfig(
+            distributed=DistributedConfig(),
+            data=DataConfig(seed=0),
+            optimizer=OptimizerConfig(),
+            loop=TrainingLoopConfig(max_train_steps=1),
+        ),
+        method={},
+        validation={},
+    )
+
+
+def test_role_modules_registered_from_checkpoint_modules():
+    roles = {
+        "student": _FakeDiffusionLikeRole(),
+        "refiner": _FakeLMRole(),
+    }
+    method = _TinyMethod(cfg=_make_cfg(), role_models=roles)
+    assert set(method.role_modules.keys()) == {"student", "refiner"}
+    assert "transformer" in method.role_modules["student"]
+    assert "model" in method.role_modules["refiner"]
+
+
+def test_checkpoint_state_covers_trainable_roles_and_modules():
+    roles = {
+        "student": _FakeDiffusionLikeRole(),
+        "refiner": _FakeLMRole(),
+        "frozen_helper": _FakeLMRole(trainable=False),
+    }
+    method = _TinyMethod(cfg=_make_cfg(), role_models=roles)
+    states = method.checkpoint_state()
+    assert "roles.student.transformer" in states
+    assert "roles.refiner.model" in states
+    # Frozen roles are excluded from the trainable-role checkpoint path.
+    assert not any(key.startswith("roles.frozen_helper") for key in states)
+
+
+def test_trainable_parameters_default_collection():
+    role = _FakeLMRole()
+    params = role.trainable_parameters()
+    assert params
+    assert all(p.requires_grad for p in params)
+    frozen = _FakeLMRole(trainable=False)
+    assert frozen.trainable_parameters() == []
+
+
+def test_builder_accepts_train_role_base():
+    from fastvideo.train.utils.builder import build_from_config
+    from fastvideo.train.utils.config import RunConfig
+
+    cfg = RunConfig(
+        models={
+            "student": {"_target_": "tests.local_tests.test_promptrl_roles._FakeDiffusionLikeRole"},
+            "refiner": {"_target_": "tests.local_tests.test_promptrl_roles._FakeLMRole"},
+        },
+        method={"_target_": "tests.local_tests.test_promptrl_roles._TinyMethod"},
+        training=_make_cfg().training,
+        callbacks={},
+        raw={},
+    )
+    _, method, _, _ = build_from_config(cfg)
+    # Pytest may import this file as ``test_promptrl_roles`` while the
+    # config target resolves the package-qualified module. Compare against
+    # the class loaded through the same canonical path as the builder.
+    expected_type = importlib.import_module(
+        "tests.local_tests.test_promptrl_roles")._TinyMethod
+    assert isinstance(method, expected_type)
+    assert set(method._role_models) == {"student", "refiner"}
+
+
+def test_builder_rejects_non_role_targets():
+    from fastvideo.train.utils.builder import build_from_config
+    from fastvideo.train.utils.config import RunConfig
+    import pytest
+
+    cfg = RunConfig(
+        models={"student": {
+            "_target_": "torch.nn.Linear",
+            "in_features": 2,
+            "out_features": 2,
+        }},
+        method={"_target_": "tests.local_tests.test_promptrl_roles._TinyMethod"},
+        training=_make_cfg().training,
+        callbacks={},
+        raw={},
+    )
+    with pytest.raises(TypeError, match="TrainRoleBase"):
+        build_from_config(cfg)

--- a/tests/local_tests/test_promptrl_sde.py
+++ b/tests/local_tests/test_promptrl_sde.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SDE transition math tests for 5D video latents."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from fastvideo.train.methods.rl.promptrl.sde import (
+    SDETransition,
+    sde_step_from_model_output,
+    transition_kl_to_reference,
+    transition_log_prob,
+)
+
+SIGMA_MAX = 0.9
+
+
+def _rand_latents(seed: int = 0) -> torch.Tensor:
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randn(2, 4, 3, 6, 8, generator=generator)  # [B, C, T, H, W]
+
+
+class TestSDEStep:
+    def test_zero_noise_scale_reduces_to_euler(self):
+        sample = _rand_latents()
+        model_output = _rand_latents(seed=1)
+        sigma, sigma_next = 0.5, 0.3
+        prev, log_prob, mean = sde_step_from_model_output(
+            model_output,
+            sample,
+            sigma=sigma,
+            sigma_next=sigma_next,
+            noise_scale=1e-12,
+            sigma_max=SIGMA_MAX,
+        )
+        euler = sample + (sigma_next - sigma) * model_output
+        assert torch.allclose(prev, euler, atol=1e-4)
+        assert torch.allclose(mean, euler, atol=1e-4)
+        # Deterministic step: sampled point sits at the mean.
+        assert torch.isfinite(log_prob).all()
+
+    def test_shapes_and_reduction(self):
+        sample = _rand_latents()
+        model_output = _rand_latents(seed=1)
+        prev, log_prob, mean = sde_step_from_model_output(
+            model_output,
+            sample,
+            sigma=0.7,
+            sigma_next=0.5,
+            noise_scale=0.8,
+            sigma_max=SIGMA_MAX,
+            generator=torch.Generator().manual_seed(7),
+        )
+        assert prev.shape == sample.shape
+        assert mean.shape == sample.shape
+        assert log_prob.shape == (sample.shape[0], )
+        assert torch.isfinite(log_prob).all()
+
+    def test_log_prob_matches_manual_gaussian(self):
+        sample = _rand_latents()
+        model_output = _rand_latents(seed=1)
+        sigma, sigma_next, noise_scale = 0.6, 0.4, 0.8
+        prev, log_prob, mean = sde_step_from_model_output(
+            model_output,
+            sample,
+            sigma=sigma,
+            sigma_next=sigma_next,
+            noise_scale=noise_scale,
+            sigma_max=SIGMA_MAX,
+            generator=torch.Generator().manual_seed(3),
+        )
+        dt = sigma_next - sigma
+        std = math.sqrt(sigma / (1 - sigma)) * noise_scale
+        step_std = std * math.sqrt(-dt)
+        manual = (-((prev - mean) ** 2) / (2 * step_std**2) - math.log(step_std) -
+                  math.log(math.sqrt(2 * math.pi)))
+        manual = manual.mean(dim=tuple(range(1, manual.ndim)))
+        assert torch.allclose(log_prob, manual, atol=1e-4)
+
+
+class TestTransitionRecomputation:
+    def test_recompute_recovers_rollout_log_prob(self):
+        sample = _rand_latents()
+        model_output = _rand_latents(seed=1)
+        kwargs = dict(sigma=0.65, sigma_next=0.45, noise_scale=0.8, sigma_max=SIGMA_MAX)
+        prev, rollout_log_prob, _ = sde_step_from_model_output(
+            model_output, sample, generator=torch.Generator().manual_seed(11), **kwargs)
+        recomputed_log_prob, mean = transition_log_prob(
+            model_output, sample, prev, **kwargs)
+        assert torch.allclose(recomputed_log_prob, rollout_log_prob, atol=1e-5)
+        assert mean.requires_grad is False
+
+    def test_recompute_gradients_flow_to_model_output(self):
+        sample = _rand_latents()
+        model_output = _rand_latents(seed=1).requires_grad_(True)
+        prev = _rand_latents(seed=2)
+        log_prob, mean = transition_log_prob(
+            model_output,
+            sample,
+            prev,
+            sigma=0.65,
+            sigma_next=0.45,
+            noise_scale=0.8,
+            sigma_max=SIGMA_MAX,
+        )
+        assert log_prob.requires_grad and mean.requires_grad
+        (-log_prob.mean()).backward()
+        assert model_output.grad is not None
+        assert torch.isfinite(model_output.grad).all()
+        assert model_output.grad.abs().sum() > 0
+
+    def test_kl_zero_for_identical_means(self):
+        mean = _rand_latents()
+        kl = transition_kl_to_reference(
+            mean, mean.clone(), sigma=0.6, sigma_next=0.4, noise_scale=0.8, sigma_max=SIGMA_MAX)
+        assert torch.allclose(kl, torch.zeros_like(kl), atol=1e-6)
+
+    def test_kl_matches_gaussian_formula(self):
+        mean_new = _rand_latents()
+        mean_ref = _rand_latents(seed=5)
+        sigma, sigma_next, noise_scale = 0.6, 0.4, 0.8
+        kl = transition_kl_to_reference(
+            mean_new, mean_ref,
+            sigma=sigma, sigma_next=sigma_next,
+            noise_scale=noise_scale, sigma_max=SIGMA_MAX)
+        dt = sigma_next - sigma
+        std = math.sqrt(sigma / (1 - sigma)) * noise_scale
+        step_std_sq = std * std * (-dt)
+        manual = ((mean_new - mean_ref) ** 2).sum(dim=(1, 2, 3, 4)) / (2 * step_std_sq)
+        assert torch.allclose(kl, manual, atol=1e-3)
+
+    def test_transition_dataclass_detached_storage(self):
+        sample = _rand_latents().requires_grad_(True)
+        transition = SDETransition(
+            sample=sample.detach(),
+            prev_sample=sample.detach(),
+            timestep=500.0,
+            sigma=0.5,
+            sigma_next=0.3,
+            old_log_prob=torch.zeros(2),
+        )
+        assert not transition.sample.requires_grad
+        assert transition.timestep == 500.0


### PR DESCRIPTION
## Summary

Adds PromptRL training support for FastVideo, including:

- PromptRL method/config plumbing with group-relative reward normalization
- Qwen prompt-refiner role with LoRA support
- HTTP reward provider and VideoScore2 reward service
- Wan PromptRL integration with inference/export helpers
- Example training recipes and focused test coverage


## Testing

- `git diff --check origin/main..HEAD`
- Python compile validation for PromptRL method/distributed code, roles, Wan PromptRL model, and updated tests
- Focused container validation completed successfully on 1 GPU
- Full training resumed from checkpoint on 9 NVIDIA Blackwell GPUs, restored RNG state, passed the reward-service failure point, and produced the next checkpoint before the duplicate run was paused
- Short post-fix training resume started on 9 NVIDIA Blackwell GPUs; reward service initialized and train containers launched without errors at last check