### PR TITLE
[misc]: refresh stale sm_120-only validation notes in QAT recipes

### DIFF
--- a/examples/train/configs/fine_tuning/ltx2/nvfp4_qat_t2v.yaml
+++ b/examples/train/configs/fine_tuning/ltx2/nvfp4_qat_t2v.yaml
@@ -12,7 +12,13 @@
 # backward, then ATTN_QAT_INFER during validation. Head-dim-64 audio
 # attention and masked text attention remain dense.
 #
-# Validation requires an sm_120 GPU with the attn_qat_infer extension.
+# Validation-time ATTN_QAT_INFER is arch-aware:
+#   * sm_120 / sm_121: the bundled fastvideo-kernel CUTLASS extension.
+#   * sm_100 (GB200-class) / sm_103 (GB300-class): the FP4 FA4 kernel —
+#     requires the flash-attention-fp4 fork and its dependency pins; see
+#     docs/inference/optimizations.md.
+#   * any other GPU: falls back to flash attention with a logged receipt
+#     (validation still runs, just not with the quantized kernel).
 #
 # Prerequisites: preprocess your dataset into the trainer's latent format
 # (see docs/training/data_preprocess.md;
@@ -20,12 +26,15 @@
 # LTX-2 reference to adapt). Data paths, step counts, and learning rate
 # below are placeholders you must adapt to your workload.
 #
-# Run on multi-GPU sm_120 hardware:
+# Run (multi-GPU; see the validation note above for kernel availability):
 #   NUM_GPUS=4 bash examples/train/run.sh \
 #     examples/train/configs/fine_tuning/ltx2/nvfp4_qat_t2v.yaml
 #
-# GB200 can train and validate with ATTN_QAT_TRAIN, but cannot load the
-# sm_120-only inference kernel. Disable only the validation-time swap:
+# `attn_qat_infer: true` below is the deployment-representative choice on
+# every arch with a quantized kernel available (see the validation note
+# above). Flip it off only when your GPU has no ATTN_QAT_INFER kernel and
+# you prefer validating with the train-time backend instead of the flash
+# fallback:
 #   NUM_GPUS=4 bash examples/train/run.sh \
 #     examples/train/configs/fine_tuning/ltx2/nvfp4_qat_t2v.yaml \
 #     --callbacks.validation.attn_qat_infer false

--- a/examples/train/configs/fine_tuning/ltx2_3/nvfp4_qat_t2v.yaml
+++ b/examples/train/configs/fine_tuning/ltx2_3/nvfp4_qat_t2v.yaml
@@ -20,7 +20,13 @@
 # gated-attention to_gate_logits projections are not in the set and
 # remain dense.
 #
-# Validation requires an sm_120 GPU with the attn_qat_infer extension.
+# Validation-time ATTN_QAT_INFER is arch-aware:
+#   * sm_120 / sm_121: the bundled fastvideo-kernel CUTLASS extension.
+#   * sm_100 (GB200-class) / sm_103 (GB300-class): the FP4 FA4 kernel —
+#     requires the flash-attention-fp4 fork and its dependency pins; see
+#     docs/inference/optimizations.md.
+#   * any other GPU: falls back to flash attention with a logged receipt
+#     (validation still runs, just not with the quantized kernel).
 #
 # Prerequisites: preprocess your dataset into the trainer's latent format
 # (see docs/training/data_preprocess.md;
@@ -30,12 +36,15 @@
 # step counts, and learning rate below are placeholders you must adapt
 # to your workload.
 #
-# Run on multi-GPU sm_120 hardware:
+# Run (multi-GPU; see the validation note above for kernel availability):
 #   NUM_GPUS=4 bash examples/train/run.sh \
 #     examples/train/configs/fine_tuning/ltx2_3/nvfp4_qat_t2v.yaml
 #
-# GB200 can train and validate with ATTN_QAT_TRAIN, but cannot load the
-# sm_120-only inference kernel. Disable only the validation-time swap:
+# `attn_qat_infer: true` below is the deployment-representative choice on
+# every arch with a quantized kernel available (see the validation note
+# above). Flip it off only when your GPU has no ATTN_QAT_INFER kernel and
+# you prefer validating with the train-time backend instead of the flash
+# fallback:
 #   NUM_GPUS=4 bash examples/train/run.sh \
 #     examples/train/configs/fine_tuning/ltx2_3/nvfp4_qat_t2v.yaml \
 #     --callbacks.validation.attn_qat_infer false


### PR DESCRIPTION
## Problem

Comment-only doc rot in both NVFP4 QAT fine-tuning recipes (`fine_tuning/ltx2/nvfp4_qat_t2v.yaml` and `fine_tuning/ltx2_3/nvfp4_qat_t2v.yaml`): the headers still say validation "requires an sm_120 GPU with the attn_qat_infer extension" and that GB200-class hardware "cannot load the sm_120-only inference kernel" — both outdated since ATTN_QAT_INFER became arch-aware: sm_120/sm_121 resolve to the bundled CUTLASS extension, sm_100/sm_103 resolve to the FP4 FA4 kernel (with the flash-attention-fp4 fork + pins per `docs/inference/optimizations.md`), and anything else falls back to flash attention with a logged receipt — validation always runs.

## Solution

Header comments in both files updated to the per-arch facts; the `attn_qat_infer: true` default (already correct) now carries a comment saying when to flip it — only when no quantized kernel exists for your GPU and you prefer the train-time backend over the flash fallback — instead of implying it cannot work off sm_120. No functional changes; comments only.

## Also batched (same doc surface, author-driven doc check)

Three fixes to the FP4-FA4 section of `docs/inference/optimizations.md`:
1. **Install command bug**: `git+ssh://git@github.com/...` fails for every user without GitHub SSH keys — now `git+https://...`.
2. Python support line said "3.10 or 3.11"; the validated environments run 3.12 and the tested range repo-wide is 3.10–3.12 — aligned.
3. Clarified the branch story: `fix/cutlass-dsl-4.5` stays the recommended install (works with pip-available `nvidia-cutlass-dsl>=4.5.2`, carries the `ThrMma` rename fix), with one sentence noting the hardware-validated receipt set used the `fp4` branch + pinned 4.4.2 toolchain from the compatibility table — same kernels, two supported configurations.

## Test evidence

Comment-only diff in two example yamls; the recipe construction sweep test in CI covers both files' loadability. pre-commit green.
