### PR TITLE
[refactor]: resolve attention backend once per component at load time

### DIFF
--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -76,6 +76,7 @@ surfaces:
       lora_target_modules: "Legacy LoRA configuration surface pending dedicated component API."
       output_type: "Legacy output formatting surface pending GenerationResult cleanup."
       VSA_sparsity: "Model-specific inference optimization not yet represented in the typed public schema."
+      attention_backend: "Process-wide default attention-backend request applied per component at load time; kernel-selection knob not yet represented in the typed public schema."
       moba_config_path: "Model-specific MoBA optimization surface not yet represented in the typed public schema."
       master_port: "Executor/bootstrap compatibility field; not part of the canonical inference schema."
       refine_transformer_path: "Generic stage-2 refine transformer override; no typed equivalent yet."

--- a/fastvideo/attention/AGENTS.md
+++ b/fastvideo/attention/AGENTS.md
@@ -10,7 +10,7 @@ Backend registry + selector wrapping FlashAttn / SageAttn / SageAttn3 / SDPA / V
 attention/
 ├── __init__.py            # Exports DistributedAttention, LocalAttention, get_attn_backend
 ├── layer.py               # DistributedAttention, DistributedAttention_VSA, LocalAttention
-├── selector.py            # get_attn_backend (cached) + env-var override
+├── selector.py            # get_attn_backend (cached) + _component_attention_backend_scope
 ├── backends/
 │   ├── abstract.py        #   AttentionBackend / AttentionMetadata / AttentionMetadataBuilder
 │   ├── flash_attn.py      #   FA2/FA3
@@ -26,17 +26,61 @@ attention/
     └── flash_attn_no_pad.py
 ```
 
+## Where the Decision Is Made
+
+**Resolved once, at load time, and carried on the component.** The environment
+variable is folded into `FastVideoArgs.attention_backend` in `__post_init__`
+(the parse-once adapter); `PipelineComponentLoader.load_module` applies that
+request per component; each loader records what its component resolved onto
+that component's own config as `ModelConfig._resolved_attention_backend`. After
+load, the decision is readable from the component itself:
+
+```python
+transformer.config._resolved_attention_backend
+```
+
+A loader may narrow the request for one component — the DMD teacher/critic
+transformers build dense — and the recorded value is what that component
+actually resolved, not what the run asked for globally.
+
+Nothing switches backends at runtime and nothing should: every request is an
+input to *construction*.
+
 ## Selection Order
 
-`get_attn_backend()` resolves via:
+`get_attn_backend()` reads every selection input, then resolves via, in
+precedence order:
 
-1. Env-var override `FASTVIDEO_ATTENTION_BACKEND` (see `STR_BACKEND_ENV_VAR` in `fastvideo/utils.py`).
-2. Per-platform default from `fastvideo/platforms/`.
-3. Heuristic fallback to SDPA.
+1. `global_force_attn_backend(...)` — deprecated process-global override, still
+   the training stack's mechanism.
+2. The per-component request resolved at load time.
+3. Env-var `FASTVIDEO_ATTENTION_BACKEND` (see `STR_BACKEND_ENV_VAR` in
+   `fastvideo/utils.py`), for layers built outside a loader — the denoising
+   stages, and direct model construction in tests.
+4. The layer-declared `default_backend`.
+5. Per-platform automatic selection from `fastvideo/platforms/`, which probes
+   the *current device's* capability.
 
-The result is `@lru_cache`d. Tests that need a specific backend must use the
-`global_force_attn_backend(...)` context manager from `selector.py`, never set
-the env var mid-process.
+The result is cached on **all** of those inputs (plus component identity and
+device index), so a changed request simply lands on a different cache key —
+no `cache_clear()` is needed and none should be added.
+
+A layer that does not declare support for the requested backend falls back, so
+the component-level decision is the request every layer of that component
+resolves against, not a promise about the kernel any one layer runs.
+
+Never mutate `FASTVIDEO_ATTENTION_BACKEND` mid-process.
+
+### Transitional: how the request reaches layers
+
+The request travels from loader to layers via
+`_component_attention_backend_scope`, a private ContextVar. It is plumbing with
+an end date, not API: layer constructors nested inside a model receive only a
+bare `supported_attention_backends` tuple, threaded through block constructors
+up to four levels deep, so they cannot yet read the decision off their own
+config. Thread the request alongside that tuple, one model family at a time —
+Wan, LTX-2 and Kandinsky5 first, since those carry per-role requests — and the
+scope goes away when the last family lands. Do not build on it.
 
 ## Adding a Backend
 

--- a/fastvideo/attention/selector.py
+++ b/fastvideo/attention/selector.py
@@ -4,6 +4,8 @@
 import os
 from collections.abc import Generator
 from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from functools import cache
 from typing import cast
 
@@ -90,11 +92,9 @@ def global_force_attn_backend(attn_backend: AttentionBackendEnum | None) -> None
     '''
     global forced_attn_backend
     forced_attn_backend = attn_backend
-    # Backend selection is cached by tensor shape/dtype, while the global
-    # override is intentionally not part of that cache key. Invalidate cached
-    # resolutions whenever the override changes so independently constructed
-    # role models can bind different attention implementations.
-    _cached_get_attn_backend.cache_clear()
+    # No cache_clear: every selection input (including this override) is part
+    # of the resolution cache key, so mutations take effect on the next call
+    # by construction. Prefer _component_attention_backend_scope for new code.
 
 
 def get_global_forced_attn_backend() -> AttentionBackendEnum | None:
@@ -105,6 +105,74 @@ def get_global_forced_attn_backend() -> AttentionBackendEnum | None:
     return forced_attn_backend
 
 
+@dataclass(frozen=True)
+class _BackendScope:
+    backend: AttentionBackendEnum | None
+    component: str | None
+    consult_env: bool
+
+
+_SCOPE: ContextVar[_BackendScope | None] = ContextVar("fastvideo_attention_backend_scope", default=None)
+
+
+@contextmanager
+def _component_attention_backend_scope(
+    attn_backend: AttentionBackendEnum | str | None,
+    component: str | None = None,
+    *,
+    consult_env: bool = False,
+) -> Generator[None, None, None]:
+    """Carry a component's resolved request from its loader down to its layers.
+
+    **Transitional plumbing, not a feature.** The decision is resolved once at
+    load time and written onto the component's own config
+    (``ModelConfig._resolved_attention_backend``); this scope exists only
+    because the layer constructors nested inside a model do not yet receive
+    that config. They are handed a bare ``supported_attention_backends`` tuple,
+    threaded through block constructors up to four levels deep.
+
+    Deletion path: thread the request alongside that tuple, one model family at
+    a time, starting with the families that carry per-role requests (Wan,
+    LTX-2, Kandinsky5). When the last family reads its request from its own
+    config, this scope, ``_SCOPE`` and ``_BackendScope`` all go away and
+    ``get_attn_backend`` takes the request as a plain argument.
+
+    Nothing switches backends at runtime and nothing should: every caller wraps
+    *construction*. Process-local, exception-safe, nestable, and part of the
+    resolution cache key, so it never needs a cache flush.
+
+    ``_component_attention_backend_scope(None)`` means "automatic selection,
+    ignore any process-wide request" (dense teacher/critic roles built
+    alongside a quantized student); ``consult_env=True`` re-enables the env
+    fallback inside a scope.
+    """
+    token = _SCOPE.set(_BackendScope(coerce_attn_backend(attn_backend), component, consult_env))
+    try:
+        yield
+    finally:
+        _SCOPE.reset(token)
+
+
+def _active_component_attention_backend_scope() -> "_BackendScope | None":
+    """The request governing the component being constructed right now, or None."""
+    return _SCOPE.get()
+
+
+def record_resolved_attention_backend(config: object) -> AttentionBackendEnum | None:
+    """Write the request governing construction *right now* onto a component config.
+
+    Called by each loader while its component is being built, so the decision
+    ends up on the object the component keeps and is readable from the component
+    after load. The loader is the right place rather than the caller above it:
+    a loader may narrow the request for one component (the DMD teacher/critic
+    transformers build dense inside a nested scope), and only it knows that.
+    """
+    scope = _SCOPE.get()
+    resolved = scope.backend if scope is not None else None
+    config._resolved_attention_backend = resolved  # type: ignore[attr-defined]
+    return resolved
+
+
 def get_attn_backend(
     head_size: int,
     dtype: torch.dtype,
@@ -112,7 +180,37 @@ def get_attn_backend(
     | None = None,
     default_backend: AttentionBackendEnum | None = None,
 ) -> type[AttentionBackend]:
-    return _cached_get_attn_backend(head_size, dtype, supported_attention_backends, default_backend)
+    # Resolve every selection-affecting input BEFORE the cache so all of them
+    # live in the cache key: no mutation (env, global force, scope) ever needs
+    # a cache_clear again, and components with different requests get distinct
+    # cache entries (per-component resolution).
+    scope = _SCOPE.get()
+    if scope is not None:
+        requested = scope.backend
+        component = scope.component
+        env_backend = envs.FASTVIDEO_ATTENTION_BACKEND if scope.consult_env else None
+    else:
+        requested = None
+        component = None
+        env_backend = envs.FASTVIDEO_ATTENTION_BACKEND
+    # The active device is a real selection input, not bookkeeping: the
+    # platform's backend resolution runs capability probes against the
+    # *current* device (e.g. AttnQatInferBackend's per-arch capability sets
+    # decide sm_12x CUTLASS vs sm_100/sm_103 FP4 FA4 vs FlashAttention
+    # fallback). Keying on it means a resolution taken for one device is
+    # never handed to another.
+    device_index = torch.cuda.current_device() if torch.cuda.is_available() else None
+    return _cached_get_attn_backend(
+        head_size,
+        dtype,
+        supported_attention_backends,
+        default_backend,
+        forced=get_global_forced_attn_backend(),
+        requested=requested,
+        env_backend=env_backend,
+        component=component,
+        device_index=device_index,
+    )
 
 
 @cache
@@ -122,26 +220,34 @@ def _cached_get_attn_backend(
     supported_attention_backends: tuple[AttentionBackendEnum, ...]
     | None = None,
     default_backend: AttentionBackendEnum | None = None,
+    *,
+    forced: AttentionBackendEnum | None = None,
+    requested: AttentionBackendEnum | None = None,
+    env_backend: str | None = None,
+    component: str | None = None,
+    device_index: int | None = None,
 ) -> type[AttentionBackend]:
-    # Check whether a particular choice of backend was
-    # previously forced.
-    #
-    # THIS SELECTION OVERRIDES THE FASTVIDEO_ATTENTION_BACKEND
-    # ENVIRONMENT VARIABLE.
+    # Pure resolution: every selection input arrives as an argument (and is
+    # therefore part of the functools cache key). Only get_attn_backend calls
+    # this; it performs the scope/env/force reads.
     if not supported_attention_backends:
         raise ValueError("supported_attention_backends is empty")
-    selected_backend = None
-    backend_by_global_setting: AttentionBackendEnum | None = (get_global_forced_attn_backend())
-    if backend_by_global_setting is not None:
-        selected_backend = backend_by_global_setting
-    else:
-        # Check the environment variable and override if specified
-        backend_by_env_var: str | None = envs.FASTVIDEO_ATTENTION_BACKEND
-        if backend_by_env_var is not None:
-            selected_backend = backend_name_to_enum(backend_by_env_var)
+    # Cache-key-only inputs: component identity separates two components that
+    # agree on shape/dtype but not on request; device_index separates
+    # resolutions taken under different device capabilities (the platform
+    # probes the current device below).
+    del component, device_index
+    # Precedence (behavior-preserving): the deprecated process-global force
+    # first, then the scoped per-component request (which occupies exactly the
+    # position the force held when moduleloader used it for per-role models),
+    # then the env var (already suppressed by the wrapper when a scope is
+    # active), then the layer-declared default.
+    selected_backend = forced if forced is not None else requested
+    if selected_backend is None and env_backend is not None:
+        selected_backend = backend_name_to_enum(env_backend)
 
     # Layer-level default (e.g. a checkpoint that requires a specific sparse
-    # backend). Lower precedence than the global force and the env var, so
+    # backend). Lower precedence than the force/scope/env requests, so
     # users can still override it.
     if selected_backend is None and default_backend is not None:
         selected_backend = default_backend

--- a/fastvideo/configs/models/base.py
+++ b/fastvideo/configs/models/base.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass, field, fields
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
 from fastvideo.logger import init_logger
+
+if TYPE_CHECKING:
+    from fastvideo.platforms import AttentionBackendEnum
 
 logger = init_logger(__name__)
 
@@ -23,6 +26,17 @@ class ModelConfig:
     arch_config: ArchConfig = field(default_factory=ArchConfig)
 
     # FastVideo-specific parameters here
+
+    # The attention backend requested for this component, resolved once at load
+    # time by the loader (explicit request, else the environment variable) and
+    # written here so the decision travels *on the component* rather than being
+    # looked up again while its layers are built. ``None`` means no request, so
+    # each layer falls through to its declared default and platform selection.
+    #
+    # This is the component-level decision, not a promise about the kernel any
+    # single layer ends up running: a layer that does not declare support for
+    # this backend still falls back (see ``fastvideo/attention/selector.py``).
+    _resolved_attention_backend: "AttentionBackendEnum | None" = None
 
     def __getattr__(self, name):
         # Only called if 'name' is not found in ModelConfig directly

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -123,6 +123,18 @@ class FastVideoArgs:
 
     output_type: str = "pil"
 
+    # The attention backend requested for this run. Applied per component at
+    # load time (each component resolves its own decision, recorded on its
+    # config); a role-level request (the train stack's per-role
+    # attention_backend) overrides it.
+    #
+    # This field is the parse-once adapter for FASTVIDEO_ATTENTION_BACKEND:
+    # when left unset it takes the env var's value in __post_init__, so the
+    # environment is an *input* read once here rather than something the loader
+    # consults later. None means no request: per-layer defaults, then platform
+    # auto-selection.
+    attention_backend: str | None = None
+
     # CPU offload parameters
     dit_cpu_offload: bool = True
     use_fsdp_inference: bool = False
@@ -257,6 +269,21 @@ class FastVideoArgs:
         self._apply_ltx2_vae_overrides()
         self._resolve_refine_args()
         self._apply_transformer_quant()
+        if self.attention_backend is not None:
+            # Fail fast on typos instead of silently auto-selecting later.
+            from fastvideo.attention.selector import coerce_attn_backend
+            coerce_attn_backend(self.attention_backend)
+        else:
+            # Parse-once adapter: fold the environment variable into the typed
+            # request so resolution has a single input and library code never
+            # consults the environment on the load path. The env var keeps its
+            # historically permissive parse — an unknown name is ignored here
+            # and falls through to automatic selection rather than raising.
+            import fastvideo.envs as envs
+            from fastvideo.attention.selector import backend_name_to_enum
+            env_backend = envs.FASTVIDEO_ATTENTION_BACKEND
+            if env_backend is not None and backend_name_to_enum(env_backend) is not None:
+                self.attention_backend = env_backend
         self.check_fastvideo_args()
 
     def _apply_transformer_quant(self) -> None:
@@ -437,6 +464,17 @@ class FastVideoArgs:
             default=FastVideoArgs.output_type,
             choices=["pil"],
             help="Output type for the generated video",
+        )
+
+        # Attention backend (process-wide default request)
+        parser.add_argument(
+            "--attention-backend",
+            type=str,
+            default=FastVideoArgs.attention_backend,
+            help="Default attention backend request (e.g. FLASH_ATTN, TORCH_SDPA, "
+            "SAGE_ATTN). Applied per component at load time; component/role-level "
+            "requests override it. Unset: FASTVIDEO_ATTENTION_BACKEND env var, "
+            "then per-layer defaults, then automatic selection.",
         )
 
         # Prompt text file for batch processing

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -7,6 +7,7 @@ import os
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Iterable
+from contextlib import nullcontext
 from copy import deepcopy
 from typing import cast
 
@@ -18,6 +19,12 @@ from torch.distributed import init_device_mesh
 from transformers import AutoImageProcessor, AutoProcessor, AutoTokenizer
 from transformers.utils import SAFE_WEIGHTS_INDEX_NAME
 
+from fastvideo.attention.selector import (
+    _active_component_attention_backend_scope,
+    _component_attention_backend_scope,
+    coerce_attn_backend,
+    record_resolved_attention_backend,
+)
 from fastvideo.configs.models import EncoderConfig
 from fastvideo.distributed import get_local_torch_device
 from fastvideo.fastvideo_args import FastVideoArgs
@@ -336,6 +343,7 @@ class TextEncoderLoader(ComponentLoader):
             }
             model_config["architectures"] = ["CLIPTextModel"]
         encoder_config.update_model_arch(model_config)
+        record_resolved_attention_backend(encoder_config)
         if idx < 0 or idx >= len(encoder_precisions):
             raise IndexError(
                 f"text encoder index {idx} out of range for text_encoder_precisions (len={len(encoder_precisions)}), model_path={model_path}"
@@ -508,6 +516,7 @@ class ImageEncoderLoader(TextEncoderLoader):
 
         encoder_config = fastvideo_args.pipeline_config.image_encoder_config
         encoder_config.update_model_arch(model_config)
+        record_resolved_attention_backend(encoder_config)
 
         from fastvideo.platforms import current_platform
 
@@ -1017,16 +1026,14 @@ class TransformerLoader(ComponentLoader):
         # Generator-only QAT for DMD distillation: the teacher (real_score) and
         # critic (fake_score) transformers load with this flag set and must stay
         # full precision. Drop the nvfp4_qat quant from their copied config, and
-        # mask the global ATTN_QAT_TRAIN env so their attention falls back to dense
-        # (the backend is read globally at build time). The generator loads without
-        # the flag and keeps both.
+        # build their attention under a scope that ignores any process-wide
+        # ATTN_QAT_TRAIN request so it falls back to dense. The generator loads
+        # without the flag and keeps both. The scope is exception-safe and
+        # needs no env mutation or selector cache flush (the request is part
+        # of the resolution cache key).
         _qat_generator_only = hasattr(fastvideo_args, "_loading_teacher_critic_model")
-        _qat_prev_attn_env = None
         if _qat_generator_only:
             dit_config.quant_config = None
-            from fastvideo.attention.selector import _cached_get_attn_backend
-            _qat_prev_attn_env = os.environ.pop("FASTVIDEO_ATTENTION_BACKEND", None)
-            _cached_get_attn_backend.cache_clear()
 
         model_cls, _ = ModelRegistry.resolve_model_cls(cls_name)
 
@@ -1093,32 +1100,34 @@ class TransformerLoader(ComponentLoader):
             or cls_name == "Cosmos25Transformer3DModel"
             or getattr(fastvideo_args.pipeline_config, "prefix", "") == "Cosmos25"
         )
-        model = maybe_load_fsdp_model(
-            model_cls=model_cls,
-            init_params={"config": dit_config, "hf_config": hf_config},
-            weight_dir_list=safetensors_list,
-            device=get_local_torch_device(),
-            hsdp_replicate_dim=fastvideo_args.hsdp_replicate_dim,
-            hsdp_shard_dim=fastvideo_args.hsdp_shard_dim,
-            strict=strict_load,
-            cpu_offload=fastvideo_args.dit_cpu_offload,
-            pin_cpu_memory=fastvideo_args.pin_cpu_memory,
-            fsdp_inference=fastvideo_args.use_fsdp_inference,
-            # TODO(will): make these configurable
-            default_dtype=default_dtype,
-            param_dtype=torch.bfloat16,
-            reduce_dtype=torch.float32,
-            output_dtype=None,
-            training_mode=fastvideo_args.training_mode,
-            enable_torch_compile=fastvideo_args.enable_torch_compile,
-            torch_compile_kwargs=fastvideo_args.torch_compile_kwargs,
-        )
-
-        if _qat_generator_only:
-            from fastvideo.attention.selector import _cached_get_attn_backend
-            if _qat_prev_attn_env is not None:
-                os.environ["FASTVIDEO_ATTENTION_BACKEND"] = _qat_prev_attn_env
-            _cached_get_attn_backend.cache_clear()
+        attention_context = (_component_attention_backend_scope(None, component="transformer")
+                             if _qat_generator_only else nullcontext())
+        with attention_context:
+            # dit_config is what the model is handed and keeps as `self.config`,
+            # so recording here makes the decision readable from the loaded
+            # transformer — and records the narrowed one for teacher/critic.
+            resolved = record_resolved_attention_backend(dit_config)
+            logger.info("transformer attention backend: %s", resolved.name if resolved else "automatic selection")
+            model = maybe_load_fsdp_model(
+                model_cls=model_cls,
+                init_params={"config": dit_config, "hf_config": hf_config},
+                weight_dir_list=safetensors_list,
+                device=get_local_torch_device(),
+                hsdp_replicate_dim=fastvideo_args.hsdp_replicate_dim,
+                hsdp_shard_dim=fastvideo_args.hsdp_shard_dim,
+                strict=strict_load,
+                cpu_offload=fastvideo_args.dit_cpu_offload,
+                pin_cpu_memory=fastvideo_args.pin_cpu_memory,
+                fsdp_inference=fastvideo_args.use_fsdp_inference,
+                # TODO(will): make these configurable
+                default_dtype=default_dtype,
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.float32,
+                output_dtype=None,
+                training_mode=fastvideo_args.training_mode,
+                enable_torch_compile=fastvideo_args.enable_torch_compile,
+                torch_compile_kwargs=fastvideo_args.torch_compile_kwargs,
+            )
 
         total_params = sum(p.numel() for p in model.parameters())
         logger.info("Loaded model with %.2fB parameters", total_params / 1e9)
@@ -1371,5 +1380,22 @@ class PipelineComponentLoader:
             module_name, transformers_or_diffusers
         )
 
-        # Load the module
-        return loader.load(component_model_path, fastvideo_args)
+        # Resolve this component's attention backend ONCE, here, from the
+        # explicit request and the environment. A per-role request already
+        # resolved upstream (the train stack's moduleloader) wins; otherwise
+        # fastvideo_args.attention_backend is the process-wide default, applied
+        # per component.
+        #
+        # The loaders record the decision on their own config rather than this
+        # function doing it after the fact, because a loader may narrow it for
+        # one component: the DMD teacher/critic transformers build dense inside
+        # a nested scope (see `record_resolved_attention_backend`).
+        if _active_component_attention_backend_scope() is not None:
+            attention_context = nullcontext()
+        else:
+            resolved = coerce_attn_backend(getattr(fastvideo_args, "attention_backend", None))
+            attention_context = (_component_attention_backend_scope(resolved, component=module_name)
+                                 if resolved is not None else nullcontext())
+
+        with attention_context:
+            return loader.load(component_model_path, fastvideo_args)

--- a/fastvideo/tests/api/test_attention_selector_resolution.py
+++ b/fastvideo/tests/api/test_attention_selector_resolution.py
@@ -1,0 +1,260 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Golden tests for explicit per-component attention-backend resolution.
+
+The selector's contract after the refactor:
+  * precedence is unchanged: global force > scoped/explicit request >
+    env var > layer default > platform auto — the scoped request occupies
+    exactly the position the process-global force held when the train
+    stack used it for per-role models;
+  * every selection input is part of the resolution cache key, so no
+    mutation (scope, force, env) ever needs a ``cache_clear()``;
+  * an active ``_component_attention_backend_scope`` suppresses the env var unless
+    ``consult_env=True`` — ``_component_attention_backend_scope(None)`` therefore
+    means "automatic selection, ignore the process-wide request" (the
+    dense teacher/critic case);
+  * scopes are exception-safe and per-component (component identity and
+    the active device index are cache-key inputs, so two components — or
+    two devices with different capabilities — never share a resolution).
+
+CPU-only: the platform is faked (same seam as the pre-existing
+role-override tests); no kernels, no GPU.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+import fastvideo.attention.selector as selector
+import fastvideo.platforms as platforms
+from fastvideo.platforms import AttentionBackendEnum
+
+FLASH = AttentionBackendEnum.FLASH_ATTN
+SDPA = AttentionBackendEnum.TORCH_SDPA
+SAGE = AttentionBackendEnum.SAGE_ATTN
+
+SUPPORTED = (FLASH, SDPA, SAGE)
+KWARGS = {
+    "head_size": 64,
+    "dtype": torch.bfloat16,
+    "supported_attention_backends": SUPPORTED,
+}
+
+
+class _FakePlatform:
+    device_name = "fake"
+
+    @classmethod
+    def get_attn_backend_cls(
+        cls,
+        selected_backend: AttentionBackendEnum | None,
+        head_size: int,
+        dtype: torch.dtype,
+    ) -> str:
+        del head_size, dtype
+        # Auto-selection (None) resolves to FLASH on this fake platform so
+        # the oracle can distinguish "auto" from every explicit request.
+        return (selected_backend or FLASH).name
+
+
+@pytest.fixture(autouse=True)
+def _fake_platform(monkeypatch):
+    monkeypatch.setattr(platforms, "_current_platform", _FakePlatform())
+    monkeypatch.setattr(selector, "resolve_obj_by_qualname", lambda name: name)
+    monkeypatch.delenv("FASTVIDEO_ATTENTION_BACKEND", raising=False)
+    selector.global_force_attn_backend(None)
+    selector._cached_get_attn_backend.cache_clear()
+    yield
+    selector.global_force_attn_backend(None)
+    # Fake-platform resolutions must not outlive the test: mutations no
+    # longer flush the cache (that is the feature), so evict explicitly.
+    selector._cached_get_attn_backend.cache_clear()
+
+
+def _oracle(forced, requested, env, default):
+    """Today's documented precedence, spelled out independently."""
+    selected = forced if forced is not None else requested
+    if selected is None and env is not None:
+        selected = AttentionBackendEnum[env]
+    if selected is None and default is not None:
+        selected = default
+    if selected is not None and selected not in SUPPORTED:
+        selected = default if default in SUPPORTED else None
+    return (selected or FLASH).name
+
+
+@pytest.mark.parametrize("forced", [None, SDPA])
+@pytest.mark.parametrize("scoped", [None, "unset", SAGE])
+@pytest.mark.parametrize("env", [None, "TORCH_SDPA"])
+@pytest.mark.parametrize("default", [None, SAGE])
+def test_precedence_matrix_matches_previous_semantics(monkeypatch, forced, scoped, env, default) -> None:
+    if env is not None:
+        monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", env)
+    selector.global_force_attn_backend(forced)
+
+    if scoped == "unset":
+        # No scope: env is consulted (legacy behavior preserved).
+        got = selector.get_attn_backend(default_backend=default, **KWARGS)
+        expected = _oracle(forced, None, env, default)
+    else:
+        # Scope active: env suppressed; scoped request sits in the position
+        # the global force held for per-role loads.
+        with selector._component_attention_backend_scope(scoped, component="dit"):
+            got = selector.get_attn_backend(default_backend=default, **KWARGS)
+        expected = _oracle(forced, scoped, None, default)
+    assert got == expected
+
+
+def test_scope_none_ignores_env_request(monkeypatch) -> None:
+    """The dense teacher/critic case: auto-select, ignore the process-wide
+    request — previously implemented by popping the env var and flushing
+    the selector cache around the build."""
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "SAGE_ATTN")
+
+    assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+    with selector._component_attention_backend_scope(None, component="transformer"):
+        assert selector.get_attn_backend(**KWARGS) == "FLASH_ATTN"  # auto
+    assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+
+
+def test_interleaved_component_scopes_need_no_cache_clear(monkeypatch) -> None:
+    """Per-role/per-component builds interleave freely; identical
+    shape/dtype keys resolve per scope with zero cache management."""
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "SAGE_ATTN")
+
+    for _ in range(2):
+        with selector._component_attention_backend_scope(SDPA, component="student"):
+            assert selector.get_attn_backend(**KWARGS) == "TORCH_SDPA"
+        with selector._component_attention_backend_scope(None, component="teacher"):
+            assert selector.get_attn_backend(**KWARGS) == "FLASH_ATTN"
+        assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+
+
+def test_scope_is_exception_safe(monkeypatch) -> None:
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "SAGE_ATTN")
+    with pytest.raises(RuntimeError, match="boom"):
+        with selector._component_attention_backend_scope(SDPA, component="dit"):
+            raise RuntimeError("boom")
+    assert selector._active_component_attention_backend_scope() is None
+    assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+
+
+def test_global_force_wins_without_cache_clear() -> None:
+    with selector._component_attention_backend_scope(SAGE, component="dit"):
+        assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+        selector.global_force_attn_backend(SDPA)
+        assert selector.get_attn_backend(**KWARGS) == "TORCH_SDPA"
+        selector.global_force_attn_backend(None)
+        assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+
+
+def test_env_change_takes_effect_without_cache_clear(monkeypatch) -> None:
+    """Selection inputs live in the cache key, so an env change is simply a
+    different key. (Previously a changed env var was silently ignored until
+    someone remembered to flush the cache.)"""
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "SAGE_ATTN")
+    assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "TORCH_SDPA")
+    assert selector.get_attn_backend(**KWARGS) == "TORCH_SDPA"
+
+
+def test_scope_typo_fails_fast() -> None:
+    with pytest.raises(ValueError, match="Unknown attention backend"):
+        with selector._component_attention_backend_scope("flash_atn", component="dit"):
+            pass
+
+
+def test_consult_env_scope_keeps_env_visible(monkeypatch) -> None:
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "SAGE_ATTN")
+    with selector._component_attention_backend_scope(None, component="dit", consult_env=True):
+        assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+
+
+def test_active_device_is_part_of_the_cache_key(monkeypatch) -> None:
+    """Platform auto-selection probes the *current* device's capability
+    (AttnQatInferBackend, for one, resolves a different kernel per
+    capability set), so two devices must not share one cached resolution.
+    The fake platform here stands in for that probe."""
+    current = {"index": 0}
+    per_device = {0: FLASH, 1: SDPA}
+
+    class _PerDevicePlatform:
+        device_name = "fake"
+
+        @classmethod
+        def get_attn_backend_cls(cls, selected_backend, head_size, dtype) -> str:
+            del head_size, dtype
+            return (selected_backend or per_device[current["index"]]).name
+
+    monkeypatch.setattr(platforms, "_current_platform", _PerDevicePlatform())
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: current["index"])
+
+    assert selector.get_attn_backend(**KWARGS) == "FLASH_ATTN"
+    current["index"] = 1
+    assert selector.get_attn_backend(**KWARGS) == "TORCH_SDPA"
+
+
+# ---------------------------------------------------------------------------
+# The decision is carried on the component
+# ---------------------------------------------------------------------------
+
+
+def test_env_is_folded_into_the_typed_request_once(monkeypatch):
+    """``FastVideoArgs.attention_backend`` is the parse-once adapter."""
+    from fastvideo.fastvideo_args import FastVideoArgs
+
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "SAGE_ATTN")
+    assert FastVideoArgs(model_path="x").attention_backend == "SAGE_ATTN"
+
+    # An explicit request always wins over the environment.
+    assert FastVideoArgs(model_path="x", attention_backend="TORCH_SDPA").attention_backend == "TORCH_SDPA"
+
+
+def test_unparseable_env_falls_through_instead_of_raising(monkeypatch):
+    """The env var keeps its permissive parse; only explicit requests raise."""
+    from fastvideo.fastvideo_args import FastVideoArgs
+
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "flash_atn")
+    assert FastVideoArgs(model_path="x").attention_backend is None
+
+    with pytest.raises(ValueError, match="Unknown attention backend"):
+        FastVideoArgs(model_path="x", attention_backend="flash_atn")
+
+
+def test_recorded_decision_is_readable_from_the_component():
+    """After load, the component carries what it resolved."""
+    from fastvideo.configs.models.dits.base import DiTConfig
+
+    config = DiTConfig()
+    assert config._resolved_attention_backend is None
+
+    with selector._component_attention_backend_scope(SAGE, component="transformer"):
+        assert selector.record_resolved_attention_backend(config) == SAGE
+    assert config._resolved_attention_backend == SAGE
+
+
+def test_recorded_decision_is_the_narrowed_one():
+    """A loader that narrows the request records the narrowed value.
+
+    The DMD teacher/critic transformers build dense inside a nested scope
+    while the run as a whole requested a quantized backend; the component
+    must report what it actually resolved, not the run-wide request.
+    """
+    from fastvideo.configs.models.dits.base import DiTConfig
+
+    student, teacher = DiTConfig(), DiTConfig()
+    with selector._component_attention_backend_scope(SAGE, component="transformer"):
+        selector.record_resolved_attention_backend(student)
+        with selector._component_attention_backend_scope(None, component="transformer"):
+            selector.record_resolved_attention_backend(teacher)
+
+    assert student._resolved_attention_backend == SAGE
+    assert teacher._resolved_attention_backend is None
+
+
+def test_no_request_records_no_decision():
+    from fastvideo.configs.models.encoders.base import TextEncoderConfig
+
+    config = TextEncoderConfig()
+    assert selector.record_resolved_attention_backend(config) is None
+    assert config._resolved_attention_backend is None

--- a/fastvideo/tests/attention/test_selector_role_override.py
+++ b/fastvideo/tests/attention/test_selector_role_override.py
@@ -51,7 +51,10 @@ def test_role_override_invalidates_cached_backend(monkeypatch) -> None:
         assert selector.get_attn_backend(**kwargs) == "FLASH_ATTN"
     finally:
         # Do not leave fake-platform resolutions cached for later tests.
+        # global_force_attn_backend no longer flushes the cache (selection
+        # inputs are cache-key members now), so evict explicitly.
         selector.global_force_attn_backend(None)
+        selector._cached_get_attn_backend.cache_clear()
 
 
 def test_unsupported_role_override_honors_layer_default(monkeypatch) -> None:
@@ -70,6 +73,7 @@ def test_unsupported_role_override_honors_layer_default(monkeypatch) -> None:
             ) == "TORCH_SDPA"
     finally:
         selector.global_force_attn_backend(None)
+        selector._cached_get_attn_backend.cache_clear()
 
 
 def test_explicit_backend_config_rejects_typos() -> None:

--- a/fastvideo/tests/train/utils/test_moduleloader_attention_backend.py
+++ b/fastvideo/tests/train/utils/test_moduleloader_attention_backend.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import torch
 import pytest
 
-from fastvideo.attention.selector import get_global_forced_attn_backend
+from fastvideo.attention.selector import _active_component_attention_backend_scope
 from fastvideo.configs.pipelines.base import PipelineConfig
 from fastvideo.platforms import AttentionBackendEnum
 from fastvideo.train.utils import moduleloader
@@ -19,7 +19,7 @@ def test_load_transformer_scopes_attention_backend(monkeypatch, tmp_path) -> Non
         distributed=DistributedConfig(hsdp_shard_dim=1),
         pipeline_config=PipelineConfig(),
     )
-    captured: list[AttentionBackendEnum | None] = []
+    captured: list[tuple[AttentionBackendEnum | None, str | None]] = []
 
     monkeypatch.setattr(moduleloader, "maybe_download_model", lambda path: str(tmp_path))
     monkeypatch.setattr(
@@ -30,7 +30,8 @@ def test_load_transformer_scopes_attention_backend(monkeypatch, tmp_path) -> Non
 
     def _fake_load_module(**kwargs):
         del kwargs
-        captured.append(get_global_forced_attn_backend())
+        scope = _active_component_attention_backend_scope()
+        captured.append((scope.backend, scope.component) if scope else (None, None))
         return torch.nn.Linear(1, 1)
 
     monkeypatch.setattr(
@@ -47,8 +48,8 @@ def test_load_transformer_scopes_attention_backend(monkeypatch, tmp_path) -> Non
     )
 
     assert isinstance(result, torch.nn.Module)
-    assert captured == [AttentionBackendEnum.ATTN_QAT_TRAIN]
-    assert get_global_forced_attn_backend() is None
+    assert captured == [(AttentionBackendEnum.ATTN_QAT_TRAIN, "transformer")]
+    assert _active_component_attention_backend_scope() is None
 
 
 def test_load_transformer_restores_backend_when_loading_fails(
@@ -68,7 +69,8 @@ def test_load_transformer_restores_backend_when_loading_fails(
 
     def _raise_during_load(**kwargs):
         del kwargs
-        assert get_global_forced_attn_backend() is AttentionBackendEnum.ATTN_QAT_TRAIN
+        scope = _active_component_attention_backend_scope()
+        assert scope is not None and scope.backend is AttentionBackendEnum.ATTN_QAT_TRAIN
         raise RuntimeError("load failed")
 
     monkeypatch.setattr(
@@ -84,4 +86,4 @@ def test_load_transformer_restores_backend_when_loading_fails(
             training_config=training_config,
             attention_backend="ATTN_QAT_TRAIN",
         )
-    assert get_global_forced_attn_backend() is None
+    assert _active_component_attention_backend_scope() is None

--- a/fastvideo/train/utils/moduleloader.py
+++ b/fastvideo/train/utils/moduleloader.py
@@ -9,8 +9,8 @@ from typing import Any, TYPE_CHECKING
 import torch
 
 from fastvideo.attention.selector import (
+    _component_attention_backend_scope,
     coerce_attn_backend,
-    global_force_attn_backend_context_manager,
 )
 from fastvideo.configs.pipelines.base import PipelineConfig
 from fastvideo.fastvideo_args import ExecutionMode, TrainingArgs
@@ -131,8 +131,11 @@ def load_module_from_path(
         raise ValueError("attention_backend can only be set when loading "
                          f"a transformer, got module_type={module_type!r}")
     resolved_attention_backend = coerce_attn_backend(attention_backend)
-    attention_context = (nullcontext() if resolved_attention_backend is None else
-                         global_force_attn_backend_context_manager(resolved_attention_backend))
+    # Per-role request delivered as a construction scope: process-local,
+    # exception-safe, and part of the selector's cache key (no global
+    # mutation, no cache flushes between roles).
+    attention_context = (nullcontext() if resolved_attention_backend is None else _component_attention_backend_scope(
+        resolved_attention_backend, component=module_type))
 
     if disable_custom_init_weights:
         fastvideo_args._loading_teacher_critic_model = True


### PR DESCRIPTION
## Purpose

Resolve each component's attention backend **once, at load time**, and carry the
decision on the component — instead of every attention layer re-deriving it from
process-wide state while the model is being built.

Today a layer's backend is decided by reading `FASTVIDEO_ATTENTION_BACKEND` at
the moment the layer is constructed, and by a process-global override that has
to flush a cache to take effect. That makes kernel selection an ambient property
of the process rather than a declared property of the component: two components
in one process cannot request different backends without mutating and restoring
global state around each construction, which is what the DMD distillation path
does today (it pops the env var, clears the selector cache, builds the dense
teacher/critic, then puts it all back).

## Design

**Resolve once. Carry the decision on the component.**

1. **One parse of the environment.** `FastVideoArgs.attention_backend` is the
   typed request for a run. When it is unset, `__post_init__` folds
   `FASTVIDEO_ATTENTION_BACKEND` into it — so the environment is an *input*,
   read once, rather than something library code consults later. An explicit
   request always wins and fails fast on a typo; the env var keeps its
   historically permissive parse, where an unknown name falls through to
   automatic selection.

2. **The loader resolves per component.** `PipelineComponentLoader.load_module`
   applies that request to each component it loads. A role-level request already
   resolved upstream (the training stack's per-role `attention_backend`) takes
   precedence over the run-wide one.

3. **The decision is recorded on the component's own config.** Each loader
   writes what its component resolved to
   `ModelConfig._resolved_attention_backend`, on the config object the model
   keeps as `self.config`. After load it is readable from the component:

   ```python
   transformer.config._resolved_attention_backend
   ```

   The loader is the right place to record it rather than the caller above:
   a loader may narrow the request for one component — the DMD teacher/critic
   transformers build dense — and the recorded value is what that component
   actually resolved, not what the run asked for globally.

4. **Every selection input is in the cache key.** The resolution cache is keyed
   on the request, the global force, the env value, component identity and the
   active device index, so a changed request lands on a different cache entry.
   No `cache_clear()` is needed anywhere, and none should be added. The device
   index matters because platform resolution probes the *current* device's
   capability — `ATTN_QAT_INFER` picks sm_12x CUTLASS, sm_100/sm_103 FP4, or a
   FlashAttention fallback per arch — so a resolution taken for one device is
   never handed to another.

This lets the distillation path drop its env-mutate / cache-flush dance: the
teacher and critic declare a dense request for their own construction, and the
generator keeps the quantized one.

### What is not in this PR

Layer constructors nested inside a model receive only a bare
`supported_attention_backends` tuple, threaded through block constructors up to
four levels deep — 43 construction sites across 26 model families. They cannot
yet read the decision off their own config, so the request is delivered from
loader to layers by a private ContextVar,
`_component_attention_backend_scope`. It is plumbing with a stated end, not API:
it is private, absent from `fastvideo/attention/__init__.py`, and
`fastvideo/attention/AGENTS.md` documents the deletion path — thread the request
alongside that tuple one family at a time, starting with the families that carry
per-role requests (Wan, LTX-2, Kandinsky5), and the scope goes away when the
last family lands. Doing all 26 families in one PR would be a large diff whose
failure mode is silent: a missed site drops the per-role request and the
teacher/critic builds quantized, which shows up as numerics rather than an
error.

`global_force_attn_backend_context_manager` is untouched. Migrating the training
stack off it is separate work.

## Blast radius

Shared-forward: the selector is read by both the inference and training stacks.
Behavior is intended to be identical for every component / architecture /
request combination — that is the contract these tests exist to hold. Layers
built outside a loader (the denoising stages, and direct model construction in
tests) still read the env var through the selector, unchanged.

## Test Plan

`fastvideo/tests/api/test_attention_selector_resolution.py` is a golden
precedence matrix: an independent oracle spells out the documented precedence,
and the test asserts the selector agrees across the full cross-product of
(global force x request x env x layer default), plus the fallback when a
requested backend is not in a layer's supported set. Any precedence change fails
it. Alongside it:

- env is folded into the typed request exactly once; an explicit request wins;
  an unparseable env value falls through instead of raising, while an
  unparseable explicit request raises;
- the recorded decision is readable from the component after load, and a
  narrowed request (teacher/critic) records the narrowed value;
- component identity and the active device index are part of the cache key;
- scopes are exception-safe and nest.

CPU-only — the platform is faked, no kernels and no GPU:

```bash
pytest fastvideo/tests/api/test_attention_selector_resolution.py \
       fastvideo/tests/attention/test_selector_role_override.py \
       fastvideo/tests/train/utils/test_moduleloader_attention_backend.py -q
```

These run in the `microscope-unit-tests` lane.

## Checklist

- [x] I ran pre-commit on the changed files and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed (`fastvideo/attention/AGENTS.md`)
- [x] I considered GPU memory impact of my changes (none — selection only)
