### PR TITLE
[ci]: run the full attention test directory in the unit lane

### DIFF
--- a/fastvideo/tests/modal/pr_test.py
+++ b/fastvideo/tests/modal/pr_test.py
@@ -382,7 +382,7 @@ def run_unit_test():
         "./fastvideo/tests/workflow/ ./fastvideo/tests/entrypoints/ ./fastvideo/tests/train/ "
         "./fastvideo/tests/stages/ ./fastvideo/tests/ops/ ./fastvideo/tests/worker/ "
         "./fastvideo/tests/training/test_trackers.py "
-        "./fastvideo/tests/attention/test_sdpa_metadata_mask_contract.py "
+        "./fastvideo/tests/attention/ "
         "./fastvideo/tests/modal/test_kernel_build_cache.py ./fastvideo/tests/modal/test_pr_test.py "
         "./fastvideo/tests/modal/test_ssim_test.py "
         "--ignore=./fastvideo/tests/entrypoints/test_openai_api_integration.py "

--- a/fastvideo/tests/modal/test_pr_test.py
+++ b/fastvideo/tests/modal/test_pr_test.py
@@ -323,3 +323,15 @@ def test_run_unit_test_collects_modal_cache_runner_tests(monkeypatch):
         "./fastvideo/tests/modal/test_ssim_test.py",
     ):
         assert test_path in commands[0]
+
+
+def test_run_unit_test_collects_the_whole_attention_directory(monkeypatch):
+    """Naming individual files under fastvideo/tests/attention/ let new ones
+    land uncovered; collect the directory so that cannot happen silently."""
+    module = _load_pr_test_module(monkeypatch)
+    commands = []
+    monkeypatch.setattr(module, "run_test", commands.append)
+
+    module.run_unit_test()
+
+    assert "./fastvideo/tests/attention/ " in commands[0]


### PR DESCRIPTION
## Problem

`run_unit_test` collects whole directories — `fastvideo/tests/api/`,
`.../train/`, `.../stages/`, `.../ops/` — but from
`fastvideo/tests/attention/` it names exactly one file:

```
"./fastvideo/tests/attention/test_sdpa_metadata_mask_contract.py "
```

The other ten files in that directory run in **no PR lane at all**. Among
them are the regression tests for the attention *selection* surface —
`test_selector_role_override.py` (per-role backend overrides) and
`test_attn_qat_infer_arch_gate.py` (the per-arch ATTN_QAT_INFER capability
sets) — plus the custom-op boundary tests for FA2/FA3, the masked/varlen
path, and FP4 FA4.

Those are precisely the tests that catch a silently mis-resolved attention
backend, which is a failure mode that produces output rather than an error.
A file-by-file selection also means every new test added to that directory
starts life uncollected, and nothing says so.

## What changes

Collect the directory:

```
"./fastvideo/tests/attention/ "
```

Every file in it is safe on the lane's L40S runner. The GPU/kernel-dependent
ones already gate themselves — `pytest.skip` on `torch.cuda.is_available()`,
on `flash_attn` / `flash_attn.cute` importability, on bf16 support, and a
module-level `find_spec("flash_attn")` guard in the resolver test. The rest
(`test_attn_qat_infer_arch_gate.py`, `test_selector_role_override.py`,
`test_attn_qat_train_kernel.py`, `test_sdpa_head_sizes.py`,
`test_attention_metadata_base.py`, `test_video_sparse_attention_metadata.py`)
are CPU tests that monkeypatch their device and import probes; the VSA
backend module guards its `fastvideo_kernel` import, so importing it without
the kernel is fine.

A test in `test_pr_test.py` now pins the directory form, so the collection
cannot silently narrow back to a file list.

## Evidence

The lane itself. `microscope-unit-tests` on this PR runs the new selection —
if any of the newly collected files is not lane-safe, it fails here rather
than after a merge.

## Note for reviewers

The open #1494 contains this same one-line widening as part of a much larger
change, and has been conflicting since mid-July. Landing it separately closes
the coverage hole now and removes one hunk from that PR's rebase; the
directory-form assertion added here is new.
