### PR TITLE
[bugfix]: harden FastVideo Studio UI reliability and accessibility

### DIFF
--- a/apps/fastvideo_studio/e2e/create-job.spec.ts
+++ b/apps/fastvideo_studio/e2e/create-job.spec.ts
@@ -13,10 +13,9 @@ test.describe('create inference job', () => {
   test('creates a T2V job and shows it in the queue', async ({ page }) => {
     await page.goto('/inference');
 
-    // The "Create Job" button reveals a workload menu on hover; wait for the
-    // T2V item to become visible before clicking so the CSS hover transition
-    // can't race the click.
-    await page.getByRole('button', { name: /create job/i }).hover();
+    // The trigger opens a real menu on click, so this path works for touch,
+    // mouse, and keyboard users.
+    await page.getByRole('button', { name: /create job/i }).click();
     const t2vItem = page.getByRole('menuitem', { name: /T2V/i });
     await expect(t2vItem).toBeVisible();
     await t2vItem.click();

--- a/apps/fastvideo_studio/e2e/gallery.spec.ts
+++ b/apps/fastvideo_studio/e2e/gallery.spec.ts
@@ -4,7 +4,7 @@ import { API_BASE, skipWithoutMock } from './helpers';
 
 /**
  * Gallery page: the seeded completed inference job surfaces as a media tile
- * (an <article> wrapping a <video>) captioned with its prompt.
+ * with playback controls or an explicit media-error fallback.
  */
 test.describe('gallery', () => {
   skipWithoutMock();
@@ -30,12 +30,15 @@ test.describe('gallery', () => {
       page.getByRole('heading', { level: 1, name: 'Gallery' }),
     ).toBeVisible();
 
-    // The completed job renders as an <article> containing a <video> tile.
-    const tile = page
-      .locator('article')
-      .filter({ has: page.locator('video') });
-    await expect(tile.first()).toBeVisible();
+    const tile = page.locator('article').filter({ hasText: completed!.prompt });
+    await expect(tile).toBeVisible();
+    await expect(
+      tile.locator('video').or(tile.getByText('Preview unavailable')),
+    ).toBeVisible();
 
-    await expect(page.getByText(completed!.prompt)).toBeVisible();
+    const video = tile.locator('video');
+    if (await video.isVisible()) {
+      await expect(video).toHaveAttribute('controls', '');
+    }
   });
 });

--- a/apps/fastvideo_studio/e2e/shell.spec.ts
+++ b/apps/fastvideo_studio/e2e/shell.spec.ts
@@ -46,36 +46,70 @@ test.describe('app shell', () => {
     }
   });
 
-  test('keeps navigation and content usable at 320px', async ({ page }) => {
-    await page.setViewportSize({ width: 320, height: 700 });
+  test('keeps navigation and content usable at responsive breakpoints', async ({
+    page,
+  }) => {
+    for (const width of [320, 375, 414, 768]) {
+      await page.setViewportSize({ width, height: 800 });
+      await page.goto('/inference');
+
+      const main = page.getByRole('main');
+      await expect(main).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: /Create Job/i }),
+      ).toBeVisible();
+
+      const initialBox = await main.boundingBox();
+      expect(initialBox?.x).toBe(width < 768 ? 0 : 220);
+      expect(initialBox?.width).toBe(width < 768 ? width : width - 220);
+
+      const navigation = page.getByRole('navigation', {
+        name: 'Primary navigation',
+      });
+      if (width < 768) {
+        await expect(
+          page.getByRole('button', { name: 'Open navigation' }),
+        ).toBeVisible();
+        await page.getByRole('button', { name: 'Open navigation' }).click();
+      }
+      await expect(navigation).toBeVisible();
+      await navigation.getByRole('link', { name: 'Datasets' }).click();
+
+      await expect(page).toHaveURL(/\/datasets$/);
+      expect(
+        await page.evaluate(
+          () => document.documentElement.scrollWidth <= window.innerWidth,
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test('uses full-width detail drawers on mobile', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 800 });
     await page.goto('/inference');
 
-    const main = page.getByRole('main');
-    await expect(main).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: 'Open navigation' }),
-    ).toBeVisible();
-    await expect(page.getByRole('button', { name: /Create Job/i })).toBeVisible();
+    await page
+      .locator('article button[aria-pressed="false"]')
+      .first()
+      .click();
+    const jobDrawer = page.getByRole('dialog', { name: 'Job details' });
+    await expect(jobDrawer).toBeVisible();
+    expect(await jobDrawer.boundingBox()).toMatchObject({ x: 0, width: 320 });
+    await jobDrawer.getByRole('button', { name: 'Close' }).click();
 
-    const initialBox = await main.boundingBox();
-    expect(initialBox?.x).toBe(0);
-    expect(initialBox?.width).toBe(320);
+    await page.goto('/datasets');
+    await page
+      .locator('article button[aria-pressed="false"]')
+      .first()
+      .click();
 
-    await page.getByRole('button', { name: 'Open navigation' }).click();
-    const navigation = page.getByRole('navigation', {
-      name: 'Primary navigation',
+    const datasetDrawer = page.getByRole('dialog', {
+      name: /dataset details$/,
     });
-    await expect(navigation).toBeVisible();
-    await navigation.getByRole('link', { name: 'Datasets' }).click();
-
-    await expect(page).toHaveURL(/\/datasets$/);
-    await expect(
-      page.getByRole('button', { name: 'Open navigation' }),
-    ).toBeVisible();
-    expect(
-      await page.evaluate(
-        () => document.documentElement.scrollWidth <= window.innerWidth,
-      ),
-    ).toBe(true);
+    await expect(datasetDrawer).toBeVisible();
+    expect(await datasetDrawer.boundingBox()).toMatchObject({
+      x: 0,
+      width: 320,
+    });
   });
 });

--- a/apps/fastvideo_studio/e2e/shell.spec.ts
+++ b/apps/fastvideo_studio/e2e/shell.spec.ts
@@ -44,4 +44,37 @@ test.describe('app shell', () => {
       ).toBeVisible();
     }
   });
+
+  test('keeps navigation and content usable at 320px', async ({ page }) => {
+    await page.setViewportSize({ width: 320, height: 700 });
+    await page.goto('/inference');
+
+    const main = page.getByRole('main');
+    await expect(main).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Open navigation' }),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: /Create Job/i })).toBeVisible();
+
+    const initialBox = await main.boundingBox();
+    expect(initialBox?.x).toBe(0);
+    expect(initialBox?.width).toBe(320);
+
+    await page.getByRole('button', { name: 'Open navigation' }).click();
+    const navigation = page.getByRole('navigation', {
+      name: 'Primary navigation',
+    });
+    await expect(navigation).toBeVisible();
+    await navigation.getByRole('link', { name: 'Datasets' }).click();
+
+    await expect(page).toHaveURL(/\/datasets$/);
+    await expect(
+      page.getByRole('button', { name: 'Open navigation' }),
+    ).toBeVisible();
+    expect(
+      await page.evaluate(
+        () => document.documentElement.scrollWidth <= window.innerWidth,
+      ),
+    ).toBe(true);
+  });
 });

--- a/apps/fastvideo_studio/e2e/shell.spec.ts
+++ b/apps/fastvideo_studio/e2e/shell.spec.ts
@@ -42,6 +42,7 @@ test.describe('app shell', () => {
       await expect(
         page.getByRole('heading', { level: 1, name: section.title }),
       ).toBeVisible();
+      await expect(page.getByRole('main')).toHaveCount(1);
     }
   });
 

--- a/apps/fastvideo_studio/package-lock.json
+++ b/apps/fastvideo_studio/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.1.0",
 			"dependencies": {
 				"@radix-ui/react-dialog": "^1.1.0",
+				"@radix-ui/react-dropdown-menu": "^2.1.24",
 				"@radix-ui/react-label": "^2.1.8",
 				"@radix-ui/react-scroll-area": "^1.2.10",
 				"@radix-ui/react-select": "^2.2.6",
@@ -1936,6 +1937,183 @@
 				}
 			}
 		},
+		"node_modules/@radix-ui/react-dropdown-menu": {
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+			"integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.7",
+				"@radix-ui/react-compose-refs": "1.1.5",
+				"@radix-ui/react-context": "1.2.2",
+				"@radix-ui/react-id": "1.1.4",
+				"@radix-ui/react-menu": "2.1.24",
+				"@radix-ui/react-primitive": "2.1.10",
+				"@radix-ui/react-use-controllable-state": "1.2.6"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/primitive": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+			"integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+			"integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-context": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+			"integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-id": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+			"integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+			"integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.3.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+			"integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.5"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+			"integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.7",
+				"@radix-ui/react-use-effect-event": "0.0.5",
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+			"integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+			"integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@radix-ui/react-focus-guards": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
@@ -2016,6 +2194,494 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/@radix-ui/react-menu": {
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+			"integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.7",
+				"@radix-ui/react-collection": "1.1.15",
+				"@radix-ui/react-compose-refs": "1.1.5",
+				"@radix-ui/react-context": "1.2.2",
+				"@radix-ui/react-direction": "1.1.4",
+				"@radix-ui/react-dismissable-layer": "1.1.19",
+				"@radix-ui/react-focus-guards": "1.1.6",
+				"@radix-ui/react-focus-scope": "1.1.16",
+				"@radix-ui/react-id": "1.1.4",
+				"@radix-ui/react-popper": "1.3.7",
+				"@radix-ui/react-portal": "1.1.17",
+				"@radix-ui/react-presence": "1.1.10",
+				"@radix-ui/react-primitive": "2.1.10",
+				"@radix-ui/react-roving-focus": "1.1.19",
+				"@radix-ui/react-slot": "1.3.3",
+				"@radix-ui/react-use-callback-ref": "1.1.4",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.7.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/primitive": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+			"integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-arrow": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+			"integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-collection": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+			"integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.5",
+				"@radix-ui/react-context": "1.2.2",
+				"@radix-ui/react-primitive": "2.1.10",
+				"@radix-ui/react-slot": "1.3.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+			"integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-context": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+			"integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-direction": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+			"integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-dismissable-layer": {
+			"version": "1.1.19",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+			"integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.7",
+				"@radix-ui/react-compose-refs": "1.1.5",
+				"@radix-ui/react-primitive": "2.1.10",
+				"@radix-ui/react-use-callback-ref": "1.1.4",
+				"@radix-ui/react-use-effect-event": "0.0.5"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-guards": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+			"integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-focus-scope": {
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+			"integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.5",
+				"@radix-ui/react-primitive": "2.1.10",
+				"@radix-ui/react-use-callback-ref": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-id": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+			"integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-popper": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+			"integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/react-dom": "^2.0.0",
+				"@radix-ui/react-arrow": "1.1.15",
+				"@radix-ui/react-compose-refs": "1.1.5",
+				"@radix-ui/react-context": "1.2.2",
+				"@radix-ui/react-primitive": "2.1.10",
+				"@radix-ui/react-use-callback-ref": "1.1.4",
+				"@radix-ui/react-use-layout-effect": "1.1.4",
+				"@radix-ui/react-use-rect": "1.1.4",
+				"@radix-ui/react-use-size": "1.1.4",
+				"@radix-ui/rect": "1.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-portal": {
+			"version": "1.1.17",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+			"integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.10",
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-presence": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+			"integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+			"integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.3.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-roving-focus": {
+			"version": "1.1.19",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+			"integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.7",
+				"@radix-ui/react-collection": "1.1.15",
+				"@radix-ui/react-compose-refs": "1.1.5",
+				"@radix-ui/react-context": "1.2.2",
+				"@radix-ui/react-direction": "1.1.4",
+				"@radix-ui/react-id": "1.1.4",
+				"@radix-ui/react-primitive": "2.1.10",
+				"@radix-ui/react-use-callback-ref": "1.1.4",
+				"@radix-ui/react-use-controllable-state": "1.2.6",
+				"@radix-ui/react-use-is-hydrated": "0.1.3",
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+			"integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.5"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+			"integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+			"integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.7",
+				"@radix-ui/react-use-effect-event": "0.0.5",
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+			"integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+			"integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-rect": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+			"integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/rect": "1.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-use-size": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+			"integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.4"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-menu/node_modules/@radix-ui/rect": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+			"integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+			"license": "MIT"
 		},
 		"node_modules/@radix-ui/react-popper": {
 			"version": "1.3.2",
@@ -2400,6 +3066,21 @@
 			"dependencies": {
 				"@radix-ui/react-use-layout-effect": "1.1.2"
 			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-is-hydrated": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+			"integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
 				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/apps/fastvideo_studio/package.json
+++ b/apps/fastvideo_studio/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"@radix-ui/react-dialog": "^1.1.0",
+		"@radix-ui/react-dropdown-menu": "^2.1.24",
 		"@radix-ui/react-label": "^2.1.8",
 		"@radix-ui/react-scroll-area": "^1.2.10",
 		"@radix-ui/react-select": "^2.2.6",

--- a/apps/fastvideo_studio/src/app/datasets/page.test.tsx
+++ b/apps/fastvideo_studio/src/app/datasets/page.test.tsx
@@ -1,0 +1,64 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HeaderActionsProvider } from '@/components/shell/HeaderActionsContext';
+import { getDatasets, type Dataset } from '@/lib/api';
+
+import DatasetsPage from './page';
+
+vi.mock('@/lib/api', () => ({
+  getDatasets: vi.fn(),
+}));
+
+vi.mock('@/components/datasets/AddDatasetButton', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/datasets/CreateDatasetModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/datasets/DatasetCard', () => ({
+  default: ({ dataset }: { dataset: Dataset }) => <div>{dataset.name}</div>,
+}));
+
+function renderPage() {
+  return render(
+    <HeaderActionsProvider>
+      <DatasetsPage />
+    </HeaderActionsProvider>,
+  );
+}
+
+describe('DatasetsPage', () => {
+  it('shows loading content before the initial request settles', async () => {
+    let resolveDatasets: (datasets: Dataset[]) => void = () => {};
+    vi.mocked(getDatasets).mockReturnValue(
+      new Promise<Dataset[]>((resolve) => {
+        resolveDatasets = resolve;
+      }),
+    );
+
+    renderPage();
+    expect(screen.getByLabelText('Loading datasets')).toBeInTheDocument();
+    expect(screen.queryByText('No datasets yet.')).not.toBeInTheDocument();
+
+    act(() => resolveDatasets([]));
+    expect(await screen.findByText('No datasets yet.')).toBeInTheDocument();
+  });
+
+  it('shows API failures separately from an empty list and retries', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(getDatasets).mockRejectedValueOnce(new Error('network down'));
+
+    renderPage();
+    expect(
+      await screen.findByText(/Could not load datasets from the Studio API/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('No datasets yet.')).not.toBeInTheDocument();
+
+    vi.mocked(getDatasets).mockResolvedValueOnce([]);
+    fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+    expect(await screen.findByText('No datasets yet.')).toBeInTheDocument();
+  });
+});

--- a/apps/fastvideo_studio/src/app/datasets/page.tsx
+++ b/apps/fastvideo_studio/src/app/datasets/page.tsx
@@ -62,7 +62,7 @@ export default function DatasetsPage() {
       <HeaderActions>
         <AddDatasetButton />
       </HeaderActions>
-      <main className="mx-auto flex w-full max-w-[850px] flex-col gap-6 px-4 pb-12">
+      <div className="mx-auto flex w-full max-w-[850px] flex-col gap-6 px-4 pb-12">
         <Card className="p-6">
           <div aria-busy={isInitialLoading}>
             {isInitialLoading ? (
@@ -122,7 +122,7 @@ export default function DatasetsPage() {
             )}
           </div>
         </Card>
-      </main>
+      </div>
       <CreateDatasetModal
         isOpen={open}
         onClose={() => setCreateDatasetModalOpen(false)}

--- a/apps/fastvideo_studio/src/app/datasets/page.tsx
+++ b/apps/fastvideo_studio/src/app/datasets/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import * as React from 'react';
+import { AlertTriangle } from 'lucide-react';
 
 import AddDatasetButton from '@/components/datasets/AddDatasetButton';
 import CreateDatasetModal from '@/components/datasets/CreateDatasetModal';
 import DatasetCard from '@/components/datasets/DatasetCard';
 import { HeaderActions } from '@/components/shell/HeaderActionsContext';
 import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { useStore } from '@/hooks/useStore';
 import { getDatasets } from '@/lib/api';
 import type { Dataset } from '@/lib/api';
@@ -21,18 +23,28 @@ import {
 
 export default function DatasetsPage() {
   const [datasets, setDatasets] = React.useState<Dataset[]>([]);
+  const [isInitialLoading, setIsInitialLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const { open } = useStore(createDatasetModalStore);
+  const fetchSequence = React.useRef(0);
 
   const fetchDatasets = React.useCallback(async () => {
+    const sequence = ++fetchSequence.current;
     try {
-      setDatasets(await getDatasets());
-      setError(null);
+      const next = await getDatasets();
+      if (sequence === fetchSequence.current) {
+        setDatasets(next);
+        setError(null);
+      }
     } catch (err) {
       console.error('Failed to fetch datasets:', err);
-      // Distinguish an API outage from a genuinely empty list, so the user
-      // isn't told they have no datasets when the server is unreachable.
-      setError(err instanceof Error ? err.message : 'Failed to load datasets');
+      if (sequence === fetchSequence.current) {
+        setError(
+          'Could not load datasets from the Studio API. Check the server and try again.',
+        );
+      }
+    } finally {
+      if (sequence === fetchSequence.current) setIsInitialLoading(false);
     }
   }, []);
 
@@ -52,22 +64,61 @@ export default function DatasetsPage() {
       </HeaderActions>
       <main className="mx-auto flex w-full max-w-[850px] flex-col gap-6 px-4 pb-12">
         <Card className="p-6">
-          <div>
-            {error ? (
-              <p className="py-8 text-center text-destructive">{error}</p>
-            ) : datasets.length === 0 ? (
-              <p className="py-8 text-center text-muted-foreground">
-                No datasets yet.
-              </p>
-            ) : (
-              datasets.map((ds) => (
-                <DatasetCard
-                  key={ds.id}
-                  dataset={ds}
-                  onUpdated={fetchDatasets}
-                  onSelect={() => handleSelectDataset(ds)}
+          <div aria-busy={isInitialLoading}>
+            {isInitialLoading ? (
+              <div
+                aria-label="Loading datasets"
+                className="flex flex-col gap-3 py-2"
+              >
+                {[0, 1, 2].map((item) => (
+                  <div
+                    key={item}
+                    className="h-24 animate-pulse rounded-lg border border-border bg-muted/50"
+                  />
+                ))}
+              </div>
+            ) : error && datasets.length === 0 ? (
+              <div
+                role="alert"
+                className="flex flex-col items-center gap-3 py-8 text-center"
+              >
+                <AlertTriangle
+                  className="size-6 text-destructive"
+                  aria-hidden
                 />
-              ))
+                <p className="max-w-md text-sm text-muted-foreground">
+                  {error}
+                </p>
+                <Button type="button" variant="outline" onClick={fetchDatasets}>
+                  Try Again
+                </Button>
+              </div>
+            ) : (
+              <>
+                {error && (
+                  <p
+                    role="status"
+                    className="mb-3 rounded-lg border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm text-foreground"
+                  >
+                    Dataset updates are temporarily unavailable. Showing the
+                    most recent results.
+                  </p>
+                )}
+                {datasets.length === 0 ? (
+                  <p className="py-8 text-center text-muted-foreground">
+                    No datasets yet.
+                  </p>
+                ) : (
+                  datasets.map((ds) => (
+                    <DatasetCard
+                      key={ds.id}
+                      dataset={ds}
+                      onUpdated={fetchDatasets}
+                      onSelect={() => handleSelectDataset(ds)}
+                    />
+                  ))
+                )}
+              </>
             )}
           </div>
         </Card>

--- a/apps/fastvideo_studio/src/app/gallery/page.test.tsx
+++ b/apps/fastvideo_studio/src/app/gallery/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import GalleryPage from './page';
@@ -41,6 +41,22 @@ describe('GalleryPage', () => {
 
     expect(await screen.findByText('a cat surfing a wave')).toBeInTheDocument();
     expect(getJobsList).toHaveBeenCalledWith('inference');
+  });
+
+  it('provides video controls and a visible fallback when media fails', async () => {
+    vi.mocked(getJobsList).mockResolvedValue([makeJob()]);
+    renderGallery();
+
+    const video = await screen.findByLabelText(
+      'Generated video: a cat surfing a wave',
+    );
+    expect(video).toHaveAttribute('controls');
+
+    fireEvent.error(video);
+    expect(screen.getByText('Preview unavailable')).toBeInTheDocument();
+    expect(
+      screen.getByText('The generated file could not be loaded.'),
+    ).toBeInTheDocument();
   });
 
   it('shows the empty state when no completed videos exist', async () => {

--- a/apps/fastvideo_studio/src/app/gallery/page.tsx
+++ b/apps/fastvideo_studio/src/app/gallery/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { ImageOff, Loader2 } from 'lucide-react';
+import { AlertTriangle, ImageOff, Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
+import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { getJobVideoUrl, getJobsList } from '@/lib/api';
 import type { Job } from '@/lib/types';
@@ -64,6 +65,8 @@ export default function GalleryPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const [reloadKey, setReloadKey] = useState(0);
+
   useEffect(() => {
     let cancelled = false;
     async function load() {
@@ -88,7 +91,13 @@ export default function GalleryPage() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reloadKey]);
+
+  function retry() {
+    setError(null);
+    setIsLoading(true);
+    setReloadKey((k) => k + 1);
+  }
 
   const galleryJobs = jobs.filter(
     (j) =>
@@ -112,7 +121,16 @@ export default function GalleryPage() {
             <span>Loading gallery…</span>
           </div>
         ) : error ? (
-          <p className="py-8 text-destructive">{error}</p>
+          <div
+            role="alert"
+            className="flex flex-col items-center gap-3 py-8 text-center"
+          >
+            <AlertTriangle className="size-6 text-destructive" aria-hidden />
+            <p className="max-w-md text-sm text-muted-foreground">{error}</p>
+            <Button type="button" variant="outline" onClick={retry}>
+              Try Again
+            </Button>
+          </div>
         ) : galleryJobs.length === 0 ? (
           <p className="py-8 text-center text-muted-foreground">
             No completed videos yet

--- a/apps/fastvideo_studio/src/app/gallery/page.tsx
+++ b/apps/fastvideo_studio/src/app/gallery/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Loader2 } from 'lucide-react';
+import { ImageOff, Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { Card } from '@/components/ui/card';
@@ -9,6 +9,54 @@ import type { Job } from '@/lib/types';
 
 function isImage(job: Job): boolean {
   return job.output_path?.toLowerCase().endsWith('.png') ?? false;
+}
+
+function GalleryMedia({ job }: { job: Job }) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return (
+      <div
+        role="status"
+        className="flex h-full flex-col items-center justify-center gap-2 px-4 text-center text-muted-foreground"
+      >
+        <ImageOff className="size-7" aria-hidden />
+        <span className="text-sm font-medium">Preview unavailable</span>
+        <span className="text-xs">
+          The generated file could not be loaded.
+        </span>
+      </div>
+    );
+  }
+
+  if (isImage(job)) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={getJobVideoUrl(job.id)}
+        alt={job.prompt}
+        className="block h-full w-full object-contain"
+        loading="lazy"
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+
+  return (
+    <video
+      src={getJobVideoUrl(job.id)}
+      aria-label={
+        job.prompt ? `Generated video: ${job.prompt}` : 'Generated video'
+      }
+      className="block h-full w-full object-contain"
+      controls
+      muted
+      loop
+      playsInline
+      preload="metadata"
+      onError={() => setFailed(true)}
+    />
+  );
 }
 
 export default function GalleryPage() {
@@ -77,24 +125,7 @@ export default function GalleryPage() {
                 className="flex flex-col overflow-hidden rounded-lg border border-border bg-background"
               >
                 <div className="relative aspect-video overflow-hidden bg-muted">
-                  {isImage(job) ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={getJobVideoUrl(job.id)}
-                      alt={job.prompt}
-                      className="block h-full w-full object-contain"
-                      loading="lazy"
-                    />
-                  ) : (
-                    <video
-                      src={getJobVideoUrl(job.id)}
-                      className="block h-full w-full object-contain"
-                      muted
-                      loop
-                      playsInline
-                      preload="metadata"
-                    />
-                  )}
+                  <GalleryMedia job={job} />
                 </div>
                 <p
                   className="line-clamp-3 border-t border-border px-4 py-3 text-sm text-muted-foreground"

--- a/apps/fastvideo_studio/src/app/globals.css
+++ b/apps/fastvideo_studio/src/app/globals.css
@@ -41,7 +41,7 @@
 
 	--border: #e2e8f0;
 	--input: #cbd5e1;
-	--ring: #94a3b8;
+	--ring: #1d4ed8;
 
 	--radius: 0.5rem;
 }
@@ -77,7 +77,7 @@
 
 	--border: #334155;
 	--input: #334155;
-	--ring: #cbd5e1;
+	--ring: #7dd3fc;
 }
 
 @theme inline {
@@ -162,6 +162,22 @@ body::after {
 
 a {
 	color: inherit;
+}
+
+:where(
+	a,
+	button,
+	input,
+	textarea,
+	select,
+	summary,
+	[role="button"],
+	[role="menuitem"],
+	[role="slider"],
+	[tabindex]
+):focus-visible {
+	outline: 3px solid var(--ring) !important;
+	outline-offset: 2px !important;
 }
 
 summary {

--- a/apps/fastvideo_studio/src/app/globals.css
+++ b/apps/fastvideo_studio/src/app/globals.css
@@ -125,6 +125,7 @@
 html,
 body {
 	min-height: 100%;
+	overflow-x: clip;
 }
 
 html {

--- a/apps/fastvideo_studio/src/app/globals.test.ts
+++ b/apps/fastvideo_studio/src/app/globals.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf8');
+
+function token(block: string, name: string): string {
+  const match = block.match(new RegExp(`--${name}:\\s*(#[0-9a-fA-F]{6})`));
+  if (!match) throw new Error(`Missing --${name} token`);
+  return match[1];
+}
+
+function luminance(hex: string): number {
+  const channels = hex
+    .slice(1)
+    .match(/.{2}/g)!
+    .map((channel) => parseInt(channel, 16) / 255)
+    .map((channel) =>
+      channel <= 0.04045
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4,
+    );
+  return (
+    0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2]
+  );
+}
+
+function contrast(first: string, second: string): number {
+  const firstLuminance = luminance(first);
+  const secondLuminance = luminance(second);
+  return (
+    (Math.max(firstLuminance, secondLuminance) + 0.05) /
+    (Math.min(firstLuminance, secondLuminance) + 0.05)
+  );
+}
+
+describe('global focus styles', () => {
+  it('keeps focus tokens above 3:1 against both page themes', () => {
+    const light = css.match(/:root\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+    const dark = css.match(/\.dark\s*{([\s\S]*?)\n}/)?.[1] ?? '';
+
+    expect(contrast(token(light, 'ring'), token(light, 'background'))).toBeGreaterThanOrEqual(
+      3,
+    );
+    expect(contrast(token(dark, 'ring'), token(dark, 'background'))).toBeGreaterThanOrEqual(
+      3,
+    );
+  });
+
+  it('applies a non-animated three-pixel outline to focus-visible controls', () => {
+    expect(css).toContain('):focus-visible {');
+    expect(css).toContain('outline: 3px solid var(--ring) !important;');
+    expect(css).toContain('outline-offset: 2px !important;');
+  });
+});

--- a/apps/fastvideo_studio/src/app/gpus/page.tsx
+++ b/apps/fastvideo_studio/src/app/gpus/page.tsx
@@ -4,8 +4,8 @@ import GpuGrid from '@/components/system/GpuGrid';
 
 export default function GpusPage() {
   return (
-    <main className="mx-auto flex w-full max-w-[1100px] flex-col gap-6 px-4 pb-12 pt-6">
+    <div className="mx-auto flex w-full max-w-[1100px] flex-col gap-6 px-4 pb-12 pt-6">
       <GpuGrid />
-    </main>
+    </div>
   );
 }

--- a/apps/fastvideo_studio/src/app/settings/page.test.tsx
+++ b/apps/fastvideo_studio/src/app/settings/page.test.tsx
@@ -52,6 +52,20 @@ describe('Settings page', () => {
     expect(updateOption).toHaveBeenCalledWith('numFrames', expect.any(Number));
   });
 
+  it('gives every slider an accessible name', () => {
+    renderPage();
+
+    const sliders = screen.getAllByRole('slider');
+    expect(sliders).toHaveLength(11);
+    for (const slider of sliders) {
+      expect(slider).toHaveAccessibleName();
+    }
+    expect(screen.getByRole('slider', { name: 'Frames' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('slider', { name: 'Guidance Scale' }),
+    ).toBeInTheDocument();
+  });
+
   it('calls resetToDefaults when Reset to Defaults is clicked', () => {
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: 'Reset to Defaults' }));

--- a/apps/fastvideo_studio/src/components/datasets/DatasetCard.test.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetCard.test.tsx
@@ -25,6 +25,16 @@ beforeEach(() => {
 });
 
 describe('DatasetCard', () => {
+  it('keeps selection and delete buttons as semantic siblings', () => {
+    render(<DatasetCard dataset={dataset} onUpdated={() => {}} />);
+
+    const selectButton = screen.getByRole('button', { pressed: false });
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+
+    expect(selectButton).toHaveTextContent('My Dataset');
+    expect(selectButton).not.toContainElement(deleteButton);
+  });
+
   it('renders the name, file count and human-readable size', () => {
     render(<DatasetCard dataset={dataset} onUpdated={() => {}} />);
     expect(screen.getByText('My Dataset')).toBeInTheDocument();

--- a/apps/fastvideo_studio/src/components/datasets/DatasetCard.test.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetCard.test.tsx
@@ -71,7 +71,7 @@ describe('DatasetCard', () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
-  it('selects on keyboard activation of the card body but not of the Delete button', () => {
+  it('keeps the selection and delete actions separate', () => {
     const onSelect = vi.fn();
     render(
       <DatasetCard dataset={dataset} onUpdated={() => {}} onSelect={onSelect} />,
@@ -83,8 +83,12 @@ describe('DatasetCard', () => {
     });
     expect(onSelect).not.toHaveBeenCalled();
 
-    // Activating the card body itself does select.
-    fireEvent.keyDown(screen.getByText('My Dataset'), { key: 'Enter' });
+    // Activating the dedicated selection button selects the dataset.
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /My Dataset.*3 files.*2.0 KB/,
+      }),
+    );
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/fastvideo_studio/src/components/datasets/DatasetCard.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetCard.tsx
@@ -55,43 +55,33 @@ export default function DatasetCard({
     }
   }
 
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if ((e.target as HTMLElement).closest('button')) return;
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onSelect();
-    }
-  }
-
   return (
-    <div
+    <article
       className={cn(
-        'mb-3 flex cursor-pointer flex-col gap-[0.6rem] rounded-lg border border-border bg-background px-[1.15rem] py-4',
+        'mb-3 flex items-start gap-3 rounded-lg border border-border bg-background px-[1.15rem] py-4',
         isSelected && 'border-accent-blue bg-accent-blue/5',
       )}
-      onClick={(e) => {
-        if ((e.target as HTMLElement).closest('button')) return;
-        onSelect();
-      }}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
     >
-      <div className="flex flex-wrap items-center justify-between gap-2">
+      <button
+        type="button"
+        aria-pressed={isSelected}
+        onClick={onSelect}
+        className="flex min-w-0 flex-1 cursor-pointer flex-col gap-[0.6rem] rounded-md text-left"
+      >
         <span className="text-[0.95rem] font-semibold">{dataset.name}</span>
-        <Button
-          type="button"
-          variant="destructive"
-          size="sm"
-          onClick={handleDelete}
-          disabled={isLoading}
-        >
-          Delete
-        </Button>
-      </div>
-      <div className="text-sm text-muted-foreground">
-        {fileCount} {fileCount === 1 ? 'file' : 'files'} · {sizeLabel}
-      </div>
-    </div>
+        <span className="text-sm text-muted-foreground">
+          {fileCount} {fileCount === 1 ? 'file' : 'files'} · {sizeLabel}
+        </span>
+      </button>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        onClick={handleDelete}
+        disabled={isLoading}
+      >
+        Delete
+      </Button>
+    </article>
   );
 }

--- a/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.test.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.test.tsx
@@ -63,6 +63,16 @@ describe('DatasetSidebar', () => {
     expect(mockedApi.getDatasetMediaUrl).toHaveBeenCalledWith('ds-1', 'b.mp4');
   });
 
+  it('shows a fallback when a dataset preview cannot load', async () => {
+    render(<DatasetSidebar dataset={dataset} onClose={() => {}} />);
+
+    const preview = await screen.findByLabelText('Preview of a.mp4');
+    fireEvent.error(preview);
+
+    expect(screen.getByText('Preview unavailable')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Preview of a.mp4')).not.toBeInTheDocument();
+  });
+
   it('debounces caption save by 500ms', async () => {
     render(<DatasetSidebar dataset={dataset} onClose={() => {}} />);
     const textarea = await screen.findByDisplayValue('cap a');

--- a/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.test.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.test.tsx
@@ -6,6 +6,9 @@ import * as api from '@/lib/api';
 import type { Dataset } from '@/lib/api';
 
 vi.mock('@/lib/api');
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}));
 
 const mockedApi = vi.mocked(api);
 
@@ -124,6 +127,39 @@ describe('DatasetSidebar', () => {
         'a.mp4',
         'two',
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows a failed save and lets the user retry it', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockedApi.updateDatasetCaption
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(undefined);
+    render(<DatasetSidebar dataset={dataset} onClose={() => {}} />);
+    const textarea = await screen.findByDisplayValue('cap a');
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(textarea, { target: { value: 'needs retry' } });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+
+      expect(screen.getByText(/Not saved/)).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockedApi.updateDatasetCaption).toHaveBeenCalledTimes(2);
+      expect(mockedApi.updateDatasetCaption).toHaveBeenLastCalledWith(
+        'ds-1',
+        'a.mp4',
+        'needs retry',
+      );
+      expect(screen.getByText('Saved')).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.test.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.test.tsx
@@ -27,6 +27,26 @@ beforeEach(() => {
 });
 
 describe('DatasetSidebar', () => {
+  it('fills the mobile viewport without reserving main-content width', async () => {
+    const onWidthChange = vi.fn();
+
+    render(
+      <DatasetSidebar
+        dataset={dataset}
+        isMobile
+        onClose={() => {}}
+        onWidthChange={onWidthChange}
+      />,
+    );
+
+    const drawer = screen.getByRole('dialog', {
+      name: 'My Dataset dataset details',
+    });
+    expect(drawer).toHaveStyle({ width: '100%', maxWidth: 'none' });
+    expect(drawer).toHaveAttribute('aria-modal', 'true');
+    expect(onWidthChange).toHaveBeenCalledWith(0);
+  });
+
   it('lists dataset files after loading', async () => {
     render(<DatasetSidebar dataset={dataset} onClose={() => {}} />);
 

--- a/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.test.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.test.tsx
@@ -47,6 +47,7 @@ describe('DatasetSidebar', () => {
     });
     expect(drawer).toHaveStyle({ width: '100%', maxWidth: 'none' });
     expect(drawer).toHaveAttribute('aria-modal', 'true');
+    expect(drawer).toHaveFocus();
     expect(onWidthChange).toHaveBeenCalledWith(0);
   });
 

--- a/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
@@ -68,10 +68,12 @@ const DatasetFileCard = React.memo(function DatasetFileCard({
 
 export default function DatasetSidebar({
   dataset,
+  isMobile = false,
   onClose,
   onWidthChange,
 }: {
   dataset: Dataset;
+  isMobile?: boolean;
   onClose: () => void;
   onWidthChange?: (w: number) => void;
 }) {
@@ -93,8 +95,8 @@ export default function DatasetSidebar({
   const scrollRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
-    onWidthChange?.(width);
-  }, [width, onWidthChange]);
+    onWidthChange?.(isMobile ? 0 : width);
+  }, [isMobile, width, onWidthChange]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -189,8 +191,14 @@ export default function DatasetSidebar({
 
   return (
     <aside
-      className="fixed bottom-0 right-0 top-[var(--header-height)] z-50 flex max-h-[calc(100vh-var(--header-height))] min-w-[320px] shrink-0 flex-col border-l border-border bg-card"
-      style={{ width, maxWidth: SIDEBAR_MAX_WIDTH }}
+      role="dialog"
+      aria-label={`${dataset.name} dataset details`}
+      aria-modal={isMobile || undefined}
+      className="fixed bottom-0 right-0 top-[var(--header-height)] z-50 flex max-h-[calc(100dvh-var(--header-height))] min-w-0 shrink-0 flex-col border-l border-border bg-card md:min-w-[320px]"
+      style={{
+        width: isMobile ? '100%' : width,
+        maxWidth: isMobile ? 'none' : SIDEBAR_MAX_WIDTH,
+      }}
     >
       <div className="flex shrink-0 items-center justify-between border-b border-border px-5 py-4">
         <h2 className="m-0 min-w-0 truncate text-base font-semibold text-foreground">
@@ -240,14 +248,14 @@ export default function DatasetSidebar({
         </div>
       </div>
 
-      <div
+      {!isMobile && <div
         role="presentation"
         onMouseDown={onMouseDown}
         className={cn(
           'absolute bottom-0 left-0 top-0 z-[1] w-1.5 cursor-col-resize hover:bg-accent-blue/25',
           isDragging && 'bg-accent-blue/25',
         )}
-      />
+      />}
     </aside>
   );
 }

--- a/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
@@ -101,7 +101,7 @@ const DatasetFileCard = React.memo(function DatasetFileCard({
             <button
               type="button"
               onClick={() => onCaptionRetry(fileName, caption)}
-              className="font-medium underline underline-offset-2"
+              className="inline-flex min-h-11 items-center font-medium underline underline-offset-2"
             >
               Retry
             </button>
@@ -291,7 +291,7 @@ export default function DatasetSidebar({
             onClick={onClose}
             title="Close"
             aria-label="Close"
-            className="flex items-center justify-center rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            className="flex size-11 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           >
             <X className="h-[18px] w-[18px]" />
           </button>

--- a/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
@@ -14,6 +14,7 @@ import {
   type Dataset,
 } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import { useDrawerFocus } from '@/hooks/useDrawerFocus';
 
 const SIDEBAR_MIN_WIDTH = 320;
 const SIDEBAR_MAX_WIDTH = 900;
@@ -123,6 +124,7 @@ export default function DatasetSidebar({
   onClose: () => void;
   onWidthChange?: (w: number) => void;
 }) {
+  const drawerRef = useDrawerFocus<HTMLElement>(isMobile);
   const [width, setWidth] = React.useState(400);
   const [isDragging, setIsDragging] = React.useState(false);
   const [fileNames, setFileNames] = React.useState<string[]>([]);
@@ -271,6 +273,8 @@ export default function DatasetSidebar({
 
   return (
     <aside
+      ref={drawerRef}
+      tabIndex={-1}
       role="dialog"
       aria-label={`${dataset.name} dataset details`}
       aria-modal={isMobile || undefined}

--- a/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { ImageOff, X } from 'lucide-react';
+import { toast } from 'sonner';
 
 import DownloadCaptions from '@/components/datasets/DownloadCaptions';
 import { Textarea } from '@/components/ui/textarea';
@@ -19,6 +20,7 @@ const SIDEBAR_MAX_WIDTH = 900;
 const INITIAL_PAGE_SIZE = 24;
 const PAGE_SIZE = 24;
 const SCROLL_THRESHOLD = 200;
+type CaptionSaveState = 'idle' | 'saving' | 'saved' | 'error';
 
 // Memoized so a caption keystroke re-renders only the edited card, not every
 // visible <video> in the grid (visibleCount grows unbounded with scrolling).
@@ -27,14 +29,18 @@ const DatasetFileCard = React.memo(function DatasetFileCard({
   mediaUrl,
   caption,
   thumbLoaded,
+  saveState,
   onCaptionChange,
+  onCaptionRetry,
   onThumbLoaded,
 }: {
   fileName: string;
   mediaUrl: string;
   caption: string;
   thumbLoaded: boolean;
+  saveState: CaptionSaveState;
   onCaptionChange: (fileName: string, value: string) => void;
+  onCaptionRetry: (fileName: string, value: string) => void;
   onThumbLoaded: (fileName: string) => void;
 }) {
   const [mediaFailed, setMediaFailed] = React.useState(false);
@@ -83,6 +89,25 @@ const DatasetFileCard = React.memo(function DatasetFileCard({
         rows={2}
         className="min-h-[2.5rem] resize-y rounded-none border-0 bg-transparent p-1.5 text-xs shadow-none focus-visible:border-transparent focus-visible:ring-0"
       />
+      <div
+        aria-live="polite"
+        className="flex min-h-6 items-center px-1.5 pb-1 text-[0.7rem] text-muted-foreground"
+      >
+        {saveState === 'saving' && <span>Saving…</span>}
+        {saveState === 'saved' && <span>Saved</span>}
+        {saveState === 'error' && (
+          <span role="alert" className="text-destructive">
+            Not saved.{' '}
+            <button
+              type="button"
+              onClick={() => onCaptionRetry(fileName, caption)}
+              className="font-medium underline underline-offset-2"
+            >
+              Retry
+            </button>
+          </span>
+        )}
+      </div>
     </div>
   );
 });
@@ -107,12 +132,16 @@ export default function DatasetSidebar({
   const [thumbLoaded, setThumbLoaded] = React.useState<
     Record<string, boolean>
   >({});
+  const [captionSaveStates, setCaptionSaveStates] = React.useState<
+    Record<string, CaptionSaveState>
+  >({});
 
   // Pending debounced caption saves, keyed per file so editing one caption
   // can't cancel another file's pending save.
   const pendingSaves = React.useRef(
     new Map<string, { timer: ReturnType<typeof setTimeout>; save: () => void }>(),
   );
+  const captionVersions = React.useRef(new Map<string, number>());
   const scrollRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -129,6 +158,8 @@ export default function DatasetSidebar({
         setCaptions(data.captions);
         setVisibleCount(INITIAL_PAGE_SIZE);
         setThumbLoaded({});
+        setCaptionSaveStates({});
+        captionVersions.current.clear();
       })
       .catch((err) => console.error('Failed to load dataset files:', err))
       .finally(() => {
@@ -161,23 +192,51 @@ export default function DatasetSidebar({
   });
 
   const datasetId = dataset.id;
+  const persistCaption = React.useCallback(
+    (fileName: string, value: string, version: number) => {
+      setCaptionSaveStates((prev) => ({ ...prev, [fileName]: 'saving' }));
+      void updateDatasetCaption(datasetId, fileName, value)
+        .then(() => {
+          if (captionVersions.current.get(fileName) !== version) return;
+          setCaptionSaveStates((prev) => ({ ...prev, [fileName]: 'saved' }));
+        })
+        .catch((error) => {
+          if (captionVersions.current.get(fileName) !== version) return;
+          console.error('Failed to save caption:', error);
+          setCaptionSaveStates((prev) => ({ ...prev, [fileName]: 'error' }));
+          toast.error('Caption was not saved', {
+            description: `${fileName}: check the Studio API, then retry.`,
+          });
+        });
+    },
+    [datasetId],
+  );
+
   const handleCaptionChange = React.useCallback(
     (fileName: string, value: string) => {
       setCaptions((prev) => ({ ...prev, [fileName]: value }));
+      setCaptionSaveStates((prev) => ({ ...prev, [fileName]: 'idle' }));
       const pending = pendingSaves.current.get(fileName);
       if (pending) clearTimeout(pending.timer);
-      const save = () => {
-        updateDatasetCaption(datasetId, fileName, value).catch((err) =>
-          console.error('Failed to save caption:', err),
-        );
-      };
+      const version = (captionVersions.current.get(fileName) ?? 0) + 1;
+      captionVersions.current.set(fileName, version);
+      const save = () => persistCaption(fileName, value, version);
       const timer = setTimeout(() => {
         pendingSaves.current.delete(fileName);
         save();
       }, 500);
       pendingSaves.current.set(fileName, { timer, save });
     },
-    [datasetId],
+    [persistCaption],
+  );
+
+  const handleCaptionRetry = React.useCallback(
+    (fileName: string, value: string) => {
+      const version = (captionVersions.current.get(fileName) ?? 0) + 1;
+      captionVersions.current.set(fileName, version);
+      persistCaption(fileName, value, version);
+    },
+    [persistCaption],
   );
 
   function handleScroll() {
@@ -260,7 +319,9 @@ export default function DatasetSidebar({
                   mediaUrl={getDatasetMediaUrl(dataset.id, fileName)}
                   caption={captions[fileName] ?? ''}
                   thumbLoaded={!!thumbLoaded[fileName]}
+                  saveState={captionSaveStates[fileName] ?? 'idle'}
                   onCaptionChange={handleCaptionChange}
+                  onCaptionRetry={handleCaptionRetry}
                   onThumbLoaded={markThumbLoaded}
                 />
               ))}

--- a/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DatasetSidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { X } from 'lucide-react';
+import { ImageOff, X } from 'lucide-react';
 
 import DownloadCaptions from '@/components/datasets/DownloadCaptions';
 import { Textarea } from '@/components/ui/textarea';
@@ -37,25 +37,46 @@ const DatasetFileCard = React.memo(function DatasetFileCard({
   onCaptionChange: (fileName: string, value: string) => void;
   onThumbLoaded: (fileName: string) => void;
 }) {
+  const [mediaFailed, setMediaFailed] = React.useState(false);
+
+  React.useEffect(() => {
+    setMediaFailed(false);
+  }, [mediaUrl]);
+
   return (
     <div className="relative flex flex-col overflow-hidden rounded-lg border border-border bg-background">
-      {!thumbLoaded && (
+      {!thumbLoaded && !mediaFailed && (
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-background/70">
           <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground/40 border-t-accent-blue" />
         </div>
       )}
-      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-      <video
-        src={mediaUrl}
-        className="aspect-video w-full bg-border object-cover"
-        muted
-        autoPlay
-        loop
-        playsInline
-        onLoadedData={() => onThumbLoaded(fileName)}
-        onError={() => onThumbLoaded(fileName)}
-      />
+      {mediaFailed ? (
+        <div
+          role="status"
+          className="flex aspect-video w-full flex-col items-center justify-center gap-1 bg-muted px-2 text-center text-muted-foreground"
+        >
+          <ImageOff className="size-5" aria-hidden />
+          <span className="text-xs">Preview unavailable</span>
+        </div>
+      ) : (
+        // eslint-disable-next-line jsx-a11y/media-has-caption
+        <video
+          src={mediaUrl}
+          aria-label={`Preview of ${fileName}`}
+          className="aspect-video w-full bg-border object-cover"
+          muted
+          autoPlay
+          loop
+          playsInline
+          onLoadedData={() => onThumbLoaded(fileName)}
+          onError={() => {
+            setMediaFailed(true);
+            onThumbLoaded(fileName);
+          }}
+        />
+      )}
       <Textarea
+        aria-label={`Caption for ${fileName}`}
         value={caption}
         onChange={(e) => onCaptionChange(fileName, e.target.value)}
         placeholder="Caption"

--- a/apps/fastvideo_studio/src/components/datasets/DownloadCaptions.tsx
+++ b/apps/fastvideo_studio/src/components/datasets/DownloadCaptions.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { downloadBlob } from '@/lib/utils';
 
 const MENU_ITEM =
-  'block w-full cursor-pointer px-4 py-2 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50';
+  'block min-h-11 w-full cursor-pointer px-4 py-2 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50';
 
 export default function DownloadCaptions({
   fileNames,

--- a/apps/fastvideo_studio/src/components/jobs/CreateJobButton.test.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/CreateJobButton.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import CreateJobButton from './CreateJobButton';
+
+vi.mock('./CreateJobModal', () => ({
+  default: ({
+    isOpen,
+    workloadType,
+  }: {
+    isOpen: boolean;
+    workloadType: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog" data-workload-type={workloadType}>
+        Create job form
+      </div>
+    ) : null,
+}));
+
+describe('CreateJobButton', () => {
+  it('opens the workload menu on click and selects an item', async () => {
+    const user = userEvent.setup();
+    render(<CreateJobButton jobType="inference" />);
+
+    await user.click(screen.getByRole('button', { name: 'Create Job' }));
+    await user.click(screen.getByRole('menuitem', { name: /I2V/i }));
+
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'data-workload-type',
+      'i2v',
+    );
+  });
+
+  it('opens and operates the workload menu from the keyboard', async () => {
+    const user = userEvent.setup();
+    render(<CreateJobButton jobType="inference" />);
+
+    const trigger = screen.getByRole('button', { name: 'Create Job' });
+    trigger.focus();
+    await user.keyboard('{Enter}');
+
+    const firstItem = await screen.findByRole('menuitem', { name: /T2V/i });
+    expect(firstItem).toHaveFocus();
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'data-workload-type',
+      't2v',
+    );
+  });
+});

--- a/apps/fastvideo_studio/src/components/jobs/CreateJobButton.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/CreateJobButton.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { ChevronDown } from 'lucide-react';
-import { DropdownMenu } from 'radix-ui';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 
 import CreateJobModal from '@/components/jobs/CreateJobModal';
 import { Button } from '@/components/ui/button';

--- a/apps/fastvideo_studio/src/components/jobs/CreateJobButton.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/CreateJobButton.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { ChevronDown } from 'lucide-react';
+import { DropdownMenu } from 'radix-ui';
 
 import CreateJobModal from '@/components/jobs/CreateJobModal';
 import { Button } from '@/components/ui/button';
@@ -33,31 +34,35 @@ export default function CreateJobButton({ jobType }: CreateJobButtonProps) {
 
   return (
     <>
-      <div className="group relative inline-block">
-        <Button type="button" className="gap-1.5">
-          Create Job
-          <ChevronDown className="size-3.5 opacity-85" aria-hidden />
-        </Button>
-        <div
-          role="menu"
-          className="invisible absolute right-0 top-full z-[200] mt-1 min-w-full -translate-y-1 rounded-lg border border-border bg-popover py-1 opacity-0 shadow-lg transition-all duration-150 group-hover:visible group-hover:translate-y-0 group-hover:opacity-100"
-        >
-          {options.map((opt) => (
-            <button
-              key={opt.type}
-              type="button"
-              role="menuitem"
-              onClick={() => openModal(opt.type)}
-              className="block w-full whitespace-nowrap px-4 py-2 text-left text-sm font-medium text-popover-foreground transition-colors hover:bg-secondary"
-            >
-              {opt.label}
-              <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
-                {opt.desc}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <Button type="button" className="gap-1.5">
+            Create Job
+            <ChevronDown className="size-3.5 opacity-85" aria-hidden />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="end"
+            sideOffset={4}
+            collisionPadding={8}
+            className="z-[200] min-w-48 overflow-hidden rounded-lg border border-border bg-popover py-1 text-popover-foreground shadow-lg"
+          >
+            {options.map((opt) => (
+              <DropdownMenu.Item
+                key={opt.type}
+                onSelect={() => openModal(opt.type)}
+                className="flex min-h-11 cursor-pointer select-none flex-col justify-center px-4 py-2 text-left text-sm font-medium outline-none data-[highlighted]:bg-secondary"
+              >
+                {opt.label}
+                <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                  {opt.desc}
+                </span>
+              </DropdownMenu.Item>
+            ))}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
       <CreateJobModal
         isOpen={modalOpen}
         onClose={() => setModalOpen(false)}

--- a/apps/fastvideo_studio/src/components/jobs/CreateJobModal.test.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/CreateJobModal.test.tsx
@@ -50,6 +50,57 @@ function renderModal(
 }
 
 describe('CreateJobModal', () => {
+  it('shows a model loading error instead of an empty model list', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(getModels).mockRejectedValueOnce(new Error('network down'));
+
+    renderModal();
+
+    expect(
+      await screen.findByText(/Models could not be loaded/),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Model')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('keeps the form open and reports job creation failures', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(createJob).mockRejectedValueOnce(new Error('API rejected job'));
+    const user = userEvent.setup();
+    const { onClose, onSuccess } = renderModal();
+
+    await screen.findByRole('option', { name: 'Wan T2V (wan/t2v-1.3b)' });
+    await user.type(screen.getByLabelText('Prompt'), 'a careful test prompt');
+    await user.click(screen.getByRole('button', { name: 'Create Job' }));
+
+    expect(
+      await screen.findByText(/API rejected job.*then try again/),
+    ).toBeInTheDocument();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('reports image upload failures next to the file input', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(uploadImage).mockRejectedValueOnce(new Error('Upload failed'));
+    const user = userEvent.setup();
+    renderModal({ workloadType: 'i2v' });
+
+    await screen.findByRole('option', { name: 'Wan T2V (wan/t2v-1.3b)' });
+    const input = screen.getByLabelText('Image');
+    await user.upload(
+      input,
+      new File(['image'], 'input.png', { type: 'image/png' }),
+    );
+
+    expect(
+      await screen.findByText(/Upload failed.*Choose the image again/),
+    ).toBeInTheDocument();
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
   it('renders the form fields for an inference job', async () => {
     renderModal();
 

--- a/apps/fastvideo_studio/src/components/jobs/CreateJobModal.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/CreateJobModal.tsx
@@ -103,6 +103,17 @@ export default function CreateJobModal({
   const [fakeScoreModelPath, setFakeScoreModelPath] = React.useState('');
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [isLoadingModels, setIsLoadingModels] = React.useState(false);
+  const [isLoadingDatasets, setIsLoadingDatasets] = React.useState(false);
+  const [modelLoadError, setModelLoadError] = React.useState<string | null>(
+    null,
+  );
+  const [datasetLoadError, setDatasetLoadError] = React.useState<string | null>(
+    null,
+  );
+  const [imageUploadError, setImageUploadError] = React.useState<string | null>(
+    null,
+  );
+  const [submitError, setSubmitError] = React.useState<string | null>(null);
   const imageInputRef = React.useRef<HTMLInputElement>(null);
 
   // Seed field values from the persisted default options each time the modal
@@ -144,6 +155,10 @@ export default function CreateJobModal({
     setImageFileName('');
     setSelectedDatasetId('');
     setSelectedValidationDatasetId('');
+    setModelLoadError(null);
+    setDatasetLoadError(null);
+    setImageUploadError(null);
+    setSubmitError(null);
     if (workloadType === 'dmd_t2v') {
       setDmdUseVsa(false);
       setDmdVsaSparsity(0.8);
@@ -162,6 +177,7 @@ export default function CreateJobModal({
     // can't overwrite the current workload's model list/selection.
     let stale = false;
     setIsLoadingModels(true);
+    setModelLoadError(null);
     getModels(inferenceWorkload)
       .then((list) => {
         if (stale) return;
@@ -180,7 +196,13 @@ export default function CreateJobModal({
         }
       })
       .catch((e) => {
-        if (!stale) console.error('Failed to load models:', e);
+        if (stale) return;
+        console.error('Failed to load models:', e);
+        setModels([]);
+        setModelId('');
+        setModelLoadError(
+          'Models could not be loaded. Check the Studio API and reopen this form to try again.',
+        );
       })
       .finally(() => {
         if (!stale) setIsLoadingModels(false);
@@ -193,11 +215,22 @@ export default function CreateJobModal({
   // Training jobs need a dataset; load the ready datasets when relevant.
   React.useEffect(() => {
     if (isOpen && !isInference) {
+      setIsLoadingDatasets(true);
+      setDatasetLoadError(null);
       getDatasets()
         .then(setReadyDatasets)
-        .catch(() => setReadyDatasets([]));
+        .catch((error) => {
+          console.error('Failed to load datasets:', error);
+          setReadyDatasets([]);
+          setDatasetLoadError(
+            'Datasets could not be loaded. Check the Studio API and reopen this form to try again.',
+          );
+        })
+        .finally(() => setIsLoadingDatasets(false));
     } else {
       setReadyDatasets([]);
+      setIsLoadingDatasets(false);
+      setDatasetLoadError(null);
     }
   }, [isOpen, isInference]);
 
@@ -206,16 +239,24 @@ export default function CreateJobModal({
     if (!file) {
       setImagePath('');
       setImageFileName('');
+      setImageUploadError(null);
       return;
     }
     setIsUploadingImage(true);
     setImageFileName(file.name);
+    setImageUploadError(null);
     try {
       const { path } = await uploadImage(file);
       setImagePath(path);
-    } catch {
+    } catch (error) {
+      console.error('Failed to upload image:', error);
       setImagePath('');
       setImageFileName('');
+      setImageUploadError(
+        error instanceof Error
+          ? `${error.message}. Choose the image again to retry.`
+          : 'The image could not be uploaded. Choose it again to retry.',
+      );
     } finally {
       setIsUploadingImage(false);
     }
@@ -224,6 +265,7 @@ export default function CreateJobModal({
   function clearImage() {
     setImagePath('');
     setImageFileName('');
+    setImageUploadError(null);
     if (imageInputRef.current) imageInputRef.current.value = '';
   }
 
@@ -239,6 +281,7 @@ export default function CreateJobModal({
       workloadType === 'lora_t2v' ? 'lora' : jobType
     ) as JobType;
     setIsSubmitting(true);
+    setSubmitError(null);
     try {
       const payload: CreateJobRequest = {
         model_id: modelId,
@@ -296,6 +339,11 @@ export default function CreateJobModal({
       onClose();
     } catch (err) {
       console.error('Failed to create job:', err);
+      setSubmitError(
+        err instanceof Error
+          ? `${err.message}. Check the form and Studio API, then try again.`
+          : 'The job could not be created. Check the form and Studio API, then try again.',
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -343,7 +391,11 @@ export default function CreateJobModal({
               value={modelId}
               onChange={(e) => setModelId(e.target.value)}
               required
-              disabled={isSubmitting || isLoadingModels}
+              aria-describedby={
+                modelLoadError ? 'modal-model-error' : undefined
+              }
+              aria-invalid={modelLoadError ? true : undefined}
+              disabled={isSubmitting || isLoadingModels || !!modelLoadError}
             >
               <option value="" disabled>
                 {isLoadingModels
@@ -358,6 +410,15 @@ export default function CreateJobModal({
                 </option>
               ))}
             </NativeSelect>
+            {modelLoadError && (
+              <p
+                id="modal-model-error"
+                role="alert"
+                className="text-sm text-destructive"
+              >
+                {modelLoadError}
+              </p>
+            )}
           </FieldRow>
 
           {isInference && workloadType === 'i2v' && (
@@ -369,6 +430,10 @@ export default function CreateJobModal({
                 accept=".png,.jpg,.jpeg,.webp,.bmp"
                 onChange={handleImageChange}
                 disabled={isSubmitting || isUploadingImage}
+                aria-describedby={
+                  imageUploadError ? 'modal-image-error' : undefined
+                }
+                aria-invalid={imageUploadError ? true : undefined}
                 required
                 className="h-auto py-2 file:mr-3 file:cursor-pointer file:rounded-md file:border-0 file:bg-secondary file:px-2 file:py-1 file:text-sm file:text-secondary-foreground"
               />
@@ -384,6 +449,15 @@ export default function CreateJobModal({
                     Clear
                   </button>
                 </span>
+              )}
+              {imageUploadError && (
+                <p
+                  id="modal-image-error"
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
+                  {imageUploadError}
+                </p>
               )}
             </FieldRow>
           )}
@@ -432,12 +506,22 @@ export default function CreateJobModal({
                     id="modal-dataset"
                     value={selectedDatasetId}
                     onChange={(e) => setSelectedDatasetId(e.target.value)}
-                    disabled={isSubmitting}
+                    aria-describedby={
+                      datasetLoadError ? 'modal-dataset-error' : undefined
+                    }
+                    aria-invalid={datasetLoadError ? true : undefined}
+                    disabled={
+                      isSubmitting || isLoadingDatasets || !!datasetLoadError
+                    }
                   >
                     <option value="" disabled>
-                      {readyDatasets.length === 0
-                        ? 'No datasets (add in Datasets tab)'
-                        : 'Select a dataset…'}
+                      {isLoadingDatasets
+                        ? 'Loading datasets…'
+                        : datasetLoadError
+                          ? 'Datasets unavailable'
+                          : readyDatasets.length === 0
+                            ? 'No datasets (add in Datasets tab)'
+                            : 'Select a dataset…'}
                     </option>
                     {readyDatasets.map((d) => (
                       <option key={d.id} value={d.id}>
@@ -445,6 +529,15 @@ export default function CreateJobModal({
                       </option>
                     ))}
                   </NativeSelect>
+                  {datasetLoadError && (
+                    <p
+                      id="modal-dataset-error"
+                      role="alert"
+                      className="text-sm text-destructive"
+                    >
+                      {datasetLoadError}
+                    </p>
+                  )}
                 </FieldRow>
                 <FieldRow
                   htmlFor="modal-validation-dataset"
@@ -457,7 +550,9 @@ export default function CreateJobModal({
                     onChange={(e) =>
                       setSelectedValidationDatasetId(e.target.value)
                     }
-                    disabled={isSubmitting}
+                    disabled={
+                      isSubmitting || isLoadingDatasets || !!datasetLoadError
+                    }
                   >
                     <option value="">None</option>
                     {readyDatasets.map((d) => (
@@ -811,9 +906,22 @@ export default function CreateJobModal({
             </details>
           )}
 
-          <div>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? 'Creating...' : 'Create Job'}
+          <div className="flex flex-col items-start gap-2">
+            {submitError && (
+              <p role="alert" className="text-sm text-destructive">
+                {submitError}
+              </p>
+            )}
+            <Button
+              type="submit"
+              disabled={
+                isSubmitting ||
+                isUploadingImage ||
+                !!modelLoadError ||
+                !!datasetLoadError
+              }
+            >
+              {isSubmitting ? 'Creating…' : 'Create Job'}
             </Button>
           </div>
         </form>

--- a/apps/fastvideo_studio/src/components/jobs/JobCard.test.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/JobCard.test.tsx
@@ -20,6 +20,14 @@ vi.mock('@/lib/api', () => ({
   downloadJobVideo: vi.fn(),
 }));
 
+vi.mock('@/lib/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/utils')>();
+  return {
+    ...actual,
+    downloadBlob: vi.fn(),
+  };
+});
+
 const makeJob = (overrides: Partial<Job> = {}): Job =>
   makeBaseJob({
     model_id: 'Wan2.1-T2V',
@@ -46,6 +54,16 @@ beforeEach(() => {
 });
 
 describe('JobCard', () => {
+  it('keeps selection and job action buttons as semantic siblings', () => {
+    render(<JobCard job={makeJob()} />);
+
+    const selectButton = screen.getByRole('button', { pressed: false });
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+
+    expect(selectButton).toHaveTextContent('Wan2.1-T2V');
+    expect(selectButton).not.toContainElement(deleteButton);
+  });
+
   it('renders the model, prompt, status and inference meta', () => {
     render(<JobCard job={makeJob()} />);
     expect(screen.getByText('Wan2.1-T2V')).toBeInTheDocument();

--- a/apps/fastvideo_studio/src/components/jobs/JobCard.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/JobCard.tsx
@@ -119,16 +119,8 @@ export default function JobCard({ job, onJobUpdated }: JobCardProps) {
     }
   }
 
-  function handleSelectJob(e: React.MouseEvent | React.KeyboardEvent) {
-    if ((e.target as HTMLElement).closest('button')) return;
+  function handleSelectJob() {
     setActiveJobId(isSelected ? null : job.id);
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleSelectJob(e);
-    }
   }
 
   async function handleDownloadVideo(e: React.MouseEvent) {
@@ -148,11 +140,7 @@ export default function JobCard({ job, onJobUpdated }: JobCardProps) {
   }
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={handleSelectJob}
-      onKeyDown={handleKeyDown}
+    <article
       className={cn(
         'mb-3 flex cursor-pointer flex-col gap-2.5 rounded-lg border bg-background p-4 transition-colors last:mb-0',
         isSelected
@@ -160,35 +148,42 @@ export default function JobCard({ job, onJobUpdated }: JobCardProps) {
           : 'border-border hover:border-muted-foreground/40',
       )}
     >
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <span className="text-[0.95rem] font-semibold text-foreground">
-          {job.model_id}
-        </span>
-        <Badge variant={BADGE_VARIANTS[job.status] ?? 'secondary'}>
-          {job.status}
-        </Badge>
-      </div>
-      <p className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm text-muted-foreground">
-        {job.prompt}
-      </p>
-      <div className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
-        {job.job_type === 'inference' ? (
-          <>
-            <span>{job.num_frames} frames</span>
-            <span>
-              {job.height}×{job.width}
-            </span>
-          </>
-        ) : (
-          <span>{job.workload_type?.replace(/_/g, ' ') ?? job.job_type}</span>
-        )}
-        {elapsedTime && (
-          <span className="inline-flex items-center gap-1">
-            <Timer className="size-3.5" aria-hidden />
-            {elapsedTime}
+      <button
+        type="button"
+        aria-pressed={isSelected}
+        onClick={handleSelectJob}
+        className="flex w-full flex-col gap-2.5 rounded-md text-left"
+      >
+        <span className="flex flex-wrap items-center justify-between gap-2">
+          <span className="text-[0.95rem] font-semibold text-foreground">
+            {job.model_id}
           </span>
-        )}
-      </div>
+          <Badge variant={BADGE_VARIANTS[job.status] ?? 'secondary'}>
+            {job.status}
+          </Badge>
+        </span>
+        <span className="max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-sm text-muted-foreground">
+          {job.prompt}
+        </span>
+        <span className="flex flex-wrap items-center gap-4 text-xs text-muted-foreground">
+          {job.job_type === 'inference' ? (
+            <>
+              <span>{job.num_frames} frames</span>
+              <span>
+                {job.height}×{job.width}
+              </span>
+            </>
+          ) : (
+            <span>{job.workload_type?.replace(/_/g, ' ') ?? job.job_type}</span>
+          )}
+          {elapsedTime && (
+            <span className="inline-flex items-center gap-1">
+              <Timer className="size-3.5" aria-hidden />
+              {elapsedTime}
+            </span>
+          )}
+        </span>
+      </button>
       <div className="flex flex-wrap items-center gap-1.5">
         {job.status === 'running' ? (
           <Button
@@ -240,6 +235,6 @@ export default function JobCard({ job, onJobUpdated }: JobCardProps) {
           Delete
         </Button>
       </div>
-    </div>
+    </article>
   );
 }

--- a/apps/fastvideo_studio/src/components/jobs/JobDetailsSidebar.test.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/JobDetailsSidebar.test.tsx
@@ -19,6 +19,31 @@ const makeJob = (overrides: Partial<Job> = {}): Job =>
   });
 
 describe('JobDetailsSidebar', () => {
+  it('fills the mobile viewport without reserving main-content width', async () => {
+    vi.mocked(getJobLogs).mockResolvedValue({
+      lines: [],
+      total: 0,
+      progress: 0,
+      progress_msg: '',
+      phase: '',
+    });
+    const onWidthChange = vi.fn();
+
+    render(
+      <JobDetailsSidebar
+        job={makeJob({ status: 'completed' })}
+        isMobile
+        onClose={vi.fn()}
+        onWidthChange={onWidthChange}
+      />,
+    );
+
+    const drawer = screen.getByRole('dialog', { name: 'Job details' });
+    expect(drawer).toHaveStyle({ width: '100%', maxWidth: 'none' });
+    expect(drawer).toHaveAttribute('aria-modal', 'true');
+    expect(onWidthChange).toHaveBeenCalledWith(0);
+  });
+
   it('renders log lines streamed from the job log poll', async () => {
     vi.mocked(getJobLogs).mockResolvedValue({
       lines: ['boot sequence started', 'loading model weights'],

--- a/apps/fastvideo_studio/src/components/jobs/JobDetailsSidebar.test.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/JobDetailsSidebar.test.tsx
@@ -41,6 +41,7 @@ describe('JobDetailsSidebar', () => {
     const drawer = screen.getByRole('dialog', { name: 'Job details' });
     expect(drawer).toHaveStyle({ width: '100%', maxWidth: 'none' });
     expect(drawer).toHaveAttribute('aria-modal', 'true');
+    expect(drawer).toHaveFocus();
     expect(onWidthChange).toHaveBeenCalledWith(0);
   });
 

--- a/apps/fastvideo_studio/src/components/jobs/JobDetailsSidebar.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/JobDetailsSidebar.tsx
@@ -15,10 +15,12 @@ const POLL_INTERVAL_MS = 2000;
 
 export default function JobDetailsSidebar({
   job,
+  isMobile = false,
   onClose,
   onWidthChange,
 }: {
   job: Job;
+  isMobile?: boolean;
   onClose: () => void;
   onWidthChange?: (w: number) => void;
 }) {
@@ -53,8 +55,8 @@ export default function JobDetailsSidebar({
   });
 
   React.useEffect(() => {
-    onWidthChange?.(width);
-  }, [width, onWidthChange]);
+    onWidthChange?.(isMobile ? 0 : width);
+  }, [isMobile, width, onWidthChange]);
 
   // Auto-scroll the console to the bottom whenever new lines land. Runs after
   // commit so scrollHeight reflects the freshly-rendered output.
@@ -137,8 +139,14 @@ export default function JobDetailsSidebar({
 
   return (
     <aside
-      className="fixed bottom-0 right-0 top-[var(--header-height)] z-50 flex max-h-[calc(100vh-var(--header-height))] min-w-[280px] shrink-0 flex-col border-l border-border bg-card"
-      style={{ width, maxWidth: SIDEBAR_MAX_WIDTH }}
+      role="dialog"
+      aria-label="Job details"
+      aria-modal={isMobile || undefined}
+      className="fixed bottom-0 right-0 top-[var(--header-height)] z-50 flex max-h-[calc(100dvh-var(--header-height))] min-w-0 shrink-0 flex-col border-l border-border bg-card md:min-w-[280px]"
+      style={{
+        width: isMobile ? '100%' : width,
+        maxWidth: isMobile ? 'none' : SIDEBAR_MAX_WIDTH,
+      }}
     >
       <div className="flex items-center justify-between border-b border-border px-5 py-4">
         <h2 className="m-0 text-base font-semibold text-foreground">
@@ -195,14 +203,14 @@ export default function JobDetailsSidebar({
         </pre>
       </div>
 
-      <div
+      {!isMobile && <div
         role="presentation"
         onMouseDown={onMouseDown}
         className={cn(
           'absolute bottom-0 left-0 top-0 z-[1] w-1.5 cursor-col-resize hover:bg-accent-blue/25',
           isDragging && 'bg-accent-blue/25',
         )}
-      />
+      />}
     </aside>
   );
 }

--- a/apps/fastvideo_studio/src/components/jobs/JobDetailsSidebar.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/JobDetailsSidebar.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { X } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
+import { useDrawerFocus } from '@/hooks/useDrawerFocus';
 import { useResizable } from '@/hooks/useResizable';
 import { downloadJobLog, getJobLogs } from '@/lib/api';
 import type { Job } from '@/lib/types';
@@ -24,6 +25,7 @@ export default function JobDetailsSidebar({
   onClose: () => void;
   onWidthChange?: (w: number) => void;
 }) {
+  const drawerRef = useDrawerFocus<HTMLElement>(isMobile);
   const [width, setWidth] = React.useState(360);
   const [isDragging, setIsDragging] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(false);
@@ -139,6 +141,8 @@ export default function JobDetailsSidebar({
 
   return (
     <aside
+      ref={drawerRef}
+      tabIndex={-1}
       role="dialog"
       aria-label="Job details"
       aria-modal={isMobile || undefined}

--- a/apps/fastvideo_studio/src/components/jobs/JobQueue.test.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/JobQueue.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import JobQueue from '@/components/jobs/JobQueue';
@@ -37,6 +37,46 @@ beforeEach(() => {
 });
 
 describe('JobQueue', () => {
+  it('shows a loading placeholder before the initial request settles', async () => {
+    let resolveJobs: (jobs: Job[]) => void = () => {};
+    vi.mocked(getJobsList).mockReturnValue(
+      new Promise<Job[]>((resolve) => {
+        resolveJobs = resolve;
+      }),
+    );
+
+    render(<JobQueue jobType="inference" />);
+
+    expect(screen.getByLabelText('Loading jobs')).toBeInTheDocument();
+    expect(
+      screen.queryByText('No inference jobs yet. Create one above.'),
+    ).not.toBeInTheDocument();
+
+    act(() => resolveJobs([]));
+    expect(
+      await screen.findByText('No inference jobs yet. Create one above.'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows request failures separately from an empty queue and retries', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(getJobsList).mockRejectedValueOnce(new Error('network down'));
+    render(<JobQueue jobType="inference" />);
+
+    expect(
+      await screen.findByText(/Could not load jobs from the Studio API/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('No inference jobs yet. Create one above.'),
+    ).not.toBeInTheDocument();
+
+    vi.mocked(getJobsList).mockResolvedValueOnce([]);
+    fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+    expect(
+      await screen.findByText('No inference jobs yet. Create one above.'),
+    ).toBeInTheDocument();
+  });
+
   it('shows an empty placeholder and fetches for the single job type', async () => {
     render(<JobQueue jobType="inference" />);
     expect(

--- a/apps/fastvideo_studio/src/components/jobs/JobQueue.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/JobQueue.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import * as React from 'react';
+import { AlertTriangle } from 'lucide-react';
 
 import JobCard from '@/components/jobs/JobCard';
+import { Button } from '@/components/ui/button';
 import { useStore } from '@/hooks/useStore';
 import { getJobsList } from '@/lib/api';
 import type { Job, JobType } from '@/lib/types';
@@ -32,6 +34,8 @@ function jobsShallowEqual(a: Job | null, b: Job | null): boolean {
 
 export default function JobQueue({ jobType, jobTypesForList }: JobQueueProps) {
   const [jobs, setJobs] = React.useState<Job[]>([]);
+  const [isInitialLoading, setIsInitialLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
   const { nonce } = useStore(jobsRefreshStore);
   const { activeJobId } = useStore(activeJobStore);
 
@@ -71,11 +75,22 @@ export default function JobQueue({ jobType, jobTypesForList }: JobQueueProps) {
               new Date(a.created_at ?? 0).getTime(),
           );
       }
-      if (seq === fetchSeq.current) setJobs(next);
+      if (seq === fetchSeq.current) {
+        setJobs(next);
+        setError(null);
+      }
     } catch (e) {
       console.error('Failed to fetch jobs:', e);
+      if (seq === fetchSeq.current) {
+        setError(
+          'Could not load jobs from the Studio API. Check the server and try again.',
+        );
+      }
     } finally {
-      if (seq === fetchSeq.current) inFlight.current = false;
+      if (seq === fetchSeq.current) {
+        inFlight.current = false;
+        setIsInitialLoading(false);
+      }
     }
   }, [typesKey]);
 
@@ -124,15 +139,54 @@ export default function JobQueue({ jobType, jobTypesForList }: JobQueueProps) {
   return (
     <main className="mx-auto flex w-full max-w-[850px] flex-col gap-6 px-4 pb-12">
       <section className="p-6">
-        <div>
-          {jobs.length === 0 ? (
+        <div aria-busy={isInitialLoading}>
+          {isInitialLoading ? (
+            <div
+              aria-label="Loading jobs"
+              className="flex flex-col gap-3 py-2"
+            >
+              {[0, 1, 2].map((item) => (
+                <div
+                  key={item}
+                  className="h-32 animate-pulse rounded-lg border border-border bg-muted/50"
+                />
+              ))}
+            </div>
+          ) : error && jobs.length === 0 ? (
+            <div
+              role="alert"
+              className="flex flex-col items-center gap-3 py-8 text-center"
+            >
+              <AlertTriangle
+                className="size-6 text-destructive"
+                aria-hidden
+              />
+              <p className="max-w-md text-sm text-muted-foreground">{error}</p>
+              <Button type="button" variant="outline" onClick={fetchJobs}>
+                Try Again
+              </Button>
+            </div>
+          ) : (
+            <>
+              {error && (
+                <p
+                  role="status"
+                  className="mb-3 rounded-lg border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm text-foreground"
+                >
+                  Job updates are temporarily unavailable. Showing the most
+                  recent results.
+                </p>
+              )}
+              {jobs.length === 0 ? (
             <p className="py-8 text-center text-muted-foreground">
               No {multiType ? 'jobs' : `${jobType} jobs`} yet. Create one above.
             </p>
-          ) : (
-            jobs.map((job) => (
-              <JobCard key={job.id} job={job} onJobUpdated={fetchJobs} />
-            ))
+              ) : (
+                jobs.map((job) => (
+                  <JobCard key={job.id} job={job} onJobUpdated={fetchJobs} />
+                ))
+              )}
+            </>
           )}
         </div>
       </section>

--- a/apps/fastvideo_studio/src/components/jobs/JobQueue.tsx
+++ b/apps/fastvideo_studio/src/components/jobs/JobQueue.tsx
@@ -137,7 +137,7 @@ export default function JobQueue({ jobType, jobTypesForList }: JobQueueProps) {
   const multiType = typesToFetch.length > 1;
 
   return (
-    <main className="mx-auto flex w-full max-w-[850px] flex-col gap-6 px-4 pb-12">
+    <div className="mx-auto flex w-full max-w-[850px] flex-col gap-6 px-4 pb-12">
       <section className="p-6">
         <div aria-busy={isInitialLoading}>
           {isInitialLoading ? (
@@ -190,6 +190,6 @@ export default function JobQueue({ jobType, jobTypesForList }: JobQueueProps) {
           )}
         </div>
       </section>
-    </main>
+    </div>
   );
 }

--- a/apps/fastvideo_studio/src/components/shell/AppShell.tsx
+++ b/apps/fastvideo_studio/src/components/shell/AppShell.tsx
@@ -96,6 +96,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         {jobSidebarOpen && activeJob && (
           <JobDetailsSidebar
             job={activeJob}
+            isMobile={isMobile}
             onClose={() => setActiveJobId(null)}
             onWidthChange={setSecondaryWidth}
           />
@@ -103,6 +104,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         {datasetSidebarOpen && activeDataset && (
           <DatasetSidebar
             dataset={activeDataset}
+            isMobile={isMobile}
             onClose={() => setActiveDatasetId(null)}
             onWidthChange={setSecondaryWidth}
           />

--- a/apps/fastvideo_studio/src/components/shell/AppShell.tsx
+++ b/apps/fastvideo_studio/src/components/shell/AppShell.tsx
@@ -34,6 +34,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const datasetSidebarOpen =
     pathname === '/datasets' && activeDataset != null;
   const secondaryOpen = jobSidebarOpen || datasetSidebarOpen;
+  // Mobile detail drawers claim aria-modal, so everything behind them must
+  // actually be inert — the platform enforces what the ARIA claims.
+  const drawerModal = isMobile && secondaryOpen;
 
   React.useEffect(() => {
     initDefaultOptions();
@@ -59,10 +62,15 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <HeaderActionsProvider>
-      <Header
-        navigationOpen={primaryOpen}
-        onNavigationToggle={() => setPrimaryOpen((open) => !open)}
-      />
+      <div
+        style={{ display: 'contents' }}
+        inert={drawerModal ? true : undefined}
+      >
+        <Header
+          navigationOpen={primaryOpen}
+          onNavigationToggle={() => setPrimaryOpen((open) => !open)}
+        />
+      </div>
       <div
         className="flex overflow-hidden"
         style={{
@@ -86,6 +94,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         )}
         <main
           className="flex min-w-0 flex-1 flex-col overflow-auto"
+          inert={drawerModal ? true : undefined}
           style={{
             marginLeft: isMobile ? 0 : primaryWidth,
             marginRight: isMobile || !secondaryOpen ? 0 : secondaryWidth,

--- a/apps/fastvideo_studio/src/components/shell/AppShell.tsx
+++ b/apps/fastvideo_studio/src/components/shell/AppShell.tsx
@@ -9,6 +9,7 @@ import { HeaderActionsProvider } from '@/components/shell/HeaderActionsContext';
 import PrimarySidebar from '@/components/shell/PrimarySidebar';
 import JobDetailsSidebar from '@/components/jobs/JobDetailsSidebar';
 import { Toaster } from '@/components/ui/sonner';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useStore } from '@/hooks/useStore';
 import {
   activeDatasetStore,
@@ -23,9 +24,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { activeJob } = useStore(activeJobStore);
   const { activeDataset } = useStore(activeDatasetStore);
+  const isMobile = useMediaQuery('(max-width: 767px)');
 
   const [primaryWidth, setPrimaryWidth] = React.useState(220);
   const [secondaryWidth, setSecondaryWidth] = React.useState(0);
+  const [primaryOpen, setPrimaryOpen] = React.useState(false);
 
   const jobSidebarOpen = JOB_ROUTES.includes(pathname) && activeJob != null;
   const datasetSidebarOpen =
@@ -37,32 +40,55 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   }, []);
 
   React.useEffect(() => {
+    setPrimaryOpen(false);
+  }, [pathname]);
+
+  React.useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape' && !document.querySelector('[data-modal]')) {
-        if (activeJobStore.get().activeJob) setActiveJobId(null);
-        if (activeDatasetStore.get().activeDataset) setActiveDatasetId(null);
+      if (e.key !== 'Escape' || document.querySelector('[data-modal]')) return;
+      if (primaryOpen) {
+        setPrimaryOpen(false);
+        return;
       }
+      if (activeJobStore.get().activeJob) setActiveJobId(null);
+      if (activeDatasetStore.get().activeDataset) setActiveDatasetId(null);
     }
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [primaryOpen]);
 
   return (
     <HeaderActionsProvider>
-      <Header />
+      <Header
+        navigationOpen={primaryOpen}
+        onNavigationToggle={() => setPrimaryOpen((open) => !open)}
+      />
       <div
         className="flex overflow-hidden"
         style={{
           marginTop: 'var(--header-height)',
-          height: 'calc(100vh - var(--header-height))',
+          height: 'calc(100dvh - var(--header-height))',
         }}
       >
-        <PrimarySidebar onWidthChange={setPrimaryWidth} />
+        <PrimarySidebar
+          isMobile={isMobile}
+          mobileOpen={primaryOpen}
+          onMobileClose={() => setPrimaryOpen(false)}
+          onWidthChange={setPrimaryWidth}
+        />
+        {primaryOpen && (
+          <button
+            type="button"
+            aria-label="Close navigation"
+            onClick={() => setPrimaryOpen(false)}
+            className="fixed inset-x-0 bottom-0 top-[var(--header-height)] z-40 bg-black/55 md:hidden"
+          />
+        )}
         <main
           className="flex min-w-0 flex-1 flex-col overflow-auto"
           style={{
-            marginLeft: primaryWidth,
-            marginRight: secondaryOpen ? secondaryWidth : 0,
+            marginLeft: isMobile ? 0 : primaryWidth,
+            marginRight: isMobile || !secondaryOpen ? 0 : secondaryWidth,
           }}
         >
           {children}

--- a/apps/fastvideo_studio/src/components/shell/Header.tsx
+++ b/apps/fastvideo_studio/src/components/shell/Header.tsx
@@ -1,8 +1,10 @@
 'use client';
 
+import { Menu, X } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 
 import { useHeaderActions } from '@/components/shell/HeaderActionsContext';
+import { Button } from '@/components/ui/button';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 
 const TAB_TITLES: Record<string, string> = {
@@ -15,25 +17,47 @@ const TAB_TITLES: Record<string, string> = {
   '/settings': 'Settings',
 };
 
-export default function Header() {
+export default function Header({
+  navigationOpen,
+  onNavigationToggle,
+}: {
+  navigationOpen: boolean;
+  onNavigationToggle: () => void;
+}) {
   const pathname = usePathname();
   const { actions } = useHeaderActions();
   const title = TAB_TITLES[pathname] ?? 'FastVideo';
 
   return (
-    <header className="fixed inset-x-0 top-0 z-[100] flex h-[var(--header-height)] items-center gap-6 border-b border-border bg-background/80 px-6 backdrop-blur">
+    <header className="fixed inset-x-0 top-0 z-[100] flex h-[var(--header-height)] items-center gap-2 border-b border-border bg-background/80 px-2 backdrop-blur sm:px-4 md:gap-6 md:px-6">
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        aria-label={navigationOpen ? 'Close navigation' : 'Open navigation'}
+        aria-controls="primary-navigation"
+        aria-expanded={navigationOpen}
+        onClick={onNavigationToggle}
+        className="shrink-0 md:hidden"
+      >
+        {navigationOpen ? (
+          <X className="size-5" aria-hidden />
+        ) : (
+          <Menu className="size-5" aria-hidden />
+        )}
+      </Button>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
         src="/logo.svg"
         alt="FastVideo Logo"
         width={100}
         height={42}
-        className="block h-[42px] w-[100px]"
+        className="hidden h-[42px] w-[78px] shrink-0 object-contain min-[361px]:block md:w-[100px]"
       />
-      <h1 className="m-0 flex-1 text-xl font-semibold tracking-tight">
+      <h1 className="sr-only m-0 flex-1 text-xl font-semibold tracking-tight md:not-sr-only">
         {title}
       </h1>
-      <div className="flex items-center gap-3">
+      <div className="ml-auto flex min-w-0 items-center gap-2 md:gap-3">
         {actions}
         <ThemeToggle />
       </div>

--- a/apps/fastvideo_studio/src/components/shell/PrimarySidebar.tsx
+++ b/apps/fastvideo_studio/src/components/shell/PrimarySidebar.tsx
@@ -20,7 +20,7 @@ const JOB_ROUTES = [
 ] as const;
 
 const TAB_BASE =
-  'block px-5 py-[0.65rem] text-left text-sm text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground';
+  'block min-h-11 px-5 py-[0.65rem] text-left text-sm text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground';
 const TAB_ACTIVE = 'bg-accent-blue/10 font-medium text-accent-blue';
 
 export default function PrimarySidebar({
@@ -188,8 +188,7 @@ export default function PrimarySidebar({
           onClick={() => setIsCollapsed((v) => !v)}
           title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           className={cn(
-            'flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground',
-            isCollapsed ? 'p-3' : 'p-2',
+            'flex size-11 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground',
           )}
         >
           <svg

--- a/apps/fastvideo_studio/src/components/shell/PrimarySidebar.tsx
+++ b/apps/fastvideo_studio/src/components/shell/PrimarySidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { X } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
@@ -23,8 +24,14 @@ const TAB_BASE =
 const TAB_ACTIVE = 'bg-accent-blue/10 font-medium text-accent-blue';
 
 export default function PrimarySidebar({
+  isMobile,
+  mobileOpen,
+  onMobileClose,
   onWidthChange,
 }: {
+  isMobile: boolean;
+  mobileOpen: boolean;
+  onMobileClose: () => void;
   onWidthChange?: (w: number) => void;
 }) {
   const pathname = usePathname();
@@ -38,8 +45,8 @@ export default function PrimarySidebar({
   const isJobsActive = JOB_ROUTES.some((r) => pathname === r.href);
 
   React.useEffect(() => {
-    onWidthChange?.(layoutWidth);
-  }, [layoutWidth, onWidthChange]);
+    onWidthChange?.(isMobile ? 0 : layoutWidth);
+  }, [isMobile, layoutWidth, onWidthChange]);
 
   React.useEffect(() => {
     if (JOB_ROUTES.some((r) => pathname === r.href)) {
@@ -58,11 +65,37 @@ export default function PrimarySidebar({
 
   return (
     <aside
-      className="fixed bottom-0 left-0 top-[var(--header-height)] z-50 flex max-h-[calc(100vh-var(--header-height))] shrink-0 flex-col border-r border-border bg-card"
-      style={{ width: effectiveWidth }}
+      id="primary-navigation"
+      aria-hidden={isMobile && !mobileOpen}
+      inert={isMobile && !mobileOpen ? true : undefined}
+      className={cn(
+        'fixed bottom-0 left-0 top-[var(--header-height)] z-50 flex max-h-[calc(100dvh-var(--header-height))] shrink-0 flex-col border-r border-border bg-card transition-transform duration-200 md:translate-x-0',
+        mobileOpen ? 'translate-x-0' : '-translate-x-full',
+      )}
+      style={{
+        width: isMobile
+          ? 'min(18rem, calc(100vw - 3rem))'
+          : effectiveWidth,
+      }}
     >
+      {isMobile && (
+        <div className="flex h-14 items-center justify-between border-b border-border px-4">
+          <span className="text-sm font-semibold">Navigation</span>
+          <button
+            type="button"
+            onClick={onMobileClose}
+            aria-label="Close navigation"
+            className="flex size-11 items-center justify-center rounded-lg text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <X className="size-5" aria-hidden />
+          </button>
+        </div>
+      )}
       {!isCollapsed && (
-        <nav className="flex flex-col py-2">
+        <nav
+          aria-label="Primary navigation"
+          className="flex flex-col overflow-y-auto py-2"
+        >
           <div className="flex flex-col">
             <button
               type="button"
@@ -95,6 +128,8 @@ export default function PrimarySidebar({
                   <Link
                     key={route.href}
                     href={route.href}
+                    aria-current={pathname === route.href ? 'page' : undefined}
+                    onClick={onMobileClose}
                     className={cn(
                       TAB_BASE,
                       'px-4 py-2 text-[0.85rem]',
@@ -109,24 +144,32 @@ export default function PrimarySidebar({
           </div>
           <Link
             href="/datasets"
+            aria-current={pathname === '/datasets' ? 'page' : undefined}
+            onClick={onMobileClose}
             className={cn(TAB_BASE, pathname === '/datasets' && TAB_ACTIVE)}
           >
             Datasets
           </Link>
           <Link
             href="/gallery"
+            aria-current={pathname === '/gallery' ? 'page' : undefined}
+            onClick={onMobileClose}
             className={cn(TAB_BASE, pathname === '/gallery' && TAB_ACTIVE)}
           >
             Gallery
           </Link>
           <Link
             href="/gpus"
+            aria-current={pathname === '/gpus' ? 'page' : undefined}
+            onClick={onMobileClose}
             className={cn(TAB_BASE, pathname === '/gpus' && TAB_ACTIVE)}
           >
             GPUs
           </Link>
           <Link
             href="/settings"
+            aria-current={pathname === '/settings' ? 'page' : undefined}
+            onClick={onMobileClose}
             className={cn(TAB_BASE, pathname === '/settings' && TAB_ACTIVE)}
           >
             Settings
@@ -134,7 +177,7 @@ export default function PrimarySidebar({
         </nav>
       )}
 
-      <div
+      {!isMobile && <div
         className={cn(
           'absolute bottom-0 p-2',
           isCollapsed ? '-right-[60px] top-0' : 'right-0',
@@ -159,9 +202,9 @@ export default function PrimarySidebar({
             <path d={isCollapsed ? 'M9 18l6-6-6-6' : 'M15 18l-6-6 6-6'} />
           </svg>
         </button>
-      </div>
+      </div>}
 
-      {!isCollapsed && (
+      {!isMobile && !isCollapsed && (
         <div
           role="presentation"
           onMouseDown={onMouseDown}

--- a/apps/fastvideo_studio/src/components/system/GpuGrid.test.tsx
+++ b/apps/fastvideo_studio/src/components/system/GpuGrid.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import GpuGrid from './GpuGrid';
@@ -72,5 +72,31 @@ describe('GpuGrid', () => {
     expect(
       await screen.findByText(/Could not reach the API server/),
     ).toBeInTheDocument();
+  });
+
+  it('keeps the last snapshot visible and warns when a refresh fails', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(getGpus)
+        .mockResolvedValueOnce(SNAPSHOT)
+        .mockRejectedValueOnce(new Error('network down'));
+
+      render(<GpuGrid />);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(screen.getAllByText('NVIDIA B200')).toHaveLength(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+
+      expect(
+        screen.getByText(/values below may be stale/),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText('NVIDIA B200')).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/fastvideo_studio/src/components/system/GpuGrid.tsx
+++ b/apps/fastvideo_studio/src/components/system/GpuGrid.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import * as React from 'react';
+import { AlertTriangle } from 'lucide-react';
 
+import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { getGpus, type GpuInfo, type GpuSnapshot } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -97,7 +99,8 @@ function GpuCard({ gpu }: { gpu: GpuInfo }) {
 
 export default function GpuGrid() {
   const [snapshot, setSnapshot] = React.useState<GpuSnapshot | null>(null);
-  const [fetchError, setFetchError] = React.useState(false);
+  const [fetchError, setFetchError] = React.useState<string | null>(null);
+  const [retryToken, setRetryToken] = React.useState(0);
 
   React.useEffect(() => {
     let mounted = true;
@@ -110,10 +113,14 @@ export default function GpuGrid() {
         const next = await getGpus();
         if (mounted) {
           setSnapshot(next);
-          setFetchError(false);
+          setFetchError(null);
         }
       } catch {
-        if (mounted) setFetchError(true);
+        if (mounted) {
+          setFetchError(
+            'GPU status could not be refreshed. The values below may be stale.',
+          );
+        }
       } finally {
         inFlight = false;
       }
@@ -125,14 +132,27 @@ export default function GpuGrid() {
       mounted = false;
       clearInterval(interval);
     };
-  }, []);
+  }, [retryToken]);
 
   if (fetchError && !snapshot) {
     return (
-      <p className="py-8 text-center text-muted-foreground">
-        Could not reach the API server. GPU status needs the studio API server
-        running.
-      </p>
+      <div
+        role="alert"
+        className="flex flex-col items-center gap-3 py-8 text-center"
+      >
+        <AlertTriangle className="size-6 text-destructive" aria-hidden />
+        <p className="text-muted-foreground">
+          Could not reach the API server. GPU status needs the Studio API server
+          running.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setRetryToken((token) => token + 1)}
+        >
+          Try Again
+        </Button>
+      </div>
     );
   }
   if (!snapshot) {
@@ -150,9 +170,22 @@ export default function GpuGrid() {
   return (
     <div className="flex flex-col gap-4">
       {fetchError && (
-        <p className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-600 dark:text-amber-400">
-          Lost contact with the API server — showing the last known values.
-        </p>
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex flex-wrap items-center gap-3 rounded-lg border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm"
+        >
+          <AlertTriangle className="size-4 text-amber-600" aria-hidden />
+          <span className="min-w-0 flex-1">{fetchError}</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setRetryToken((token) => token + 1)}
+          >
+            Refresh Now
+          </Button>
+        </div>
       )}
       <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
         {snapshot.gpus.map((gpu) => (

--- a/apps/fastvideo_studio/src/components/ui/accessibility.test.tsx
+++ b/apps/fastvideo_studio/src/components/ui/accessibility.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Button } from './button';
+import { Input } from './input';
+import { NativeSelect } from './native-select';
+import { Slider } from './slider';
+import { Switch } from './switch';
+
+describe('shared control accessibility', () => {
+  it('keeps button, input, and select targets at least 44px tall', () => {
+    render(
+      <>
+        <Button size="sm">Small action</Button>
+        <Input aria-label="Text value" />
+        <NativeSelect aria-label="Choice" defaultValue="one">
+          <option value="one">One</option>
+        </NativeSelect>
+      </>,
+    );
+
+    expect(screen.getByRole('button', { name: 'Small action' })).toHaveClass(
+      'h-11',
+    );
+    expect(screen.getByRole('textbox', { name: 'Text value' })).toHaveClass(
+      'h-11',
+    );
+    expect(screen.getByRole('combobox', { name: 'Choice' })).toHaveClass(
+      'h-11',
+    );
+  });
+
+  it('uses 44px switch and slider interaction surfaces', () => {
+    render(
+      <>
+        <Switch aria-label="Enabled" />
+        <Slider aria-label="Amount" defaultValue={[50]} />
+      </>,
+    );
+
+    expect(screen.getByRole('switch', { name: 'Enabled' })).toHaveClass(
+      'size-11',
+    );
+    expect(screen.getByRole('slider', { name: 'Amount' })).toHaveClass(
+      'size-11',
+    );
+  });
+});

--- a/apps/fastvideo_studio/src/components/ui/badge.tsx
+++ b/apps/fastvideo_studio/src/components/ui/badge.tsx
@@ -29,11 +29,12 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
+  extends React.HTMLAttributes<HTMLSpanElement>,
     VariantProps<typeof badgeVariants> {}
 
+// A span (phrasing content), so badges stay valid inside buttons and links.
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
 export { Badge, badgeVariants };

--- a/apps/fastvideo_studio/src/components/ui/button.tsx
+++ b/apps/fastvideo_studio/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl border !text-sm !font-semibold transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl border !text-sm !font-semibold transition-colors duration-150 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
 	{
 		variants: {
 			variant: {

--- a/apps/fastvideo_studio/src/components/ui/button.tsx
+++ b/apps/fastvideo_studio/src/components/ui/button.tsx
@@ -18,11 +18,11 @@ const buttonVariants = cva(
 				destructive: "border-rose-500/60 bg-rose-600/90 text-white hover:bg-rose-500",
 			},
 			size: {
-				default: "h-10 px-4 py-2",
-				sm: "h-9 rounded-lg px-3 !text-xs",
-				lg: "h-11 px-5 !text-sm",
-				icon: "size-10",
-				"icon-sm": "size-8",
+				default: "h-11 px-4 py-2",
+				sm: "h-11 rounded-lg px-3 !text-xs",
+				lg: "h-12 px-5 !text-sm",
+				icon: "size-11",
+				"icon-sm": "size-11",
 			},
 		},
 		defaultVariants: {

--- a/apps/fastvideo_studio/src/components/ui/dialog.tsx
+++ b/apps/fastvideo_studio/src/components/ui/dialog.tsx
@@ -42,7 +42,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-lg p-1 text-muted-foreground opacity-70 transition-opacity hover:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-sky-400/40 disabled:pointer-events-none">
+      <DialogPrimitive.Close className="absolute right-2 top-2 flex size-11 items-center justify-center rounded-lg text-muted-foreground opacity-70 transition-opacity hover:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-sky-400/40 disabled:pointer-events-none sm:right-4 sm:top-4">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/apps/fastvideo_studio/src/components/ui/dialog.tsx
+++ b/apps/fastvideo_studio/src/components/ui/dialog.tsx
@@ -42,7 +42,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-2 top-2 flex size-11 items-center justify-center rounded-lg text-muted-foreground opacity-70 transition-opacity hover:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-sky-400/40 disabled:pointer-events-none sm:right-4 sm:top-4">
+      <DialogPrimitive.Close className="absolute right-2 top-2 flex size-11 items-center justify-center rounded-lg text-muted-foreground opacity-70 transition-opacity hover:bg-secondary hover:opacity-100 disabled:pointer-events-none sm:right-4 sm:top-4">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/apps/fastvideo_studio/src/components/ui/input.tsx
+++ b/apps/fastvideo_studio/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
 		<input
 			type={type}
 			className={cn(
-				"flex h-10 w-full rounded-xl border border-input bg-card/60 px-3 py-2 text-sm text-foreground shadow-sm backdrop-blur-md transition-colors placeholder:text-muted-foreground focus-visible:border-sky-400/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50",
+				"flex h-11 w-full rounded-xl border border-input bg-card/60 px-3 py-2 text-sm text-foreground shadow-sm backdrop-blur-md transition-colors placeholder:text-muted-foreground focus-visible:border-sky-400/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50",
 				className,
 			)}
 			ref={ref}

--- a/apps/fastvideo_studio/src/components/ui/input.tsx
+++ b/apps/fastvideo_studio/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
 		<input
 			type={type}
 			className={cn(
-				"flex h-11 w-full rounded-xl border border-input bg-card/60 px-3 py-2 text-sm text-foreground shadow-sm backdrop-blur-md transition-colors placeholder:text-muted-foreground focus-visible:border-sky-400/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50",
+				"flex h-11 w-full rounded-xl border border-input bg-card/60 px-3 py-2 text-sm text-foreground shadow-sm backdrop-blur-md transition-colors placeholder:text-muted-foreground focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50",
 				className,
 			)}
 			ref={ref}

--- a/apps/fastvideo_studio/src/components/ui/native-select.tsx
+++ b/apps/fastvideo_studio/src/components/ui/native-select.tsx
@@ -11,7 +11,7 @@ const NativeSelect = React.forwardRef<
   <select
     ref={ref}
     className={cn(
-      'flex h-11 w-full appearance-none rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm transition-colors focus-visible:border-sky-400/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50',
+      'flex h-11 w-full appearance-none rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm transition-colors focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50',
       className,
     )}
     {...props}

--- a/apps/fastvideo_studio/src/components/ui/native-select.tsx
+++ b/apps/fastvideo_studio/src/components/ui/native-select.tsx
@@ -11,7 +11,7 @@ const NativeSelect = React.forwardRef<
   <select
     ref={ref}
     className={cn(
-      'flex h-10 w-full appearance-none rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm transition-colors focus-visible:border-sky-400/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50',
+      'flex h-11 w-full appearance-none rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm transition-colors focus-visible:border-sky-400/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50',
       className,
     )}
     {...props}

--- a/apps/fastvideo_studio/src/components/ui/select.tsx
+++ b/apps/fastvideo_studio/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between gap-2 rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-sky-400/70 focus:ring-2 focus:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-11 w-full items-center justify-between gap-2 rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-sky-400/70 focus:ring-2 focus:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
     {...props}
@@ -117,7 +117,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-xl py-2 pl-8 pr-3 text-sm text-foreground outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground',
+      'relative flex min-h-11 w-full cursor-default select-none items-center rounded-xl py-2 pl-8 pr-3 text-sm text-foreground outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground',
       className,
     )}
     {...props}

--- a/apps/fastvideo_studio/src/components/ui/select.tsx
+++ b/apps/fastvideo_studio/src/components/ui/select.tsx
@@ -17,7 +17,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-11 w-full items-center justify-between gap-2 rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-sky-400/70 focus:ring-2 focus:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-11 w-full items-center justify-between gap-2 rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
       className,
     )}
     {...props}

--- a/apps/fastvideo_studio/src/components/ui/slider.tsx
+++ b/apps/fastvideo_studio/src/components/ui/slider.tsx
@@ -23,7 +23,7 @@ const Slider = React.forwardRef<
     <SliderPrimitive.Root
       ref={ref}
       className={cn(
-        'relative flex w-full touch-none select-none items-center',
+        'relative flex h-11 w-full touch-none select-none items-center',
         className,
       )}
       {...props}
@@ -36,7 +36,7 @@ const Slider = React.forwardRef<
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}
-        className="block h-4 w-4 rounded-full border-2 border-accent-blue bg-accent-blue shadow transition-colors hover:border-accent-blue/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:pointer-events-none disabled:opacity-50"
+        className="relative block size-11 rounded-full bg-transparent after:absolute after:left-1/2 after:top-1/2 after:size-4 after:-translate-x-1/2 after:-translate-y-1/2 after:rounded-full after:border-2 after:border-accent-blue after:bg-accent-blue after:shadow after:content-[''] hover:after:border-accent-blue/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:pointer-events-none disabled:opacity-50"
       />
     </SliderPrimitive.Root>
   ),

--- a/apps/fastvideo_studio/src/components/ui/slider.tsx
+++ b/apps/fastvideo_studio/src/components/ui/slider.tsx
@@ -8,21 +8,39 @@ import { cn } from '@/lib/utils';
 const Slider = React.forwardRef<
   React.ElementRef<typeof SliderPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn(
-      'relative flex w-full touch-none select-none items-center',
+>(
+  (
+    {
       className,
-    )}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-border">
-      <SliderPrimitive.Range className="absolute h-full bg-accent-blue" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border-2 border-accent-blue bg-accent-blue shadow transition-colors hover:border-accent-blue/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-));
+      id,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
+      'aria-describedby': ariaDescribedBy,
+      ...props
+    },
+    ref,
+  ) => (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn(
+        'relative flex w-full touch-none select-none items-center',
+        className,
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-border">
+        <SliderPrimitive.Range className="absolute h-full bg-accent-blue" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        id={id}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        className="block h-4 w-4 rounded-full border-2 border-accent-blue bg-accent-blue shadow transition-colors hover:border-accent-blue/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:pointer-events-none disabled:opacity-50"
+      />
+    </SliderPrimitive.Root>
+  ),
+);
 Slider.displayName = SliderPrimitive.Root.displayName;
 
 export { Slider };

--- a/apps/fastvideo_studio/src/components/ui/slider.tsx
+++ b/apps/fastvideo_studio/src/components/ui/slider.tsx
@@ -36,7 +36,7 @@ const Slider = React.forwardRef<
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledBy}
         aria-describedby={ariaDescribedBy}
-        className="relative block size-11 rounded-full bg-transparent after:absolute after:left-1/2 after:top-1/2 after:size-4 after:-translate-x-1/2 after:-translate-y-1/2 after:rounded-full after:border-2 after:border-accent-blue after:bg-accent-blue after:shadow after:content-[''] hover:after:border-accent-blue/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:pointer-events-none disabled:opacity-50"
+        className="relative block size-11 rounded-full bg-transparent after:absolute after:left-1/2 after:top-1/2 after:size-4 after:-translate-x-1/2 after:-translate-y-1/2 after:rounded-full after:border-2 after:border-accent-blue after:bg-accent-blue after:shadow after:content-[''] hover:after:border-accent-blue/80 disabled:pointer-events-none disabled:opacity-50"
       />
     </SliderPrimitive.Root>
   ),

--- a/apps/fastvideo_studio/src/components/ui/switch.tsx
+++ b/apps/fastvideo_studio/src/components/ui/switch.tsx
@@ -12,14 +12,14 @@ const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     ref={ref}
     className={cn(
-      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-accent-blue data-[state=checked]:bg-accent-blue data-[state=unchecked]:bg-background',
+      'peer relative inline-flex size-11 shrink-0 cursor-pointer items-center justify-center rounded-xl bg-transparent transition-colors before:absolute before:h-5 before:w-9 before:rounded-full before:border before:border-border before:bg-background data-[state=checked]:before:border-accent-blue data-[state=checked]:before:bg-accent-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:cursor-not-allowed disabled:opacity-50',
       className,
     )}
     {...props}
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        'pointer-events-none block h-3.5 w-3.5 rounded-full bg-muted-foreground shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=checked]:bg-white data-[state=unchecked]:translate-x-0.5',
+        'pointer-events-none absolute left-1.5 top-[15px] z-[1] block h-3.5 w-3.5 rounded-full bg-muted-foreground shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=checked]:bg-white',
       )}
     />
   </SwitchPrimitives.Root>

--- a/apps/fastvideo_studio/src/components/ui/switch.tsx
+++ b/apps/fastvideo_studio/src/components/ui/switch.tsx
@@ -12,7 +12,7 @@ const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     ref={ref}
     className={cn(
-      'peer relative inline-flex size-11 shrink-0 cursor-pointer items-center justify-center rounded-xl bg-transparent transition-colors before:absolute before:h-5 before:w-9 before:rounded-full before:border before:border-border before:bg-background data-[state=checked]:before:border-accent-blue data-[state=checked]:before:bg-accent-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:cursor-not-allowed disabled:opacity-50',
+      'peer relative inline-flex size-11 shrink-0 cursor-pointer items-center justify-center rounded-xl bg-transparent transition-colors before:absolute before:h-5 before:w-9 before:rounded-full before:border before:border-border before:bg-background data-[state=checked]:before:border-accent-blue data-[state=checked]:before:bg-accent-blue disabled:cursor-not-allowed disabled:opacity-50',
       className,
     )}
     {...props}

--- a/apps/fastvideo_studio/src/components/ui/tabs.tsx
+++ b/apps/fastvideo_studio/src/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/40 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className,
     )}
     {...props}

--- a/apps/fastvideo_studio/src/components/ui/textarea.tsx
+++ b/apps/fastvideo_studio/src/components/ui/textarea.tsx
@@ -8,7 +8,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
 	return (
 		<textarea
 			className={cn(
-				"flex min-h-24 w-full resize-y rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:border-sky-400/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/25 disabled:cursor-not-allowed disabled:opacity-50",
+				"flex min-h-24 w-full resize-y rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:border-ring disabled:cursor-not-allowed disabled:opacity-50",
 				className,
 			)}
 			ref={ref}

--- a/apps/fastvideo_studio/src/hooks/useDrawerFocus.ts
+++ b/apps/fastvideo_studio/src/hooks/useDrawerFocus.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * Move focus into a drawer when it opens as a modal (mobile), and hand it
+ * back to the previously focused element on close. Pairs with `inert` on
+ * the background content — together they make `aria-modal` truthful.
+ */
+export function useDrawerFocus<T extends HTMLElement>(active: boolean) {
+  const ref = React.useRef<T | null>(null);
+
+  React.useEffect(() => {
+    if (!active) return;
+    const previous = document.activeElement;
+    ref.current?.focus();
+    return () => {
+      if (previous instanceof HTMLElement) previous.focus();
+    };
+  }, [active]);
+
+  return ref;
+}

--- a/apps/fastvideo_studio/src/hooks/useMediaQuery.ts
+++ b/apps/fastvideo_studio/src/hooks/useMediaQuery.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import * as React from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState(false);
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+    const updateMatch = () => setMatches(mediaQuery.matches);
+
+    updateMatch();
+    mediaQuery.addEventListener('change', updateMatch);
+    return () => mediaQuery.removeEventListener('change', updateMatch);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Problem

FastVideo Studio has some UI reliability/accessibility problems:

- the application shell and detail sidebars were not usable on narrow viewports;
- the "Create Job" menu depended on hover
- gallery and dataset media failures rendered as empty content.
- API failures and initial loads could look like real empty states
- create-job, GPU refresh, and caption-save failures were not actionable
- job and dataset cards nested actions inside button-like cards
- routes emitted duplicate "main" landmarks
- sliders lacked names on the actual controls
- shared controls missed 44 px touch targets and sufficiently visible focus indicators.

## Solution

- Add a responsive navigation and full-width mobile job/dataset detail drawers
- Cover 320, 375, 414, and 768 px layouts without horizontal overflow
- Replace the hover-only Create Job trigger with an accessible radix menu
- Add media controls and explicit media-error fallbacks
- Separate loading, empty, error, retry, and stale-data states
- Surface create-job and caption-save errors with recovery paths
- Restructure cards so selection and action buttons are semantic siblings
- Enforce one `main` landmark, accessible slider names, 44 px targets, and high-contrast focus rings

## Test evidence

- `npm test` 16 files, 75 tests passed.
- `npm run typecheck` passed.
- `npm run e2e -- --reporter=line` 10/10 Chromium scenarios passed.
- `npm run build` optimized Next.js production build passed; 12 static pages generated.
- Rendered inspection desktop shell, Create Job menu, settings sliders, 375 px navigation, and full-width dataset drawer verified.
- Rendered semantics: one `main`, no horizontal overflow, 11 named 44×44 sliders, and mobile drawer `aria-modal="true"` verified.
- Fresh browser console: no warnings or errors.