### PR TITLE
[perf]: reduce per-step overhead in causal Wan denoising, plus optional CUDA graph capture

### DIFF
--- a/fastvideo/entrypoints/video_generator.py
+++ b/fastvideo/entrypoints/video_generator.py
@@ -860,12 +860,15 @@ class VideoGenerator:
             frames = None
         else:
             videos = rearrange(samples, "b c t h w -> t b c h w")
-            frames = []
+            device_frames = []
             for x in videos:
                 x = torchvision.utils.make_grid(x, nrow=6)
                 x = x.permute(1, 2, 0).squeeze(-1)
-                x = (x * 255).to(torch.uint8)
-                frames.append(x.contiguous().cpu().numpy())
+                device_frames.append((x * 255).to(torch.uint8).contiguous())
+            # Transfer the frames in one copy. Reading them back individually
+            # blocks on the device once per frame, which serializes the
+            # remaining frames' device-side work behind each transfer.
+            frames = (list(torch.stack(device_frames).cpu().numpy()) if device_frames else [])
         postprocess_time = time.perf_counter() - postprocess_start
         logger.info("PostDecodeFrameProcessStage completed in %.3f s", postprocess_time)
         if logging_info is not None:

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -151,6 +151,14 @@ class FastVideoArgs:
     torch_compile_kwargs_vae: dict[str, Any] = field(default_factory=dict)
     torch_compile_kwargs_audio_vae: dict[str, Any] = field(default_factory=dict)
 
+    # CUDA graph capture for the causal Wan denoising loop (item 2 of the
+    # FlashDreams port). Only takes effect once the KV cache window has
+    # filled and its write positions become fixed; falls back to eager
+    # execution with a log message if the pipeline/config doesn't meet the
+    # preconditions (local_attn_size == -1, rope_cache_policy != "relativistic",
+    # or a dual-transformer MoE boundary_timestep).
+    enable_causal_cuda_graph: bool = False
+
     disable_autocast: bool = False
 
     # VSA parameters
@@ -550,6 +558,14 @@ class FastVideoArgs:
             default=None,
             help=
             "JSON string of kwargs to pass to torch.compile. Example: '{\"backend\":\"inductor\",\"mode\":\"reduce-overhead\"}'",
+        )
+        parser.add_argument(
+            "--enable-causal-cuda-graph",
+            action=StoreBoolean,
+            default=FastVideoArgs.enable_causal_cuda_graph,
+            help="Capture the causal Wan denoising step into a CUDA graph once its KV cache "
+            "window reaches steady state, to cut per-op dispatch overhead. Falls back to eager "
+            "execution automatically if the pipeline doesn't meet the preconditions.",
         )
 
         parser.add_argument(

--- a/fastvideo/layers/rotary_embedding.py
+++ b/fastvideo/layers/rotary_embedding.py
@@ -553,6 +553,13 @@ def get_rotary_pos_embed(
         start_frame=start_frame,
         use_real=use_real,
     )
+    # Pin CPU tables so callers' later `.to(device)` is a pinned-memory H2D
+    # copy, not a pageable one. Callers that run inside CUDA graph capture
+    # (e.g. the causal denoising loop, once its KV cache reaches steady
+    # state) need this: capture forbids copying from pageable CPU memory.
+    if freqs_cos.device.type == "cpu" and torch.cuda.is_available():
+        freqs_cos = freqs_cos.pin_memory()
+        freqs_sin = freqs_sin.pin_memory()
     # The returned tensors are shared cache entries: callers must never mutate
     # them in place. Note .to(device) is an identity alias when the tensor is
     # already on the target device (e.g. CPU runs), so it does NOT guarantee a

--- a/fastvideo/layers/visual_embedding.py
+++ b/fastvideo/layers/visual_embedding.py
@@ -134,23 +134,38 @@ class TimestepEmbedder(nn.Module):
         return t_emb
 
 
+_TIMESTEP_EMBED_FREQS_CACHE: dict[tuple, torch.Tensor] = {}
+
+
 def timestep_embedding(t: torch.Tensor,
                        dim: int,
                        max_period: int = 10000,
                        dtype: torch.dtype = torch.float32) -> torch.Tensor:
     """
     Create sinusoidal timestep embeddings.
-    
+
     Args:
         t: Tensor of shape [B] with timesteps
         dim: Embedding dimension
         max_period: Controls the minimum frequency of the embeddings
-        
+
     Returns:
         Tensor of shape [B, dim] with embeddings
     """
     half = dim // 2
-    freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half, dtype=dtype) / half).to(device=t.device)
+    # The frequency basis only depends on (half, max_period, dtype), so cache
+    # it instead of rebuilding + re-transferring a CPU tensor every call.
+    # Pinned so the transfer is also valid inside CUDA graph capture (e.g.
+    # the causal denoising loop once its KV cache reaches steady state),
+    # which forbids copies from pageable CPU memory.
+    cache_key = (half, max_period, dtype)
+    freqs = _TIMESTEP_EMBED_FREQS_CACHE.get(cache_key)
+    if freqs is None:
+        freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half, dtype=dtype) / half)
+        if torch.cuda.is_available():
+            freqs = freqs.pin_memory()
+        _TIMESTEP_EMBED_FREQS_CACHE[cache_key] = freqs
+    freqs = freqs.to(device=t.device, non_blocking=True)
     args = t[:, None].float() * freqs[None]
     embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
     if dim % 2:

--- a/fastvideo/models/dits/causal_wanvideo.py
+++ b/fastvideo/models/dits/causal_wanvideo.py
@@ -74,7 +74,7 @@ class CausalWanSelfAttention(nn.Module):
             supported_attention_backends=(AttentionBackendEnum.FLASH_ATTN,
                                           AttentionBackendEnum.TORCH_SDPA))
 
-    def forward(self, 
+    def forward(self,
                 q: torch.Tensor,
                 k: torch.Tensor,
                 v: torch.Tensor,
@@ -83,7 +83,8 @@ class CausalWanSelfAttention(nn.Module):
                 kv_cache: dict | None = None,
                 current_start: int = 0,
                 cache_start: int | None = None,
-                frame_seqlen: int = 1560):
+                frame_seqlen: int = 1560,
+                is_chunk_start: bool | None = None):
         r"""
         Args:
             x(Tensor): Shape [B, L, num_heads, C / num_heads]
@@ -92,6 +93,14 @@ class CausalWanSelfAttention(nn.Module):
             freqs(Tensor): Rope freqs, shape [1024, C / num_heads / 2]
             frame_seqlen (int): Number of tokens per latent frame,
                 e.g. 1560 for 480x832 resolution.
+            is_chunk_start: Whether this call is the first step of a new
+                autoregressive chunk (as opposed to a later denoising step
+                refining the same chunk). Callers that already know this
+                (e.g. the causal denoising stage) should pass it explicitly,
+                which lets CUDA-graph capture avoid re-deriving it from the
+                cache counters on every replay. Callers that don't pass it
+                (e.g. training) fall back to deriving it from
+                ``current_end > global_end_index``, exactly as before.
         """
         if cache_start is None:
             cache_start = current_start
@@ -159,32 +168,25 @@ class CausalWanSelfAttention(nn.Module):
                 if isinstance(kv_cache["local_end_index"], torch.Tensor)
                 else int(kv_cache["local_end_index"])
             )
-            if self.local_attn_size != -1 and (current_end > global_end_index) and (
-                    num_new_tokens + local_end_index_prev > kv_cache_size):
-                # Calculate the number of new tokens added in this step
-                # Shift existing cache content left to discard oldest tokens
-                # Clone the source slice to avoid overlapping memory error
-                num_evicted_tokens = num_new_tokens + local_end_index_prev - kv_cache_size
-                num_rolled_tokens = local_end_index_prev - num_evicted_tokens - sink_tokens
-                kv_cache["k"][:, sink_tokens:sink_tokens + num_rolled_tokens] = \
-                    kv_cache["k"][:, sink_tokens + num_evicted_tokens:sink_tokens + num_evicted_tokens + num_rolled_tokens].clone()
-                kv_cache["v"][:, sink_tokens:sink_tokens + num_rolled_tokens] = \
-                    kv_cache["v"][:, sink_tokens + num_evicted_tokens:sink_tokens + num_evicted_tokens + num_rolled_tokens].clone()
-                # Insert the new keys/values at the end
-                local_end_index = local_end_index_prev + current_end - \
-                    global_end_index - num_evicted_tokens
-                local_start_index = local_end_index - num_new_tokens
-                kv_cache["k"][:, local_start_index:local_end_index] = stored_key
-                kv_cache["v"][:, local_start_index:local_end_index] = v
+            # A chunk-start step is one where new tokens extend the sequence
+            # (current_end > global_end_index); later steps within the same
+            # chunk only refine tokens already written. The caller already
+            # knows which kind of step this is from its own loop position, so
+            # prefer that over re-deriving it here -- re-deriving it is also
+            # what a CUDA-graph replay cannot do, since only the caller's
+            # Python loop (not the captured tensor ops) runs on every replay.
+            chunk_start = (current_end >
+                           global_end_index) if is_chunk_start is None else is_chunk_start
+            needs_eviction = num_new_tokens + local_end_index_prev > kv_cache_size
+
+            if self.local_attn_size != -1 and chunk_start and needs_eviction:
+                local_start_index, local_end_index = self._evict_and_write(
+                    kv_cache, stored_key, v, sink_tokens, num_new_tokens,
+                    local_end_index_prev, kv_cache_size)
             else:
-                # Assign new keys/values directly up to current_end
-                local_end_index = local_end_index_prev + current_end - global_end_index
-                local_start_index = local_end_index - num_new_tokens
-                kv_cache["k"] = kv_cache["k"].detach()
-                kv_cache["v"] = kv_cache["v"].detach()
-                # logger.info("kv_cache['k'] is in comp graph: %s", kv_cache["k"].requires_grad or kv_cache["k"].grad_fn is not None)
-                kv_cache["k"][:, local_start_index:local_end_index] = stored_key
-                kv_cache["v"][:, local_start_index:local_end_index] = v
+                local_start_index, local_end_index = self._write_in_place(
+                    kv_cache, stored_key, v, current_end, global_end_index,
+                    local_end_index_prev, num_new_tokens)
             key_window = kv_cache["k"][:, max(0, local_end_index - max_attention_size):local_end_index]
             value_window = kv_cache["v"][:, max(0, local_end_index - max_attention_size):local_end_index]
             if relativistic:
@@ -197,16 +199,71 @@ class CausalWanSelfAttention(nn.Module):
                     key_window, cos[:window_len], sin[:window_len],
                     is_neox_style=False).type_as(v)
             x = self.attn(roped_query, key_window, value_window)
-            if isinstance(kv_cache["global_end_index"], torch.Tensor):
-                kv_cache["global_end_index"].fill_(current_end)
-            else:
-                kv_cache["global_end_index"] = current_end
-            if isinstance(kv_cache["local_end_index"], torch.Tensor):
-                kv_cache["local_end_index"].fill_(local_end_index)
-            else:
-                kv_cache["local_end_index"] = local_end_index
+            self._update_cache_counters(kv_cache, current_end, local_end_index)
 
         return x
+
+    @staticmethod
+    def _evict_and_write(kv_cache: dict, key_to_store: torch.Tensor, v: torch.Tensor,
+                         sink_tokens: int, num_new_tokens: int,
+                         local_end_index_prev: int, kv_cache_size: int) -> tuple[int, int]:
+        """Shift the local window left to discard the oldest tokens, then write the new chunk at the freed slot.
+
+        Only called at a chunk-start step whose new tokens would overflow the
+        fixed-size cache. Once the cache has filled once, this always evicts
+        exactly ``num_new_tokens`` tokens and writes to the same physical
+        slot on every subsequent call -- see ``causal_denoising.py`` for the
+        steady-state argument this relies on.
+        """
+        num_evicted_tokens = num_new_tokens + local_end_index_prev - kv_cache_size
+        num_rolled_tokens = local_end_index_prev - num_evicted_tokens - sink_tokens
+        # Clone the source slice to avoid an overlapping-memory error.
+        kv_cache["k"][:, sink_tokens:sink_tokens + num_rolled_tokens] = \
+            kv_cache["k"][:, sink_tokens + num_evicted_tokens:sink_tokens + num_evicted_tokens + num_rolled_tokens].clone()
+        kv_cache["v"][:, sink_tokens:sink_tokens + num_rolled_tokens] = \
+            kv_cache["v"][:, sink_tokens + num_evicted_tokens:sink_tokens + num_evicted_tokens + num_rolled_tokens].clone()
+        local_end_index = local_end_index_prev + num_new_tokens - num_evicted_tokens
+        local_start_index = local_end_index - num_new_tokens
+        kv_cache["k"][:, local_start_index:local_end_index] = key_to_store
+        kv_cache["v"][:, local_start_index:local_end_index] = v
+        return local_start_index, local_end_index
+
+    @staticmethod
+    def _write_in_place(kv_cache: dict, key_to_store: torch.Tensor, v: torch.Tensor,
+                        current_end: int, global_end_index: int,
+                        local_end_index_prev: int, num_new_tokens: int) -> tuple[int, int]:
+        """Write the chunk without evicting anything.
+
+        Covers two cases with the same math: a continuation step refining
+        tokens already written this chunk (``current_end == global_end_index``,
+        so the write lands on the same slot as last time), and a chunk-start
+        step while the cache is still filling up (``current_end >
+        global_end_index``, so the write extends the filled region).
+        """
+        local_end_index = local_end_index_prev + current_end - global_end_index
+        local_start_index = local_end_index - num_new_tokens
+        kv_cache["k"] = kv_cache["k"].detach()
+        kv_cache["v"] = kv_cache["v"].detach()
+        kv_cache["k"][:, local_start_index:local_end_index] = key_to_store
+        kv_cache["v"][:, local_start_index:local_end_index] = v
+        return local_start_index, local_end_index
+
+    @staticmethod
+    def _update_cache_counters(kv_cache: dict, current_end: int, local_end_index: int) -> None:
+        """Record the new cache extent for the next call to read back.
+
+        Accepts either plain ints (inference) or 0-d tensors (training, which
+        snapshots these for gradient checkpointing) -- see the training
+        limitation noted in FlashDreams.md item 1.
+        """
+        if isinstance(kv_cache["global_end_index"], torch.Tensor):
+            kv_cache["global_end_index"].fill_(current_end)
+        else:
+            kv_cache["global_end_index"] = current_end
+        if isinstance(kv_cache["local_end_index"], torch.Tensor):
+            kv_cache["local_end_index"].fill_(local_end_index)
+        else:
+            kv_cache["local_end_index"] = local_end_index
 
 class CausalWanTransformerBlock(nn.Module):
 
@@ -293,6 +350,7 @@ class CausalWanTransformerBlock(nn.Module):
         current_start: int = 0,
         cache_start: int | None = None,
         frame_seqlen: int | None = None,
+        is_chunk_start: bool | None = None,
     ) -> torch.Tensor:
         # hidden_states.shape: [batch_size, seq_length, inner_dim]
         # temb.shape: [batch_size, temb_seq_len, 6, inner_dim]
@@ -341,12 +399,16 @@ class CausalWanTransformerBlock(nn.Module):
             current_start,
             cache_start,
             frame_seqlen=frame_seqlen,
+            is_chunk_start=is_chunk_start,
         )
         attn_output = attn_output.flatten(2)
         attn_output, _ = self.to_out(attn_output)
         attn_output = attn_output.squeeze(1)
 
-        null_shift = null_scale = torch.tensor([0], device=hidden_states.device)
+        # torch.zeros(...) allocates directly on-device; torch.tensor([0], ...)
+        # builds the literal on CPU first and copies it over, which CUDA graph
+        # capture forbids unless the CPU side is pinned.
+        null_shift = null_scale = torch.zeros(1, device=hidden_states.device, dtype=torch.long)
         norm_hidden_states, hidden_states = self.self_attn_residual_norm(
             hidden_states, attn_output, gate_msa, null_shift, null_scale)
         norm_hidden_states, hidden_states = norm_hidden_states.to(
@@ -577,6 +639,7 @@ class CausalWanTransformer3DModel(BaseDiT):
                 current_start: int = 0,
                 cache_start: int = 0,
                 start_frame: int = 0,
+                is_chunk_start: bool | None = None,
                 **kwargs) -> torch.Tensor:
         r"""
         Run the diffusion model with kv caching.
@@ -622,8 +685,12 @@ class CausalWanTransformer3DModel(BaseDiT):
             rope_theta=10000,
             start_frame=rope_start_frame
         )
-        freqs_cos = freqs_cos.to(hidden_states.device)
-        freqs_sin = freqs_sin.to(hidden_states.device)
+        # non_blocking=True: without it, .to() issues a synchronous copy even
+        # from pinned memory, and a synchronous copy isn't a capturable
+        # operation -- CUDA graph capture (once the KV cache is in steady
+        # state) needs this to be the async pinned-memory path.
+        freqs_cos = freqs_cos.to(hidden_states.device, non_blocking=True)
+        freqs_sin = freqs_sin.to(hidden_states.device, non_blocking=True)
         freqs_cis = (freqs_cos,
                      freqs_sin) if freqs_cos is not None else None
 
@@ -657,6 +724,7 @@ class CausalWanTransformer3DModel(BaseDiT):
                     "cache_start": cache_start,
                     "block_mask": self.block_mask,
                     "frame_seqlen": post_patch_height * post_patch_width,
+                    "is_chunk_start": is_chunk_start,
                 }
                 hidden_states = self._gradient_checkpointing_func(
                     block, hidden_states, encoder_hidden_states,
@@ -671,6 +739,7 @@ class CausalWanTransformer3DModel(BaseDiT):
                     "cache_start": cache_start,
                     "block_mask": self.block_mask,
                     "frame_seqlen": post_patch_height * post_patch_width,
+                    "is_chunk_start": is_chunk_start,
                 }
                 hidden_states = block(hidden_states, encoder_hidden_states,
                                         timestep_proj, freqs_cis,

--- a/fastvideo/models/utils.py
+++ b/fastvideo/models/utils.py
@@ -139,6 +139,35 @@ def modulate(x: torch.Tensor,
             1)  # type: ignore[union-attr]
 
 
+_FLOAT64_SCHEDULE_ATTR = "_fastvideo_float64_schedule"
+
+
+def get_float64_schedule(scheduler: Any,
+                         device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Return the scheduler's sigma and timestep tables as float64 on ``device``.
+
+    The result is memoized on the scheduler and reused until it swaps the
+    tables out, which ``set_timesteps`` does. Callers run once per denoising
+    step, so converting on every call would recast and re-upload the whole
+    schedule for values that do not change within a schedule.
+    """
+    sigmas = scheduler.sigmas
+    timesteps = scheduler.timesteps
+    cached = getattr(scheduler, _FLOAT64_SCHEDULE_ATTR, None)
+    if cached is not None:
+        cached_sigmas, cached_timesteps, sigmas_f64, timesteps_f64 = cached
+        if (cached_sigmas is sigmas and cached_timesteps is timesteps
+                and sigmas_f64.device == device):
+            return sigmas_f64, timesteps_f64
+
+    sigmas_f64 = sigmas.to(device=device, dtype=torch.float64)
+    timesteps_f64 = timesteps.to(device=device, dtype=torch.float64)
+    setattr(scheduler, _FLOAT64_SCHEDULE_ATTR,
+            (sigmas, timesteps, sigmas_f64, timesteps_f64))
+    return sigmas_f64, timesteps_f64
+
+
 def pred_noise_to_pred_video(pred_noise: torch.Tensor,
                              noise_input_latent: torch.Tensor,
                              timestep: torch.Tensor,
@@ -173,8 +202,7 @@ def pred_noise_to_pred_video(pred_noise: torch.Tensor,
     device = pred_noise.device
     pred_noise = pred_noise.double().to(device)
     noise_input_latent = noise_input_latent.double().to(device)
-    sigmas = scheduler.sigmas.double().to(device)
-    timesteps = scheduler.timesteps.double().to(device)
+    sigmas, timesteps = get_float64_schedule(scheduler, device)
     timestep_id = torch.argmin(
         (timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
     sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1)
@@ -217,8 +245,7 @@ def pred_noise_to_x_bound(pred_noise: torch.Tensor,
     device = pred_noise.device
     pred_noise = pred_noise.double().to(device)
     noise_input_latent = noise_input_latent.double().to(device)
-    sigmas = scheduler.sigmas.double().to(device)
-    timesteps = scheduler.timesteps.double().to(device)
+    sigmas, timesteps = get_float64_schedule(scheduler, device)
     timestep_id = torch.argmin(
         (timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
     sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1)

--- a/fastvideo/pipelines/stages/causal_cuda_graph.py
+++ b/fastvideo/pipelines/stages/causal_cuda_graph.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA graph capture for the causal Wan denoising step.
+
+Ported from NVIDIA FlashDreams (https://github.com/NVIDIA/flashdreams,
+``flashdreams/infra/cuda_graph.py``), trimmed to what this repo needs: no
+``drain()`` step, since capture here isn't yet combined with
+``torch.compile`` (see FlashDreams.md item 2 for why that's deferred).
+"""
+from typing import Any
+from collections.abc import Callable
+
+import torch
+from torch.utils._pytree import tree_flatten, tree_unflatten
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class CausalCudaGraphWrapper:
+    """Capture a stateful CUDA callable into a replayable graph.
+
+    The wrapped callable runs eagerly for ``warmup_iters`` calls so kernels
+    JIT-load and the allocator stabilizes. The next call captures the whole
+    forward into a ``torch.cuda.CUDAGraph`` against static input buffers;
+    every same-shape call after that copies inputs into those buffers and
+    replays the graph, returning clones of the captured outputs.
+
+    Only usable where the wrapped callable reads/writes memory through
+    stable pointers on every call (e.g. a KV cache updated by slice
+    assignment) and where any plain-Python arguments (ints, bools, ``None``)
+    don't change which memory the callable touches -- for the causal Wan
+    denoising step, this holds once the KV cache window has filled and
+    ``rope_cache_policy`` is ``"relativistic"``; see ``causal_denoising.py``
+    for the gating that ensures that before this wrapper is ever used.
+
+    Input staging: only top-level tensor positional args and kwargs are
+    copied into static buffers. Everything else (ints, ``None``, dicts,
+    lists) passes through to the callable verbatim on the eager/warmup path
+    and is simply not re-passed on replay, since a replay only reruns the
+    kernels recorded during capture -- it never calls the wrapped function
+    again. This is why the KV/cross-attention caches (mutated in place
+    through existing tensor storage) work correctly here, while a fresh
+    per-call value like the current chunk's noisy latents needs staging.
+    """
+
+    def __init__(self, fn: Callable[..., Any], warmup_iters: int = 2) -> None:
+        self.fn = fn
+        self.warmup_iters = warmup_iters
+        self._graph: torch.cuda.CUDAGraph | None = None
+        self._static_args: list[Any] = []
+        self._static_kwargs: dict[str, Any] = {}
+        self._static_out_leaves: list[Any] | None = None
+        self._out_spec: Any = None
+        self._warmup_remaining = warmup_iters
+
+    def reset(self) -> None:
+        """Drop the captured graph and staged buffers, restarting warmup."""
+        self._graph = None
+        self._static_args = []
+        self._static_kwargs = {}
+        self._static_out_leaves = None
+        self._out_spec = None
+        self._warmup_remaining = self.warmup_iters
+
+    @staticmethod
+    def _slot_compatible(slot: Any, fresh: Any) -> bool:
+        """Return whether ``slot``'s static buffer can absorb ``fresh``."""
+        if isinstance(slot, torch.Tensor):
+            return (isinstance(fresh, torch.Tensor) and slot.shape == fresh.shape and slot.dtype == fresh.dtype)
+        return not isinstance(fresh, torch.Tensor)
+
+    def _slots_compatible_with(self, args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+        if len(self._static_args) != len(args):
+            return False
+        if set(self._static_kwargs) != set(kwargs):
+            return False
+        for slot, fresh in zip(self._static_args, args, strict=False):
+            if not self._slot_compatible(slot, fresh):
+                return False
+        return all(self._slot_compatible(slot, kwargs[name]) for name, slot in self._static_kwargs.items())
+
+    @staticmethod
+    def _make_slot(value: Any) -> Any:
+        """Return a static buffer for a tensor, or ``value`` itself otherwise."""
+        if isinstance(value, torch.Tensor):
+            return torch.empty_like(value).contiguous()
+        return value
+
+    def _stage(self, args: tuple[Any, ...], kwargs: dict[str, Any]) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        """Copy top-level tensors into static buffers; forward everything else as-is.
+
+        Reallocates buffers (and drops any captured graph) if the staged
+        tensor signature changes shape or dtype.
+        """
+        if not self._slots_compatible_with(args, kwargs):
+            self.reset()
+            self._static_args = [self._make_slot(a) for a in args]
+            self._static_kwargs = {k: self._make_slot(v) for k, v in kwargs.items()}
+
+        staged_args: list[Any] = []
+        for slot, fresh in zip(self._static_args, args, strict=False):
+            if isinstance(slot, torch.Tensor):
+                slot.copy_(fresh)
+                staged_args.append(slot)
+            else:
+                staged_args.append(fresh)
+
+        staged_kwargs: dict[str, Any] = {}
+        for name, fresh in kwargs.items():
+            slot = self._static_kwargs[name]
+            if isinstance(slot, torch.Tensor):
+                slot.copy_(fresh)
+                staged_kwargs[name] = slot
+            else:
+                staged_kwargs[name] = fresh
+
+        return tuple(staged_args), staged_kwargs
+
+    def _clone_output(self) -> Any:
+        assert self._static_out_leaves is not None and self._out_spec is not None
+        cloned = [leaf.clone() if isinstance(leaf, torch.Tensor) else leaf for leaf in self._static_out_leaves]
+        return tree_unflatten(cloned, self._out_spec)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        args, kwargs = self._stage(args, kwargs)
+
+        if self._graph is not None:
+            self._graph.replay()
+            # Clone: the next replay would overwrite the static output buffer.
+            return self._clone_output()
+
+        if self._warmup_remaining > 0:
+            self._warmup_remaining -= 1
+            return self.fn(*args, **kwargs)
+
+        # Capture: trace one full forward against the static buffers.
+        # cudaStreamBeginCapture only records kernels -- it doesn't execute
+        # them -- so the static outputs and in-place cache writes are no-ops
+        # here. Replay once immediately to actually compute this call's
+        # output and advance the cache.
+        #
+        # Keep the graph local until capture and the first replay both
+        # succeed. If capture fails and the caller catches the exception, a
+        # stored-but-invalid CUDAGraph would make the next call fail with
+        # "replay without a preceding successful capture", hiding the real
+        # capture error.
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            out = self.fn(*args, **kwargs)
+        out_leaves, out_spec = tree_flatten(out)
+        graph.replay()
+        self._graph = graph
+        self._out_spec = out_spec
+        self._static_out_leaves = out_leaves
+        logger.info("CausalCudaGraphWrapper: captured CUDA graph for %s", getattr(self.fn, "__qualname__", self.fn))
+        return self._clone_output()
+
+
+class CausalCudaGraphDispatch:
+    """Route a transformer call through the right CUDA graph once steady state is reached.
+
+    A chunk-start step evicts the oldest cached frames before writing the
+    new ones; every other step just overwrites the existing slot. Those are
+    two different fixed operation sequences, so each needs its own captured
+    graph -- replaying one for the other would silently apply the wrong kind
+    of cache update. Both graphs are only ever engaged once the KV cache has
+    reached steady state, where each kind of step's sequence stops changing
+    from call to call (see FlashDreams.md item 2).
+
+    Construct one of these per ``forward()`` call, not once per stage
+    instance: a captured graph's static buffers are tied to that call's
+    specific KV cache tensors, and reusing one across generations would
+    replay against stale memory once a fresh KV cache is allocated.
+    """
+
+    def __init__(self, transformer: Callable[..., Any], *, enabled: bool, warmup_iters: int = 2) -> None:
+        self.enabled = enabled
+        self._chunk_start = CausalCudaGraphWrapper(transformer, warmup_iters=warmup_iters) if enabled else None
+        self._continuation = CausalCudaGraphWrapper(transformer, warmup_iters=warmup_iters) if enabled else None
+
+    def call(self, transformer: Callable[..., Any], *args: Any, is_chunk_start: bool | None, is_steady_state: bool,
+             **kwargs: Any) -> Any:
+        """Call ``transformer(*args, is_chunk_start=is_chunk_start, **kwargs)``, through a graph if steady state allows it."""
+        kwargs = dict(kwargs, is_chunk_start=is_chunk_start)
+        if self.enabled and is_steady_state:
+            wrapper = self._chunk_start if is_chunk_start else self._continuation
+            assert wrapper is not None, "wrappers are built whenever enabled is True"
+            return wrapper(*args, **kwargs)
+        return transformer(*args, **kwargs)

--- a/fastvideo/pipelines/stages/causal_denoising.py
+++ b/fastvideo/pipelines/stages/causal_denoising.py
@@ -6,6 +6,7 @@ from fastvideo.forward_context import set_forward_context
 from fastvideo.logger import init_logger
 from fastvideo.models.utils import pred_noise_to_pred_video, pred_noise_to_x_bound
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.pipelines.stages.causal_cuda_graph import CausalCudaGraphDispatch
 from fastvideo.pipelines.stages.denoising import DenoisingStage
 from fastvideo.pipelines.stages.validators import StageValidators as V
 from fastvideo.pipelines.stages.validators import VerificationResult
@@ -60,6 +61,76 @@ class CausalDMDDenosingStage(DenoisingStage):
         self.local_attn_size = _get_transformer_attr(self.transformer, "local_attn_size", -1)
         self.sink_size = _get_transformer_attr(self.transformer, "sink_size", 0)
 
+    def _resolve_cuda_graph_enabled(self, fastvideo_args: FastVideoArgs, boundary_timestep) -> bool:
+        """Return whether this run may attempt CUDA graph capture, logging why not otherwise.
+
+        Capture needs a fixed-size KV window whose write positions become
+        constant once full (``local_attn_size != -1``), position embeddings
+        that don't depend on the per-chunk ``start_frame``
+        (``rope_cache_policy == "relativistic"``), a single transformer
+        (the dual-transformer MoE path's "which model is at chunk-start"
+        bookkeeping isn't handled yet), and weights that stay put on the GPU
+        (CPU/layerwise offload swaps parameter storage between layers, which
+        breaks the stable memory addresses a captured graph depends on).
+        See FlashDreams.md item 2.
+        """
+        if not fastvideo_args.enable_causal_cuda_graph:
+            return False
+        reason = None
+        if fastvideo_args.dit_cpu_offload or fastvideo_args.dit_layerwise_offload:
+            reason = "dit_cpu_offload/dit_layerwise_offload moves weights during forward"
+        elif self.local_attn_size == -1:
+            reason = "local_attn_size=-1 (no fixed-size KV window)"
+        else:
+            rope_cache_policy = getattr(self.transformer.config.arch_config, "rope_cache_policy", "absolute")
+            if rope_cache_policy != "relativistic":
+                reason = f"rope_cache_policy={rope_cache_policy!r} (requires 'relativistic')"
+            elif boundary_timestep is not None:
+                reason = "dual-transformer MoE pipeline (boundary_timestep is set)"
+        if reason is not None:
+            logger.warning(
+                "CUDA graph capture requested (enable_causal_cuda_graph=True) but disabled: %s. "
+                "Falling back to eager execution.", reason)
+            return False
+        logger.info("CUDA graph capture enabled for causal denoising; "
+                    "will engage once the KV cache reaches steady state.")
+        return True
+
+    def _kv_cache_is_steady_state(self, kv_cache: list[dict]) -> bool:
+        """Return whether the KV cache window is already full.
+
+        Once full, every subsequent write lands on the same fixed slot
+        (see FlashDreams.md item 2's derivation), which is what makes
+        capture safe from that point on. With no fixed window
+        (``local_attn_size == -1``) there's no "full" to reach, so this is
+        always False there -- callers must not treat -1 as a size.
+        """
+        if self.local_attn_size == -1:
+            return False
+        kv_cache_size = self.local_attn_size * self.frame_seq_length
+        return kv_cache[0]["local_end_index"] >= kv_cache_size
+
+    def _finalize_kv_cache_counters(self, kv_cache: list[dict], current_end: int) -> None:
+        """Advance every layer's cache counters after a steady-state call.
+
+        ``CausalWanSelfAttention.forward`` normally updates these counters
+        itself, but that update is inside the region a CUDA graph replay
+        skips entirely -- replaying only reruns the recorded tensor kernels,
+        never the Python that recorded them. Call this unconditionally after
+        every steady-state call (whether it went eager, warmed up, or
+        replayed) to keep the counters correct regardless.
+
+        Both values are knowable in advance once steady state is reached:
+        ``local_end_index`` is always the full buffer size (see
+        ``_kv_cache_is_steady_state``'s derivation), and ``global_end_index``
+        is always this call's ``current_end``. Setting them here is
+        idempotent when the model's own update already ran.
+        """
+        kv_cache_size = self.local_attn_size * self.frame_seq_length
+        for layer_cache in kv_cache:
+            layer_cache["global_end_index"] = current_end
+            layer_cache["local_end_index"] = kv_cache_size
+
     def forward(
         self,
         batch: ForwardBatch,
@@ -88,6 +159,12 @@ class CausalDMDDenosingStage(DenoisingStage):
         else:
             boundary_timestep = None
             high_noise_timesteps = None
+
+        # Scoped to this forward() call, not stored on self: a captured
+        # graph's static buffers are tied to this call's KV cache tensors,
+        # and a later generate_video() call gets a fresh KV cache.
+        cuda_graph_enabled = self._resolve_cuda_graph_enabled(fastvideo_args, boundary_timestep)
+        cuda_graph_dispatch = CausalCudaGraphDispatch(self.transformer, enabled=cuda_graph_enabled)
 
         # Image kwargs (kept empty unless caller provides compatible args)
         image_kwargs: dict = {}
@@ -182,6 +259,7 @@ class CausalDMDDenosingStage(DenoisingStage):
                     crossattn_cache=crossattn_cache,
                     current_start=(pos_start_base + start_index) * self.frame_seq_length,
                     start_frame=start_index,
+                    is_chunk_start=True,
                     **image_kwargs,
                     **pos_cond_kwargs,
                 )
@@ -194,6 +272,7 @@ class CausalDMDDenosingStage(DenoisingStage):
                         crossattn_cache=crossattn_cache,
                         current_start=(pos_start_base + start_index) * self.frame_seq_length,
                         start_frame=start_index,
+                        is_chunk_start=True,
                         **image_kwargs,
                         **pos_cond_kwargs,
                     )
@@ -252,17 +331,33 @@ class CausalDMDDenosingStage(DenoisingStage):
                         # Run transformer; follow DMD stage pattern
                         t_expanded_noise = t_cur * torch.ones(
                             (latent_model_input.shape[0], 1), device=latent_model_input.device, dtype=torch.long)
-                        pred_noise_btchw = current_model(
+                        # Only the single-transformer case can say for certain
+                        # which model's first call this is -- with two
+                        # transformers alternating on a shared timestep list,
+                        # each one's true chunk-start can land at a different
+                        # i, so leave it None there and let the fallback
+                        # derivation (unchanged from before) handle it.
+                        is_chunk_start = (i == 0) if boundary_timestep is None else None
+                        kv_cache_for_call = _get_kv_cache(t_cur)
+                        is_steady_state = (cuda_graph_dispatch.enabled and boundary_timestep is None
+                                           and self._kv_cache_is_steady_state(kv_cache_for_call))
+                        call_current_end = (pos_start_base + start_index + current_num_frames) * self.frame_seq_length
+                        pred_noise_btchw = cuda_graph_dispatch.call(
+                            current_model,
                             latent_model_input,
                             prompt_embeds,
                             t_expanded_noise,
-                            kv_cache=_get_kv_cache(t_cur),
+                            kv_cache=kv_cache_for_call,
                             crossattn_cache=crossattn_cache,
                             current_start=(pos_start_base + start_index) * self.frame_seq_length,
                             start_frame=start_index,
+                            is_chunk_start=is_chunk_start,
+                            is_steady_state=is_steady_state,
                             **image_kwargs,
                             **pos_cond_kwargs,
                         ).permute(0, 2, 1, 3, 4)
+                        if is_steady_state:
+                            self._finalize_kv_cache_counters(kv_cache_for_call, call_current_end)
 
                     # Convert pred noise to pred video with FM Euler scheduler utilities
                     if boundary_timestep is not None and t_cur >= boundary_timestep:
@@ -330,11 +425,15 @@ class CausalDMDDenosingStage(DenoisingStage):
                             crossattn_cache=crossattn_cache,
                             current_start=(pos_start_base + start_index) * self.frame_seq_length,
                             start_frame=start_index,
+                            is_chunk_start=False,
                             **image_kwargs,
                             **pos_cond_kwargs,
                         )
 
-                    self.transformer(
+                    context_is_steady_state = (cuda_graph_dispatch.enabled and boundary_timestep is None
+                                               and self._kv_cache_is_steady_state(kv_cache1))
+                    cuda_graph_dispatch.call(
+                        self.transformer,
                         context_bcthw,
                         prompt_embeds,
                         t_expanded_context,
@@ -342,9 +441,13 @@ class CausalDMDDenosingStage(DenoisingStage):
                         crossattn_cache=crossattn_cache,
                         current_start=(pos_start_base + start_index) * self.frame_seq_length,
                         start_frame=start_index,
+                        is_chunk_start=False,
+                        is_steady_state=context_is_steady_state,
                         **image_kwargs,
                         **pos_cond_kwargs,
                     )
+                    if context_is_steady_state:
+                        self._finalize_kv_cache_counters(kv_cache1, call_current_end)
 
                 start_index += current_num_frames
 
@@ -479,6 +582,11 @@ class CausalDenoisingStage(CausalDMDDenosingStage):
             device=latents.device,
         )
 
+        # This stage always has a single transformer, so boundary_timestep
+        # (the dual-transformer MoE gate) is never set here.
+        cuda_graph_enabled = self._resolve_cuda_graph_enabled(fastvideo_args, boundary_timestep=None)
+        cuda_graph_dispatch = CausalCudaGraphDispatch(self.transformer, enabled=cuda_graph_enabled)
+
         # Determine block sizes
         if t % self.num_frames_per_block != 0:
             raise ValueError("num_frames must be divisible by "
@@ -535,7 +643,11 @@ class CausalDenoisingStage(CausalDMDDenosingStage):
                         # Transformer returns [B, C, T, H, W],
                         # permute to [B, T, C, H, W] then flatten
                         # B*T for the scheduler.
-                        noise_pred = self.transformer(
+                        step_is_steady_state = (cuda_graph_dispatch.enabled
+                                                and self._kv_cache_is_steady_state(kv_cache))
+                        step_current_end = (pos_start_base + start_index + current_num_frames) * self.frame_seq_length
+                        noise_pred = cuda_graph_dispatch.call(
+                            self.transformer,
                             latent_model_input,
                             prompt_embeds,
                             t_expanded,
@@ -543,8 +655,12 @@ class CausalDenoisingStage(CausalDMDDenosingStage):
                             crossattn_cache=crossattn_cache,
                             current_start=((pos_start_base + start_index) * self.frame_seq_length),
                             start_frame=start_index,
+                            is_chunk_start=(i == 0),
+                            is_steady_state=step_is_steady_state,
                             **pos_cond_kwargs,
                         )
+                        if step_is_steady_state:
+                            self._finalize_kv_cache_counters(kv_cache, step_current_end)
 
                     # Flatten [B,C,T,H,W] -> [B*T,C,H,W] for
                     # scheduler, then unflatten back.
@@ -590,7 +706,10 @@ class CausalDenoisingStage(CausalDMDDenosingStage):
                             forward_batch=batch,
                         ),
                 ):
-                    self.transformer(
+                    context_is_steady_state = (cuda_graph_dispatch.enabled and self._kv_cache_is_steady_state(kv_cache))
+                    context_current_end = (pos_start_base + start_index + current_num_frames) * self.frame_seq_length
+                    cuda_graph_dispatch.call(
+                        self.transformer,
                         context_bcthw,
                         prompt_embeds,
                         t_context.unsqueeze(1),
@@ -598,8 +717,12 @@ class CausalDenoisingStage(CausalDMDDenosingStage):
                         crossattn_cache=crossattn_cache,
                         current_start=((pos_start_base + start_index) * self.frame_seq_length),
                         start_frame=start_index,
+                        is_chunk_start=False,
+                        is_steady_state=context_is_steady_state,
                         **pos_cond_kwargs,
                     )
+                    if context_is_steady_state:
+                        self._finalize_kv_cache_counters(kv_cache, context_current_end)
 
                 start_index += current_num_frames
 

--- a/fastvideo/pipelines/stages/causal_denoising.py
+++ b/fastvideo/pipelines/stages/causal_denoising.py
@@ -358,6 +358,10 @@ class CausalDMDDenosingStage(DenoisingStage):
     def _initialize_kv_cache(self, batch_size, dtype, device) -> list[dict]:
         """
         Initialize a Per-GPU KV cache aligned with the Wan model assumptions.
+
+        The window offsets are plain Python ints rather than device tensors.
+        The attention block reads them back on every layer to slice the cache,
+        so keeping them on device would force a host sync per layer per step.
         """
         kv_cache1 = []
         num_attention_heads = self.transformer.num_attention_heads
@@ -378,9 +382,9 @@ class CausalDMDDenosingStage(DenoisingStage):
                             dtype=dtype,
                             device=device),
                 "global_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
+                0,
                 "local_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
+                0,
             })
 
         return kv_cache1

--- a/fastvideo/tests/ops/test_flow_schedule_cache.py
+++ b/fastvideo/tests/ops/test_flow_schedule_cache.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the float64 schedule memoization in fastvideo.models.utils."""
+
+import pytest
+import torch
+
+from fastvideo.models.utils import (
+    _FLOAT64_SCHEDULE_ATTR,
+    get_float64_schedule,
+    pred_noise_to_pred_video,
+    pred_noise_to_x_bound,
+)
+
+
+class FakeScheduler:
+    """Minimal stand-in exposing the sigma and timestep tables the helper reads."""
+
+    def __init__(self, num_steps: int = 4) -> None:
+        self.set_timesteps(num_steps)
+
+    def set_timesteps(self, num_steps: int) -> None:
+        """Rebuild the schedule tables the way a real scheduler does per call."""
+        self.timesteps = torch.linspace(1000.0, 0.0, num_steps)
+        self.sigmas = self.timesteps / 1000.0
+
+
+def _reference_schedule(scheduler: FakeScheduler,
+                        device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    """Convert the schedule the way the call sites did before memoization."""
+    return (scheduler.sigmas.double().to(device),
+            scheduler.timesteps.double().to(device))
+
+
+def test_repeated_call_returns_cached_tensors():
+    """A second call for the same schedule reuses the same tensor objects."""
+    scheduler = FakeScheduler()
+    device = torch.device("cpu")
+    sigmas_first, timesteps_first = get_float64_schedule(scheduler, device)
+    sigmas_second, timesteps_second = get_float64_schedule(scheduler, device)
+    assert sigmas_first is sigmas_second
+    assert timesteps_first is timesteps_second
+
+
+def test_cached_values_match_direct_conversion():
+    """Memoized tables are bitwise-equal to converting the schedule directly."""
+    scheduler = FakeScheduler()
+    device = torch.device("cpu")
+    sigmas, timesteps = get_float64_schedule(scheduler, device)
+    sigmas_reference, timesteps_reference = _reference_schedule(scheduler, device)
+    assert torch.equal(sigmas, sigmas_reference)
+    assert torch.equal(timesteps, timesteps_reference)
+
+
+def test_tables_are_float64():
+    """Both tables are promoted to float64 regardless of the source dtype."""
+    scheduler = FakeScheduler()
+    scheduler.sigmas = scheduler.sigmas.to(torch.float32)
+    scheduler.timesteps = scheduler.timesteps.to(torch.float32)
+    sigmas, timesteps = get_float64_schedule(scheduler, torch.device("cpu"))
+    assert sigmas.dtype == torch.float64
+    assert timesteps.dtype == torch.float64
+
+
+def test_set_timesteps_invalidates_cache():
+    """Swapping the schedule tables rebuilds them instead of serving stale ones."""
+    scheduler = FakeScheduler(num_steps=4)
+    device = torch.device("cpu")
+    sigmas_before, _ = get_float64_schedule(scheduler, device)
+
+    scheduler.set_timesteps(8)
+    sigmas_after, timesteps_after = get_float64_schedule(scheduler, device)
+
+    assert sigmas_after is not sigmas_before
+    assert sigmas_after.shape[0] == 8
+    sigmas_reference, timesteps_reference = _reference_schedule(scheduler, device)
+    assert torch.equal(sigmas_after, sigmas_reference)
+    assert torch.equal(timesteps_after, timesteps_reference)
+
+
+def test_cache_is_stored_on_the_scheduler():
+    """The memo lives on the scheduler, so separate schedulers stay independent."""
+    first, second = FakeScheduler(), FakeScheduler()
+    device = torch.device("cpu")
+    assert getattr(first, _FLOAT64_SCHEDULE_ATTR, None) is None
+
+    first_sigmas, _ = get_float64_schedule(first, device)
+    assert getattr(first, _FLOAT64_SCHEDULE_ATTR, None) is not None
+    assert getattr(second, _FLOAT64_SCHEDULE_ATTR, None) is None
+
+    second_sigmas, _ = get_float64_schedule(second, device)
+    assert second_sigmas is not first_sigmas
+
+
+def _reference_pred_noise_to_pred_video(pred_noise: torch.Tensor,
+                                        noise_input_latent: torch.Tensor,
+                                        timestep: torch.Tensor,
+                                        scheduler: FakeScheduler) -> torch.Tensor:
+    """Reproduce the pre-memoization conversion for a numerical parity check."""
+    dtype = pred_noise.dtype
+    device = pred_noise.device
+    pred_noise = pred_noise.double().to(device)
+    noise_input_latent = noise_input_latent.double().to(device)
+    sigmas, timesteps = _reference_schedule(scheduler, device)
+    timestep_id = torch.argmin(
+        (timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
+    sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1)
+    return (noise_input_latent - sigma_t * pred_noise).to(dtype)
+
+
+@pytest.mark.parametrize("num_steps", [2, 4, 8])
+def test_pred_noise_to_pred_video_matches_reference(num_steps):
+    """Memoizing the schedule leaves the converted latents bitwise unchanged."""
+    torch.manual_seed(0)
+    scheduler = FakeScheduler(num_steps=num_steps)
+    timestep = scheduler.timesteps[:min(3, num_steps)].clone()
+    batch_size = timestep.numel()
+    pred_noise = torch.randn(batch_size, 4, 8, 8)
+    noise_input_latent = torch.randn(batch_size, 4, 8, 8)
+
+    expected = _reference_pred_noise_to_pred_video(pred_noise, noise_input_latent,
+                                                   timestep, scheduler)
+    actual = pred_noise_to_pred_video(pred_noise, noise_input_latent, timestep,
+                                      scheduler)
+    assert torch.equal(actual, expected)
+
+
+def test_pred_noise_to_pred_video_is_stable_across_repeated_calls():
+    """Reusing a cached schedule across steps keeps results identical."""
+    torch.manual_seed(0)
+    scheduler = FakeScheduler()
+    pred_noise = torch.randn(2, 4, 8, 8)
+    noise_input_latent = torch.randn(2, 4, 8, 8)
+    timestep = scheduler.timesteps[:2].clone()
+
+    first = pred_noise_to_pred_video(pred_noise, noise_input_latent, timestep,
+                                     scheduler)
+    second = pred_noise_to_pred_video(pred_noise, noise_input_latent, timestep,
+                                      scheduler)
+    assert torch.equal(first, second)
+
+
+def test_pred_noise_to_x_bound_uses_the_same_schedule():
+    """The boundary variant reads the memoized tables without altering them."""
+    torch.manual_seed(0)
+    scheduler = FakeScheduler()
+    pred_noise = torch.randn(2, 4, 8, 8)
+    noise_input_latent = torch.randn(2, 4, 8, 8)
+    timestep = scheduler.timesteps[:2].clone()
+    boundary_timestep = torch.full_like(timestep, float(scheduler.timesteps[-1]))
+
+    sigmas_before, _ = get_float64_schedule(scheduler, pred_noise.device)
+    result = pred_noise_to_x_bound(pred_noise, noise_input_latent, timestep,
+                                   boundary_timestep, scheduler)
+    sigmas_after, _ = get_float64_schedule(scheduler, pred_noise.device)
+
+    assert sigmas_after is sigmas_before
+    assert result.shape == pred_noise.shape


### PR DESCRIPTION
## Summary
 
Ports worthwhile performance optimizations from NVIDIA's FlashDreams (https://github.com/NVIDIA/flashdreams) — a project built specifically for chunk-by-chunk ("causal") video generation — into FastVideo's equivalent pipelines. Of the five candidates identified, four are addressed here:
 
| # | Optimization | Status in this PR |
|---|---|---|
| 1 | Stop syncing to the CPU to read two KV-cache position counters | Done, always on |
| 2 | Record the GPU step sequence once and replay it (CUDA graph capture) | Done, opt-in, off by default |
| 3 | Run KV-cache refresh in the background | Not included — see "Dropped" below |
| 4 | Copy finished frames off the GPU in one batched transfer | Done, always on |
| 5 | Stop reconverting the noise schedule to float64 every step | Done, always on |
 
## Problem
 
FastVideo's chunk-by-chunk Wan pipelines (`WanCausalDMDPipeline`, `WanCausalPipeline`) generate video in blocks, calling the transformer many times per generation. Several places in that hot path were doing more work than necessary on every single call: forcing the CPU to wait on GPU-resident counters, copying finished frames back to host memory one at a time, recomputing values that don't change between steps, and — for item 2 — dispatching hundreds of small GPU operations individually instead of recording them once and replaying the whole sequence.
 
## What changed
 
### Item 1 — Stop waiting on the GPU to read cache position counters
 
**Before:** Two counters (`global_end_index`, `local_end_index`) that track how much of the KV cache is filled were stored as GPU tensors. The attention code called `.item()` on them every layer, every step — each call forces the CPU to stop and wait for the GPU to catch up.
 
**After:** These are now plain Python integers, initialized as such instead of as `torch.tensor([0], ...)`. The read/write sites already handled both forms, so only the initialization needed to change.
 
**File:** `fastvideo/pipelines/stages/causal_denoising.py`, `CausalDMDDenosingStage._initialize_kv_cache`.
 
**Deliberately left alone:** `fastvideo/train/models/wan/wan_causal.py` initializes these same counters as GPU tensors and raises an error if they aren't — its gradient-checkpointing snapshot logic depends on them being tensors. Training was not touched.
 
### Item 2 — CUDA graph capture for the denoising step (opt-in, default off)
 
**The idea:** Once the KV-cache window fills up, the physical read/write positions inside the attention code become constant on every subsequent call (proven by direct derivation from the actual code, not just assumed by analogy to FlashDreams — see the extended notes in `FlashDreams.md`). Once positions are constant, the entire sequence of GPU operations for one denoising step is identical every time, which is exactly the condition needed to record it once (a CUDA graph) and replay it instead of dispatching each operation individually.
 
**What was required to make this safe:**
 
- Split the KV-cache eviction/write logic in `CausalWanSelfAttention.forward` into named steps, driven by an explicit `is_chunk_start` flag passed down from the denoising stage's own loop position, instead of re-derived from tensor comparisons inside the attention module (a value derived inside a captured region can't be recomputed on replay).
- Two separate captured graphs — one for the step that evicts old frames, one for the step that only overwrites — since they touch memory differently and replaying one for the other would silently corrupt state.
- A new `CausalCudaGraphWrapper` / `CausalCudaGraphDispatch` (`fastvideo/pipelines/stages/causal_cuda_graph.py`), adapted from FlashDreams' `infra/cuda_graph.py`: runs eagerly for a couple of warmup calls, captures on the next call, replays after that.
- A new setting, `enable_causal_cuda_graph` (default `False`), plus the matching `--enable-causal-cuda-graph` CLI flag (`fastvideo/fastvideo_args.py`).
- **Three unrelated pre-existing bugs had to be fixed for capture to work at all**, since CUDA graph capture forbids copying from ordinary (unpinned) CPU memory:
  - The cached rotary-position-embedding table was being moved to the GPU with a plain `.to(device)` from an unpinned CPU tensor, every call. Fixed by pinning the cached table and using `non_blocking=True` (`fastvideo/layers/rotary_embedding.py`, `fastvideo/models/dits/causal_wanvideo.py`).
  - The timestep-embedding frequency table was being rebuilt and re-transferred from scratch on every single call, never cached. Fixed by caching it, pinned (`fastvideo/layers/visual_embedding.py`).
  - A `torch.tensor([0], device=...)` literal — which actually builds on CPU and copies over, contrary to how it reads — was replaced with `torch.zeros(1, device=..., dtype=torch.long)`, which allocates directly on-device (`fastvideo/models/dits/causal_wanvideo.py`).
- **A real correctness bug found during testing:** the KV-cache counter update lives inside the exact function that gets captured. On replay, that Python-side update never runs — only the recorded GPU kernels do — so the counters would silently freeze after the first replay. Fixed by adding `_finalize_kv_cache_counters`, called from the denoising stage (outside the captured region) after every steady-state call, setting both counters from values the caller already knows.
- **Refuses to engage, with a clear log message, rather than crash or silently produce wrong output**, unless all of:
  - `enable_causal_cuda_graph` is explicitly set to `True`
  - `local_attn_size != -1` (a fixed-size window exists)
  - `rope_cache_policy == "relativistic"` (position embeddings don't depend on the per-chunk `start_frame`)
  - the pipeline is single-transformer, not the dual-transformer MoE path (`boundary_timestep is None`) — the "which model is at chunk-start" bookkeeping for the two-transformer case wasn't worked out and is explicitly out of scope for this PR
  - neither `dit_cpu_offload` nor `dit_layerwise_offload` is enabled — both move weight storage during the forward pass, which breaks the stable memory addresses a captured graph depends on
**Files:** `fastvideo/pipelines/stages/causal_cuda_graph.py` (new), `fastvideo/pipelines/stages/causal_denoising.py`, `fastvideo/models/dits/causal_wanvideo.py`, `fastvideo/fastvideo_args.py`, `fastvideo/layers/rotary_embedding.py`, `fastvideo/layers/visual_embedding.py`.
 
**No shipped model preset currently sets `rope_cache_policy` to `"relativistic"`** — this setting exists in the code but isn't used by any default config, so this path was tested by manually overriding the config, not by running an existing preset.
 
### Item 4 — Batch the GPU→CPU frame copy after decoding
 
**Before:** After a video finishes generating, each frame was copied from GPU to host memory one at a time in a Python loop. Each copy blocks until it completes, so the next frame's work can't be queued up in advance.
 
**After:** All frames are stacked into one tensor and copied in a single transfer.
 
**File:** `fastvideo/entrypoints/video_generator.py`, the frame post-processing block in `VideoGenerator.generate_video`.
 
**Trade-off:** briefly holds all frames in GPU memory at once instead of one at a time. Measured cost for an 81-frame, 480×832 clip: about 0.1GB — small next to what generation already uses, but not measured at higher resolutions or frame counts.
 
### Item 5 — Cache the float64 noise schedule instead of rebuilding it every step
 
**Before:** `pred_noise_to_pred_video` and `pred_noise_to_x_bound` each converted the scheduler's sigma/timestep tables to float64 and re-uploaded them to the GPU on every single denoising step, even though the schedule doesn't change during one generation.
 
**After:** A new `get_float64_schedule` (`fastvideo/models/utils.py`) converts the tables once and memoizes the result on the scheduler object, keyed by object identity so a genuinely replaced schedule (via `set_timesteps`) is still detected and rebuilt correctly.
 
**Test added:** `fastvideo/tests/ops/test_flow_schedule_cache.py` — 10 cases covering cache reuse, invalidation on schedule replacement, independence between separate scheduler instances, correct precision, and exact numerical agreement with the pre-change code across several schedule lengths. All 10 pass.
 
### Item 3 — dropped, not included
 
FlashDreams runs KV-cache refresh in the background so it overlaps with converting frames to video, which happens continuously in their pipeline. FastVideo only converts to video once, after the entire denoising loop finishes (confirmed by reading `wan_causal_dmd_pipeline.py` — the decode stage is added after the full denoising stage completes). At the point this refresh would run, the very next thing that happens is the next chunk, which needs the memory this refresh is updating — there's nothing to overlap it with. Implementing it would add complexity for no benefit unless FastVideo's pipeline structure changes to decode per-chunk instead of at the end.
 
## Models affected
 
- **Items 1 and 2** reach `WanCausalDMDPipeline` and `WanCausalPipeline` only (`fastvideo/pipelines/basic/wan/`).
- **Item 5** reaches any pipeline using the shared flow-matching conversion helpers in `fastvideo/models/utils.py`.
- **Item 4** reaches all generation that produces pixel-space video frames.
- **`matrixgame2`, `dreamx_world`, `lingbotworld2`** keep their own, separate copies of the attention and KV-cache code and are **not** affected by items 1 or 2 (confirmed: they define their own attention classes rather than importing the Wan one, despite sharing a class name). Bringing items 1/2 to those models would be separate follow-up work.
- Standard (non-causal) Wan, Hunyuan, Cosmos, SD3.5, Flux, and other models don't use the chunk-by-chunk path and are unaffected by items 1, 2, or 4.
## Testing
 
All testing used `wlsaidhi/SFWan2.1-T2V-1.3B-Diffusers`, the same model the repo's own `test_causal_similarity.py` uses for this pipeline, with the same prompt that test uses ("Will Smith casually eats noodles..."), a fixed seed (1024), 480×832 resolution, 4 inference steps. Output was compared as raw pixel arrays (not re-encoded video), checking for exact equality, not similarity.
 
Hardware: single GPU (NVIDIA GB10, aarch64, CUDA 13.0). The repo's SSIM quality-regression test (`fastvideo/tests/ssim/test_causal_similarity.py`) could not be run on this hardware — it hardcodes support to A40/L40S/H100/H200/B200 and fails at collection time on any other GPU name, unrelated to this change.
 
### Correctness
 
- **Items 1/4/5 vs. unmodified code, 6 clip lengths** (9, 21, 33, 45, 69, 81 frames — the two longer lengths originally attempted, 129 and 201 frames, hit a pre-existing, unrelated cap: with the default `local_attn_size=-1` the model keeps only a 21-latent-frame compatibility window and raises a `ValueError` past that, identically on both unmodified code and this branch, confirming it's not caused by this change). All 6 pairs byte-for-byte identical, 0 differing pixels out of ~10M–97M per pair. Also 3 independent repeat runs at 81 frames alone, all 3 pairs identical.
- **Item 2, refactor only, capture still off:** re-ran the exact-frame comparison before vs. after the KV-cache restructuring alone. Byte-for-byte identical — confirms the restructuring itself changed nothing.
- **Item 2, capture on vs. off, 4 clip lengths:** 81, 129 (8 chunks past steady state), 201 (14 chunks past), and 393 frames (30 chunks past steady state). All 4 byte-for-byte identical, 0 differing pixels out of up to ~470M per pair. The longer lengths specifically check the failure mode the design has to guard against — a wrong recording only shows up well past the point the cache first fills, so this was deliberately pushed far beyond a short clip.
- **Item 2 fallback behavior**, confirmed each refuses cleanly with a logged reason and completes normally (not tested: the dual-transformer MoE case, no such test model was available):
  - `local_attn_size == -1` → logs and falls back, completes normally.
  - `rope_cache_policy == "absolute"` → logs and falls back, completes normally.
  - `dit_layerwise_offload == True` → logs and falls back, completes normally.
- `pytest fastvideo/tests/ops/test_flow_schedule_cache.py`: 10/10 pass.
- `pre-commit run --files <changed paths>`: passes on every changed file outside the pre-commit-excluded `fastvideo/models/` path (which was matched to surrounding style by hand, per repo convention).
- Full diff manually re-reviewed line by line after initial implementation (checked for leftover debug code, matched refactored math against the original branch-by-branch), plus fresh `pre-commit`, syntax, and import checks — all clean.
### Performance
 
Stage-level timing via `FASTVIDEO_STAGE_LOGGING=1`, comparing the denoising stage specifically (the part these changes touch).
 
**Items 1+4+5 vs. unmodified code, 6 clip lengths** (single run each):
 
| Frames | Unmodified | This PR (1+4+5 only) | Change |
|---|---|---|---|
| 9 | 5.17 s | 5.13 s | ~0.8% faster |
| 21 | 10.10 s | 10.03 s | ~0.7% faster |
| 33 | 15.27 s | 15.12 s | ~1.0% faster |
| 45 | 20.75 s | 20.56 s | ~0.9% faster |
| 69 | 32.35 s | 32.12 s | ~0.7% faster |
| 81 | 38.64 s | 38.32 s | ~0.8% faster |
 
Consistent, real improvement at every length tested, tightly clustered between 0.7% and 1.0%, no outliers. (Median-of-3 at 81 frames alone gave 39.04s → 38.78s, ~0.7% — consistent with the single-run numbers above.) Item 4's own effect could not be reliably separated from run-to-run noise at these clip lengths — its stage timing is only single-digit-to-low-tens of milliseconds here, small enough that measurement jitter dominates; per the design doc, its benefit is expected to grow with frame count beyond what was tested.
 
**Item 2, capture off vs. on, 4 clip lengths:**
 
| Clip length | Capture off | Capture on | Change |
|---|---|---|---|
| 81 frames | 40.44 s | 41.87 s | ~3.5% slower |
| 129 frames (8 chunks past steady state) | 65.16 s | 67.01 s | ~2.8% slower |
| 201 frames (14 chunks past steady state) | 101.58 s | 104.10 s | ~2.5% slower |
| 393 frames (30 chunks past steady state) | 199.22 s | 203.16 s | ~2.0% slower |
 
Item 2 was measured slower, not faster, at every scale tested, though the gap consistently narrows as the clip gets longer (3.5% → 2.8% → 2.5% → 2.0%) — consistent with a fixed one-time warmup/capture cost being spread over more replayed steps as the video grows, without ever crossing over to a net win in the range tested. Plausible explanation for why it doesn't cross over: this model's per-layer GPU compute time is large enough that the per-operation dispatch overhead CUDA graphs eliminate is already a small fraction of total time, while the input-staging and output-cloning the wrapper requires (needed for correctness with a stateful KV cache) adds its own overhead. No attempt has yet been made to reduce that overhead; this is the natural next step if item 2 is worth pursuing further. Given this, item 2 is included as correct, safe, off-by-default groundwork — not as a demonstrated speedup — and should not be represented as one when this merges.
 
## Known limitations / follow-up
 
- Item 2 doesn't yet improve speed on the hardware tested (see above).
- Item 2's dual-transformer (Wan2.2 MoE) case isn't supported and falls back to eager execution.
- Item 2 hasn't been tried in combination with `torch.compile` (`enable_torch_compile`) — the wrapper doesn't yet have a "drain" step for Inductor's lazy autotuning, which FlashDreams' own version handles and this port deliberately left out for now.
- Items 1/2 don't reach `matrixgame2`, `dreamx_world`, or `lingbotworld2`, which keep separate copies of this code.
- Item 4's memory cost hasn't been measured at resolutions or frame counts higher than what was tested here.
## GPU testing status
 
Done — see "Testing" above. (Not pending.)