### PR TITLE
[bugfix]: left-align Gemma connector tokens per batch row

### DIFF
--- a/fastvideo/models/encoders/gemma.py
+++ b/fastvideo/models/encoders/gemma.py
@@ -285,22 +285,23 @@ class Embeddings1DConnector(nn.Module):
         learnable_registers = torch.tile(
             self.learnable_registers, (num_registers_duplications, 1)
         )
-        attention_mask_binary = (
-            attention_mask.squeeze(1).squeeze(1).unsqueeze(-1) >= -9000.0
-        ).int()
+        seq_len = hidden_states.shape[1]
+        valid = attention_mask.squeeze(1).squeeze(1) >= -9000.0  # (batch, seq)
 
-        non_zero_hidden_states = hidden_states[
-            :, attention_mask_binary.squeeze().bool(), :
-        ]
-        non_zero_nums = non_zero_hidden_states.shape[1]
-        pad_length = hidden_states.shape[1] - non_zero_nums
-        adjusted_hidden_states = torch.nn.functional.pad(
-            non_zero_hidden_states, pad=(0, 0, 0, pad_length), value=0
-        )
-        flipped_mask = torch.flip(attention_mask_binary, dims=[1])
-        hidden_states = flipped_mask * adjusted_hidden_states + (
-            1 - flipped_mask
-        ) * learnable_registers
+        # Left-align each row's valid tokens, then fill the tail with registers.
+        # A boolean index cannot express this: every row may keep a different
+        # number of tokens, so the result is not rectangular. Gathering a stable
+        # descending argsort of the mask moves the valid tokens to the front of
+        # each row while preserving their original relative order.
+        order = torch.argsort(valid.to(torch.int8), dim=1, descending=True, stable=True)
+        adjusted_hidden_states = torch.gather(hidden_states, 1, order.unsqueeze(-1).expand_as(hidden_states))
+
+        # After the gather, row b holds its valid tokens in slots
+        # [0, valid[b].sum()). Deriving the keep-mask from that per-row count is
+        # what makes this correct when rows have different token counts.
+        keep = (torch.arange(seq_len, device=hidden_states.device).unsqueeze(0)
+                < valid.sum(dim=1, keepdim=True)).unsqueeze(-1).to(hidden_states.dtype)
+        hidden_states = keep * adjusted_hidden_states + (1 - keep) * learnable_registers
 
         attention_mask = torch.full_like(
             attention_mask,

--- a/fastvideo/tests/encoders/test_gemma_connector_register_padding.py
+++ b/fastvideo/tests/encoders/test_gemma_connector_register_padding.py
@@ -21,17 +21,21 @@ class _Stub:
 
     def __init__(self, num_registers: int, hidden: int) -> None:
         self.num_learnable_registers = num_registers
-        # Distinct from any hidden state below, so register slots are obvious.
-        self.learnable_registers = torch.full((num_registers, hidden), -1.0)
+        # Register i holds -(i+1) in every channel: distinct from any hidden
+        # state below, and distinct from each other, so an assertion can pin
+        # not just "a register landed here" but *which* register landed here.
+        self.learnable_registers = -(torch.arange(num_registers, dtype=torch.float32) +
+                                     1.0).unsqueeze(-1).expand(num_registers, hidden).contiguous()
 
 
-def _run(hidden_states: torch.Tensor, valid_lengths: list[int]):
+def _run(hidden_states: torch.Tensor, valid_lengths: list[int], num_registers: int | None = None):
     """Drive the real method with a left-padded mask (Gemma pads on the left)."""
     batch, seq_len, hidden = hidden_states.shape
-    mask = torch.full((batch, 1, 1, seq_len), -10000.0)
+    mask = torch.full((batch, 1, 1, seq_len), -10000.0, device=hidden_states.device)
     for row, n in enumerate(valid_lengths):
         mask[row, 0, 0, seq_len - n:] = 0.0  # left padding: valid tokens at the end
-    stub = _Stub(num_registers=seq_len, hidden=hidden)
+    stub = _Stub(num_registers=num_registers or seq_len, hidden=hidden)
+    stub.learnable_registers = stub.learnable_registers.to(hidden_states.device)
     return Embeddings1DConnector._replace_padded_with_learnable_registers(stub, hidden_states, mask)
 
 
@@ -53,11 +57,12 @@ def test_ragged_batch_left_aligns_each_row_independently() -> None:
     assert out[0, 0].tolist() == [11.0, 11.0]
     assert out[0, 1].tolist() == [12.0, 12.0]
     assert out[0, 2].tolist() == [13.0, 13.0]
-    assert out[0, 3].tolist() == [-1.0, -1.0]  # register
+    assert out[0, 3].tolist() == [-4.0, -4.0]  # register 3, not just "a register"
 
-    # Row 1 keeps only the last token; the other three slots are registers.
+    # Row 1 keeps only the last token; the other three slots take registers
+    # 1, 2 and 3 -- the register bank is indexed by slot, not by fill order.
     assert out[1, 0].tolist() == [23.0, 23.0]
-    assert out[1, 1:].tolist() == [[-1.0, -1.0]] * 3
+    assert out[1, 1:].tolist() == [[-2.0, -2.0], [-3.0, -3.0], [-4.0, -4.0]]
 
 
 def test_row_with_no_padding_is_unchanged() -> None:
@@ -65,6 +70,23 @@ def test_row_with_no_padding_is_unchanged() -> None:
     hidden_states = torch.arange(seq_len * hidden, dtype=torch.float32).reshape(1, seq_len, hidden)
     out, _ = _run(hidden_states, valid_lengths=[seq_len])
     assert torch.equal(out, hidden_states)
+
+
+def test_registers_tile_across_the_sequence() -> None:
+    """The shipped ratio is 8 duplications (1024 slots / 128 registers), not 1.
+
+    Every other test here uses ``num_registers == seq_len``, where the tile is
+    a no-op -- so a wrong tile, or no tile at all, would pass them. With fewer
+    registers than slots, padded slot ``i`` must hold register ``i % n``.
+    """
+    hidden_states = torch.tensor([[[10.0, 10.0], [11.0, 11.0], [12.0, 12.0], [13.0, 13.0]]])
+    out, _ = _run(hidden_states, valid_lengths=[1], num_registers=2)
+
+    assert out[0, 0].tolist() == [13.0, 13.0]  # the single valid token, left-aligned
+    # Tiled bank is [r0, r1, r0, r1], so the padded tail reads r1, r0, r1.
+    assert out[0, 1].tolist() == [-2.0, -2.0]
+    assert out[0, 2].tolist() == [-1.0, -1.0]
+    assert out[0, 3].tolist() == [-2.0, -2.0]
 
 
 def test_single_row_matches_ragged_batch_row() -> None:

--- a/fastvideo/tests/encoders/test_gemma_connector_register_padding.py
+++ b/fastvideo/tests/encoders/test_gemma_connector_register_padding.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``Embeddings1DConnector`` must left-align each row's valid tokens.
+
+The connector replaces padded positions with learnable register tokens. Rows
+in a batch generally have different prompt lengths, so the selection of valid
+tokens is not rectangular and cannot be expressed as a boolean index -- it has
+to be a per-row gather.
+
+CPU-only, no model download: the method is exercised directly against a stub
+carrying just the two attributes it reads.
+"""
+from __future__ import annotations
+
+import torch
+
+from fastvideo.models.encoders.gemma import Embeddings1DConnector
+
+
+class _Stub:
+    """Only what ``_replace_padded_with_learnable_registers`` touches."""
+
+    def __init__(self, num_registers: int, hidden: int) -> None:
+        self.num_learnable_registers = num_registers
+        # Distinct from any hidden state below, so register slots are obvious.
+        self.learnable_registers = torch.full((num_registers, hidden), -1.0)
+
+
+def _run(hidden_states: torch.Tensor, valid_lengths: list[int]):
+    """Drive the real method with a left-padded mask (Gemma pads on the left)."""
+    batch, seq_len, hidden = hidden_states.shape
+    mask = torch.full((batch, 1, 1, seq_len), -10000.0)
+    for row, n in enumerate(valid_lengths):
+        mask[row, 0, 0, seq_len - n:] = 0.0  # left padding: valid tokens at the end
+    stub = _Stub(num_registers=seq_len, hidden=hidden)
+    return Embeddings1DConnector._replace_padded_with_learnable_registers(stub, hidden_states, mask)
+
+
+def test_ragged_batch_left_aligns_each_row_independently() -> None:
+    """The regression: two rows with different prompt lengths.
+
+    Row 0 keeps 3 tokens, row 1 keeps 1. Each row's valid tokens must land at
+    the front of that row, with registers filling only that row's tail.
+    """
+    seq_len, hidden = 4, 2
+    # Token values encode (row, position) so misplacement is visible.
+    hidden_states = torch.tensor(
+        [[[10.0, 10.0], [11.0, 11.0], [12.0, 12.0], [13.0, 13.0]],
+         [[20.0, 20.0], [21.0, 21.0], [22.0, 22.0], [23.0, 23.0]]],
+    )
+    out, _ = _run(hidden_states, valid_lengths=[3, 1])
+
+    # Row 0's valid tokens are the last 3 (11, 12, 13), left-aligned in order.
+    assert out[0, 0].tolist() == [11.0, 11.0]
+    assert out[0, 1].tolist() == [12.0, 12.0]
+    assert out[0, 2].tolist() == [13.0, 13.0]
+    assert out[0, 3].tolist() == [-1.0, -1.0]  # register
+
+    # Row 1 keeps only the last token; the other three slots are registers.
+    assert out[1, 0].tolist() == [23.0, 23.0]
+    assert out[1, 1:].tolist() == [[-1.0, -1.0]] * 3
+
+
+def test_row_with_no_padding_is_unchanged() -> None:
+    seq_len, hidden = 4, 2
+    hidden_states = torch.arange(seq_len * hidden, dtype=torch.float32).reshape(1, seq_len, hidden)
+    out, _ = _run(hidden_states, valid_lengths=[seq_len])
+    assert torch.equal(out, hidden_states)
+
+
+def test_single_row_matches_ragged_batch_row() -> None:
+    """A row's result must not depend on what else is in the batch."""
+    hidden_states = torch.tensor(
+        [[[10.0, 10.0], [11.0, 11.0], [12.0, 12.0], [13.0, 13.0]],
+         [[20.0, 20.0], [21.0, 21.0], [22.0, 22.0], [23.0, 23.0]]],
+    )
+    batched, _ = _run(hidden_states, valid_lengths=[3, 1])
+    alone, _ = _run(hidden_states[1:2], valid_lengths=[1])
+    assert torch.equal(batched[1], alone[0])


### PR DESCRIPTION
## Problem

`Embeddings1DConnector._replace_padded_with_learnable_registers` replaces
padded positions in the Gemma text embeddings with learnable register tokens.
It selects the valid tokens with a boolean index:

```python
attention_mask_binary = (attention_mask.squeeze(1).squeeze(1).unsqueeze(-1) >= -9000.0).int()
non_zero_hidden_states = hidden_states[:, attention_mask_binary.squeeze().bool(), :]
```

`attention_mask_binary` is `(batch, seq, 1)`, and `.squeeze()` drops **every**
size-1 dimension, so the mask's rank depends on the batch size:

- `batch == 1` → `(seq,)`, a 1-D mask over dim 1.
- `batch > 1` → `(batch, seq)`, a 2-D mask. Indexing dim 1 of a 3-D tensor with
  it consumes two dimensions, so the expression asks for four.

The operation is also not expressible as a boolean index in the first place.
Rows in a batch have different prompt lengths, so each row keeps a different
number of tokens and the selection is not rectangular — it has to be a per-row
gather.

There is a second batch assumption immediately after. The valid tokens are
re-aligned using `torch.flip(attention_mask_binary, dims=[1])` as the
keep-mask, which only coincides with "the first N slots of this row" when every
row's padding is contiguous, left-aligned, and the same length.

**Net effect.** Any `batch > 1` raises `IndexError: too many indices for tensor
of dimension 3` — uniform-length batches included, since batch size alone
decides the mask's rank. This is a hard failure rather than silent corruption:
no output has ever been wrong because of it. Separately, `batch == 1` is
correct only for contiguous **left** padding, which is what LTX-2 ships
(`padding_side="left"`); right-padded and interior-gap masks are wrong today at
any batch size, and are fixed here too.

Nothing in-tree hits this yet, because every shipped LTX-2 training config sets
`train_batch_size: 1`. What the bug does is cap the connector at batch size 1 —
it fires the moment anyone raises that knob, through
`LTX2TrainingPipeline._get_next_batch_{parquet,pt}` → `run_connectors`, and at
inference when the text-encoding stage is handed a list of prompts.

## What changes

Left-align each row independently:

```python
order = torch.argsort(valid.to(torch.int8), dim=1, descending=True, stable=True)
adjusted_hidden_states = torch.gather(hidden_states, 1, order.unsqueeze(-1).expand_as(hidden_states))
keep = (torch.arange(seq_len, device=...).unsqueeze(0) < valid.sum(dim=1, keepdim=True)).unsqueeze(-1)
hidden_states = keep * adjusted_hidden_states + (1 - keep) * learnable_registers
```

- A **stable** descending argsort of the mask moves each row's valid tokens to
  the front of that row while preserving their original relative order, which
  is what the old code achieved with select-then-pad.
- The keep-mask is derived from each row's **own** token count rather than from
  a reversed mask, so rows of different lengths get the right split between
  real tokens and register tokens.

Padding side stops mattering: the gather left-aligns valid tokens whether the
padding sits on the left, on the right, or in gaps. Behavior for the shipped
left-padded `batch == 1` path is unchanged bit for bit — `keep` is exactly 0 or
1, which is exact in every float format, so `1*x + 0*r` is `x`. The diff is a
net simplification; the intermediate pad and the flip both go away.

## Evidence

New `fastvideo/tests/encoders/test_gemma_connector_register_padding.py`, which
runs in the encoder lane. CPU-only and downloads no model — it drives the real
method against a stub holding the two attributes it reads:

- **ragged batch**: rows keeping 3 and 1 tokens. Each row's valid tokens must
  land at the front of that row, in order, with registers filling only that
  row's tail. This is the case the old code cannot express.
- **register tiling**: fewer registers than slots — the shipped ratio is eight
  duplications, 1024 slots over 128 registers — asserting that padded slot `i`
  holds register `i % n`.
- **row independence**: a row's result must be identical whether it is
  processed alone or alongside a longer row.
- **no-padding row** is returned unchanged.

Reverting the source while keeping the tests gives 2 failed / 1 passed; restored,
4 passed. The no-padding case passes either way — it is a no-regression control,
not a proof of the fix.

The tiling and register-identity assertions were themselves checked by mutation:
an implementation that puts register 0 in every padded slot, and one that drops
the tile entirely, each passed the original three cases and each fails now.

Verified on GB200 as well as CPU — bitwise match against a per-row loop oracle
at the production shape (batch 4 × 1024 tokens × 128 registers, bf16) and across
ragged, uniform, all-valid and tile-ratio-1 shapes, plus a direct probe that
`torch.argsort(..., descending=True, stable=True)` is stable on CUDA, since that
is the primitive the whole rewrite rests on.
