### PR TITLE
[bugfix] keep loader-populated text encoder configs in the validation pipeline

### DIFF
--- a/fastvideo/tests/train/callbacks/test_validation.py
+++ b/fastvideo/tests/train/callbacks/test_validation.py
@@ -638,3 +638,93 @@ class TestActionOverlay:
         )
 
         assert overlay is None
+
+
+class TestKeepLoadedEncoderWidths:
+    """``_keep_loaded_encoder_widths`` merges the two config sources.
+
+    Validation runs the encoder weights the loader brought in, but reaches
+    the stages through configs derived from the training side, which never
+    see the checkpoint's ``config.json``. Each side therefore holds the
+    real value for a different set of fields: the loader knows the widths,
+    training knows the FastVideo-only fields HF configs never carry.
+    """
+
+    @staticmethod
+    def _encoder(hidden_size: int, text_len: int = 0) -> SimpleNamespace:
+        return SimpleNamespace(arch_config=SimpleNamespace(
+            hidden_size=hidden_size,
+            text_len=text_len,
+        ))
+
+    def test_copies_loaded_width(self) -> None:
+        # ByT5 at the generic T5 default vs the checkpoint's real width.
+        validation = SimpleNamespace(text_encoder_configs=(self._encoder(512), ))
+        loaded = SimpleNamespace(text_encoder_configs=(self._encoder(1472), ))
+
+        ValidationCallback._keep_loaded_encoder_widths(validation, loaded)
+
+        assert validation.text_encoder_configs[0].arch_config.hidden_size == 1472
+
+    def test_preserves_training_owned_fields(self) -> None:
+        # ``text_len`` is a FastVideo-only field absent from HF configs, so
+        # the loader never populates it and the training value must survive.
+        validation = SimpleNamespace(text_encoder_configs=(self._encoder(512, text_len=1000), ))
+        loaded = SimpleNamespace(text_encoder_configs=(self._encoder(1472, text_len=0), ))
+
+        ValidationCallback._keep_loaded_encoder_widths(validation, loaded)
+
+        assert validation.text_encoder_configs[0].arch_config.text_len == 1000
+
+    def test_keeps_config_objects_unshared(self) -> None:
+        # The second call site writes into ``tc.pipeline_config`` itself, so
+        # the merge must not alias the loaded encoder objects into it.
+        validation = SimpleNamespace(text_encoder_configs=(self._encoder(512), ))
+        original = validation.text_encoder_configs
+        loaded = SimpleNamespace(text_encoder_configs=(self._encoder(1472), ))
+
+        ValidationCallback._keep_loaded_encoder_widths(validation, loaded)
+
+        assert validation.text_encoder_configs is original
+        assert validation.text_encoder_configs[0] is not loaded.text_encoder_configs[0]
+
+    def test_skips_unpopulated_loaded_width(self) -> None:
+        # ``TextEncoderArchConfig.hidden_size`` defaults to 0; a loader that
+        # never filled it must not clobber a real training-side width.
+        validation = SimpleNamespace(text_encoder_configs=(self._encoder(3584), ))
+        loaded = SimpleNamespace(text_encoder_configs=(self._encoder(0), ))
+
+        ValidationCallback._keep_loaded_encoder_widths(validation, loaded)
+
+        assert validation.text_encoder_configs[0].arch_config.hidden_size == 3584
+
+    def test_multiple_encoders_are_matched_by_index(self) -> None:
+        validation = SimpleNamespace(text_encoder_configs=(
+            self._encoder(512),
+            self._encoder(512),
+        ))
+        loaded = SimpleNamespace(text_encoder_configs=(
+            self._encoder(3584),
+            self._encoder(1472),
+        ))
+
+        ValidationCallback._keep_loaded_encoder_widths(validation, loaded)
+
+        widths = [e.arch_config.hidden_size for e in validation.text_encoder_configs]
+        assert widths == [3584, 1472]
+
+    @pytest.mark.parametrize(
+        "validation, loaded",
+        [
+            (SimpleNamespace(), SimpleNamespace(text_encoder_configs=())),
+            (SimpleNamespace(text_encoder_configs=()), SimpleNamespace()),
+            (SimpleNamespace(text_encoder_configs=()), SimpleNamespace(text_encoder_configs=())),
+        ],
+    )
+    def test_missing_or_empty_encoders_is_noop(
+        self,
+        validation: SimpleNamespace,
+        loaded: SimpleNamespace,
+    ) -> None:
+        # Pipelines without text encoders must not raise here.
+        ValidationCallback._keep_loaded_encoder_widths(validation, loaded)

--- a/fastvideo/train/callbacks/validation.py
+++ b/fastvideo/train/callbacks/validation.py
@@ -1079,27 +1079,52 @@ class ValidationCallback(Callback):
         return pipeline_config
 
     @staticmethod
-    def _keep_loaded_text_encoder_configs(
+    def _keep_loaded_encoder_widths(
         validation_config: Any,
         loaded_config: Any,
     ) -> None:
-        """Carry the loader-populated text encoder configs onto a config.
+        """Carry the loader-populated encoder widths onto ``validation_config``.
 
-        Validation reaches the stages through two configs that never pass
-        through ``ModelConfig.update_model_arch``: the deep copy
+        Validation reaches the stages through two pipeline configs that never
+        pass through ``ModelConfig.update_model_arch``: the deep copy
         ``_validation_pipeline_config`` makes of the training-side config, and
-        the fresh ``make_inference_args`` result handed to
-        ``pipeline.forward``. Both start from the encoder dataclass defaults,
-        and stages read those directly. HunyuanVideo 1.5 sizes its zero-length
-        ByT5 placeholder from ``hidden_size``, so the stale 512 default makes
-        the transformer reject it against its real width of 1472.
+        ``tc.pipeline_config`` itself, which ``make_inference_args`` hands to
+        ``pipeline.forward`` by reference. Both still hold the encoder dataclass
+        defaults for whatever the checkpoint would have supplied.
+
+        Stages read ``hidden_size`` only when they have to synthesise an
+        embedding instead of measuring one: HunyuanVideo 1.5 sizes its
+        zero-length ByT5 placeholder from it, so the generic ``T5ArchConfig``
+        default of 512 collides with the checkpoint's real width of 1472.
+
+        Only ``hidden_size`` is copied. Training owns the rest: model plugins
+        set ``text_len`` from ``text_encoder_max_lengths`` to size the parquet
+        text padding, and ``tokenizer_kwargs`` carry run-specific settings, so
+        both keep their training values. A falsy width means the loader never
+        populated that encoder, so there is nothing to carry over.
         """
         loaded_encoders = getattr(loaded_config, "text_encoder_configs", None)
-        if loaded_encoders is None:
+        validation_encoders = getattr(
+            validation_config,
+            "text_encoder_configs",
+            None,
+        )
+        if not loaded_encoders or not validation_encoders:
             return
-        if not hasattr(validation_config, "text_encoder_configs"):
-            return
-        validation_config.text_encoder_configs = loaded_encoders
+
+        for validation_encoder, loaded_encoder in zip(
+                validation_encoders,
+                loaded_encoders,
+                strict=False,
+        ):
+            hidden_size = getattr(
+                getattr(loaded_encoder, "arch_config", None),
+                "hidden_size",
+                None,
+            )
+            arch_config = getattr(validation_encoder, "arch_config", None)
+            if hidden_size and arch_config is not None:
+                arch_config.hidden_size = hidden_size
 
     @staticmethod
     def _sync_runtime_dit_arch_config(
@@ -1173,7 +1198,7 @@ class ValidationCallback(Callback):
         if tc.pipeline_config is not None:
             loaded_config = self._pipeline.fastvideo_args.pipeline_config
             validation_config = self._validation_pipeline_config(transformer)
-            self._keep_loaded_text_encoder_configs(
+            self._keep_loaded_encoder_widths(
                 validation_config,
                 loaded_config,
             )
@@ -1334,7 +1359,7 @@ class ValidationCallback(Callback):
             inference_args.pipeline_config,
             transformer,
         )
-        self._keep_loaded_text_encoder_configs(
+        self._keep_loaded_encoder_widths(
             inference_args.pipeline_config,
             pipeline.fastvideo_args.pipeline_config,
         )

--- a/fastvideo/train/callbacks/validation.py
+++ b/fastvideo/train/callbacks/validation.py
@@ -1079,6 +1079,28 @@ class ValidationCallback(Callback):
         return pipeline_config
 
     @staticmethod
+    def _keep_loaded_text_encoder_configs(
+        validation_config: Any,
+        loaded_config: Any,
+    ) -> None:
+        """Carry the loader-populated text encoder configs into the swap.
+
+        ``_validation_pipeline_config`` deep-copies the training-side pipeline
+        config, which never passes through ``ModelConfig.update_model_arch``,
+        so its encoder arch fields still hold the dataclass defaults. The
+        pipeline's own config does carry the checkpoint values, and stages read
+        those defaults directly: HunyuanVideo 1.5 sizes its zero-length ByT5
+        placeholder from ``hidden_size``, and the stale 512 default makes the
+        transformer reject it against its real width of 1472.
+        """
+        loaded_encoders = getattr(loaded_config, "text_encoder_configs", None)
+        if loaded_encoders is None:
+            return
+        if not hasattr(validation_config, "text_encoder_configs"):
+            return
+        validation_config.text_encoder_configs = loaded_encoders
+
+    @staticmethod
     def _sync_runtime_dit_arch_config(
         pipeline_config: Any,
         transformer: torch.nn.Module,
@@ -1148,7 +1170,13 @@ class ValidationCallback(Callback):
             **kwargs,
         )
         if tc.pipeline_config is not None:
-            self._pipeline.fastvideo_args.pipeline_config = self._validation_pipeline_config(transformer)
+            loaded_config = self._pipeline.fastvideo_args.pipeline_config
+            validation_config = self._validation_pipeline_config(transformer)
+            self._keep_loaded_text_encoder_configs(
+                validation_config,
+                loaded_config,
+            )
+            self._pipeline.fastvideo_args.pipeline_config = validation_config
             arch_config = self._pipeline.fastvideo_args.pipeline_config.dit_config.arch_config
             logger.info(
                 "Validation pipeline runtime config: local_attn_size=%s sink_size=%s boundary_ratio=%s",

--- a/fastvideo/train/callbacks/validation.py
+++ b/fastvideo/train/callbacks/validation.py
@@ -1083,15 +1083,16 @@ class ValidationCallback(Callback):
         validation_config: Any,
         loaded_config: Any,
     ) -> None:
-        """Carry the loader-populated text encoder configs into the swap.
+        """Carry the loader-populated text encoder configs onto a config.
 
-        ``_validation_pipeline_config`` deep-copies the training-side pipeline
-        config, which never passes through ``ModelConfig.update_model_arch``,
-        so its encoder arch fields still hold the dataclass defaults. The
-        pipeline's own config does carry the checkpoint values, and stages read
-        those defaults directly: HunyuanVideo 1.5 sizes its zero-length ByT5
-        placeholder from ``hidden_size``, and the stale 512 default makes the
-        transformer reject it against its real width of 1472.
+        Validation reaches the stages through two configs that never pass
+        through ``ModelConfig.update_model_arch``: the deep copy
+        ``_validation_pipeline_config`` makes of the training-side config, and
+        the fresh ``make_inference_args`` result handed to
+        ``pipeline.forward``. Both start from the encoder dataclass defaults,
+        and stages read those directly. HunyuanVideo 1.5 sizes its zero-length
+        ByT5 placeholder from ``hidden_size``, so the stale 512 default makes
+        the transformer reject it against its real width of 1472.
         """
         loaded_encoders = getattr(loaded_config, "text_encoder_configs", None)
         if loaded_encoders is None:
@@ -1332,6 +1333,10 @@ class ValidationCallback(Callback):
         self._sync_runtime_dit_arch_config(
             inference_args.pipeline_config,
             transformer,
+        )
+        self._keep_loaded_text_encoder_configs(
+            inference_args.pipeline_config,
+            pipeline.fastvideo_args.pipeline_config,
         )
 
         # Propagate sampling_timesteps to pipeline_config so


### PR DESCRIPTION
## Purpose

Validation inside the modular trainer crashes for HunyuanVideo 1.5 because the
pipeline configs it hands to the stages never receive the encoder widths the
loader read off the checkpoint.

Fixes #1661

## Changes

`ValidationCallback` reaches the stages through two pipeline configs that never
pass through `ModelConfig.update_model_arch`:

1. `_validation_pipeline_config` deep-copies the training-side config
2. `make_inference_args` hands `tc.pipeline_config` itself to `pipeline.forward`,
   by reference

Both are derived from `TrainingArgs.pipeline_config`, which is built from the
training YAML plus dataclass defaults and never opens the checkpoint's
`config.json`. Stages read the encoder configs off those objects directly.

HunyuanVideo 1.5 has a second text encoder (ByT5) that produces zero tokens when
the prompt contains no quoted glyph text. A zero-length tensor carries no width,
so `TextEncodingStage` sizes the placeholder from the config
(`fastvideo/pipelines/stages/text_encoding.py:266`):

```python
prompt_embeds = torch.zeros((1, 0, encoder_config.hidden_size), device=target_device)
```

The generic `T5ArchConfig` default is `d_model = 512` while the checkpoint's
ByT5 is 1472, so validation dies in layer norm:

```
RuntimeError: Given normalized_shape=[1472], expected input with shape [*, 1472],
              but got input of size [1, 0, 512]
```

This PR adds `_keep_loaded_encoder_widths`, which copies `arch_config.hidden_size`
per encoder, by index, from the loaded config onto each of the two swapped
objects.

### Why field-level and not the whole tuple

The two config objects are complementary rather than ranked. The loader fills
the fields HF `config.json` carries and leaves everything else at its dataclass
default; the training side fills the FastVideo-only fields HF configs never
mention. Copying either tuple wholesale overwrites the target's real values with
the source's unfilled defaults, which is exactly the shape of the original bug.

| field | loaded config | training config |
|---|---|---|
| ByT5 `hidden_size` | 1472 (from `d_model`) | 512 (dataclass default) |
| Qwen `text_len` | 0 (no such key in HF configs) | 1000 (set by the model plugin) |

`Hunyuan15Model.init_preprocessors` derives `text_len` from
`text_encoder_max_lengths` minus `text_encoder_crop_start` (1108 - 108) to size
the parquet text padding, and `fastvideo/train/models/{hunyuan,cosmos,kandinsky5}`
read `tc.pipeline_config.text_encoder_configs` the same way. Since
`make_inference_args` passes `tc.pipeline_config` through by reference, a
wholesale assignment at the second call site would also mutate the trainer's own
config permanently. Copying one field avoids both problems, and the loaded
encoder objects are never aliased into the trainer's config.

`hidden_size` is the only field a stage reads when it has to synthesise an
embedding instead of measuring one, and the only one whose stale default causes
a crash. A falsy loaded width means the loader never populated that encoder, so
it is skipped rather than zeroing a real value.

### Why both call sites

Patching only `_get_pipeline` leaves the `make_inference_args` config stale, and
that is the object the stages actually read. Patching only the second site
copies from a source `_get_pipeline` has already replaced.

This mirrors the existing `_sync_runtime_dit_arch_config`, which already restores
DiT runtime fields at the same two sites after the same swaps. The DiT half of
this problem was patched when it was found; the text encoder half was not,
because until HunyuanVideo 1.5 nothing read those fields.

No behavior change for other models. Single-encoder pipelines (Wan, Cosmos)
derive the width from the real encoder output and never read `hidden_size` off
the config, so they go from a stale-but-unread default to a correct-but-unread
value. `text_len`, which `causal_denoising.py` does read, is now explicitly left
alone.

## Test Plan

CPU unit tests, no GPU required:

```bash
pytest fastvideo/tests/train/callbacks/test_validation.py -q
```

End-to-end reproduction on DGX Spark (GB10, CUDA 13.0) with the HunyuanVideo 1.5
LoRA overfit config from #1662, validation re-enabled, one training step and
4-step sampling:

```bash
bash examples/train/run.sh /tmp/val_check.yaml
```

Lint:

```bash
pre-commit run --files fastvideo/train/callbacks/validation.py \
                       fastvideo/tests/train/callbacks/test_validation.py
```

## Test Results

Before, on the first sampling step:

```
RuntimeError: Given normalized_shape=[1472], expected input with shape [*, 1472],
              but got input of size [1, 0, 512]
```

<details>
<summary>Test output</summary>

Unit tests, including 8 new cases covering both directions of the merge, the
unshared config objects, the unpopulated-width skip, index matching, and the
no-op guards:

```
37 passed, 14 warnings in 0.24s
```

End-to-end, with a temporary debug print of the placeholder width in
`TextEncodingStage`:

```
[DBG-STAGE] i=1 enc_id=267474740756304 hidden=1472 cfg_id=267476362597232
[DBG-STAGE] i=1 enc_id=267474740756304 hidden=1472 cfg_id=267476362597232
100%|██████████| 4/4 [24:13<00:00, 363.26s/it]
[DBG-STAGE] i=1 enc_id=267474740756304 hidden=1472 cfg_id=267476362597232
[DBG-STAGE] i=1 enc_id=267474740756304 hidden=1472 cfg_id=267476362597232

-rw-rw-r-- 1 kyle kyle 158839 Jul 30 03:40 validation_step_0_inference_steps_4_rank_0_video_0.mp4
```

The stage sees 1472, denoising completes 4/4, both validation passes run clean,
and the video is written. The debug print was removed before commit.

Note: that run predates the switch from tuple replacement to the field-level
copy. The unit tests cover the difference between the two, and the code path
into the stages is unchanged.

Lint:

```
yapf.....................................................................Passed
ruff (legacy alias)......................................................Passed
codespell................................................................Passed
```

</details>

## Relationship to #1662

Independent and non-overlapping: #1662 touches 13 files under
`fastvideo/train/models/hunyuan15/`, the example configs, tests and docs, and
does not touch `fastvideo/train/callbacks/validation.py`. Either can merge
first.

Once this lands, the two "validation is commented out" notes in #1662's configs
can be relaxed from "it does not work" to a plain memory-headroom note.

## Checklist

- [x] I ran pre-commit on the changed files and fixed all issues
- [x] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

Documentation: this is an internal fix with no user-visible behavior change, so
there is nothing in `docs/` to update.

The `mypy` pre-commit hook could not run locally: it rejects the checkout
directory name (`FastVideo-hy15`) as an invalid Python package name. The other
hooks pass on both changed files.
