### PR TITLE
[refactor]: delete the dead global attention-backend override

### DIFF
--- a/fastvideo/attention/AGENTS.md
+++ b/fastvideo/attention/AGENTS.md
@@ -43,6 +43,21 @@ A loader may narrow the request for one component — the DMD teacher/critic
 transformers build dense — and the recorded value is what that component
 actually resolved, not what the run asked for globally.
 
+A call site that already knows its component passes the decision explicitly:
+
+```python
+get_attn_backend(..., requested=component_attention_backend(self.transformer))
+```
+
+`requested` distinguishes three cases, and the distinction matters — `None` is
+an answer, not an absence:
+
+| value | meaning |
+|---|---|
+| a backend | use it; ignore the scope and the environment |
+| `None` | this component resolved to *automatic selection*; do **not** consult the environment behind it |
+| omitted (`NO_REQUEST`) | the caller has no opinion; fall back to the scope, then the environment |
+
 Nothing switches backends at runtime and nothing should: every request is an
 input to *construction*.
 
@@ -51,12 +66,12 @@ input to *construction*.
 `get_attn_backend()` reads every selection input, then resolves via, in
 precedence order:
 
-1. `global_force_attn_backend(...)` — deprecated process-global override, still
-   the training stack's mechanism.
-2. The per-component request resolved at load time.
+1. An explicit `requested=` argument — the component's own recorded decision.
+2. The per-component request carried by the construction scope.
 3. Env-var `FASTVIDEO_ATTENTION_BACKEND` (see `STR_BACKEND_ENV_VAR` in
-   `fastvideo/utils.py`), for layers built outside a loader — the denoising
-   stages, and direct model construction in tests.
+   `fastvideo/utils.py`), consulted only when the caller supplied no request
+   and no scope is active — layers built outside a loader, and direct model
+   construction in tests.
 4. The layer-declared `default_backend`.
 5. Per-platform automatic selection from `fastvideo/platforms/`, which probes
    the *current device's* capability.

--- a/fastvideo/attention/selector.py
+++ b/fastvideo/attention/selector.py
@@ -153,15 +153,25 @@ def record_resolved_attention_backend(config: object) -> AttentionBackendEnum | 
     return resolved
 
 
-def component_attention_backend(component: object) -> AttentionBackendEnum | None | _NoRequest:
+def component_attention_backend(component: object) -> AttentionBackendEnum | _NoRequest:
     """Read back the decision :func:`record_resolved_attention_backend` wrote.
 
-    Returns ``NO_REQUEST`` when ``component`` carries no recorded decision — it
-    was not built through a loader, or its config is not a FastVideo
-    ``ModelConfig`` — so the caller keeps today's fallback behavior rather than
-    being told "automatic selection" by something that was never asked.
+    Returns ``NO_REQUEST`` unless the component recorded a *concrete* backend,
+    so a caller that passes this through only overrides the ambient fallback
+    when there is a real decision to override it with.
+
+    ``NO_REQUEST`` rather than ``None`` for the no-decision case is deliberate,
+    and cannot be derived from the attribute's presence: ``ModelConfig`` declares
+    ``_resolved_attention_backend`` as a field defaulting to ``None``, so the
+    attribute always exists and a ``getattr`` default can never fire. Worse,
+    ``record_resolved_attention_backend`` writes ``None`` whenever no scope is
+    active, so "resolved to automatic selection" and "never recorded" are the
+    same stored value. Neither state should suppress the environment variable at
+    a call site that previously honoured it, and collapsing both to
+    ``NO_REQUEST`` keeps that behavior identical.
     """
-    return getattr(getattr(component, "config", None), "_resolved_attention_backend", NO_REQUEST)
+    resolved = getattr(getattr(component, "config", None), "_resolved_attention_backend", None)
+    return NO_REQUEST if resolved is None else resolved
 
 
 def get_attn_backend(

--- a/fastvideo/attention/selector.py
+++ b/fastvideo/attention/selector.py
@@ -69,40 +69,20 @@ def get_env_variable_attn_backend() -> AttentionBackendEnum | None:
     return (None if backend_name is None else backend_name_to_enum(backend_name))
 
 
-# Global state allows a particular choice of backend
-# to be forced, overriding the logic which auto-selects
-# a backend based on system & workload configuration
-# (default behavior if this variable is None)
-#
-# THIS SELECTION TAKES PRECEDENCE OVER THE
-# FASTVIDEO ATTENTION BACKEND ENVIRONMENT VARIABLE
-forced_attn_backend: AttentionBackendEnum | None = None
+class _NoRequest:
+    """Type of the "caller expressed no opinion" sentinel.
+
+    ``None`` cannot carry that meaning: it is a real answer — "this component
+    resolved to automatic selection" — and a caller passing it wants automatic
+    selection, not a fallback to whatever the environment says.
+    """
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<no request>"
 
 
-def global_force_attn_backend(attn_backend: AttentionBackendEnum | None) -> None:
-    '''
-    Force all attention operations to use a specified backend.
-
-    Passing `None` for the argument re-enables automatic
-    backend selection.,
-
-    Arguments:
-
-    * attn_backend: backend selection (None to revert to auto)
-    '''
-    global forced_attn_backend
-    forced_attn_backend = attn_backend
-    # No cache_clear: every selection input (including this override) is part
-    # of the resolution cache key, so mutations take effect on the next call
-    # by construction. Prefer _component_attention_backend_scope for new code.
-
-
-def get_global_forced_attn_backend() -> AttentionBackendEnum | None:
-    '''
-    Get the currently-forced choice of attention backend,
-    or None if auto-selection is currently enabled.
-    '''
-    return forced_attn_backend
+NO_REQUEST = _NoRequest()
 
 
 @dataclass(frozen=True)
@@ -173,26 +153,59 @@ def record_resolved_attention_backend(config: object) -> AttentionBackendEnum | 
     return resolved
 
 
+def component_attention_backend(component: object) -> AttentionBackendEnum | None | _NoRequest:
+    """Read back the decision :func:`record_resolved_attention_backend` wrote.
+
+    Returns ``NO_REQUEST`` when ``component`` carries no recorded decision — it
+    was not built through a loader, or its config is not a FastVideo
+    ``ModelConfig`` — so the caller keeps today's fallback behavior rather than
+    being told "automatic selection" by something that was never asked.
+    """
+    return getattr(getattr(component, "config", None), "_resolved_attention_backend", NO_REQUEST)
+
+
 def get_attn_backend(
     head_size: int,
     dtype: torch.dtype,
     supported_attention_backends: tuple[AttentionBackendEnum, ...]
     | None = None,
     default_backend: AttentionBackendEnum | None = None,
+    *,
+    requested: AttentionBackendEnum | None | _NoRequest = NO_REQUEST,
 ) -> type[AttentionBackend]:
+    """Resolve the attention backend class for one call site.
+
+    ``requested`` is the decision made for the component this call site belongs
+    to — read from ``ModelConfig._resolved_attention_backend``. Passing it means
+    the caller knows the answer, so nothing ambient is consulted:
+
+    * ``requested=SOME_BACKEND`` — use it (subject to the layer's declared
+      support), ignoring the construction scope and the environment;
+    * ``requested=None`` — that component resolved to *automatic selection*.
+      That is an answer, not an absence, so the environment is not consulted
+      behind it;
+    * ``requested`` omitted (``NO_REQUEST``) — the caller has no opinion; fall
+      back to the construction scope, then the environment. This is the path
+      every layer built inside a loader still takes.
+    """
     # Resolve every selection-affecting input BEFORE the cache so all of them
-    # live in the cache key: no mutation (env, global force, scope) ever needs
-    # a cache_clear again, and components with different requests get distinct
-    # cache entries (per-component resolution).
-    scope = _SCOPE.get()
-    if scope is not None:
-        requested = scope.backend
-        component = scope.component
-        env_backend = envs.FASTVIDEO_ATTENTION_BACKEND if scope.consult_env else None
-    else:
-        requested = None
+    # live in the cache key: no mutation (env, scope) ever needs a cache_clear
+    # again, and components with different requests get distinct cache entries
+    # (per-component resolution).
+    if not isinstance(requested, _NoRequest):
+        # Explicit: the component's own decision outranks anything ambient.
         component = None
-        env_backend = envs.FASTVIDEO_ATTENTION_BACKEND
+        env_backend = None
+    else:
+        scope = _SCOPE.get()
+        if scope is not None:
+            requested = scope.backend
+            component = scope.component
+            env_backend = envs.FASTVIDEO_ATTENTION_BACKEND if scope.consult_env else None
+        else:
+            requested = None
+            component = None
+            env_backend = envs.FASTVIDEO_ATTENTION_BACKEND
     # The active device is a real selection input, not bookkeeping: the
     # platform's backend resolution runs capability probes against the
     # *current* device (e.g. AttnQatInferBackend's per-arch capability sets
@@ -205,7 +218,6 @@ def get_attn_backend(
         dtype,
         supported_attention_backends,
         default_backend,
-        forced=get_global_forced_attn_backend(),
         requested=requested,
         env_backend=env_backend,
         component=component,
@@ -221,7 +233,6 @@ def _cached_get_attn_backend(
     | None = None,
     default_backend: AttentionBackendEnum | None = None,
     *,
-    forced: AttentionBackendEnum | None = None,
     requested: AttentionBackendEnum | None = None,
     env_backend: str | None = None,
     component: str | None = None,
@@ -237,12 +248,12 @@ def _cached_get_attn_backend(
     # resolutions taken under different device capabilities (the platform
     # probes the current device below).
     del component, device_index
-    # Precedence (behavior-preserving): the deprecated process-global force
-    # first, then the scoped per-component request (which occupies exactly the
-    # position the force held when moduleloader used it for per-role models),
-    # then the env var (already suppressed by the wrapper when a scope is
-    # active), then the layer-declared default.
-    selected_backend = forced if forced is not None else requested
+    # Precedence: the per-component request (explicit argument, else the
+    # construction scope), then the env var (already resolved to None by the
+    # wrapper whenever the caller supplied a request), then the layer-declared
+    # default. Every one of these arrived as an argument, so all of them are in
+    # the cache key.
+    selected_backend = requested
     if selected_backend is None and env_backend is not None:
         selected_backend = backend_name_to_enum(env_backend)
 
@@ -269,34 +280,3 @@ def _cached_get_attn_backend(
     if not attention_cls:
         raise ValueError(f"Invalid attention backend for {current_platform.device_name}")
     return cast(type[AttentionBackend], resolve_obj_by_qualname(attention_cls))
-
-
-@contextmanager
-def global_force_attn_backend_context_manager(attn_backend: AttentionBackendEnum) -> Generator[None, None, None]:
-    '''
-    Globally force a FastVideo attention backend override within a
-    context manager, reverting the global attention backend
-    override to its prior state upon exiting the context
-    manager.
-
-    Arguments:
-
-    * attn_backend: attention backend to force
-
-    Returns:
-
-    * Generator
-    '''
-
-    # Save the current state of the global backend override (if any)
-    original_value = get_global_forced_attn_backend()
-
-    # Globally force the new backend override
-    global_force_attn_backend(attn_backend)
-
-    # Yield control back to the enclosed code block
-    try:
-        yield
-    finally:
-        # Revert the original global backend override, if any
-        global_force_attn_backend(original_value)

--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -14,6 +14,7 @@ from tqdm.auto import tqdm
 
 import fastvideo.envs as envs
 from fastvideo.attention import get_attn_backend
+from fastvideo.attention.selector import component_attention_backend
 from fastvideo.distributed import (get_local_torch_device, get_world_group)
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.forward_context import set_forward_context
@@ -66,7 +67,13 @@ class DenoisingStage(PipelineStage):
             dtype=torch.float16,  # TODO(will): hack
             supported_attention_backends=(AttentionBackendEnum.VIDEO_SPARSE_ATTN, AttentionBackendEnum.BSA_ATTN,
                                           AttentionBackendEnum.VMOBA_ATTN, AttentionBackendEnum.FLASH_ATTN,
-                                          AttentionBackendEnum.TORCH_SDPA, AttentionBackendEnum.SAGE_ATTN_THREE)  # hack
+                                          AttentionBackendEnum.TORCH_SDPA,
+                                          AttentionBackendEnum.SAGE_ATTN_THREE),  # hack
+            # Build metadata for the backend this transformer actually resolved
+            # instead of re-deriving it from the environment. The two agreed
+            # only when the request arrived via the env var: a request passed as
+            # `attention_backend` reached the layers but never this stage.
+            requested=component_attention_backend(self.transformer),
         )
 
     def forward(

--- a/fastvideo/pipelines/stages/sr_denoising.py
+++ b/fastvideo/pipelines/stages/sr_denoising.py
@@ -15,6 +15,7 @@ import numpy as np
 from tqdm.auto import tqdm
 
 from fastvideo.attention import get_attn_backend
+from fastvideo.attention.selector import component_attention_backend
 from fastvideo.distributed import (get_local_torch_device, get_world_group)
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.forward_context import set_forward_context
@@ -63,7 +64,10 @@ class SRDenoisingStage(PipelineStage):
             dtype=torch.float16,  # TODO(will): hack
             supported_attention_backends=(AttentionBackendEnum.VIDEO_SPARSE_ATTN, AttentionBackendEnum.VMOBA_ATTN,
                                           AttentionBackendEnum.FLASH_ATTN, AttentionBackendEnum.TORCH_SDPA,
-                                          AttentionBackendEnum.SAGE_ATTN_THREE)  # hack
+                                          AttentionBackendEnum.SAGE_ATTN_THREE),  # hack
+            # See DenoisingStage: use this transformer's recorded decision
+            # rather than the environment.
+            requested=component_attention_backend(self.transformer),
         )
 
     def add_noise_to_lq(self, lq_latents: torch.Tensor, strength: float = 0.7) -> torch.Tensor:

--- a/fastvideo/tests/api/test_attention_selector_resolution.py
+++ b/fastvideo/tests/api/test_attention_selector_resolution.py
@@ -310,9 +310,41 @@ def test_component_attention_backend_reads_the_recorded_decision():
     assert selector.component_attention_backend(_Component(config)) == SAGE
 
 
-def test_component_that_resolved_to_auto_reports_none_not_absence():
-    """A component the loader stamped with "no request" reports None — an
-    answer — so its stage gets automatic selection rather than the env var."""
+def test_component_with_no_concrete_decision_reports_no_request(monkeypatch):
+    """"Stamped with no request" and "never stamped" are the SAME stored value.
+
+    ``ModelConfig._resolved_attention_backend`` is a field defaulting to None,
+    so the attribute always exists and ``record_resolved_attention_backend``
+    writes None whenever no scope is active. Neither state may suppress the env
+    var at a call site that previously honoured it, so both report NO_REQUEST.
+    """
+    from fastvideo.configs.models.dits.base import DiTConfig
+
+    class _Component:
+
+        def __init__(self, config):
+            self.config = config
+
+    # (a) stamped outside any scope -> stored None -> NO_REQUEST
+    stamped = DiTConfig()
+    assert selector.record_resolved_attention_backend(stamped) is None
+    assert selector.component_attention_backend(_Component(stamped)) is selector.NO_REQUEST
+
+    # (b) never stamped at all -> same stored value, same answer
+    untouched = DiTConfig()
+    assert untouched._resolved_attention_backend is None  # the field always exists
+    assert selector.component_attention_backend(_Component(untouched)) is selector.NO_REQUEST
+
+    # (c) and it does NOT suppress the env var, which is the whole point
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "TORCH_SDPA")
+    selector._cached_get_attn_backend.cache_clear()
+    passthrough = selector.get_attn_backend(
+        requested=selector.component_attention_backend(_Component(untouched)), **KWARGS)
+    assert passthrough == selector.get_attn_backend(**KWARGS)
+
+
+def test_component_with_a_concrete_decision_reports_it():
+    """A real recorded backend is an answer, and overrides the ambient fallback."""
     from fastvideo.configs.models.dits.base import DiTConfig
 
     class _Component:
@@ -321,8 +353,9 @@ def test_component_that_resolved_to_auto_reports_none_not_absence():
             self.config = config
 
     config = DiTConfig()
-    assert selector.record_resolved_attention_backend(config) is None
-    assert selector.component_attention_backend(_Component(config)) is None
+    with selector._component_attention_backend_scope(SAGE, component="transformer"):
+        assert selector.record_resolved_attention_backend(config) == SAGE
+    assert selector.component_attention_backend(_Component(config)) == SAGE
 
 
 def test_component_without_a_recorded_decision_reports_no_request():

--- a/fastvideo/tests/api/test_attention_selector_resolution.py
+++ b/fastvideo/tests/api/test_attention_selector_resolution.py
@@ -61,18 +61,16 @@ def _fake_platform(monkeypatch):
     monkeypatch.setattr(platforms, "_current_platform", _FakePlatform())
     monkeypatch.setattr(selector, "resolve_obj_by_qualname", lambda name: name)
     monkeypatch.delenv("FASTVIDEO_ATTENTION_BACKEND", raising=False)
-    selector.global_force_attn_backend(None)
     selector._cached_get_attn_backend.cache_clear()
     yield
-    selector.global_force_attn_backend(None)
     # Fake-platform resolutions must not outlive the test: mutations no
     # longer flush the cache (that is the feature), so evict explicitly.
     selector._cached_get_attn_backend.cache_clear()
 
 
-def _oracle(forced, requested, env, default):
-    """Today's documented precedence, spelled out independently."""
-    selected = forced if forced is not None else requested
+def _oracle(requested, env, default):
+    """The documented precedence, spelled out independently."""
+    selected = requested
     if selected is None and env is not None:
         selected = AttentionBackendEnum[env]
     if selected is None and default is not None:
@@ -82,26 +80,36 @@ def _oracle(forced, requested, env, default):
     return (selected or FLASH).name
 
 
-@pytest.mark.parametrize("forced", [None, SDPA])
 @pytest.mark.parametrize("scoped", [None, "unset", SAGE])
 @pytest.mark.parametrize("env", [None, "TORCH_SDPA"])
 @pytest.mark.parametrize("default", [None, SAGE])
-def test_precedence_matrix_matches_previous_semantics(monkeypatch, forced, scoped, env, default) -> None:
+def test_precedence_matrix_matches_previous_semantics(monkeypatch, scoped, env, default) -> None:
     if env is not None:
         monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", env)
-    selector.global_force_attn_backend(forced)
 
     if scoped == "unset":
-        # No scope: env is consulted (legacy behavior preserved).
+        # No scope and no explicit request: env is consulted.
         got = selector.get_attn_backend(default_backend=default, **KWARGS)
-        expected = _oracle(forced, None, env, default)
+        expected = _oracle(None, env, default)
     else:
-        # Scope active: env suppressed; scoped request sits in the position
-        # the global force held for per-role loads.
+        # Scope active: env suppressed, scoped request used.
         with selector._component_attention_backend_scope(scoped, component="dit"):
             got = selector.get_attn_backend(default_backend=default, **KWARGS)
-        expected = _oracle(forced, scoped, None, default)
+        expected = _oracle(scoped, None, default)
     assert got == expected
+
+
+@pytest.mark.parametrize("requested", [None, SAGE])
+@pytest.mark.parametrize("env", [None, "TORCH_SDPA"])
+@pytest.mark.parametrize("default", [None, SAGE])
+def test_explicit_request_matches_the_same_oracle(monkeypatch, requested, env, default) -> None:
+    """An explicit `requested=` resolves exactly as the same request would via
+    a scope, and never consults the environment behind it."""
+    if env is not None:
+        monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", env)
+
+    got = selector.get_attn_backend(default_backend=default, requested=requested, **KWARGS)
+    assert got == _oracle(requested, None, default)
 
 
 def test_scope_none_ignores_env_request(monkeypatch) -> None:
@@ -138,13 +146,26 @@ def test_scope_is_exception_safe(monkeypatch) -> None:
     assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
 
 
-def test_global_force_wins_without_cache_clear() -> None:
-    with selector._component_attention_backend_scope(SAGE, component="dit"):
-        assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
-        selector.global_force_attn_backend(SDPA)
+def test_explicit_none_means_auto_not_absence(monkeypatch) -> None:
+    """`requested=None` is an answer ("this component resolved to automatic
+    selection"), so the env var must NOT be consulted behind it. Omitting the
+    argument is the absence, and still falls back to the env."""
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "SAGE_ATTN")
+
+    # Explicit "automatic selection" -> the fake platform's auto answer.
+    assert selector.get_attn_backend(requested=None, **KWARGS) == "FLASH_ATTN"
+    # Counterfactual: same call, no opinion -> env still wins.
+    assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+    assert selector.get_attn_backend(requested=selector.NO_REQUEST, **KWARGS) == "SAGE_ATTN"
+
+
+def test_explicit_request_outranks_the_construction_scope(monkeypatch) -> None:
+    """A caller that knows its component's decision is not overridden by an
+    ambient scope that happens to be active."""
+    monkeypatch.setenv("FASTVIDEO_ATTENTION_BACKEND", "TORCH_SDPA")
+    with selector._component_attention_backend_scope(SDPA, component="dit"):
         assert selector.get_attn_backend(**KWARGS) == "TORCH_SDPA"
-        selector.global_force_attn_backend(None)
-        assert selector.get_attn_backend(**KWARGS) == "SAGE_ATTN"
+        assert selector.get_attn_backend(requested=SAGE, **KWARGS) == "SAGE_ATTN"
 
 
 def test_env_change_takes_effect_without_cache_clear(monkeypatch) -> None:
@@ -258,3 +279,54 @@ def test_no_request_records_no_decision():
     config = TextEncoderConfig()
     assert selector.record_resolved_attention_backend(config) is None
     assert config._resolved_attention_backend is None
+
+
+# ---------------------------------------------------------------------------
+# Reading the component's recorded decision back
+# ---------------------------------------------------------------------------
+
+
+def test_component_attention_backend_reads_the_recorded_decision():
+    from fastvideo.configs.models.dits.base import DiTConfig
+
+    class _Component:
+
+        def __init__(self, config):
+            self.config = config
+
+    config = DiTConfig()
+    with selector._component_attention_backend_scope(SAGE, component="transformer"):
+        selector.record_resolved_attention_backend(config)
+
+    assert selector.component_attention_backend(_Component(config)) == SAGE
+
+
+def test_component_that_resolved_to_auto_reports_none_not_absence():
+    """A component the loader stamped with "no request" reports None — an
+    answer — so its stage gets automatic selection rather than the env var."""
+    from fastvideo.configs.models.dits.base import DiTConfig
+
+    class _Component:
+
+        def __init__(self, config):
+            self.config = config
+
+    config = DiTConfig()
+    assert selector.record_resolved_attention_backend(config) is None
+    assert selector.component_attention_backend(_Component(config)) is None
+
+
+def test_component_without_a_recorded_decision_reports_no_request():
+    """A transformer built outside a loader (or carrying a non-FastVideo
+    config) has no decision, so callers keep the previous fallback."""
+
+    class _Bare:
+        pass
+
+    class _HFStyle:
+
+        def __init__(self):
+            self.config = object()
+
+    assert selector.component_attention_backend(_Bare()) is selector.NO_REQUEST
+    assert selector.component_attention_backend(_HFStyle()) is selector.NO_REQUEST

--- a/fastvideo/tests/api/test_attention_selector_resolution.py
+++ b/fastvideo/tests/api/test_attention_selector_resolution.py
@@ -44,6 +44,15 @@ class _FakePlatform:
     device_name = "fake"
 
     @classmethod
+    def is_mps(cls) -> bool:
+        # Not decoration. The autouse fixture swaps this stub in process-wide,
+        # so anything that constructs FastVideoArgs under it reaches
+        # check_fastvideo_args, which calls current_platform.is_mps(). Without
+        # this, the two env-folding tests raise AttributeError before they
+        # assert anything.
+        return False
+
+    @classmethod
     def get_attn_backend_cls(
         cls,
         selected_backend: AttentionBackendEnum | None,

--- a/fastvideo/tests/attention/test_selector_role_override.py
+++ b/fastvideo/tests/attention/test_selector_role_override.py
@@ -27,7 +27,6 @@ class _FakePlatform:
 def test_role_override_invalidates_cached_backend(monkeypatch) -> None:
     monkeypatch.setattr(platforms, "_current_platform", _FakePlatform())
     monkeypatch.setattr(selector, "resolve_obj_by_qualname", lambda name: name)
-    selector.global_force_attn_backend(None)
 
     supported = (
         AttentionBackendEnum.FLASH_ATTN,
@@ -42,29 +41,26 @@ def test_role_override_invalidates_cached_backend(monkeypatch) -> None:
 
     try:
         assert selector.get_attn_backend(**kwargs) == "FLASH_ATTN"
-        with selector.global_force_attn_backend_context_manager(
-                AttentionBackendEnum.TORCH_SDPA):
-            # Same cache key as above; the role-local override must still win.
+        with selector._component_attention_backend_scope(
+                AttentionBackendEnum.TORCH_SDPA, component="role"):
+            # Same cache key as above; the role-local request must still win.
             assert selector.get_attn_backend(**kwargs) == "TORCH_SDPA"
 
         # Exiting the role scope restores the previous resolution as well.
         assert selector.get_attn_backend(**kwargs) == "FLASH_ATTN"
     finally:
-        # Do not leave fake-platform resolutions cached for later tests.
-        # global_force_attn_backend no longer flushes the cache (selection
-        # inputs are cache-key members now), so evict explicitly.
-        selector.global_force_attn_backend(None)
+        # Do not leave fake-platform resolutions cached for later tests:
+        # selection inputs are cache-key members, so evict explicitly.
         selector._cached_get_attn_backend.cache_clear()
 
 
 def test_unsupported_role_override_honors_layer_default(monkeypatch) -> None:
     monkeypatch.setattr(platforms, "_current_platform", _FakePlatform())
     monkeypatch.setattr(selector, "resolve_obj_by_qualname", lambda name: name)
-    selector.global_force_attn_backend(None)
 
     try:
-        with selector.global_force_attn_backend_context_manager(
-                AttentionBackendEnum.ATTN_QAT_TRAIN):
+        with selector._component_attention_backend_scope(
+                AttentionBackendEnum.ATTN_QAT_TRAIN, component="role"):
             assert selector.get_attn_backend(
                 head_size=128,
                 dtype=torch.bfloat16,
@@ -72,7 +68,6 @@ def test_unsupported_role_override_honors_layer_default(monkeypatch) -> None:
                 default_backend=AttentionBackendEnum.TORCH_SDPA,
             ) == "TORCH_SDPA"
     finally:
-        selector.global_force_attn_backend(None)
         selector._cached_get_attn_backend.cache_clear()
 
 


### PR DESCRIPTION
## Purpose

Two follow-ups to load-time attention-backend resolution: remove the override
that resolution made dead, and let the two denoising stages use the decision
their transformer already recorded.

## 1. Delete the global attention-backend override

`global_force_attn_backend`, `get_global_forced_attn_backend` and
`global_force_attn_backend_context_manager` mutate a module-level global that
forces one backend process-wide. Nothing outside tests calls them — backends are
resolved per component at load time — yet the global still occupied the **top**
precedence rung in `_cached_get_attn_backend`, above the component's own
decision. Deleted, along with the `forced` parameter and its argument threading.

Sweep before deleting, on `main`:

| checked | result |
|---|---|
| `fastvideo/` production code | 0 references |
| `fastvideo/attention/__init__.py` re-export / `__all__` | absent |
| `docs/`, MkDocs, `README` | 0 references |
| `examples/`, `apps/`, `csrc/`, ComfyUI trees | 0 references |
| tests | 2 files, migrated below |

The symbols were importable via a deep module path (`fastvideo.attention.
selector`) but were never exported from the package or documented, so this is
being treated as internal. Flagging it explicitly rather than burying it: if
anyone considers that path public, say so and it can be kept as a deprecated
shim instead.

Tests migrated onto the construction scope, which expresses the same intent
("this component uses this backend") without a process-wide mutation:
`test_selector_role_override.py` (both cases) and the golden matrix's `forced`
axis.

## 2. The denoising stages use the component's decision

`DenoisingStage` and `SRDenoisingStage` call `get_attn_backend` outside any
loader, so they fell through to the selector's environment read. Both already
hold `self.transformer`, whose config carries the decision the loader recorded,
so they now pass it explicitly.

`get_attn_backend` gains a keyword-only `requested=`:

```python
requested=component_attention_backend(self.transformer)
```

### The `None` problem, and the choice made

`requested=None` is ambiguous: it could mean "I have no opinion" or "this
component resolved to automatic selection". Those need different behavior — the
first should fall back to the environment, the second must not, or a component
that deliberately resolved to automatic selection would silently pick up an
unrelated env var.

**Chosen: a sentinel default, `NO_REQUEST`.** It keeps `None` meaning the same
thing it means everywhere else in this module (no backend requested → automatic
selection), needs no second parameter that can drift out of sync with the first,
and reads correctly at the call site. It is a typed singleton (`_NoRequest`)
rather than a bare `object()` so the annotation stays honest and `isinstance`
narrows for mypy; `repr` is `<no request>` so a failed assertion says what it is.

| `requested` | behavior |
|---|---|
| a backend | use it (subject to the layer's declared support); scope and env ignored |
| `None` | automatic selection; env **not** consulted behind it |
| omitted | no opinion: scope, then env — unchanged for every existing caller |

Both directions are tested (`test_explicit_none_means_auto_not_absence` asserts
the counterfactual in the same test: explicit `None` → auto, omitted → env).

`component_attention_backend()` returns `NO_REQUEST` for a transformer that
carries no recorded decision — built outside a loader, or holding a non-FastVideo
config — so those keep the previous behavior rather than being told "automatic
selection" by something that was never asked.

### Behavior change, stated

Previously these stages saw a request **only** when it arrived via the env var. A
request passed as `attention_backend` reached the model's layers but never the
stage, so the stage could build metadata for a different backend than the layers
were running. That inconsistency is fixed. When the request arrives via the env
var — the common path — resolution is unchanged, because the loader records the
same value the stage used to read.

### This does not remove the environment read

It removes it *for these two call sites*. Layers built outside a loader still
reach the env var through the selector. That is the documented remaining gap,
not something this PR closes; `fastvideo/attention/AGENTS.md` still lists it as
precedence rung 3. Closing it means threading the request from model to layer per
family, which is deferred.

## Found, not fixed

`denoising.py` passes `dtype=torch.float16  # TODO(will): hack` and a hardcoded
supported-backend tuple marked `# hack`, on the path that selects the sparse
attention backend. Both are load-bearing for selection — `dtype` is an argument
to the platform's backend resolution and part of the cache key, and the tuple
decides the fallback — so changing either alters which backend gets picked. Left
alone deliberately; they want their own change with GPU evidence.

## Test Plan

CPU-only, no GPU:

```bash
pytest fastvideo/tests/api/test_attention_selector_resolution.py \
       fastvideo/tests/attention/test_selector_role_override.py -q
```

40 cases: 37 in the golden resolution matrix (12 precedence-matrix combinations,
8 asserting an explicit `requested=` resolves identically to the same request via
a scope, plus the sentinel, scope, cache-key and recorded-decision cases) and 3
role-override cases. These run in the `microscope-unit-tests` lane.

## Checklist

- [x] I ran pre-commit on the changed files and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed (`fastvideo/attention/AGENTS.md`)
- [x] I considered GPU memory impact of my changes (none — selection only)

## Follow-up fixes on this branch (post-review)

Two defects were found by an independent pass and fixed here rather than in a
separate PR, since both live in the files this one already touches.

**`component_attention_backend` could never report "no decision".** It fell
back to `NO_REQUEST` through a `getattr` default, which can never fire:
`ModelConfig` declares `_resolved_attention_backend` as a field defaulting to
`None`, so the attribute always exists. And `record_resolved_attention_backend`
writes `None` whenever no scope is active, so "resolved to automatic selection"
and "never recorded" are the same stored value.

The consequence ran the wrong way: the two denoising stages passed
`requested=None` for every component without a concrete decision, and
`get_attn_backend` treats any non-`NO_REQUEST` value as explicit and drops the
env fallback. With `FASTVIDEO_ATTENTION_BACKEND` set after `FastVideoArgs`
construction, or a transformer built outside a loader, the stage resolved to
automatic selection while the layers ran the env backend - the stage/layer
divergence this PR set out to fix, inverted. Both no-decision states now report
`NO_REQUEST`; a concrete recorded backend still overrides the ambient fallback.
The test that asserted the old behavior encoded the defect and was replaced.

**Two selector tests have never passed, and fail on main today.**
`test_env_is_folded_into_the_typed_request_once` and
`test_unparseable_env_falls_through_instead_of_raising` construct
`FastVideoArgs` under the autouse fake-platform fixture, and
`check_fastvideo_args` calls `current_platform.is_mps()`, which the stub does
not implement - `AttributeError` before either asserts anything. That call has
been in `check_fastvideo_args` since June, so this was never a merge-order
casualty; the tests were broken when written and landed while the CI queue was
stalled. The stub now implements `is_mps`.

**Measured, not static:** these suites were executed in the project container
on a GB200 host, CPU-only paths. On main and at the first head of this branch:
**2 failed / 38 passed**. At this head: **41 passed, 0 failed** (the replaced
test becomes two).
