### PR TITLE
[bugfix] Wan I2V: CLIP image conditioning silently dropped when passed as a tensor during training

### DIFF
--- a/fastvideo/models/dits/causal_wanvideo.py
+++ b/fastvideo/models/dits/causal_wanvideo.py
@@ -588,11 +588,9 @@ class CausalWanTransformer3DModel(BaseDiT):
         orig_dtype = hidden_states.dtype
         if not isinstance(encoder_hidden_states, torch.Tensor):
             encoder_hidden_states = encoder_hidden_states[0]
-        if isinstance(encoder_hidden_states_image,
-                      list) and len(encoder_hidden_states_image) > 0:
-            encoder_hidden_states_image = encoder_hidden_states_image[0]
-        else:
-            encoder_hidden_states_image = None
+        if isinstance(encoder_hidden_states_image, list):
+            encoder_hidden_states_image = (encoder_hidden_states_image[0]
+                                           if len(encoder_hidden_states_image) > 0 else None)
 
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
         p_t, p_h, p_w = self.patch_size
@@ -702,11 +700,9 @@ class CausalWanTransformer3DModel(BaseDiT):
         teacher_forcing = clean_x is not None
         if not isinstance(encoder_hidden_states, torch.Tensor):
             encoder_hidden_states = encoder_hidden_states[0]
-        if isinstance(encoder_hidden_states_image,
-                      list) and len(encoder_hidden_states_image) > 0:
-            encoder_hidden_states_image = encoder_hidden_states_image[0]
-        else:
-            encoder_hidden_states_image = None
+        if isinstance(encoder_hidden_states_image, list):
+            encoder_hidden_states_image = (encoder_hidden_states_image[0]
+                                           if len(encoder_hidden_states_image) > 0 else None)
 
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
         p_t, p_h, p_w = self.patch_size

--- a/fastvideo/models/dits/dreamx_world.py
+++ b/fastvideo/models/dits/dreamx_world.py
@@ -416,11 +416,9 @@ class DreamXWorldTransformer3DModel(WanTransformer3DModel):
         if encoder_hidden_states is not None and not isinstance(
                 encoder_hidden_states, torch.Tensor):
             encoder_hidden_states = encoder_hidden_states[0]
-        if isinstance(encoder_hidden_states_image,
-                      list) and len(encoder_hidden_states_image) > 0:
-            encoder_hidden_states_image = encoder_hidden_states_image[0]
-        else:
-            encoder_hidden_states_image = None
+        if isinstance(encoder_hidden_states_image, list):
+            encoder_hidden_states_image = (encoder_hidden_states_image[0]
+                                           if len(encoder_hidden_states_image) > 0 else None)
 
         batch_size, _, num_frames, height, width = hidden_states.shape
         p_t, p_h, p_w = self.patch_size

--- a/fastvideo/models/dits/lingbotworld/model.py
+++ b/fastvideo/models/dits/lingbotworld/model.py
@@ -311,11 +311,9 @@ class LingBotWorldTransformer3DModel(BaseDiT):
         orig_dtype = hidden_states.dtype
         if encoder_hidden_states is not None and not isinstance(encoder_hidden_states, torch.Tensor):
             encoder_hidden_states = encoder_hidden_states[0]
-        if isinstance(encoder_hidden_states_image,
-                      list) and len(encoder_hidden_states_image) > 0:
-            encoder_hidden_states_image = encoder_hidden_states_image[0]
-        else:
-            encoder_hidden_states_image = None
+        if isinstance(encoder_hidden_states_image, list):
+            encoder_hidden_states_image = (encoder_hidden_states_image[0]
+                                           if len(encoder_hidden_states_image) > 0 else None)
 
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
         p_t, p_h, p_w = self.patch_size

--- a/fastvideo/models/dits/wanvideo.py
+++ b/fastvideo/models/dits/wanvideo.py
@@ -694,11 +694,9 @@ class WanTransformer3DModel(BaseDiT):
         orig_dtype = hidden_states.dtype
         if encoder_hidden_states is not None and not isinstance(encoder_hidden_states, torch.Tensor):
             encoder_hidden_states = encoder_hidden_states[0]
-        if isinstance(encoder_hidden_states_image,
-                      list) and len(encoder_hidden_states_image) > 0:
-            encoder_hidden_states_image = encoder_hidden_states_image[0]
-        else:
-            encoder_hidden_states_image = None
+        if isinstance(encoder_hidden_states_image, list):
+            encoder_hidden_states_image = (encoder_hidden_states_image[0]
+                                           if len(encoder_hidden_states_image) > 0 else None)
 
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
         p_t, p_h, p_w = self.patch_size


### PR DESCRIPTION
## Purpose

`WanTransformer3DModel.forward` (and the causal/dreamx/lingbotworld variants) unwrapped `encoder_hidden_states_image` only when it was a list, and set it to `None` otherwise — discarding a bare tensor even though the signature accepts `torch.Tensor | list[torch.Tensor] | None`.

The inference pipelines store `image_embeds` as a list (`image_encoding.py`), so they were unaffected. Every I2V **training** pipeline passes the CLIP features directly as a tensor (`wan_i2v_training_pipeline.py:129`, `wan_i2v_distillation_pipeline.py:170`, `self_forcing_distillation_pipeline.py`), so those trained with no image cross-attention at all, silently and without error.

Models with `image_dim=None` (Wan2.2 I2V/TI2V, LingBotWorld) build no image embedder and are unaffected either way.

## Changes

Unwrap a list, leave a tensor alone. Matches the handling of `encoder_hidden_states` two lines above, and the form already used in `matrixgame2/causal_model.py` and `matrixgame2/model.py`.

Touches `wanvideo.py`, `causal_wanvideo.py` (2 sites), `dreamx_world.py`, `lingbotworld/model.py`.

## Test Plan

Wan2.1-I2V-14B-720P, one image, 480x832, 121 frames, 30 steps, guidance 3.0, seed 1000.

The inference stack passes a list, so it never hits the bug. To exercise the *training* convention end-to-end, `denoising.py` was temporarily patched to hand the DiT a bare tensor — this patch is **not** part of the PR:

```bash
# DenoisingStage.forward, right after:
#   image_embeds = [image_embed.to(target_dtype) for image_embed in image_embeds]
image_embeds = image_embeds[0]   # training convention: bare tensor
```

Then generate twice on the same node/seed: once with `wanvideo.py` from `main`, once with this branch.

## Test Results

`std` = per-video pixel standard deviation (contrast/detail proxy).

| | mean | std | last-frame std |
|---|---|---|---|
| before — tensor silently nulled | 120.1 | 60.5 | 57.5 |
| after — tensor kept | 80.7 | **63.7** | **66.3** |
| unmodified inference (list, reference) | 80.7 | 63.8 | 66.8 |

After the fix, passing a tensor reproduces the untouched list path exactly. Before it, the output is brighter and washed out, degrading over the clip.

Same fix measured through a training-side validation callback (Wan2.1-I2V-14B, stock weights), against ground truth:

| clip | before | after | GT |
|---|---|---|---|
| 720p, clip A | 19.3 | **70.3** | 64.7 |
| 720p, clip B | 26.8 | **57.2** | 58.4 |
| 480p, clip A | 32.0 | **70.3** | 64.6 |

## Checklist

- [x] `pre-commit run` — all four files live under `fastvideo/models/`, which the config's global `exclude` skips, so no hooks apply to this diff
- [ ] I added or updated tests for my changes — none added. A regression test asserting `forward(..., encoder_hidden_states_image=tensor) != forward(..., encoder_hidden_states_image=None)` would prevent this from recurring; happy to add if wanted.
- [ ] I updated documentation if needed — n/a
- [x] I considered GPU memory impact — none

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass — not run locally; inference output is unchanged (list path untouched), so SSIM should be unaffected
- [ ] I updated the support matrix — n/a
