### PR TITLE
[kernel] attention: sm_100a CUDA forward for block-causal-sink (Blackwell)

### DIFF
--- a/fastvideo-kernel/CMakeLists.txt
+++ b/fastvideo-kernel/CMakeLists.txt
@@ -308,6 +308,21 @@ if(BUILD_CXX_KERNELS)
         csrc/turbodiffusion/quant/quant.cu
     )
     
+    # Blackwell block-causal + sink + sliding-window attention (sm_100a only).
+    # NOTE the "a" suffix: -arch=sm_100a is NOT enough -- it emits a plain sm_100 target and
+    # ptxas rejects every tcgen05 / setmaxnreg / .cta_group instruction. The explicit gencode
+    # spelling below is required, and matches the 10.0a entry in TORCH_CUDA_ARCH_LIST.
+    set(ENABLE_BCS_SM100A OFF)
+    if(TORCH_CUDA_ARCH_LIST MATCHES "(^|[; ,])(10\\.0a|100a|sm_100a)([; ,]|$)")
+        set(ENABLE_BCS_SM100A ON)
+    endif()
+    if(ENABLE_BCS_SM100A)
+        message(STATUS "fastvideo-kernel: building block_causal_sink_sm100a (Blackwell)")
+        list(APPEND EXTENSION_SOURCES csrc/attention/block_causal_sink_sm100a.cu)
+        set_source_files_properties(csrc/attention/block_causal_sink_sm100a.cu PROPERTIES
+            COMPILE_OPTIONS "-gencode;arch=compute_100a,code=sm_100a")
+    endif()
+
     # Conditionally add TK kernels
     if(ENABLE_TK_KERNELS)
         list(APPEND EXTENSION_SOURCES
@@ -336,6 +351,9 @@ if(BUILD_CXX_KERNELS)
     if(ENABLE_TK_KERNELS)
         list(APPEND COMPILE_DEFS TK_COMPILE_ST_ATTN TK_COMPILE_BLOCK_SPARSE)
     endif()
+    if(ENABLE_BCS_SM100A)
+        list(APPEND COMPILE_DEFS TK_COMPILE_BLOCK_CAUSAL_SINK_SM100A)
+    endif()
 
     target_compile_definitions(fastvideo_kernel_ops PRIVATE ${COMPILE_DEFS})
 
@@ -346,6 +364,13 @@ if(BUILD_CXX_KERNELS)
     # Link against Torch libraries to avoid undefined symbols at import time
     # (e.g., torch::autograd vtables) when loading the extension module.
     target_link_libraries(fastvideo_kernel_ops PRIVATE ${TORCH_LIBRARIES})
+
+    # The Blackwell kernel builds its TMA descriptors with cuTensorMapEncodeTiled, a CUDA
+    # DRIVER API entry point -- it is not in libcudart, so the module fails to import with
+    # "undefined symbol: cuTensorMapEncodeTiled" unless libcuda is linked explicitly.
+    if(ENABLE_BCS_SM100A)
+        target_link_libraries(fastvideo_kernel_ops PRIVATE cuda)
+    endif()
 
     # Also link against libtorch_python to satisfy Python-binding symbols
     # (e.g., torch::PyWarningHandler) required by torch/extension.h.

--- a/fastvideo-kernel/csrc/attention/block_causal_sink_kernel_sm100a.cuh
+++ b/fastvideo-kernel/csrc/attention/block_causal_sink_kernel_sm100a.cuh
@@ -1,0 +1,1012 @@
+// block_causal_sink_kernel_sm100a.cuh -- block-causal + sink + sliding-window FMHA forward, sm_100a.
+// Warp-specialized: load / MMA (tcgen05) / softmax / correction / epilogue / scheduler.
+// Writes O and, when asked, the log-sum-exp the backward consumes.
+//
+// Generated (comments stripped). Do not edit by hand.
+#pragma once
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <type_traits>
+#include <cstring>
+#include <cmath>
+#include <vector>
+#include "primitives.cuh"
+
+constexpr int M_TILE = 128;
+constexpr int M_TILES_PER_CTA = 2;
+constexpr int K_TILE = 128;
+constexpr int HEAD_DIM = 128;
+
+constexpr int SUB_COLS_BF16 = 64;
+constexpr int SUB_COLS_BYTES = SUB_COLS_BF16 * (int)sizeof(__nv_bfloat16);
+constexpr int Q_SUBTILES = HEAD_DIM / SUB_COLS_BF16;
+constexpr int K_SUBTILES = HEAD_DIM / SUB_COLS_BF16;
+constexpr int V_SUBTILES = K_TILE / SUB_COLS_BF16;
+constexpr int P_SUBTILES = K_TILE / SUB_COLS_BF16;
+constexpr int Q_SUB_COLS_BYTES = M_TILE * SUB_COLS_BYTES;
+constexpr int K_SUB_COLS_BYTES = K_TILE * SUB_COLS_BYTES;
+constexpr int Q_TILE_BYTES = Q_SUBTILES * Q_SUB_COLS_BYTES;
+constexpr int K_TILE_BYTES = K_SUBTILES * K_SUB_COLS_BYTES;
+constexpr int V_TILE_BYTES = V_SUBTILES * Q_SUB_COLS_BYTES;
+constexpr int P_TILE_BYTES = P_SUBTILES * Q_SUB_COLS_BYTES;
+constexpr int K_ATOMS_PER_TILE = SUB_COLS_BF16 / 16;
+constexpr int SPLIT_P_N    = K_TILE / 4 * 3;
+constexpr int SPLIT_P_ATOM = SPLIT_P_N / 16;
+constexpr int SPLIT_P_COL  = SPLIT_P_N / 2;
+constexpr int EX2_FRG_PAIRS = 16;
+constexpr int EX2_FRG_CNT   = K_TILE / 32;
+
+constexpr int EX2_RES       = 4;
+constexpr int EX2_START_FRG = 1;
+constexpr int NUM_KV_STAGES = 3;
+constexpr int S_COLS = K_TILE;
+constexpr int O_COLS = HEAD_DIM;
+constexpr int TMEM_TOTAL = 512;
+constexpr int W_CORR0 = 8, W_MMA = 12, W_EPI = 13, W_LOAD = 14, W_SCHED = 15;
+constexpr int N_WARPS = 16;
+constexpr int CLC_STAGES = 4;
+
+extern __shared__ __align__(1024) uint8_t fmha_smem[];
+
+union SmemDescPair { uint64_t u64; uint2 w; };
+
+__device__ __forceinline__ void desc_add_lo(SmemDescPair& d, uint32_t inc) {
+  asm volatile("{\n\t"
+      ".reg .b32 lo, hi;\n\t"
+      "mov.b64 {lo, hi}, %0;\n\t"
+      "add.u32 lo, lo, %1;\n\t"
+      "mov.b64 %0, {lo, hi};\n\t"
+      "}" : "+l"(d.u64) : "r"(inc));
+}
+
+__device__ __forceinline__ int tile_for_processing(int step, int window_tiles, int window_hi_tile, int k_tiles) {
+  return (step < window_tiles) ? (window_hi_tile - 1 - step) : (k_tiles - 1 - step);
+}
+
+template <bool Q_RASTER, bool LPT, bool HAS_SINK_ROPE_DELTA = false>
+__device__ __forceinline__ void decode_workitem(
+    int workitem_id, int seqlen, int num_kv_heads,
+    int packed_mtiles_per_seq, int packed_mtiles_per_sample, int q_tile_per_cta,
+    unsigned long long magic0, unsigned long long magic1, unsigned long long magic2,
+    int lpt_swz_log2, int lpt_hb_quot, int lpt_hb_rem,
+    unsigned long long lpt_major_magic, unsigned long long lpt_rem_magic,
+    int tokens_per_block, int rolling_window_tokens, int sink_tokens,
+    int& sample, int& h_kv, int& q_tile_base, int& k_tiles,
+    int& window_tiles, int& window_hi_tile) {
+  int packed_mtiles_index;
+  if constexpr (LPT) {
+
+    const int major = (int)fdiv((unsigned)workitem_id, lpt_major_magic);
+    const int l2mod = workitem_id - major * (packed_mtiles_per_seq << lpt_swz_log2);
+    int block, res;
+    if (major < lpt_hb_quot) {
+      block = l2mod >> lpt_swz_log2;
+      res   = l2mod & ((1 << lpt_swz_log2) - 1);
+    } else {
+      block = (int)fdiv((unsigned)l2mod, lpt_rem_magic);
+      res   = l2mod - block * lpt_hb_rem;
+    }
+    const int hb = (major << lpt_swz_log2) + res;
+    sample = (int)fdiv((unsigned)hb, magic2);
+    h_kv   = hb - sample * num_kv_heads;
+    packed_mtiles_index = packed_mtiles_per_seq - 1 - block;
+    q_tile_base = packed_mtiles_index * q_tile_per_cta;
+  } else {
+    sample = (int)fdiv((unsigned)workitem_id, magic0);
+    const int rr = workitem_id - sample * packed_mtiles_per_sample;
+    if constexpr (Q_RASTER) {
+      h_kv                = (int)fdiv((unsigned)rr, magic1);
+      packed_mtiles_index = rr - h_kv * packed_mtiles_per_seq;
+    } else {
+      packed_mtiles_index = (int)fdiv((unsigned)rr, magic2);
+      h_kv                = rr - packed_mtiles_index * num_kv_heads;
+    }
+    q_tile_base = packed_mtiles_index * q_tile_per_cta;
+  }
+
+  const int first_q = q_tile_base;
+  const int last_q  = q_tile_base + q_tile_per_cta - 1;
+
+  int max_block_end = (last_q / tokens_per_block + 1) * tokens_per_block;
+  if (max_block_end > seqlen) max_block_end = seqlen;
+
+  int min_window_start = ((first_q / tokens_per_block + 1) * tokens_per_block) - rolling_window_tokens;
+  if (min_window_start < 0) min_window_start = 0;
+
+  const int hi_tile = (max_block_end + K_TILE - 1) / K_TILE;
+  int lo_tile = min_window_start / K_TILE;
+  int sink_tiles = (sink_tokens + K_TILE - 1) / K_TILE;
+
+  if constexpr (HAS_SINK_ROPE_DELTA) {
+
+    if (lo_tile < sink_tiles - 1) lo_tile = sink_tiles - 1;
+    if (lo_tile > hi_tile) lo_tile = hi_tile;
+  } else {
+    if (sink_tiles > lo_tile) sink_tiles = lo_tile;
+  }
+
+  window_hi_tile = hi_tile;
+  window_tiles   = hi_tile - lo_tile;
+  k_tiles        = window_tiles + sink_tiles;
+}
+
+template <int K_TILE, bool USE_R2P_ASM = true>
+__device__ __forceinline__ void mask_s_row_block_causal_sink(float* scores, int k_tile_offset,
+    int block_end, int sink_tokens, int window_start) {
+  const int hi  = block_end     - k_tile_offset;
+  const int snk = sink_tokens   - k_tile_offset;
+  const int lo  = window_start  - k_tile_offset;
+  uint32_t* u = reinterpret_cast<uint32_t*>(scores);
+  #pragma unroll
+  for (int s = 0; s < K_TILE / 32; ++s) {
+    const int base = s * 32;
+    int hb = hi - base;  hb = hb < 0 ? 0 : (hb > 32 ? 32 : hb);
+    int sb = snk - base; sb = sb < 0 ? 0 : (sb > 32 ? 32 : sb);
+    int lb = lo - base;  lb = lb < 0 ? 0 : (lb > 32 ? 32 : lb);
+    const uint32_t keep_hi   = (hb >= 32) ? 0xFFFFFFFFu : (hb <= 0 ? 0u : ((1u << hb) - 1u));
+    const uint32_t keep_sink = (sb >= 32) ? 0xFFFFFFFFu : (sb <= 0 ? 0u : ((1u << sb) - 1u));
+    const uint32_t keep_win  = (lb >= 32) ? 0u : (0xFFFFFFFFu << lb);
+    const uint32_t keep = keep_hi & (keep_sink | keep_win);
+    if constexpr (USE_R2P_ASM) {
+      #pragma unroll
+      for (int g = 0; g < 32; g += 8) {
+        const uint32_t kg = keep >> g;
+        asm("{\n\t"
+            ".reg .pred p0, p1, p2, p3, p4, p5, p6, p7;\n\t"
+            ".reg .b32  t0, t1, t2, t3, t4, t5, t6, t7;\n\t"
+            "and.b32 t0, %8, 1;    setp.ne.b32 p0, t0, 0; selp.b32 %0, %0, 0xFF800000, p0;\n\t"
+            "and.b32 t1, %8, 2;    setp.ne.b32 p1, t1, 0; selp.b32 %1, %1, 0xFF800000, p1;\n\t"
+            "and.b32 t2, %8, 4;    setp.ne.b32 p2, t2, 0; selp.b32 %2, %2, 0xFF800000, p2;\n\t"
+            "and.b32 t3, %8, 8;    setp.ne.b32 p3, t3, 0; selp.b32 %3, %3, 0xFF800000, p3;\n\t"
+            "and.b32 t4, %8, 16;   setp.ne.b32 p4, t4, 0; selp.b32 %4, %4, 0xFF800000, p4;\n\t"
+            "and.b32 t5, %8, 32;   setp.ne.b32 p5, t5, 0; selp.b32 %5, %5, 0xFF800000, p5;\n\t"
+            "and.b32 t6, %8, 64;   setp.ne.b32 p6, t6, 0; selp.b32 %6, %6, 0xFF800000, p6;\n\t"
+            "and.b32 t7, %8, 128;  setp.ne.b32 p7, t7, 0; selp.b32 %7, %7, 0xFF800000, p7;\n\t"
+            "}"
+            : "+r"(u[s * 32 + g + 0]), "+r"(u[s * 32 + g + 1]),
+              "+r"(u[s * 32 + g + 2]), "+r"(u[s * 32 + g + 3]),
+              "+r"(u[s * 32 + g + 4]), "+r"(u[s * 32 + g + 5]),
+              "+r"(u[s * 32 + g + 6]), "+r"(u[s * 32 + g + 7])
+            : "r"(kg));
+      }
+    } else {
+      #pragma unroll
+      for (int i = 0; i < 32; ++i)
+        if (!(keep & (1u << i))) scores[s * 32 + i] = -INFINITY;
+    }
+  }
+}
+
+template <int S_LD_COLS = 32, bool FULL_NAMED_BAR = false, bool EX2_EMU = false, bool SPLIT_P = true,
+          bool SOFTMAX_THROTTLE = false, bool USE_CLC = true, bool Q_RASTER = true, bool MHA = false,
+          bool LPT = false, int RESCALE_THRESHOLD = 8, bool HAS_SINK_ROPE_DELTA = false>
+__global__ void __cluster_dims__(1, 1, 1) __launch_bounds__(N_WARPS * 32, 1)
+block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
+    const __grid_constant__ CUtensorMap tmap_k, const __grid_constant__ CUtensorMap tmap_v_t,
+    const __grid_constant__ CUtensorMap tmap_o, const __grid_constant__ CUtensorMap tmap_q_sink,
+    float* __restrict__ lse_out,
+    int seqlen,
+    int num_q_heads, int num_kv_heads, float scale_log2,
+    int packed_mtiles_per_seq, int num_samples,
+    unsigned long long magic0, unsigned long long magic1, unsigned long long magic2,
+    int lpt_swz_log2, int lpt_hb_quot, int lpt_hb_rem,
+    unsigned long long lpt_major_magic, unsigned long long lpt_rem_magic,
+    int tokens_per_block, int sink_tokens, int rolling_window_tokens) {
+  const int gqa_group_size = MHA ? 1 : (num_q_heads / num_kv_heads);
+  const int q_tile_per_mtile = M_TILE / gqa_group_size;
+  const int q_tile_per_cta   = M_TILES_PER_CTA * q_tile_per_mtile;
+  const int total_workitems = num_samples * packed_mtiles_per_seq * num_kv_heads;
+
+  uint8_t* sQ0 = fmha_smem;
+  uint8_t* sQ1 = sQ0 + Q_TILE_BYTES;
+  uint8_t* sQ[2] = { sQ0, sQ1 };
+  uint8_t* sKV = sQ1 + Q_TILE_BYTES;
+  __nv_bfloat16* sO0 = reinterpret_cast<__nv_bfloat16*>(sKV + NUM_KV_STAGES * K_TILE_BYTES);
+  __nv_bfloat16* sO1 = sO0 + M_TILE * HEAD_DIM;
+  __nv_bfloat16* sO_bufs[2] = { sO0, sO1 };
+  uint64_t* full_bar = reinterpret_cast<uint64_t*>(reinterpret_cast<uint8_t*>(sO1) + M_TILE * HEAD_DIM * sizeof(__nv_bfloat16));
+  uint64_t* empty_bar= full_bar + NUM_KV_STAGES;
+  uint64_t* full_bar_q  = empty_bar + NUM_KV_STAGES;
+  uint64_t* empty_bar_q   = full_bar_q + 2;
+  uint64_t* full_bar_spo  = empty_bar_q + 2;
+  uint64_t* empty_bar_spo = full_bar_spo + 2;
+  uint64_t* full_bar_o_acc   = empty_bar_spo + 2;
+  uint64_t* full_bar_alpha = full_bar_o_acc + 2;
+  uint64_t* full_bar_l   = full_bar_alpha + 2;
+  uint64_t* full_bar_p_last    = full_bar_l + 2;
+  uint64_t* empty_bar_alpha_and_l = full_bar_p_last + 2;
+  uint64_t* full_bar_o_epi  = empty_bar_alpha_and_l + 2;
+  uint64_t* empty_bar_o_epi = full_bar_o_epi + 2;
+  uint64_t* clc_full  = empty_bar_o_epi + 2;
+  uint64_t* clc_empty = clc_full + CLC_STAGES;
+  uint32_t* clc_response = reinterpret_cast<uint32_t*>(
+      (reinterpret_cast<uintptr_t>(clc_empty + CLC_STAGES) + 15u) & ~uintptr_t(15u));
+
+  uint32_t* tmem_slot = clc_response + CLC_STAGES * 4;
+  float* alpha_and_l_smem = reinterpret_cast<float*>(tmem_slot + 2);
+
+  const int tid = threadIdx.x, warp_id = tid >> 5, lane = tid & 31;
+
+  if (warp_id == 0) {
+    tcgen05_alloc<1>(smem_ptr_u32(tmem_slot), TMEM_TOTAL);
+    tcgen05_relinquish_alloc_permit<1>();
+  }
+  __syncthreads();
+  if (*tmem_slot != 0u) __trap();
+  const uint32_t tmem_base = 0u;
+
+  const int packed_mtiles_per_sample = packed_mtiles_per_seq * num_kv_heads;
+  if (tid == 0) {
+    #pragma unroll
+    for (int s = 0; s < NUM_KV_STAGES; ++s) {
+      mbarrier_init(smem_ptr_u32(&full_bar[s]), 1);
+      mbarrier_init(smem_ptr_u32(&empty_bar[s]), 1);
+    }
+    for (int i = 0; i < 2; ++i) {
+      mbarrier_init(smem_ptr_u32(&full_bar_q[i]), 1);
+      mbarrier_init(smem_ptr_u32(&empty_bar_q[i]), 1);
+      mbarrier_init(smem_ptr_u32(&full_bar_l[i]), 128);
+      mbarrier_init(smem_ptr_u32(&full_bar_spo[i]), 1);
+      mbarrier_init(smem_ptr_u32(&empty_bar_spo[i]), 256);
+      mbarrier_init(smem_ptr_u32(&full_bar_o_acc[i]), 1);
+      mbarrier_init(smem_ptr_u32(&full_bar_alpha[i]), 128);
+      mbarrier_init(smem_ptr_u32(&empty_bar_alpha_and_l[i]), 128);
+      mbarrier_init(smem_ptr_u32(&full_bar_p_last[i]), 128);
+      mbarrier_init(smem_ptr_u32(&full_bar_o_epi[i]), 128);
+      mbarrier_init(smem_ptr_u32(&empty_bar_o_epi[i]), 1);
+    }
+    if constexpr (USE_CLC) {
+      #pragma unroll
+      for (int s = 0; s < CLC_STAGES; ++s) {
+        mbarrier_init(smem_ptr_u32(&clc_full[s]), 1);
+        mbarrier_init(smem_ptr_u32(&clc_empty[s]), N_WARPS);
+      }
+      #pragma unroll
+      for (int i = 0; i < CLC_STAGES * 4; ++i)
+        clc_response[i] = 0;
+    }
+  }
+  fence_mbarrier_init_release_cluster();
+  __syncthreads();
+
+  if (warp_id == W_LOAD) {
+    setmaxnreg_dec<48>();
+
+    EmptyPhaseTracker<NUM_KV_STAGES> kv_empty_ph;
+    EmptyPhaseTracker<1> q_empty_ph;
+    [[maybe_unused]] int clc_stage = 0;
+    [[maybe_unused]] uint32_t clc_phase = 0;
+    int workitem_id = (int)blockIdx.x;
+    while (true) {
+      int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
+          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
+          magic0, magic1, magic2,
+          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
+          tokens_per_block, rolling_window_tokens, sink_tokens,
+          sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
+      const int k_start = sample * seqlen;
+
+      for (int k = 0; k < K_TILES; ++k) {
+        const int k_tile_offset = tile_for_processing(k, window_tiles, window_hi_tile, K_TILES) * K_TILE;
+
+        if constexpr (HAS_SINK_ROPE_DELTA) {
+          if (k == window_tiles) {
+            #pragma unroll
+            for (int m = 0; m < M_TILES_PER_CTA; ++m) {
+              mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_q[m]), q_empty_ph.get_phase());
+              const uint32_t qbar = smem_ptr_u32(&full_bar_q[m]);
+              const int q_token = q_tile_base + m * q_tile_per_mtile;
+              const int q_head  = h_kv * gqa_group_size;
+              if (elect_one_sync()) {
+                mbarrier_arrive_expect_tx(qbar, Q_TILE_BYTES);
+                #pragma unroll
+                for (int s = 0; s < Q_SUBTILES; ++s)
+                  tma_load_4d(smem_ptr_u32(sQ[m] + s * Q_SUB_COLS_BYTES), &tmap_q_sink, qbar,
+                              s * SUB_COLS_BF16, q_head, q_token, sample);
+              }
+            }
+            q_empty_ph.advance();
+          }
+        }
+        int kv_stage = kv_empty_ph.get_stage();
+
+        mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar[kv_stage]), kv_empty_ph.get_phase());
+        kv_empty_ph.advance();
+
+        const uint32_t kbar = smem_ptr_u32(&full_bar[kv_stage]);
+        const uint32_t kdst = smem_ptr_u32(sKV + kv_stage * K_TILE_BYTES);
+        const int      k_token = k_tile_offset;
+        const int      k_head_atom  = sample * num_kv_heads + h_kv;
+        if (elect_one_sync()) {
+          mbarrier_arrive_expect_tx(kbar, K_TILE_BYTES);
+          tma_load_4d(kdst, &tmap_k, kbar, 0, k_token, 0, k_head_atom);
+        }
+
+        if (k == 0) {
+
+          #pragma unroll
+          for (int m = 0; m < M_TILES_PER_CTA; ++m) {
+            mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_q[m]), q_empty_ph.get_phase());
+
+            const uint32_t qbar = smem_ptr_u32(&full_bar_q[m]);
+            const int q_token = q_tile_base + m * q_tile_per_mtile;
+            const int q_head  = h_kv * gqa_group_size;
+
+            if (elect_one_sync()) {
+              mbarrier_arrive_expect_tx(qbar, Q_TILE_BYTES);
+              #pragma unroll
+              for (int s = 0; s < Q_SUBTILES; ++s) {
+                tma_load_4d(smem_ptr_u32(sQ[m] + s * Q_SUB_COLS_BYTES), &tmap_q, qbar,
+                            s * SUB_COLS_BF16, q_head, q_token, sample);
+              }
+            }
+          }
+          q_empty_ph.advance();
+          }
+        kv_stage = kv_empty_ph.get_stage();
+
+        mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar[kv_stage]), kv_empty_ph.get_phase());
+        kv_empty_ph.advance();
+
+        const uint32_t vbar = smem_ptr_u32(&full_bar[kv_stage]);
+        const uint32_t vdst = smem_ptr_u32(sKV + kv_stage * K_TILE_BYTES);
+        const int      v_token = k_tile_offset;
+        const int      v_head_col = sample * num_kv_heads + h_kv;
+        if (elect_one_sync()) {
+          mbarrier_arrive_expect_tx(vbar, V_TILE_BYTES);
+
+          tma_load_4d(vdst, &tmap_v_t, vbar, 0, v_token, 0, v_head_col);
+        }
+      }
+      if constexpr (USE_CLC) {
+        ClcTileInfo next = clc_fetch_next_tile<1, 1, ClcRasterOrder::AlongN, 1, true>(
+            clc_full, clc_empty, clc_response, clc_stage, clc_phase, elect_one_sync());
+        clc_fetch_next_tile_advance<CLC_STAGES>(clc_stage, clc_phase);
+        if (!next.valid) break;
+        workitem_id = next.n_tile;
+      } else {
+        workitem_id += gridDim.x;
+        if (workitem_id >= total_workitems) break;
+      }
+    }
+  }
+  else if (warp_id == W_MMA) {
+    setmaxnreg_dec<48>();
+
+    const uint32_t lead = elect_one_sync() ? 1u : 0u;
+    constexpr uint32_t DESC_SBO = 1024, DESC_LBO = 16;
+
+    const uint32_t idesc_qk = make_idesc_bf16_f32(M_TILE, K_TILE, false, false);
+    const uint32_t idesc_pv = make_idesc_bf16_f32(M_TILE, HEAD_DIM,  false, true);
+    const uint64_t desc_q0  = build_smem_desc_blackwell(smem_ptr_u32(sQ0), DESC_SBO, DESC_LBO, SmemSwizzleBlackwell::B128);
+    const uint64_t desc_kv0 = build_smem_desc_blackwell(smem_ptr_u32(sKV), DESC_SBO, DESC_LBO, SmemSwizzleBlackwell::B128);
+
+    constexpr uint32_t DESC_LBO_MN = (uint32_t)(K_TILE * SUB_COLS_BF16 * 2);
+    const uint64_t desc_v0 = build_smem_desc_blackwell(smem_ptr_u32(sKV), DESC_SBO, DESC_LBO_MN, SmemSwizzleBlackwell::B128);
+    constexpr int      PV_K_STEPS   = HEAD_DIM / 16;
+    constexpr uint32_t PV_DESC_STEP = (uint32_t)((16 * SUB_COLS_BF16 * 2) >> 4);
+
+    constexpr uint64_t KV_DESC_DELTA      = K_TILE_BYTES >> 4;
+    constexpr uint64_t SUB_DESC_DELTA     = Q_SUB_COLS_BYTES >> 4;
+    constexpr uint64_t Q_MTILE_DESC_DELTA = Q_TILE_BYTES >> 4;
+
+    PhaseTracker<NUM_KV_STAGES> kv_ph;
+    PhaseTracker<1> q_ph;
+    PhaseTracker<1> spo_ph;
+    [[maybe_unused]] int clc_stage = 0;
+    [[maybe_unused]] uint32_t clc_phase = 0;
+    int workitem_id = (int)blockIdx.x;
+    while (true) {
+      int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
+          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
+          magic0, magic1, magic2,
+          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
+          tokens_per_block, rolling_window_tokens, sink_tokens,
+          sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
+
+      int kv_stage = kv_ph.get_stage();
+
+      mbarrier_wait_parity(smem_ptr_u32(&full_bar[kv_stage]), kv_ph.get_phase());
+      kv_ph.advance();
+      #pragma unroll
+      for (int i = 0; i < M_TILES_PER_CTA; ++i) {
+        mbarrier_wait_parity(smem_ptr_u32(&full_bar_q[i]), q_ph.get_phase());
+
+        {
+          const uint32_t s_tmem_addr = tmem_base + (uint32_t)(i * S_COLS);
+          SmemDescPair desc_a, desc_b;
+          desc_a.u64 = desc_q0;  desc_a.w.x += (uint32_t)(i * (int)Q_MTILE_DESC_DELTA);
+          desc_b.u64 = desc_kv0; desc_b.w.x += (uint32_t)(kv_stage * (int)KV_DESC_DELTA);
+
+          #pragma unroll
+          for (int s = 0; s < Q_SUBTILES; ++s) {
+            #pragma unroll
+            for (int ki = 0; ki < K_ATOMS_PER_TILE; ++ki) {
+              const bool enable_d = (s != 0) || (ki != 0);
+              tcgen05_mma_f16_ss_lead(lead, s_tmem_addr, desc_a.u64, desc_b.u64, idesc_qk, enable_d);
+              desc_add_lo(desc_a, 2); desc_add_lo(desc_b, 2);
+            }
+            desc_add_lo(desc_a, (uint32_t)(SUB_DESC_DELTA - 2 * K_ATOMS_PER_TILE));
+            desc_add_lo(desc_b, (uint32_t)(SUB_DESC_DELTA - 2 * K_ATOMS_PER_TILE));
+          }
+        }
+
+        tcgen05_commit1_lead(lead, smem_ptr_u32(&full_bar_spo[i]));
+      }
+
+      tcgen05_commit1_lead(lead, smem_ptr_u32(&empty_bar[kv_stage]));
+
+      for (int k_tile_id = 0; k_tile_id < K_TILES - 1; ++k_tile_id) {
+
+        const int kv_stage = kv_ph.get_stage();
+
+        mbarrier_wait_parity(smem_ptr_u32(&full_bar[kv_stage]), kv_ph.get_phase());
+        kv_ph.advance();
+
+        if constexpr (HAS_SINK_ROPE_DELTA) {
+          if (k_tile_id == window_tiles - 1) {
+            #pragma unroll
+            for (int i = 0; i < M_TILES_PER_CTA; ++i)
+              tcgen05_commit1_lead(lead, smem_ptr_u32(&empty_bar_q[i]));
+            q_ph.advance();
+            #pragma unroll
+            for (int i = 0; i < M_TILES_PER_CTA; ++i)
+              mbarrier_wait_parity(smem_ptr_u32(&full_bar_q[i]), q_ph.get_phase());
+          }
+        }
+
+        int kv_stage_next = 0;
+        #pragma unroll
+        for (int i = 0; i < M_TILES_PER_CTA; ++i) {
+          mbarrier_wait_parity(smem_ptr_u32(&empty_bar_spo[i]), spo_ph.get_phase());
+
+          const uint32_t s_tmem_addr = tmem_base + (uint32_t)(i * S_COLS);
+          const uint32_t o_tmem_addr = tmem_base + (uint32_t)(2 * S_COLS + i * O_COLS);
+          SmemDescPair desc_bv;
+          desc_bv.u64 = desc_v0;
+          desc_bv.w.x += (uint32_t)(kv_stage * (int)KV_DESC_DELTA);
+
+          {
+            #pragma unroll
+            for (int a = 0; a < PV_K_STEPS; ++a) {
+              if constexpr (SPLIT_P) if (a == SPLIT_P_ATOM) {
+                mbarrier_wait_parity(smem_ptr_u32(&full_bar_p_last[i]), spo_ph.get_phase());
+              }
+              const bool accumulate = (k_tile_id != 0) || (a != 0);
+              tcgen05_mma_f16_ts_1sm_lead(lead, o_tmem_addr, s_tmem_addr + (uint32_t)(a * 8), desc_bv.u64, idesc_pv, accumulate);
+              desc_add_lo(desc_bv, PV_DESC_STEP);
+            }
+          }
+
+          if (i == 0) {
+            kv_stage_next = kv_ph.get_stage();
+            mbarrier_wait_parity(smem_ptr_u32(&full_bar[kv_stage_next]), kv_ph.get_phase());
+            kv_ph.advance();
+          }
+
+          if (i == M_TILES_PER_CTA - 1) {
+            tcgen05_commit1_lead(lead, smem_ptr_u32(&empty_bar[kv_stage]));
+          }
+
+          {
+            SmemDescPair desc_a, desc_b;
+            desc_a.u64 = desc_q0;  desc_a.w.x += (uint32_t)(i * (int)Q_MTILE_DESC_DELTA);
+            desc_b.u64 = desc_kv0; desc_b.w.x += (uint32_t)(kv_stage_next * (int)KV_DESC_DELTA);
+            #pragma unroll
+            for (int s = 0; s < Q_SUBTILES; ++s) {
+              #pragma unroll
+              for (int ki = 0; ki < K_ATOMS_PER_TILE; ++ki) {
+                const bool enable_d = (s != 0) || (ki != 0);
+                tcgen05_mma_f16_ss_lead(lead, s_tmem_addr, desc_a.u64, desc_b.u64, idesc_qk, enable_d);
+                desc_add_lo(desc_a, 2); desc_add_lo(desc_b, 2);
+              }
+              desc_add_lo(desc_a, (uint32_t)(SUB_DESC_DELTA - 2 * K_ATOMS_PER_TILE));
+              desc_add_lo(desc_b, (uint32_t)(SUB_DESC_DELTA - 2 * K_ATOMS_PER_TILE));
+            }
+          }
+
+          tcgen05_commit1_lead(lead, smem_ptr_u32(&full_bar_spo[i]));
+        }
+        tcgen05_commit1_lead(lead, smem_ptr_u32(&empty_bar[kv_stage_next]));
+
+        spo_ph.advance();
+      }
+
+      #pragma unroll
+      for (int i = 0; i < M_TILES_PER_CTA; ++i) {
+        tcgen05_commit1_lead(lead, smem_ptr_u32(&empty_bar_q[i]));
+      }
+
+      kv_stage = kv_ph.get_stage();
+
+      mbarrier_wait_parity(smem_ptr_u32(&full_bar[kv_stage]), kv_ph.get_phase());
+      kv_ph.advance();
+
+      #pragma unroll
+      for (int i = 0; i < M_TILES_PER_CTA; ++i) {
+        mbarrier_wait_parity(smem_ptr_u32(&empty_bar_spo[i]), spo_ph.get_phase());
+
+        const uint32_t s_tmem_addr = tmem_base + (uint32_t)(i * S_COLS);
+        const uint32_t o_tmem_addr = tmem_base + (uint32_t)(2 * S_COLS + i * O_COLS);
+        SmemDescPair desc_bv;
+        desc_bv.u64 = desc_v0;
+        desc_bv.w.x += (uint32_t)(kv_stage * (int)KV_DESC_DELTA);
+
+        {
+          #pragma unroll
+          for (int a = 0; a < PV_K_STEPS; ++a) {
+            if constexpr (SPLIT_P) if (a == SPLIT_P_ATOM) {
+              mbarrier_wait_parity(smem_ptr_u32(&full_bar_p_last[i]), spo_ph.get_phase());
+            }
+            const bool accumulate = (K_TILES != 1) || (a != 0);
+            tcgen05_mma_f16_ts_1sm_lead(lead, o_tmem_addr, s_tmem_addr + (uint32_t)(a * 8), desc_bv.u64, idesc_pv, accumulate);
+            desc_add_lo(desc_bv, PV_DESC_STEP);
+          }
+        }
+
+        tcgen05_commit1_lead(lead, smem_ptr_u32(&full_bar_o_acc[i]));
+      }
+      tcgen05_commit1_lead(lead, smem_ptr_u32(&empty_bar[kv_stage]));
+
+      spo_ph.advance();
+      q_ph.advance();
+
+      if constexpr (USE_CLC) {
+        ClcTileInfo next = clc_fetch_next_tile<1, 1, ClcRasterOrder::AlongN, 1, true>(
+            clc_full, clc_empty, clc_response, clc_stage, clc_phase, elect_one_sync());
+        clc_fetch_next_tile_advance<CLC_STAGES>(clc_stage, clc_phase);
+        if (!next.valid) break;
+        workitem_id = next.n_tile;
+      } else {
+        workitem_id += gridDim.x;
+        if (workitem_id >= total_workitems) break;
+      }
+    }
+  }
+  else if (warp_id == W_EPI) {
+    setmaxnreg_dec<48>();
+
+    PhaseTracker<1> full_o_ph;
+
+    if (elect_one_sync()) {
+      #pragma unroll
+      for (int m = 0; m < M_TILES_PER_CTA; ++m)
+        mbarrier_arrive(smem_ptr_u32(&empty_bar_o_epi[m]));
+    }
+    [[maybe_unused]] int clc_stage = 0;
+    [[maybe_unused]] uint32_t clc_phase = 0;
+    int workitem_id = (int)blockIdx.x;
+    while (true) {
+      int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
+          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
+          magic0, magic1, magic2,
+          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
+          tokens_per_block, rolling_window_tokens, sink_tokens,
+          sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
+
+      #pragma unroll
+      for (int m = 0; m < M_TILES_PER_CTA; ++m) {
+        mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_o_epi[m]), full_o_ph.get_phase());
+
+        if (elect_one_sync()) {
+          const int q_token = q_tile_base + m * q_tile_per_mtile;
+
+          #pragma unroll
+          for (int s = 0; s < Q_SUBTILES; ++s) {
+            tma_store_4d(&tmap_o, s * SUB_COLS_BF16, h_kv * gqa_group_size, q_token, sample,
+                         smem_ptr_u32(reinterpret_cast<const uint8_t*>(sO_bufs[m]) + s * Q_SUB_COLS_BYTES));
+          }
+          cp_async_bulk_commit_group();
+        }
+      }
+
+      if (elect_one_sync()) {
+        cp_async_bulk_wait_group_read<1>();
+        mbarrier_arrive(smem_ptr_u32(&empty_bar_o_epi[0]));
+        cp_async_bulk_wait_group_read<0>();
+        mbarrier_arrive(smem_ptr_u32(&empty_bar_o_epi[1]));
+      }
+
+      full_o_ph.advance();
+      if constexpr (USE_CLC) {
+        ClcTileInfo next = clc_fetch_next_tile<1, 1, ClcRasterOrder::AlongN, 1, true>(
+            clc_full, clc_empty, clc_response, clc_stage, clc_phase, elect_one_sync());
+        clc_fetch_next_tile_advance<CLC_STAGES>(clc_stage, clc_phase);
+        if (!next.valid) break;
+        workitem_id = next.n_tile;
+      } else {
+        workitem_id += gridDim.x;
+        if (workitem_id >= total_workitems) break;
+      }
+    }
+  }
+  else if (warp_id == W_SCHED) {
+    setmaxnreg_dec<48>();
+
+    if constexpr (USE_CLC) {
+      int prod_stage = 0; uint32_t prod_phase = 1;
+      int cons_stage = 0; uint32_t cons_phase = 0;
+      while (true) {
+        if (lane == 0)
+          mbarrier_wait_parity_suspend(smem_ptr_u32(&clc_empty[prod_stage]), prod_phase);
+        __syncwarp();
+        clc_arrive_expect_tx_cta(smem_ptr_u32(&clc_full[prod_stage]), 16);
+        if (lane == 0)
+          clc_try_cancel_async(smem_ptr_u32(&clc_response[prod_stage * 4]),
+                               smem_ptr_u32(&clc_full[prod_stage]));
+        advance_stage_phase<CLC_STAGES>(prod_stage, prod_phase);
+        ClcTileInfo next = clc_fetch_next_tile<1, 1, ClcRasterOrder::AlongN, 1, true>(
+            clc_full, clc_empty, clc_response, cons_stage, cons_phase, elect_one_sync());
+        clc_fetch_next_tile_advance<CLC_STAGES>(cons_stage, cons_phase);
+        if (!next.valid) break;
+      }
+
+      for (int s = 0; s < CLC_STAGES; ++s) {
+        if (lane == 0)
+          mbarrier_wait_parity_suspend(smem_ptr_u32(&clc_empty[prod_stage]), prod_phase);
+        __syncwarp();
+        advance_stage_phase<CLC_STAGES>(prod_stage, prod_phase);
+      }
+    }
+  }
+  else if (warp_id >= W_CORR0 && warp_id < W_MMA) {
+    setmaxnreg_dec<80>();
+
+    const int corr_warp_id = warp_id - W_CORR0;
+    [[maybe_unused]] PhaseTracker<1> alpha_ph;
+    PhaseTracker<1> o_acc_ph;
+    PhaseTracker<1> o_epi_empty_ph;
+    [[maybe_unused]] int clc_stage = 0;
+    [[maybe_unused]] uint32_t clc_phase = 0;
+
+    #pragma unroll
+    for (int i = 0; i < M_TILES_PER_CTA; ++i) {
+      mbarrier_arrive(smem_ptr_u32(&empty_bar_spo[i]));
+      mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[i]));
+    }
+
+    int workitem_id = (int)blockIdx.x;
+    while (true) {
+      int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
+          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
+          magic0, magic1, magic2,
+          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
+          tokens_per_block, rolling_window_tokens, sink_tokens,
+          sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
+
+      #pragma unroll
+      for (int i = 0; i < M_TILES_PER_CTA; ++i) {
+        if constexpr (FULL_NAMED_BAR) full_bar_wait(i, corr_warp_id);
+        else mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_alpha[i]), alpha_ph.get_phase());
+
+        if constexpr (SOFTMAX_THROTTLE) {
+          if (i == 0) mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[0]));
+        } else {
+          mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[i]));
+        }
+      }
+      if constexpr (!FULL_NAMED_BAR) alpha_ph.advance();
+
+      for (int k = 1; k < K_TILES; ++k) {
+        #pragma unroll
+        for (int i = 0; i < M_TILES_PER_CTA; ++i) {
+          if constexpr (FULL_NAMED_BAR) full_bar_wait(i, corr_warp_id);
+          else mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_alpha[i]), alpha_ph.get_phase());
+
+          float alpha = alpha_and_l_smem[i * M_TILE + corr_warp_id * 32 + lane];
+          if constexpr (!SOFTMAX_THROTTLE) mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[i]));
+
+          bool skip = __all_sync(0xffffffffu, alpha == 1.0f);
+          if (!skip) {
+
+            const uint32_t o_tmem_addr = tmem_base + (uint32_t)(2 * S_COLS + i * O_COLS) + ((uint32_t)(corr_warp_id * 32) << 16);
+
+            const float2 alpha2 = f32x2_splat(alpha);
+
+            #pragma unroll
+            for (int c0 = 0; c0 < HEAD_DIM; c0 += 16) {
+              uint32_t o_regs[16];
+              tcgen05_ld_32x32b_x16(o_tmem_addr + (uint32_t)c0, o_regs);
+              float2* o2 = reinterpret_cast<float2*>(o_regs);
+              #pragma unroll
+              for (int e = 0; e < 8; ++e) o2[e] = fmul2(o2[e], alpha2);
+              tcgen05_st_32x32b_x16(o_tmem_addr + (uint32_t)c0, o_regs);
+            }
+            tcgen05_wait_st();
+
+            tcgen05_fence_before_thread_sync();
+          }
+
+          if constexpr (SOFTMAX_THROTTLE) mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[M_TILES_PER_CTA - 1 - i]));
+          mbarrier_arrive(smem_ptr_u32(&empty_bar_spo[i]));
+        }
+        if constexpr (!FULL_NAMED_BAR) alpha_ph.advance();
+      }
+
+      if constexpr (SOFTMAX_THROTTLE) mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[M_TILES_PER_CTA - 1]));
+
+      #pragma unroll
+      for (int i = 0; i < M_TILES_PER_CTA; ++i) {
+        mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_o_acc[i]), o_acc_ph.get_phase());
+
+        if constexpr (FULL_NAMED_BAR) full_bar_wait(i, corr_warp_id);
+        else mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_l[i]), o_acc_ph.get_phase());
+
+        const int corr_tid = corr_warp_id * 32 + lane;
+        float l = alpha_and_l_smem[i * M_TILE + corr_tid];
+        mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[i]));
+        float inv_l = (l > 0.f) ? rcp_approx_ftz_f32(l) : 0.f;
+        const float2 inv_l2 = f32x2_splat(inv_l);
+        const uint32_t o_tmem_addr = tmem_base + (uint32_t)(2 * S_COLS + i * O_COLS) + ((uint32_t)(corr_warp_id * 32) << 16);
+        #pragma unroll
+        for (int c0 = 0; c0 < HEAD_DIM; c0 += 16) {
+          uint32_t o_regs[16];
+          tcgen05_ld_32x32b_x16(o_tmem_addr + (uint32_t)c0, o_regs);
+          if (c0 == 0) mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_o_epi[i]), o_epi_empty_ph.get_phase());
+          float2* o2 = reinterpret_cast<float2*>(o_regs);
+          const int s = c0 / SUB_COLS_BF16;
+          const int v_base = (c0 % SUB_COLS_BF16) / 8;
+          __nv_bfloat16* so_sub = sO_bufs[i] + s * (M_TILE * SUB_COLS_BF16);
+          #pragma unroll
+          for (int vv = 0; vv < 2; ++vv) {
+            const int v = v_base + vv;
+            const float2 r0 = fmul2(o2[vv * 4 + 0], inv_l2);
+            const float2 r1 = fmul2(o2[vv * 4 + 1], inv_l2);
+            const float2 r2 = fmul2(o2[vv * 4 + 2], inv_l2);
+            const float2 r3 = fmul2(o2[vv * 4 + 3], inv_l2);
+            uint4 packed;
+            packed.x = cvt_f32x2_to_bf16x2(r0.x, r0.y);
+            packed.y = cvt_f32x2_to_bf16x2(r1.x, r1.y);
+            packed.z = cvt_f32x2_to_bf16x2(r2.x, r2.y);
+            packed.w = cvt_f32x2_to_bf16x2(r3.x, r3.y);
+            *reinterpret_cast<uint4*>(&so_sub[corr_tid * SUB_COLS_BF16 + (v ^ (corr_tid & 7)) * 8]) = packed;
+          }
+        }
+
+        tcgen05_fence_before_thread_sync();
+
+        mbarrier_arrive(smem_ptr_u32(&empty_bar_spo[i]));
+
+        fence_proxy_async_shared();
+
+        mbarrier_arrive(smem_ptr_u32(&full_bar_o_epi[i]));
+      }
+      o_acc_ph.advance();
+      o_epi_empty_ph.advance();
+
+      if constexpr (USE_CLC) {
+        ClcTileInfo next = clc_fetch_next_tile<1, 1, ClcRasterOrder::AlongN, 1, true>(
+            clc_full, clc_empty, clc_response, clc_stage, clc_phase, elect_one_sync());
+        clc_fetch_next_tile_advance<CLC_STAGES>(clc_stage, clc_phase);
+        if (!next.valid) break;
+        workitem_id = next.n_tile;
+      } else {
+        workitem_id += gridDim.x;
+        if (workitem_id >= total_workitems) break;
+      }
+    }
+  }
+  else {
+    setmaxnreg_inc<192>();
+
+    const int warp_id_u = __shfl_sync(0xffffffffu, warp_id, 0);
+    const int m_tile = warp_id_u < 4 ? 0 : 1;
+    const int warp_in_group = warp_id_u & 3;
+    const int row_in_m_tile = warp_in_group * 32 + lane;
+    const uint32_t s_tmem_addr = tmem_base + (uint32_t)(m_tile * S_COLS) + ((uint32_t)(warp_in_group * 32) << 16);
+    PhaseTracker<1> spo_ph;
+    PhaseTracker<1> scale_empty_ph;
+    [[maybe_unused]] int clc_stage = 0;
+    [[maybe_unused]] uint32_t clc_phase = 0;
+    int workitem_id = (int)blockIdx.x;
+    while (true) {
+      int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
+          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
+          magic0, magic1, magic2,
+          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
+          tokens_per_block, rolling_window_tokens, sink_tokens,
+          sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
+
+      const int q_pos = q_tile_base + m_tile * q_tile_per_mtile + row_in_m_tile / gqa_group_size;
+
+      int block_end_in_tokens = (q_pos / tokens_per_block + 1) * tokens_per_block;
+      int window_start_in_tokens = block_end_in_tokens - rolling_window_tokens;
+      if (window_start_in_tokens < 0) window_start_in_tokens = 0;
+      if (block_end_in_tokens > seqlen) block_end_in_tokens = seqlen;
+
+      const int cta_last_q = q_tile_base + q_tile_per_cta - 1;
+      int cta_min_block_end = (q_tile_base / tokens_per_block + 1) * tokens_per_block;
+      if (cta_min_block_end > seqlen) cta_min_block_end = seqlen;
+      int cta_max_window_start = ((cta_last_q  / tokens_per_block + 1) * tokens_per_block) - rolling_window_tokens;
+      if (cta_max_window_start < 0) cta_max_window_start = 0;
+
+      const int lo_tile = window_hi_tile - window_tiles;
+      int bottom_mask_bound = cta_max_window_start;
+      if constexpr (HAS_SINK_ROPE_DELTA) bottom_mask_bound = max(bottom_mask_bound, sink_tokens);
+      int masked_top_tiles    = window_hi_tile - cta_min_block_end / K_TILE;
+      int masked_bottom_tiles = (bottom_mask_bound + K_TILE - 1) / K_TILE - lo_tile;
+      masked_top_tiles    = masked_top_tiles    < 0 ? 0 : (masked_top_tiles    > window_tiles ? window_tiles : masked_top_tiles);
+      masked_bottom_tiles = masked_bottom_tiles < 0 ? 0 : (masked_bottom_tiles > window_tiles ? window_tiles : masked_bottom_tiles);
+      const int interior_begin = masked_top_tiles;
+      int interior_end = window_tiles - masked_bottom_tiles;
+      if (interior_end < interior_begin) interior_end = interior_begin;
+
+      float m_run = -INFINITY, l_run = 0.f;
+      mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_alpha_and_l[m_tile]), scale_empty_ph.get_phase());
+      scale_empty_ph.advance();
+      float* const alpha_slot = &alpha_and_l_smem[m_tile * M_TILE + row_in_m_tile];
+      const uint32_t alpha_slot_u32 = smem_ptr_u32(alpha_slot);
+
+      auto softmax_step = [&](auto masked_c, auto is_first_c, int k) {
+        constexpr bool MASKED   = decltype(masked_c)::value;
+        constexpr bool IS_FIRST = decltype(is_first_c)::value;
+
+        const int k_tile_offset = tile_for_processing(k, window_tiles, window_hi_tile, K_TILES) * K_TILE;
+
+        mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_spo[m_tile]), spo_ph.get_phase());
+
+        uint32_t s_regs[K_TILE];
+        #pragma unroll
+        for (int c0 = 0; c0 < K_TILE; c0 += S_LD_COLS) {
+          const uint32_t taddr = s_tmem_addr + (uint32_t)c0;
+          if      constexpr (S_LD_COLS == 32)  tcgen05_ld_32x32b_x32 (taddr, *reinterpret_cast<uint32_t(*)[32]>(&s_regs[c0]));
+          else if constexpr (S_LD_COLS == 64)  tcgen05_ld_32x32b_x64 (taddr, *reinterpret_cast<uint32_t(*)[64]>(&s_regs[c0]));
+          else if constexpr (S_LD_COLS == 128) tcgen05_ld_32x32b_x128(taddr, *reinterpret_cast<uint32_t(*)[128]>(&s_regs[c0]));
+        }
+        float* scores = reinterpret_cast<float*>(s_regs);
+        float2* scores2 = reinterpret_cast<float2*>(s_regs);
+
+        tcgen05_fence_before_thread_sync();
+
+        if constexpr (MASKED) {
+
+          const bool is_sink_tile = (k >= window_tiles);
+          int effective_sink_tokens = sink_tokens;
+          int effective_window_start = window_start_in_tokens;
+          if constexpr (HAS_SINK_ROPE_DELTA) {
+
+            if (is_sink_tile) {
+
+              effective_window_start = block_end_in_tokens;
+            } else {
+
+              effective_sink_tokens = 0;
+              effective_window_start = max(window_start_in_tokens, sink_tokens);
+            }
+          }
+
+          mask_s_row_block_causal_sink<K_TILE>(scores, k_tile_offset, block_end_in_tokens,
+                                 effective_sink_tokens, effective_window_start);
+        }
+
+        float rmax0 = m_run, rmax1 = -INFINITY, rmax2 = -INFINITY, rmax3 = -INFINITY;
+        #pragma unroll
+        for (int j = 0; j < K_TILE; j += 8) {
+          rmax0 = fmaxf(fmaxf(rmax0, scores[j + 0]), scores[j + 1]);
+          rmax1 = fmaxf(fmaxf(rmax1, scores[j + 2]), scores[j + 3]);
+          rmax2 = fmaxf(fmaxf(rmax2, scores[j + 4]), scores[j + 5]);
+          rmax3 = fmaxf(fmaxf(rmax3, scores[j + 6]), scores[j + 7]);
+        }
+        float new_m = fmaxf(fmaxf(rmax0, rmax1), fmaxf(rmax2, rmax3));
+
+        float row_max_safe = (new_m == -INFINITY) ? 0.0f : new_m;
+        float alpha = 0.0f;
+        if constexpr (!IS_FIRST) {
+          const float acc_scale_ = (m_run - row_max_safe) * scale_log2;
+          alpha = ex2_approx_f32(acc_scale_);
+          if (acc_scale_ >= -(float)RESCALE_THRESHOLD) {
+            new_m = m_run;
+            row_max_safe = m_run;
+            alpha = 1.0f;
+          }
+
+          sts_f32(alpha_slot_u32, alpha);
+        }
+        if constexpr (FULL_NAMED_BAR) full_bar_arrive(m_tile, warp_in_group);
+        else mbarrier_arrive(smem_ptr_u32(&full_bar_alpha[m_tile]));
+
+        const float2 scale2        = f32x2_splat(scale_log2);
+        const float2 neg_m_scaled2 = f32x2_splat(-row_max_safe * scale_log2);
+        uint32_t p_regs[K_TILE / 2];
+
+        #pragma unroll
+        for (int c = 0; c < K_TILE / 2; ++c) {
+          const float2 a2 = ffma2(scores2[c], scale2, neg_m_scaled2);
+          if constexpr (EX2_EMU) {
+            const int jj = c / EX2_FRG_PAIRS;
+            const int kk = 2 * (c % EX2_FRG_PAIRS);
+            constexpr int EX2_FREQ = 16;
+            const bool use_hw = (kk % EX2_FREQ < EX2_FREQ - EX2_RES) || (jj >= EX2_FRG_CNT - 1) || (jj < EX2_START_FRG);
+            scores2[c] = use_hw ? make_float2(ex2_approx_f32(a2.x), ex2_approx_f32(a2.y)) : ex2_emu_f32x2(a2.x, a2.y);
+          } else {
+            scores2[c] = make_float2(ex2_approx_f32(a2.x), ex2_approx_f32(a2.y));
+          }
+          p_regs[c] = cvt_f32x2_to_bf16x2(scores2[c].x, scores2[c].y);
+        }
+        const uint32_t p_tmem_addr = s_tmem_addr;
+
+        if constexpr (SPLIT_P) {
+          tcgen05_st_32x32b_x32(p_tmem_addr, *reinterpret_cast<uint32_t(*)[32]>(&p_regs[0]));
+          tcgen05_st_32x32b_x16(p_tmem_addr + 32, *reinterpret_cast<uint32_t(*)[16]>(&p_regs[32]));
+
+          tcgen05_wait_st();
+          tcgen05_fence_before_thread_sync();
+          mbarrier_arrive(smem_ptr_u32(&empty_bar_spo[m_tile]));
+          tcgen05_st_32x32b_x16(p_tmem_addr + SPLIT_P_COL, *reinterpret_cast<uint32_t(*)[16]>(&p_regs[SPLIT_P_COL]));
+          tcgen05_wait_st();
+          tcgen05_fence_before_thread_sync();
+          mbarrier_arrive(smem_ptr_u32(&full_bar_p_last[m_tile]));
+        } else {
+          tcgen05_st_32x32b_x32(p_tmem_addr, *reinterpret_cast<uint32_t(*)[32]>(&p_regs[0]));
+          tcgen05_st_32x32b_x32(p_tmem_addr + 32, *reinterpret_cast<uint32_t(*)[32]>(&p_regs[32]));
+          tcgen05_wait_st();
+          tcgen05_fence_before_thread_sync();
+          mbarrier_arrive(smem_ptr_u32(&empty_bar_spo[m_tile]));
+        }
+        spo_ph.advance();
+        mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_alpha_and_l[m_tile]), scale_empty_ph.get_phase());
+        scale_empty_ph.advance();
+
+        float2 lt2a = make_float2(IS_FIRST ? 0.0f : l_run * alpha, 0.0f);
+        float2 lt2b = make_float2(0.f, 0.f), lt2c = make_float2(0.f, 0.f), lt2d = make_float2(0.f, 0.f);
+        #pragma unroll
+        for (int c = 0; c < K_TILE / 2; c += 4) {
+          lt2a = fadd2(lt2a, scores2[c + 0]);
+          lt2b = fadd2(lt2b, scores2[c + 1]);
+          lt2c = fadd2(lt2c, scores2[c + 2]);
+          lt2d = fadd2(lt2d, scores2[c + 3]);
+        }
+        const float2 lt2 = fadd2(fadd2(lt2a, lt2b), fadd2(lt2c, lt2d));
+        l_run = lt2.x + lt2.y;
+        m_run = new_m;
+      };
+
+      const bool first_masked = !(window_tiles > 0 && interior_begin == 0 && interior_end > 0);
+      if (first_masked) softmax_step(std::true_type{},  std::true_type{}, 0);
+      else              softmax_step(std::false_type{}, std::true_type{}, 0);
+      int k = 1;
+      if (window_tiles > 0) {
+        for (; k < interior_begin; ++k) softmax_step(std::true_type{},  std::false_type{}, k);
+        for (; k < interior_end;   ++k) softmax_step(std::false_type{}, std::false_type{}, k);
+        for (; k < window_tiles;   ++k) softmax_step(std::true_type{},  std::false_type{}, k);
+        if (window_tiles < K_TILES) { softmax_step(std::true_type{}, std::false_type{}, window_tiles); ++k; }
+      }
+      for (; k < K_TILES; ++k)          softmax_step(std::false_type{}, std::false_type{}, k);
+
+      if (lse_out != nullptr) {
+        const int q_head = h_kv * gqa_group_size + (gqa_group_size == 1 ? 0 : row_in_m_tile % gqa_group_size);
+        if (q_pos < seqlen) {
+          const float l_safe = (l_run > 0.f) ? l_run : 1.0f;
+          lse_out[((long)sample * num_q_heads + q_head) * (long)seqlen + q_pos] =
+              m_run * scale_log2 + __log2f(l_safe);
+        }
+      }
+      *alpha_slot = l_run;
+      if constexpr (FULL_NAMED_BAR) full_bar_arrive(m_tile, warp_in_group);
+      else mbarrier_arrive(smem_ptr_u32(&full_bar_l[m_tile]));
+
+      if constexpr (USE_CLC) {
+        ClcTileInfo next = clc_fetch_next_tile<1, 1, ClcRasterOrder::AlongN, 1, true>(
+            clc_full, clc_empty, clc_response, clc_stage, clc_phase, elect_one_sync());
+        clc_fetch_next_tile_advance<CLC_STAGES>(clc_stage, clc_phase);
+        if (!next.valid) break;
+        workitem_id = next.n_tile;
+      } else {
+        workitem_id += gridDim.x;
+        if (workitem_id >= total_workitems) break;
+      }
+    }
+  }
+  __syncthreads();
+  if (warp_id == 0) tcgen05_dealloc<1>(tmem_base, TMEM_TOTAL);
+}

--- a/fastvideo-kernel/csrc/attention/block_causal_sink_kernel_sm100a.cuh
+++ b/fastvideo-kernel/csrc/attention/block_causal_sink_kernel_sm100a.cuh
@@ -1,5 +1,5 @@
-// block_causal_sink_kernel_sm100a.cuh -- block-causal + sink + sliding-window FMHA forward, sm_100a.
-// Warp-specialized: load / MMA (tcgen05) / softmax / correction / epilogue / scheduler.
+// block_causal_sink_kernel_sm100a.cuh -- block-causal + sink + sliding-window FMHA forward,
+// sm_100a. Warp-specialized: load / MMA (tcgen05) / softmax / correction / epilogue / scheduler.
 // Writes O and, when asked, the log-sum-exp the backward consumes.
 //
 // Generated (comments stripped). Do not edit by hand.
@@ -35,13 +35,13 @@ constexpr int K_TILE_BYTES = K_SUBTILES * K_SUB_COLS_BYTES;
 constexpr int V_TILE_BYTES = V_SUBTILES * Q_SUB_COLS_BYTES;
 constexpr int P_TILE_BYTES = P_SUBTILES * Q_SUB_COLS_BYTES;
 constexpr int K_ATOMS_PER_TILE = SUB_COLS_BF16 / 16;
-constexpr int SPLIT_P_N    = K_TILE / 4 * 3;
+constexpr int SPLIT_P_N = K_TILE / 4 * 3;
 constexpr int SPLIT_P_ATOM = SPLIT_P_N / 16;
-constexpr int SPLIT_P_COL  = SPLIT_P_N / 2;
+constexpr int SPLIT_P_COL = SPLIT_P_N / 2;
 constexpr int EX2_FRG_PAIRS = 16;
-constexpr int EX2_FRG_CNT   = K_TILE / 32;
+constexpr int EX2_FRG_CNT = K_TILE / 32;
 
-constexpr int EX2_RES       = 4;
+constexpr int EX2_RES = 4;
 constexpr int EX2_START_FRG = 1;
 constexpr int NUM_KV_STAGES = 3;
 constexpr int S_COLS = K_TILE;
@@ -53,69 +53,74 @@ constexpr int CLC_STAGES = 4;
 
 extern __shared__ __align__(1024) uint8_t fmha_smem[];
 
-union SmemDescPair { uint64_t u64; uint2 w; };
+union SmemDescPair {
+  uint64_t u64;
+  uint2 w;
+};
 
 __device__ __forceinline__ void desc_add_lo(SmemDescPair& d, uint32_t inc) {
-  asm volatile("{\n\t"
+  asm volatile(
+      "{\n\t"
       ".reg .b32 lo, hi;\n\t"
       "mov.b64 {lo, hi}, %0;\n\t"
       "add.u32 lo, lo, %1;\n\t"
       "mov.b64 %0, {lo, hi};\n\t"
-      "}" : "+l"(d.u64) : "r"(inc));
+      "}"
+      : "+l"(d.u64)
+      : "r"(inc));
 }
 
-__device__ __forceinline__ int tile_for_processing(int step, int window_tiles, int window_hi_tile, int k_tiles) {
+__device__ __forceinline__ int tile_for_processing(int step, int window_tiles, int window_hi_tile,
+                                                   int k_tiles) {
   return (step < window_tiles) ? (window_hi_tile - 1 - step) : (k_tiles - 1 - step);
 }
 
 template <bool Q_RASTER, bool LPT, bool HAS_SINK_ROPE_DELTA = false>
 __device__ __forceinline__ void decode_workitem(
-    int workitem_id, int seqlen, int num_kv_heads,
-    int packed_mtiles_per_seq, int packed_mtiles_per_sample, int q_tile_per_cta,
-    unsigned long long magic0, unsigned long long magic1, unsigned long long magic2,
-    int lpt_swz_log2, int lpt_hb_quot, int lpt_hb_rem,
-    unsigned long long lpt_major_magic, unsigned long long lpt_rem_magic,
-    int tokens_per_block, int rolling_window_tokens, int sink_tokens,
-    int& sample, int& h_kv, int& q_tile_base, int& k_tiles,
-    int& window_tiles, int& window_hi_tile) {
+    int workitem_id, int seqlen, int num_kv_heads, int packed_mtiles_per_seq,
+    int packed_mtiles_per_sample, int q_tile_per_cta, unsigned long long magic0,
+    unsigned long long magic1, unsigned long long magic2, int lpt_swz_log2, int lpt_hb_quot,
+    int lpt_hb_rem, unsigned long long lpt_major_magic, unsigned long long lpt_rem_magic,
+    int tokens_per_block, int rolling_window_tokens, int sink_tokens, int& sample, int& h_kv,
+    int& q_tile_base, int& k_tiles, int& window_tiles, int& window_hi_tile) {
   int packed_mtiles_index;
   if constexpr (LPT) {
-
     const int major = (int)fdiv((unsigned)workitem_id, lpt_major_magic);
     const int l2mod = workitem_id - major * (packed_mtiles_per_seq << lpt_swz_log2);
     int block, res;
     if (major < lpt_hb_quot) {
       block = l2mod >> lpt_swz_log2;
-      res   = l2mod & ((1 << lpt_swz_log2) - 1);
+      res = l2mod & ((1 << lpt_swz_log2) - 1);
     } else {
       block = (int)fdiv((unsigned)l2mod, lpt_rem_magic);
-      res   = l2mod - block * lpt_hb_rem;
+      res = l2mod - block * lpt_hb_rem;
     }
     const int hb = (major << lpt_swz_log2) + res;
     sample = (int)fdiv((unsigned)hb, magic2);
-    h_kv   = hb - sample * num_kv_heads;
+    h_kv = hb - sample * num_kv_heads;
     packed_mtiles_index = packed_mtiles_per_seq - 1 - block;
     q_tile_base = packed_mtiles_index * q_tile_per_cta;
   } else {
     sample = (int)fdiv((unsigned)workitem_id, magic0);
     const int rr = workitem_id - sample * packed_mtiles_per_sample;
     if constexpr (Q_RASTER) {
-      h_kv                = (int)fdiv((unsigned)rr, magic1);
+      h_kv = (int)fdiv((unsigned)rr, magic1);
       packed_mtiles_index = rr - h_kv * packed_mtiles_per_seq;
     } else {
       packed_mtiles_index = (int)fdiv((unsigned)rr, magic2);
-      h_kv                = rr - packed_mtiles_index * num_kv_heads;
+      h_kv = rr - packed_mtiles_index * num_kv_heads;
     }
     q_tile_base = packed_mtiles_index * q_tile_per_cta;
   }
 
   const int first_q = q_tile_base;
-  const int last_q  = q_tile_base + q_tile_per_cta - 1;
+  const int last_q = q_tile_base + q_tile_per_cta - 1;
 
   int max_block_end = (last_q / tokens_per_block + 1) * tokens_per_block;
   if (max_block_end > seqlen) max_block_end = seqlen;
 
-  int min_window_start = ((first_q / tokens_per_block + 1) * tokens_per_block) - rolling_window_tokens;
+  int min_window_start =
+      ((first_q / tokens_per_block + 1) * tokens_per_block) - rolling_window_tokens;
   if (min_window_start < 0) min_window_start = 0;
 
   const int hi_tile = (max_block_end + K_TILE - 1) / K_TILE;
@@ -123,7 +128,6 @@ __device__ __forceinline__ void decode_workitem(
   int sink_tiles = (sink_tokens + K_TILE - 1) / K_TILE;
 
   if constexpr (HAS_SINK_ROPE_DELTA) {
-
     if (lo_tile < sink_tiles - 1) lo_tile = sink_tiles - 1;
     if (lo_tile > hi_tile) lo_tile = hi_tile;
   } else {
@@ -131,29 +135,33 @@ __device__ __forceinline__ void decode_workitem(
   }
 
   window_hi_tile = hi_tile;
-  window_tiles   = hi_tile - lo_tile;
-  k_tiles        = window_tiles + sink_tiles;
+  window_tiles = hi_tile - lo_tile;
+  k_tiles = window_tiles + sink_tiles;
 }
 
 template <int K_TILE, bool USE_R2P_ASM = true>
 __device__ __forceinline__ void mask_s_row_block_causal_sink(float* scores, int k_tile_offset,
-    int block_end, int sink_tokens, int window_start) {
-  const int hi  = block_end     - k_tile_offset;
-  const int snk = sink_tokens   - k_tile_offset;
-  const int lo  = window_start  - k_tile_offset;
+                                                             int block_end, int sink_tokens,
+                                                             int window_start) {
+  const int hi = block_end - k_tile_offset;
+  const int snk = sink_tokens - k_tile_offset;
+  const int lo = window_start - k_tile_offset;
   uint32_t* u = reinterpret_cast<uint32_t*>(scores);
-  #pragma unroll
+#pragma unroll
   for (int s = 0; s < K_TILE / 32; ++s) {
     const int base = s * 32;
-    int hb = hi - base;  hb = hb < 0 ? 0 : (hb > 32 ? 32 : hb);
-    int sb = snk - base; sb = sb < 0 ? 0 : (sb > 32 ? 32 : sb);
-    int lb = lo - base;  lb = lb < 0 ? 0 : (lb > 32 ? 32 : lb);
-    const uint32_t keep_hi   = (hb >= 32) ? 0xFFFFFFFFu : (hb <= 0 ? 0u : ((1u << hb) - 1u));
+    int hb = hi - base;
+    hb = hb < 0 ? 0 : (hb > 32 ? 32 : hb);
+    int sb = snk - base;
+    sb = sb < 0 ? 0 : (sb > 32 ? 32 : sb);
+    int lb = lo - base;
+    lb = lb < 0 ? 0 : (lb > 32 ? 32 : lb);
+    const uint32_t keep_hi = (hb >= 32) ? 0xFFFFFFFFu : (hb <= 0 ? 0u : ((1u << hb) - 1u));
     const uint32_t keep_sink = (sb >= 32) ? 0xFFFFFFFFu : (sb <= 0 ? 0u : ((1u << sb) - 1u));
-    const uint32_t keep_win  = (lb >= 32) ? 0u : (0xFFFFFFFFu << lb);
+    const uint32_t keep_win = (lb >= 32) ? 0u : (0xFFFFFFFFu << lb);
     const uint32_t keep = keep_hi & (keep_sink | keep_win);
     if constexpr (USE_R2P_ASM) {
-      #pragma unroll
+#pragma unroll
       for (int g = 0; g < 32; g += 8) {
         const uint32_t kg = keep >> g;
         asm("{\n\t"
@@ -168,61 +176,60 @@ __device__ __forceinline__ void mask_s_row_block_causal_sink(float* scores, int 
             "and.b32 t6, %8, 64;   setp.ne.b32 p6, t6, 0; selp.b32 %6, %6, 0xFF800000, p6;\n\t"
             "and.b32 t7, %8, 128;  setp.ne.b32 p7, t7, 0; selp.b32 %7, %7, 0xFF800000, p7;\n\t"
             "}"
-            : "+r"(u[s * 32 + g + 0]), "+r"(u[s * 32 + g + 1]),
-              "+r"(u[s * 32 + g + 2]), "+r"(u[s * 32 + g + 3]),
-              "+r"(u[s * 32 + g + 4]), "+r"(u[s * 32 + g + 5]),
+            : "+r"(u[s * 32 + g + 0]), "+r"(u[s * 32 + g + 1]), "+r"(u[s * 32 + g + 2]),
+              "+r"(u[s * 32 + g + 3]), "+r"(u[s * 32 + g + 4]), "+r"(u[s * 32 + g + 5]),
               "+r"(u[s * 32 + g + 6]), "+r"(u[s * 32 + g + 7])
             : "r"(kg));
       }
     } else {
-      #pragma unroll
+#pragma unroll
       for (int i = 0; i < 32; ++i)
         if (!(keep & (1u << i))) scores[s * 32 + i] = -INFINITY;
     }
   }
 }
 
-template <int S_LD_COLS = 32, bool FULL_NAMED_BAR = false, bool EX2_EMU = false, bool SPLIT_P = true,
-          bool SOFTMAX_THROTTLE = false, bool USE_CLC = true, bool Q_RASTER = true, bool MHA = false,
-          bool LPT = false, int RESCALE_THRESHOLD = 8, bool HAS_SINK_ROPE_DELTA = false>
+template <int S_LD_COLS = 32, bool FULL_NAMED_BAR = false, bool EX2_EMU = false,
+          bool SPLIT_P = true, bool SOFTMAX_THROTTLE = false, bool USE_CLC = true,
+          bool Q_RASTER = true, bool MHA = false, bool LPT = false, int RESCALE_THRESHOLD = 8,
+          bool HAS_SINK_ROPE_DELTA = false>
 __global__ void __cluster_dims__(1, 1, 1) __launch_bounds__(N_WARPS * 32, 1)
-block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
-    const __grid_constant__ CUtensorMap tmap_k, const __grid_constant__ CUtensorMap tmap_v_t,
-    const __grid_constant__ CUtensorMap tmap_o, const __grid_constant__ CUtensorMap tmap_q_sink,
-    float* __restrict__ lse_out,
-    int seqlen,
-    int num_q_heads, int num_kv_heads, float scale_log2,
-    int packed_mtiles_per_seq, int num_samples,
-    unsigned long long magic0, unsigned long long magic1, unsigned long long magic2,
-    int lpt_swz_log2, int lpt_hb_quot, int lpt_hb_rem,
-    unsigned long long lpt_major_magic, unsigned long long lpt_rem_magic,
-    int tokens_per_block, int sink_tokens, int rolling_window_tokens) {
+    block_causal_sink_sm100a_kernel(
+        const __grid_constant__ CUtensorMap tmap_q, const __grid_constant__ CUtensorMap tmap_k,
+        const __grid_constant__ CUtensorMap tmap_v_t, const __grid_constant__ CUtensorMap tmap_o,
+        const __grid_constant__ CUtensorMap tmap_q_sink, float* __restrict__ lse_out, int seqlen,
+        int num_q_heads, int num_kv_heads, float scale_log2, int packed_mtiles_per_seq,
+        int num_samples, unsigned long long magic0, unsigned long long magic1,
+        unsigned long long magic2, int lpt_swz_log2, int lpt_hb_quot, int lpt_hb_rem,
+        unsigned long long lpt_major_magic, unsigned long long lpt_rem_magic, int tokens_per_block,
+        int sink_tokens, int rolling_window_tokens) {
   const int gqa_group_size = MHA ? 1 : (num_q_heads / num_kv_heads);
   const int q_tile_per_mtile = M_TILE / gqa_group_size;
-  const int q_tile_per_cta   = M_TILES_PER_CTA * q_tile_per_mtile;
+  const int q_tile_per_cta = M_TILES_PER_CTA * q_tile_per_mtile;
   const int total_workitems = num_samples * packed_mtiles_per_seq * num_kv_heads;
 
   uint8_t* sQ0 = fmha_smem;
   uint8_t* sQ1 = sQ0 + Q_TILE_BYTES;
-  uint8_t* sQ[2] = { sQ0, sQ1 };
+  uint8_t* sQ[2] = {sQ0, sQ1};
   uint8_t* sKV = sQ1 + Q_TILE_BYTES;
   __nv_bfloat16* sO0 = reinterpret_cast<__nv_bfloat16*>(sKV + NUM_KV_STAGES * K_TILE_BYTES);
   __nv_bfloat16* sO1 = sO0 + M_TILE * HEAD_DIM;
-  __nv_bfloat16* sO_bufs[2] = { sO0, sO1 };
-  uint64_t* full_bar = reinterpret_cast<uint64_t*>(reinterpret_cast<uint8_t*>(sO1) + M_TILE * HEAD_DIM * sizeof(__nv_bfloat16));
-  uint64_t* empty_bar= full_bar + NUM_KV_STAGES;
-  uint64_t* full_bar_q  = empty_bar + NUM_KV_STAGES;
-  uint64_t* empty_bar_q   = full_bar_q + 2;
-  uint64_t* full_bar_spo  = empty_bar_q + 2;
+  __nv_bfloat16* sO_bufs[2] = {sO0, sO1};
+  uint64_t* full_bar = reinterpret_cast<uint64_t*>(reinterpret_cast<uint8_t*>(sO1) +
+                                                   M_TILE * HEAD_DIM * sizeof(__nv_bfloat16));
+  uint64_t* empty_bar = full_bar + NUM_KV_STAGES;
+  uint64_t* full_bar_q = empty_bar + NUM_KV_STAGES;
+  uint64_t* empty_bar_q = full_bar_q + 2;
+  uint64_t* full_bar_spo = empty_bar_q + 2;
   uint64_t* empty_bar_spo = full_bar_spo + 2;
-  uint64_t* full_bar_o_acc   = empty_bar_spo + 2;
+  uint64_t* full_bar_o_acc = empty_bar_spo + 2;
   uint64_t* full_bar_alpha = full_bar_o_acc + 2;
-  uint64_t* full_bar_l   = full_bar_alpha + 2;
-  uint64_t* full_bar_p_last    = full_bar_l + 2;
+  uint64_t* full_bar_l = full_bar_alpha + 2;
+  uint64_t* full_bar_p_last = full_bar_l + 2;
   uint64_t* empty_bar_alpha_and_l = full_bar_p_last + 2;
-  uint64_t* full_bar_o_epi  = empty_bar_alpha_and_l + 2;
+  uint64_t* full_bar_o_epi = empty_bar_alpha_and_l + 2;
   uint64_t* empty_bar_o_epi = full_bar_o_epi + 2;
-  uint64_t* clc_full  = empty_bar_o_epi + 2;
+  uint64_t* clc_full = empty_bar_o_epi + 2;
   uint64_t* clc_empty = clc_full + CLC_STAGES;
   uint32_t* clc_response = reinterpret_cast<uint32_t*>(
       (reinterpret_cast<uintptr_t>(clc_empty + CLC_STAGES) + 15u) & ~uintptr_t(15u));
@@ -242,7 +249,7 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
 
   const int packed_mtiles_per_sample = packed_mtiles_per_seq * num_kv_heads;
   if (tid == 0) {
-    #pragma unroll
+#pragma unroll
     for (int s = 0; s < NUM_KV_STAGES; ++s) {
       mbarrier_init(smem_ptr_u32(&full_bar[s]), 1);
       mbarrier_init(smem_ptr_u32(&empty_bar[s]), 1);
@@ -261,14 +268,13 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
       mbarrier_init(smem_ptr_u32(&empty_bar_o_epi[i]), 1);
     }
     if constexpr (USE_CLC) {
-      #pragma unroll
+#pragma unroll
       for (int s = 0; s < CLC_STAGES; ++s) {
         mbarrier_init(smem_ptr_u32(&clc_full[s]), 1);
         mbarrier_init(smem_ptr_u32(&clc_empty[s]), N_WARPS);
       }
-      #pragma unroll
-      for (int i = 0; i < CLC_STAGES * 4; ++i)
-        clc_response[i] = 0;
+#pragma unroll
+      for (int i = 0; i < CLC_STAGES * 4; ++i) clc_response[i] = 0;
     }
   }
   fence_mbarrier_init_release_cluster();
@@ -284,28 +290,28 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
     int workitem_id = (int)blockIdx.x;
     while (true) {
       int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
-      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
-          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
-          magic0, magic1, magic2,
-          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
-          tokens_per_block, rolling_window_tokens, sink_tokens,
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(
+          workitem_id, seqlen, num_kv_heads, packed_mtiles_per_seq, packed_mtiles_per_sample,
+          q_tile_per_cta, magic0, magic1, magic2, lpt_swz_log2, lpt_hb_quot, lpt_hb_rem,
+          lpt_major_magic, lpt_rem_magic, tokens_per_block, rolling_window_tokens, sink_tokens,
           sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
       const int k_start = sample * seqlen;
 
       for (int k = 0; k < K_TILES; ++k) {
-        const int k_tile_offset = tile_for_processing(k, window_tiles, window_hi_tile, K_TILES) * K_TILE;
+        const int k_tile_offset =
+            tile_for_processing(k, window_tiles, window_hi_tile, K_TILES) * K_TILE;
 
         if constexpr (HAS_SINK_ROPE_DELTA) {
           if (k == window_tiles) {
-            #pragma unroll
+#pragma unroll
             for (int m = 0; m < M_TILES_PER_CTA; ++m) {
               mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_q[m]), q_empty_ph.get_phase());
               const uint32_t qbar = smem_ptr_u32(&full_bar_q[m]);
               const int q_token = q_tile_base + m * q_tile_per_mtile;
-              const int q_head  = h_kv * gqa_group_size;
+              const int q_head = h_kv * gqa_group_size;
               if (elect_one_sync()) {
                 mbarrier_arrive_expect_tx(qbar, Q_TILE_BYTES);
-                #pragma unroll
+#pragma unroll
                 for (int s = 0; s < Q_SUBTILES; ++s)
                   tma_load_4d(smem_ptr_u32(sQ[m] + s * Q_SUB_COLS_BYTES), &tmap_q_sink, qbar,
                               s * SUB_COLS_BF16, q_head, q_token, sample);
@@ -321,26 +327,25 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
 
         const uint32_t kbar = smem_ptr_u32(&full_bar[kv_stage]);
         const uint32_t kdst = smem_ptr_u32(sKV + kv_stage * K_TILE_BYTES);
-        const int      k_token = k_tile_offset;
-        const int      k_head_atom  = sample * num_kv_heads + h_kv;
+        const int k_token = k_tile_offset;
+        const int k_head_atom = sample * num_kv_heads + h_kv;
         if (elect_one_sync()) {
           mbarrier_arrive_expect_tx(kbar, K_TILE_BYTES);
           tma_load_4d(kdst, &tmap_k, kbar, 0, k_token, 0, k_head_atom);
         }
 
         if (k == 0) {
-
-          #pragma unroll
+#pragma unroll
           for (int m = 0; m < M_TILES_PER_CTA; ++m) {
             mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_q[m]), q_empty_ph.get_phase());
 
             const uint32_t qbar = smem_ptr_u32(&full_bar_q[m]);
             const int q_token = q_tile_base + m * q_tile_per_mtile;
-            const int q_head  = h_kv * gqa_group_size;
+            const int q_head = h_kv * gqa_group_size;
 
             if (elect_one_sync()) {
               mbarrier_arrive_expect_tx(qbar, Q_TILE_BYTES);
-              #pragma unroll
+#pragma unroll
               for (int s = 0; s < Q_SUBTILES; ++s) {
                 tma_load_4d(smem_ptr_u32(sQ[m] + s * Q_SUB_COLS_BYTES), &tmap_q, qbar,
                             s * SUB_COLS_BF16, q_head, q_token, sample);
@@ -348,7 +353,7 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
             }
           }
           q_empty_ph.advance();
-          }
+        }
         kv_stage = kv_empty_ph.get_stage();
 
         mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar[kv_stage]), kv_empty_ph.get_phase());
@@ -356,8 +361,8 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
 
         const uint32_t vbar = smem_ptr_u32(&full_bar[kv_stage]);
         const uint32_t vdst = smem_ptr_u32(sKV + kv_stage * K_TILE_BYTES);
-        const int      v_token = k_tile_offset;
-        const int      v_head_col = sample * num_kv_heads + h_kv;
+        const int v_token = k_tile_offset;
+        const int v_head_col = sample * num_kv_heads + h_kv;
         if (elect_one_sync()) {
           mbarrier_arrive_expect_tx(vbar, V_TILE_BYTES);
 
@@ -375,25 +380,27 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         if (workitem_id >= total_workitems) break;
       }
     }
-  }
-  else if (warp_id == W_MMA) {
+  } else if (warp_id == W_MMA) {
     setmaxnreg_dec<48>();
 
     const uint32_t lead = elect_one_sync() ? 1u : 0u;
     constexpr uint32_t DESC_SBO = 1024, DESC_LBO = 16;
 
     const uint32_t idesc_qk = make_idesc_bf16_f32(M_TILE, K_TILE, false, false);
-    const uint32_t idesc_pv = make_idesc_bf16_f32(M_TILE, HEAD_DIM,  false, true);
-    const uint64_t desc_q0  = build_smem_desc_blackwell(smem_ptr_u32(sQ0), DESC_SBO, DESC_LBO, SmemSwizzleBlackwell::B128);
-    const uint64_t desc_kv0 = build_smem_desc_blackwell(smem_ptr_u32(sKV), DESC_SBO, DESC_LBO, SmemSwizzleBlackwell::B128);
+    const uint32_t idesc_pv = make_idesc_bf16_f32(M_TILE, HEAD_DIM, false, true);
+    const uint64_t desc_q0 = build_smem_desc_blackwell(smem_ptr_u32(sQ0), DESC_SBO, DESC_LBO,
+                                                       SmemSwizzleBlackwell::B128);
+    const uint64_t desc_kv0 = build_smem_desc_blackwell(smem_ptr_u32(sKV), DESC_SBO, DESC_LBO,
+                                                        SmemSwizzleBlackwell::B128);
 
     constexpr uint32_t DESC_LBO_MN = (uint32_t)(K_TILE * SUB_COLS_BF16 * 2);
-    const uint64_t desc_v0 = build_smem_desc_blackwell(smem_ptr_u32(sKV), DESC_SBO, DESC_LBO_MN, SmemSwizzleBlackwell::B128);
-    constexpr int      PV_K_STEPS   = HEAD_DIM / 16;
+    const uint64_t desc_v0 = build_smem_desc_blackwell(smem_ptr_u32(sKV), DESC_SBO, DESC_LBO_MN,
+                                                       SmemSwizzleBlackwell::B128);
+    constexpr int PV_K_STEPS = HEAD_DIM / 16;
     constexpr uint32_t PV_DESC_STEP = (uint32_t)((16 * SUB_COLS_BF16 * 2) >> 4);
 
-    constexpr uint64_t KV_DESC_DELTA      = K_TILE_BYTES >> 4;
-    constexpr uint64_t SUB_DESC_DELTA     = Q_SUB_COLS_BYTES >> 4;
+    constexpr uint64_t KV_DESC_DELTA = K_TILE_BYTES >> 4;
+    constexpr uint64_t SUB_DESC_DELTA = Q_SUB_COLS_BYTES >> 4;
     constexpr uint64_t Q_MTILE_DESC_DELTA = Q_TILE_BYTES >> 4;
 
     PhaseTracker<NUM_KV_STAGES> kv_ph;
@@ -404,34 +411,37 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
     int workitem_id = (int)blockIdx.x;
     while (true) {
       int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
-      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
-          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
-          magic0, magic1, magic2,
-          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
-          tokens_per_block, rolling_window_tokens, sink_tokens,
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(
+          workitem_id, seqlen, num_kv_heads, packed_mtiles_per_seq, packed_mtiles_per_sample,
+          q_tile_per_cta, magic0, magic1, magic2, lpt_swz_log2, lpt_hb_quot, lpt_hb_rem,
+          lpt_major_magic, lpt_rem_magic, tokens_per_block, rolling_window_tokens, sink_tokens,
           sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
 
       int kv_stage = kv_ph.get_stage();
 
       mbarrier_wait_parity(smem_ptr_u32(&full_bar[kv_stage]), kv_ph.get_phase());
       kv_ph.advance();
-      #pragma unroll
+#pragma unroll
       for (int i = 0; i < M_TILES_PER_CTA; ++i) {
         mbarrier_wait_parity(smem_ptr_u32(&full_bar_q[i]), q_ph.get_phase());
 
         {
           const uint32_t s_tmem_addr = tmem_base + (uint32_t)(i * S_COLS);
           SmemDescPair desc_a, desc_b;
-          desc_a.u64 = desc_q0;  desc_a.w.x += (uint32_t)(i * (int)Q_MTILE_DESC_DELTA);
-          desc_b.u64 = desc_kv0; desc_b.w.x += (uint32_t)(kv_stage * (int)KV_DESC_DELTA);
+          desc_a.u64 = desc_q0;
+          desc_a.w.x += (uint32_t)(i * (int)Q_MTILE_DESC_DELTA);
+          desc_b.u64 = desc_kv0;
+          desc_b.w.x += (uint32_t)(kv_stage * (int)KV_DESC_DELTA);
 
-          #pragma unroll
+#pragma unroll
           for (int s = 0; s < Q_SUBTILES; ++s) {
-            #pragma unroll
+#pragma unroll
             for (int ki = 0; ki < K_ATOMS_PER_TILE; ++ki) {
               const bool enable_d = (s != 0) || (ki != 0);
-              tcgen05_mma_f16_ss_lead(lead, s_tmem_addr, desc_a.u64, desc_b.u64, idesc_qk, enable_d);
-              desc_add_lo(desc_a, 2); desc_add_lo(desc_b, 2);
+              tcgen05_mma_f16_ss_lead(lead, s_tmem_addr, desc_a.u64, desc_b.u64, idesc_qk,
+                                      enable_d);
+              desc_add_lo(desc_a, 2);
+              desc_add_lo(desc_b, 2);
             }
             desc_add_lo(desc_a, (uint32_t)(SUB_DESC_DELTA - 2 * K_ATOMS_PER_TILE));
             desc_add_lo(desc_b, (uint32_t)(SUB_DESC_DELTA - 2 * K_ATOMS_PER_TILE));
@@ -444,7 +454,6 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
       tcgen05_commit1_lead(lead, smem_ptr_u32(&empty_bar[kv_stage]));
 
       for (int k_tile_id = 0; k_tile_id < K_TILES - 1; ++k_tile_id) {
-
         const int kv_stage = kv_ph.get_stage();
 
         mbarrier_wait_parity(smem_ptr_u32(&full_bar[kv_stage]), kv_ph.get_phase());
@@ -452,18 +461,18 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
 
         if constexpr (HAS_SINK_ROPE_DELTA) {
           if (k_tile_id == window_tiles - 1) {
-            #pragma unroll
+#pragma unroll
             for (int i = 0; i < M_TILES_PER_CTA; ++i)
               tcgen05_commit1_lead(lead, smem_ptr_u32(&empty_bar_q[i]));
             q_ph.advance();
-            #pragma unroll
+#pragma unroll
             for (int i = 0; i < M_TILES_PER_CTA; ++i)
               mbarrier_wait_parity(smem_ptr_u32(&full_bar_q[i]), q_ph.get_phase());
           }
         }
 
         int kv_stage_next = 0;
-        #pragma unroll
+#pragma unroll
         for (int i = 0; i < M_TILES_PER_CTA; ++i) {
           mbarrier_wait_parity(smem_ptr_u32(&empty_bar_spo[i]), spo_ph.get_phase());
 
@@ -474,13 +483,15 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
           desc_bv.w.x += (uint32_t)(kv_stage * (int)KV_DESC_DELTA);
 
           {
-            #pragma unroll
+#pragma unroll
             for (int a = 0; a < PV_K_STEPS; ++a) {
-              if constexpr (SPLIT_P) if (a == SPLIT_P_ATOM) {
-                mbarrier_wait_parity(smem_ptr_u32(&full_bar_p_last[i]), spo_ph.get_phase());
-              }
+              if constexpr (SPLIT_P)
+                if (a == SPLIT_P_ATOM) {
+                  mbarrier_wait_parity(smem_ptr_u32(&full_bar_p_last[i]), spo_ph.get_phase());
+                }
               const bool accumulate = (k_tile_id != 0) || (a != 0);
-              tcgen05_mma_f16_ts_1sm_lead(lead, o_tmem_addr, s_tmem_addr + (uint32_t)(a * 8), desc_bv.u64, idesc_pv, accumulate);
+              tcgen05_mma_f16_ts_1sm_lead(lead, o_tmem_addr, s_tmem_addr + (uint32_t)(a * 8),
+                                          desc_bv.u64, idesc_pv, accumulate);
               desc_add_lo(desc_bv, PV_DESC_STEP);
             }
           }
@@ -497,15 +508,19 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
 
           {
             SmemDescPair desc_a, desc_b;
-            desc_a.u64 = desc_q0;  desc_a.w.x += (uint32_t)(i * (int)Q_MTILE_DESC_DELTA);
-            desc_b.u64 = desc_kv0; desc_b.w.x += (uint32_t)(kv_stage_next * (int)KV_DESC_DELTA);
-            #pragma unroll
+            desc_a.u64 = desc_q0;
+            desc_a.w.x += (uint32_t)(i * (int)Q_MTILE_DESC_DELTA);
+            desc_b.u64 = desc_kv0;
+            desc_b.w.x += (uint32_t)(kv_stage_next * (int)KV_DESC_DELTA);
+#pragma unroll
             for (int s = 0; s < Q_SUBTILES; ++s) {
-              #pragma unroll
+#pragma unroll
               for (int ki = 0; ki < K_ATOMS_PER_TILE; ++ki) {
                 const bool enable_d = (s != 0) || (ki != 0);
-                tcgen05_mma_f16_ss_lead(lead, s_tmem_addr, desc_a.u64, desc_b.u64, idesc_qk, enable_d);
-                desc_add_lo(desc_a, 2); desc_add_lo(desc_b, 2);
+                tcgen05_mma_f16_ss_lead(lead, s_tmem_addr, desc_a.u64, desc_b.u64, idesc_qk,
+                                        enable_d);
+                desc_add_lo(desc_a, 2);
+                desc_add_lo(desc_b, 2);
               }
               desc_add_lo(desc_a, (uint32_t)(SUB_DESC_DELTA - 2 * K_ATOMS_PER_TILE));
               desc_add_lo(desc_b, (uint32_t)(SUB_DESC_DELTA - 2 * K_ATOMS_PER_TILE));
@@ -519,7 +534,7 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         spo_ph.advance();
       }
 
-      #pragma unroll
+#pragma unroll
       for (int i = 0; i < M_TILES_PER_CTA; ++i) {
         tcgen05_commit1_lead(lead, smem_ptr_u32(&empty_bar_q[i]));
       }
@@ -529,7 +544,7 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
       mbarrier_wait_parity(smem_ptr_u32(&full_bar[kv_stage]), kv_ph.get_phase());
       kv_ph.advance();
 
-      #pragma unroll
+#pragma unroll
       for (int i = 0; i < M_TILES_PER_CTA; ++i) {
         mbarrier_wait_parity(smem_ptr_u32(&empty_bar_spo[i]), spo_ph.get_phase());
 
@@ -540,13 +555,15 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         desc_bv.w.x += (uint32_t)(kv_stage * (int)KV_DESC_DELTA);
 
         {
-          #pragma unroll
+#pragma unroll
           for (int a = 0; a < PV_K_STEPS; ++a) {
-            if constexpr (SPLIT_P) if (a == SPLIT_P_ATOM) {
-              mbarrier_wait_parity(smem_ptr_u32(&full_bar_p_last[i]), spo_ph.get_phase());
-            }
+            if constexpr (SPLIT_P)
+              if (a == SPLIT_P_ATOM) {
+                mbarrier_wait_parity(smem_ptr_u32(&full_bar_p_last[i]), spo_ph.get_phase());
+              }
             const bool accumulate = (K_TILES != 1) || (a != 0);
-            tcgen05_mma_f16_ts_1sm_lead(lead, o_tmem_addr, s_tmem_addr + (uint32_t)(a * 8), desc_bv.u64, idesc_pv, accumulate);
+            tcgen05_mma_f16_ts_1sm_lead(lead, o_tmem_addr, s_tmem_addr + (uint32_t)(a * 8),
+                                        desc_bv.u64, idesc_pv, accumulate);
             desc_add_lo(desc_bv, PV_DESC_STEP);
           }
         }
@@ -569,40 +586,38 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         if (workitem_id >= total_workitems) break;
       }
     }
-  }
-  else if (warp_id == W_EPI) {
+  } else if (warp_id == W_EPI) {
     setmaxnreg_dec<48>();
 
     PhaseTracker<1> full_o_ph;
 
     if (elect_one_sync()) {
-      #pragma unroll
-      for (int m = 0; m < M_TILES_PER_CTA; ++m)
-        mbarrier_arrive(smem_ptr_u32(&empty_bar_o_epi[m]));
+#pragma unroll
+      for (int m = 0; m < M_TILES_PER_CTA; ++m) mbarrier_arrive(smem_ptr_u32(&empty_bar_o_epi[m]));
     }
     [[maybe_unused]] int clc_stage = 0;
     [[maybe_unused]] uint32_t clc_phase = 0;
     int workitem_id = (int)blockIdx.x;
     while (true) {
       int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
-      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
-          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
-          magic0, magic1, magic2,
-          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
-          tokens_per_block, rolling_window_tokens, sink_tokens,
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(
+          workitem_id, seqlen, num_kv_heads, packed_mtiles_per_seq, packed_mtiles_per_sample,
+          q_tile_per_cta, magic0, magic1, magic2, lpt_swz_log2, lpt_hb_quot, lpt_hb_rem,
+          lpt_major_magic, lpt_rem_magic, tokens_per_block, rolling_window_tokens, sink_tokens,
           sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
 
-      #pragma unroll
+#pragma unroll
       for (int m = 0; m < M_TILES_PER_CTA; ++m) {
         mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_o_epi[m]), full_o_ph.get_phase());
 
         if (elect_one_sync()) {
           const int q_token = q_tile_base + m * q_tile_per_mtile;
 
-          #pragma unroll
+#pragma unroll
           for (int s = 0; s < Q_SUBTILES; ++s) {
-            tma_store_4d(&tmap_o, s * SUB_COLS_BF16, h_kv * gqa_group_size, q_token, sample,
-                         smem_ptr_u32(reinterpret_cast<const uint8_t*>(sO_bufs[m]) + s * Q_SUB_COLS_BYTES));
+            tma_store_4d(
+                &tmap_o, s * SUB_COLS_BF16, h_kv * gqa_group_size, q_token, sample,
+                smem_ptr_u32(reinterpret_cast<const uint8_t*>(sO_bufs[m]) + s * Q_SUB_COLS_BYTES));
           }
           cp_async_bulk_commit_group();
         }
@@ -627,13 +642,14 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         if (workitem_id >= total_workitems) break;
       }
     }
-  }
-  else if (warp_id == W_SCHED) {
+  } else if (warp_id == W_SCHED) {
     setmaxnreg_dec<48>();
 
     if constexpr (USE_CLC) {
-      int prod_stage = 0; uint32_t prod_phase = 1;
-      int cons_stage = 0; uint32_t cons_phase = 0;
+      int prod_stage = 0;
+      uint32_t prod_phase = 1;
+      int cons_stage = 0;
+      uint32_t cons_phase = 0;
       while (true) {
         if (lane == 0)
           mbarrier_wait_parity_suspend(smem_ptr_u32(&clc_empty[prod_stage]), prod_phase);
@@ -656,8 +672,7 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         advance_stage_phase<CLC_STAGES>(prod_stage, prod_phase);
       }
     }
-  }
-  else if (warp_id >= W_CORR0 && warp_id < W_MMA) {
+  } else if (warp_id >= W_CORR0 && warp_id < W_MMA) {
     setmaxnreg_dec<80>();
 
     const int corr_warp_id = warp_id - W_CORR0;
@@ -667,7 +682,7 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
     [[maybe_unused]] int clc_stage = 0;
     [[maybe_unused]] uint32_t clc_phase = 0;
 
-    #pragma unroll
+#pragma unroll
     for (int i = 0; i < M_TILES_PER_CTA; ++i) {
       mbarrier_arrive(smem_ptr_u32(&empty_bar_spo[i]));
       mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[i]));
@@ -676,17 +691,18 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
     int workitem_id = (int)blockIdx.x;
     while (true) {
       int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
-      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
-          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
-          magic0, magic1, magic2,
-          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
-          tokens_per_block, rolling_window_tokens, sink_tokens,
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(
+          workitem_id, seqlen, num_kv_heads, packed_mtiles_per_seq, packed_mtiles_per_sample,
+          q_tile_per_cta, magic0, magic1, magic2, lpt_swz_log2, lpt_hb_quot, lpt_hb_rem,
+          lpt_major_magic, lpt_rem_magic, tokens_per_block, rolling_window_tokens, sink_tokens,
           sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
 
-      #pragma unroll
+#pragma unroll
       for (int i = 0; i < M_TILES_PER_CTA; ++i) {
-        if constexpr (FULL_NAMED_BAR) full_bar_wait(i, corr_warp_id);
-        else mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_alpha[i]), alpha_ph.get_phase());
+        if constexpr (FULL_NAMED_BAR)
+          full_bar_wait(i, corr_warp_id);
+        else
+          mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_alpha[i]), alpha_ph.get_phase());
 
         if constexpr (SOFTMAX_THROTTLE) {
           if (i == 0) mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[0]));
@@ -697,27 +713,29 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
       if constexpr (!FULL_NAMED_BAR) alpha_ph.advance();
 
       for (int k = 1; k < K_TILES; ++k) {
-        #pragma unroll
+#pragma unroll
         for (int i = 0; i < M_TILES_PER_CTA; ++i) {
-          if constexpr (FULL_NAMED_BAR) full_bar_wait(i, corr_warp_id);
-          else mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_alpha[i]), alpha_ph.get_phase());
+          if constexpr (FULL_NAMED_BAR)
+            full_bar_wait(i, corr_warp_id);
+          else
+            mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_alpha[i]), alpha_ph.get_phase());
 
           float alpha = alpha_and_l_smem[i * M_TILE + corr_warp_id * 32 + lane];
           if constexpr (!SOFTMAX_THROTTLE) mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[i]));
 
           bool skip = __all_sync(0xffffffffu, alpha == 1.0f);
           if (!skip) {
-
-            const uint32_t o_tmem_addr = tmem_base + (uint32_t)(2 * S_COLS + i * O_COLS) + ((uint32_t)(corr_warp_id * 32) << 16);
+            const uint32_t o_tmem_addr = tmem_base + (uint32_t)(2 * S_COLS + i * O_COLS) +
+                                         ((uint32_t)(corr_warp_id * 32) << 16);
 
             const float2 alpha2 = f32x2_splat(alpha);
 
-            #pragma unroll
+#pragma unroll
             for (int c0 = 0; c0 < HEAD_DIM; c0 += 16) {
               uint32_t o_regs[16];
               tcgen05_ld_32x32b_x16(o_tmem_addr + (uint32_t)c0, o_regs);
               float2* o2 = reinterpret_cast<float2*>(o_regs);
-              #pragma unroll
+#pragma unroll
               for (int e = 0; e < 8; ++e) o2[e] = fmul2(o2[e], alpha2);
               tcgen05_st_32x32b_x16(o_tmem_addr + (uint32_t)c0, o_regs);
             }
@@ -726,37 +744,44 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
             tcgen05_fence_before_thread_sync();
           }
 
-          if constexpr (SOFTMAX_THROTTLE) mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[M_TILES_PER_CTA - 1 - i]));
+          if constexpr (SOFTMAX_THROTTLE)
+            mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[M_TILES_PER_CTA - 1 - i]));
           mbarrier_arrive(smem_ptr_u32(&empty_bar_spo[i]));
         }
         if constexpr (!FULL_NAMED_BAR) alpha_ph.advance();
       }
 
-      if constexpr (SOFTMAX_THROTTLE) mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[M_TILES_PER_CTA - 1]));
+      if constexpr (SOFTMAX_THROTTLE)
+        mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[M_TILES_PER_CTA - 1]));
 
-      #pragma unroll
+#pragma unroll
       for (int i = 0; i < M_TILES_PER_CTA; ++i) {
         mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_o_acc[i]), o_acc_ph.get_phase());
 
-        if constexpr (FULL_NAMED_BAR) full_bar_wait(i, corr_warp_id);
-        else mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_l[i]), o_acc_ph.get_phase());
+        if constexpr (FULL_NAMED_BAR)
+          full_bar_wait(i, corr_warp_id);
+        else
+          mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_l[i]), o_acc_ph.get_phase());
 
         const int corr_tid = corr_warp_id * 32 + lane;
         float l = alpha_and_l_smem[i * M_TILE + corr_tid];
         mbarrier_arrive(smem_ptr_u32(&empty_bar_alpha_and_l[i]));
         float inv_l = (l > 0.f) ? rcp_approx_ftz_f32(l) : 0.f;
         const float2 inv_l2 = f32x2_splat(inv_l);
-        const uint32_t o_tmem_addr = tmem_base + (uint32_t)(2 * S_COLS + i * O_COLS) + ((uint32_t)(corr_warp_id * 32) << 16);
-        #pragma unroll
+        const uint32_t o_tmem_addr =
+            tmem_base + (uint32_t)(2 * S_COLS + i * O_COLS) + ((uint32_t)(corr_warp_id * 32) << 16);
+#pragma unroll
         for (int c0 = 0; c0 < HEAD_DIM; c0 += 16) {
           uint32_t o_regs[16];
           tcgen05_ld_32x32b_x16(o_tmem_addr + (uint32_t)c0, o_regs);
-          if (c0 == 0) mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_o_epi[i]), o_epi_empty_ph.get_phase());
+          if (c0 == 0)
+            mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_o_epi[i]),
+                                         o_epi_empty_ph.get_phase());
           float2* o2 = reinterpret_cast<float2*>(o_regs);
           const int s = c0 / SUB_COLS_BF16;
           const int v_base = (c0 % SUB_COLS_BF16) / 8;
           __nv_bfloat16* so_sub = sO_bufs[i] + s * (M_TILE * SUB_COLS_BF16);
-          #pragma unroll
+#pragma unroll
           for (int vv = 0; vv < 2; ++vv) {
             const int v = v_base + vv;
             const float2 r0 = fmul2(o2[vv * 4 + 0], inv_l2);
@@ -768,7 +793,8 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
             packed.y = cvt_f32x2_to_bf16x2(r1.x, r1.y);
             packed.z = cvt_f32x2_to_bf16x2(r2.x, r2.y);
             packed.w = cvt_f32x2_to_bf16x2(r3.x, r3.y);
-            *reinterpret_cast<uint4*>(&so_sub[corr_tid * SUB_COLS_BF16 + (v ^ (corr_tid & 7)) * 8]) = packed;
+            *reinterpret_cast<uint4*>(
+                &so_sub[corr_tid * SUB_COLS_BF16 + (v ^ (corr_tid & 7)) * 8]) = packed;
           }
         }
 
@@ -794,15 +820,15 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         if (workitem_id >= total_workitems) break;
       }
     }
-  }
-  else {
+  } else {
     setmaxnreg_inc<192>();
 
     const int warp_id_u = __shfl_sync(0xffffffffu, warp_id, 0);
     const int m_tile = warp_id_u < 4 ? 0 : 1;
     const int warp_in_group = warp_id_u & 3;
     const int row_in_m_tile = warp_in_group * 32 + lane;
-    const uint32_t s_tmem_addr = tmem_base + (uint32_t)(m_tile * S_COLS) + ((uint32_t)(warp_in_group * 32) << 16);
+    const uint32_t s_tmem_addr =
+        tmem_base + (uint32_t)(m_tile * S_COLS) + ((uint32_t)(warp_in_group * 32) << 16);
     PhaseTracker<1> spo_ph;
     PhaseTracker<1> scale_empty_ph;
     [[maybe_unused]] int clc_stage = 0;
@@ -810,11 +836,10 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
     int workitem_id = (int)blockIdx.x;
     while (true) {
       int sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile;
-      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(workitem_id, seqlen, num_kv_heads,
-          packed_mtiles_per_seq, packed_mtiles_per_sample, q_tile_per_cta,
-          magic0, magic1, magic2,
-          lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
-          tokens_per_block, rolling_window_tokens, sink_tokens,
+      decode_workitem<Q_RASTER, LPT, HAS_SINK_ROPE_DELTA>(
+          workitem_id, seqlen, num_kv_heads, packed_mtiles_per_seq, packed_mtiles_per_sample,
+          q_tile_per_cta, magic0, magic1, magic2, lpt_swz_log2, lpt_hb_quot, lpt_hb_rem,
+          lpt_major_magic, lpt_rem_magic, tokens_per_block, rolling_window_tokens, sink_tokens,
           sample, h_kv, q_tile_base, K_TILES, window_tiles, window_hi_tile);
 
       const int q_pos = q_tile_base + m_tile * q_tile_per_mtile + row_in_m_tile / gqa_group_size;
@@ -827,41 +852,52 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
       const int cta_last_q = q_tile_base + q_tile_per_cta - 1;
       int cta_min_block_end = (q_tile_base / tokens_per_block + 1) * tokens_per_block;
       if (cta_min_block_end > seqlen) cta_min_block_end = seqlen;
-      int cta_max_window_start = ((cta_last_q  / tokens_per_block + 1) * tokens_per_block) - rolling_window_tokens;
+      int cta_max_window_start =
+          ((cta_last_q / tokens_per_block + 1) * tokens_per_block) - rolling_window_tokens;
       if (cta_max_window_start < 0) cta_max_window_start = 0;
 
       const int lo_tile = window_hi_tile - window_tiles;
       int bottom_mask_bound = cta_max_window_start;
       if constexpr (HAS_SINK_ROPE_DELTA) bottom_mask_bound = max(bottom_mask_bound, sink_tokens);
-      int masked_top_tiles    = window_hi_tile - cta_min_block_end / K_TILE;
+      int masked_top_tiles = window_hi_tile - cta_min_block_end / K_TILE;
       int masked_bottom_tiles = (bottom_mask_bound + K_TILE - 1) / K_TILE - lo_tile;
-      masked_top_tiles    = masked_top_tiles    < 0 ? 0 : (masked_top_tiles    > window_tiles ? window_tiles : masked_top_tiles);
-      masked_bottom_tiles = masked_bottom_tiles < 0 ? 0 : (masked_bottom_tiles > window_tiles ? window_tiles : masked_bottom_tiles);
+      masked_top_tiles = masked_top_tiles < 0
+                             ? 0
+                             : (masked_top_tiles > window_tiles ? window_tiles : masked_top_tiles);
+      masked_bottom_tiles =
+          masked_bottom_tiles < 0
+              ? 0
+              : (masked_bottom_tiles > window_tiles ? window_tiles : masked_bottom_tiles);
       const int interior_begin = masked_top_tiles;
       int interior_end = window_tiles - masked_bottom_tiles;
       if (interior_end < interior_begin) interior_end = interior_begin;
 
       float m_run = -INFINITY, l_run = 0.f;
-      mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_alpha_and_l[m_tile]), scale_empty_ph.get_phase());
+      mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_alpha_and_l[m_tile]),
+                                   scale_empty_ph.get_phase());
       scale_empty_ph.advance();
       float* const alpha_slot = &alpha_and_l_smem[m_tile * M_TILE + row_in_m_tile];
       const uint32_t alpha_slot_u32 = smem_ptr_u32(alpha_slot);
 
       auto softmax_step = [&](auto masked_c, auto is_first_c, int k) {
-        constexpr bool MASKED   = decltype(masked_c)::value;
+        constexpr bool MASKED = decltype(masked_c)::value;
         constexpr bool IS_FIRST = decltype(is_first_c)::value;
 
-        const int k_tile_offset = tile_for_processing(k, window_tiles, window_hi_tile, K_TILES) * K_TILE;
+        const int k_tile_offset =
+            tile_for_processing(k, window_tiles, window_hi_tile, K_TILES) * K_TILE;
 
         mbarrier_wait_parity_suspend(smem_ptr_u32(&full_bar_spo[m_tile]), spo_ph.get_phase());
 
         uint32_t s_regs[K_TILE];
-        #pragma unroll
+#pragma unroll
         for (int c0 = 0; c0 < K_TILE; c0 += S_LD_COLS) {
           const uint32_t taddr = s_tmem_addr + (uint32_t)c0;
-          if      constexpr (S_LD_COLS == 32)  tcgen05_ld_32x32b_x32 (taddr, *reinterpret_cast<uint32_t(*)[32]>(&s_regs[c0]));
-          else if constexpr (S_LD_COLS == 64)  tcgen05_ld_32x32b_x64 (taddr, *reinterpret_cast<uint32_t(*)[64]>(&s_regs[c0]));
-          else if constexpr (S_LD_COLS == 128) tcgen05_ld_32x32b_x128(taddr, *reinterpret_cast<uint32_t(*)[128]>(&s_regs[c0]));
+          if constexpr (S_LD_COLS == 32)
+            tcgen05_ld_32x32b_x32(taddr, *reinterpret_cast<uint32_t (*)[32]>(&s_regs[c0]));
+          else if constexpr (S_LD_COLS == 64)
+            tcgen05_ld_32x32b_x64(taddr, *reinterpret_cast<uint32_t (*)[64]>(&s_regs[c0]));
+          else if constexpr (S_LD_COLS == 128)
+            tcgen05_ld_32x32b_x128(taddr, *reinterpret_cast<uint32_t (*)[128]>(&s_regs[c0]));
         }
         float* scores = reinterpret_cast<float*>(s_regs);
         float2* scores2 = reinterpret_cast<float2*>(s_regs);
@@ -869,28 +905,24 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         tcgen05_fence_before_thread_sync();
 
         if constexpr (MASKED) {
-
           const bool is_sink_tile = (k >= window_tiles);
           int effective_sink_tokens = sink_tokens;
           int effective_window_start = window_start_in_tokens;
           if constexpr (HAS_SINK_ROPE_DELTA) {
-
             if (is_sink_tile) {
-
               effective_window_start = block_end_in_tokens;
             } else {
-
               effective_sink_tokens = 0;
               effective_window_start = max(window_start_in_tokens, sink_tokens);
             }
           }
 
           mask_s_row_block_causal_sink<K_TILE>(scores, k_tile_offset, block_end_in_tokens,
-                                 effective_sink_tokens, effective_window_start);
+                                               effective_sink_tokens, effective_window_start);
         }
 
         float rmax0 = m_run, rmax1 = -INFINITY, rmax2 = -INFINITY, rmax3 = -INFINITY;
-        #pragma unroll
+#pragma unroll
         for (int j = 0; j < K_TILE; j += 8) {
           rmax0 = fmaxf(fmaxf(rmax0, scores[j + 0]), scores[j + 1]);
           rmax1 = fmaxf(fmaxf(rmax1, scores[j + 2]), scores[j + 3]);
@@ -912,22 +944,26 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
 
           sts_f32(alpha_slot_u32, alpha);
         }
-        if constexpr (FULL_NAMED_BAR) full_bar_arrive(m_tile, warp_in_group);
-        else mbarrier_arrive(smem_ptr_u32(&full_bar_alpha[m_tile]));
+        if constexpr (FULL_NAMED_BAR)
+          full_bar_arrive(m_tile, warp_in_group);
+        else
+          mbarrier_arrive(smem_ptr_u32(&full_bar_alpha[m_tile]));
 
-        const float2 scale2        = f32x2_splat(scale_log2);
+        const float2 scale2 = f32x2_splat(scale_log2);
         const float2 neg_m_scaled2 = f32x2_splat(-row_max_safe * scale_log2);
         uint32_t p_regs[K_TILE / 2];
 
-        #pragma unroll
+#pragma unroll
         for (int c = 0; c < K_TILE / 2; ++c) {
           const float2 a2 = ffma2(scores2[c], scale2, neg_m_scaled2);
           if constexpr (EX2_EMU) {
             const int jj = c / EX2_FRG_PAIRS;
             const int kk = 2 * (c % EX2_FRG_PAIRS);
             constexpr int EX2_FREQ = 16;
-            const bool use_hw = (kk % EX2_FREQ < EX2_FREQ - EX2_RES) || (jj >= EX2_FRG_CNT - 1) || (jj < EX2_START_FRG);
-            scores2[c] = use_hw ? make_float2(ex2_approx_f32(a2.x), ex2_approx_f32(a2.y)) : ex2_emu_f32x2(a2.x, a2.y);
+            const bool use_hw = (kk % EX2_FREQ < EX2_FREQ - EX2_RES) || (jj >= EX2_FRG_CNT - 1) ||
+                                (jj < EX2_START_FRG);
+            scores2[c] = use_hw ? make_float2(ex2_approx_f32(a2.x), ex2_approx_f32(a2.y))
+                                : ex2_emu_f32x2(a2.x, a2.y);
           } else {
             scores2[c] = make_float2(ex2_approx_f32(a2.x), ex2_approx_f32(a2.y));
           }
@@ -936,30 +972,33 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         const uint32_t p_tmem_addr = s_tmem_addr;
 
         if constexpr (SPLIT_P) {
-          tcgen05_st_32x32b_x32(p_tmem_addr, *reinterpret_cast<uint32_t(*)[32]>(&p_regs[0]));
-          tcgen05_st_32x32b_x16(p_tmem_addr + 32, *reinterpret_cast<uint32_t(*)[16]>(&p_regs[32]));
+          tcgen05_st_32x32b_x32(p_tmem_addr, *reinterpret_cast<uint32_t (*)[32]>(&p_regs[0]));
+          tcgen05_st_32x32b_x16(p_tmem_addr + 32, *reinterpret_cast<uint32_t (*)[16]>(&p_regs[32]));
 
           tcgen05_wait_st();
           tcgen05_fence_before_thread_sync();
           mbarrier_arrive(smem_ptr_u32(&empty_bar_spo[m_tile]));
-          tcgen05_st_32x32b_x16(p_tmem_addr + SPLIT_P_COL, *reinterpret_cast<uint32_t(*)[16]>(&p_regs[SPLIT_P_COL]));
+          tcgen05_st_32x32b_x16(p_tmem_addr + SPLIT_P_COL,
+                                *reinterpret_cast<uint32_t (*)[16]>(&p_regs[SPLIT_P_COL]));
           tcgen05_wait_st();
           tcgen05_fence_before_thread_sync();
           mbarrier_arrive(smem_ptr_u32(&full_bar_p_last[m_tile]));
         } else {
-          tcgen05_st_32x32b_x32(p_tmem_addr, *reinterpret_cast<uint32_t(*)[32]>(&p_regs[0]));
-          tcgen05_st_32x32b_x32(p_tmem_addr + 32, *reinterpret_cast<uint32_t(*)[32]>(&p_regs[32]));
+          tcgen05_st_32x32b_x32(p_tmem_addr, *reinterpret_cast<uint32_t (*)[32]>(&p_regs[0]));
+          tcgen05_st_32x32b_x32(p_tmem_addr + 32, *reinterpret_cast<uint32_t (*)[32]>(&p_regs[32]));
           tcgen05_wait_st();
           tcgen05_fence_before_thread_sync();
           mbarrier_arrive(smem_ptr_u32(&empty_bar_spo[m_tile]));
         }
         spo_ph.advance();
-        mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_alpha_and_l[m_tile]), scale_empty_ph.get_phase());
+        mbarrier_wait_parity_suspend(smem_ptr_u32(&empty_bar_alpha_and_l[m_tile]),
+                                     scale_empty_ph.get_phase());
         scale_empty_ph.advance();
 
         float2 lt2a = make_float2(IS_FIRST ? 0.0f : l_run * alpha, 0.0f);
-        float2 lt2b = make_float2(0.f, 0.f), lt2c = make_float2(0.f, 0.f), lt2d = make_float2(0.f, 0.f);
-        #pragma unroll
+        float2 lt2b = make_float2(0.f, 0.f), lt2c = make_float2(0.f, 0.f),
+               lt2d = make_float2(0.f, 0.f);
+#pragma unroll
         for (int c = 0; c < K_TILE / 2; c += 4) {
           lt2a = fadd2(lt2a, scores2[c + 0]);
           lt2b = fadd2(lt2b, scores2[c + 1]);
@@ -972,19 +1011,25 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
       };
 
       const bool first_masked = !(window_tiles > 0 && interior_begin == 0 && interior_end > 0);
-      if (first_masked) softmax_step(std::true_type{},  std::true_type{}, 0);
-      else              softmax_step(std::false_type{}, std::true_type{}, 0);
+      if (first_masked)
+        softmax_step(std::true_type{}, std::true_type{}, 0);
+      else
+        softmax_step(std::false_type{}, std::true_type{}, 0);
       int k = 1;
       if (window_tiles > 0) {
-        for (; k < interior_begin; ++k) softmax_step(std::true_type{},  std::false_type{}, k);
-        for (; k < interior_end;   ++k) softmax_step(std::false_type{}, std::false_type{}, k);
-        for (; k < window_tiles;   ++k) softmax_step(std::true_type{},  std::false_type{}, k);
-        if (window_tiles < K_TILES) { softmax_step(std::true_type{}, std::false_type{}, window_tiles); ++k; }
+        for (; k < interior_begin; ++k) softmax_step(std::true_type{}, std::false_type{}, k);
+        for (; k < interior_end; ++k) softmax_step(std::false_type{}, std::false_type{}, k);
+        for (; k < window_tiles; ++k) softmax_step(std::true_type{}, std::false_type{}, k);
+        if (window_tiles < K_TILES) {
+          softmax_step(std::true_type{}, std::false_type{}, window_tiles);
+          ++k;
+        }
       }
-      for (; k < K_TILES; ++k)          softmax_step(std::false_type{}, std::false_type{}, k);
+      for (; k < K_TILES; ++k) softmax_step(std::false_type{}, std::false_type{}, k);
 
       if (lse_out != nullptr) {
-        const int q_head = h_kv * gqa_group_size + (gqa_group_size == 1 ? 0 : row_in_m_tile % gqa_group_size);
+        const int q_head =
+            h_kv * gqa_group_size + (gqa_group_size == 1 ? 0 : row_in_m_tile % gqa_group_size);
         if (q_pos < seqlen) {
           const float l_safe = (l_run > 0.f) ? l_run : 1.0f;
           lse_out[((long)sample * num_q_heads + q_head) * (long)seqlen + q_pos] =
@@ -992,8 +1037,10 @@ block_causal_sink_sm100a_kernel(const __grid_constant__ CUtensorMap tmap_q,
         }
       }
       *alpha_slot = l_run;
-      if constexpr (FULL_NAMED_BAR) full_bar_arrive(m_tile, warp_in_group);
-      else mbarrier_arrive(smem_ptr_u32(&full_bar_l[m_tile]));
+      if constexpr (FULL_NAMED_BAR)
+        full_bar_arrive(m_tile, warp_in_group);
+      else
+        mbarrier_arrive(smem_ptr_u32(&full_bar_l[m_tile]));
 
       if constexpr (USE_CLC) {
         ClcTileInfo next = clc_fetch_next_tile<1, 1, ClcRasterOrder::AlongN, 1, true>(

--- a/fastvideo-kernel/csrc/attention/block_causal_sink_launch_sm100a.cuh
+++ b/fastvideo-kernel/csrc/attention/block_causal_sink_launch_sm100a.cuh
@@ -1,6 +1,7 @@
-// block_causal_sink_launch_sm100a.cuh -- callable entry point for the block-causal + sink + sliding-window
-// FMHA kernel (sm_100a, forward only). No env vars, no allocation, no host-side reordering:
-// everything comes from the caller, so a torch extension and our benchmark harness share it.
+// block_causal_sink_launch_sm100a.cuh -- callable entry point for the block-causal + sink +
+// sliding-window FMHA kernel (sm_100a, forward only). No env vars, no allocation, no host-side
+// reordering: everything comes from the caller, so a torch extension and our benchmark harness
+// share it.
 //
 // LAYOUT. Q/K/V/O are [B, H, L, D] with head_dim CONTIGUOUS. Only head_dim contiguity is
 // required -- the outer strides are read from the caller, so a torch tensor that has merely
@@ -13,20 +14,20 @@
 #include "block_causal_sink_kernel_sm100a.cuh"
 
 struct BlockCausalSinkArgs {
-  const __nv_bfloat16* q = nullptr;        // [B, H_q,  L, D]
-  const __nv_bfloat16* k = nullptr;        // [B, H_kv, L, D]
-  const __nv_bfloat16* v = nullptr;        // [B, H_kv, L, D]  (MN-major, NOT transposed)
-  const __nv_bfloat16* q_sink = nullptr;   // [B, H_q,  L, D], required iff has_delta
-  __nv_bfloat16*       o = nullptr;        // [B, H_q,  L, D]
-  float*               lse = nullptr;      // [B*H_q, L] fp32; nullptr skips the store
+  const __nv_bfloat16* q = nullptr;       // [B, H_q,  L, D]
+  const __nv_bfloat16* k = nullptr;       // [B, H_kv, L, D]
+  const __nv_bfloat16* v = nullptr;       // [B, H_kv, L, D]  (MN-major, NOT transposed)
+  const __nv_bfloat16* q_sink = nullptr;  // [B, H_q,  L, D], required iff has_delta
+  __nv_bfloat16* o = nullptr;             // [B, H_q,  L, D]
+  float* lse = nullptr;                   // [B*H_q, L] fp32; nullptr skips the store
 
   int batch = 0, seqlen = 0, num_q_heads = 0, num_kv_heads = 0, head_dim = 128;
 
-  int   tokens_per_block = 0;              // num_frame_per_block * frame_seqlen
-  int   sink_tokens = 0;                   // sink_size          * frame_seqlen
-  int   rolling_window_tokens = 0;         // local_attn_size    * frame_seqlen
-  float sm_scale = 0.f;                    // 0 -> 1/sqrt(head_dim)
-  bool  has_delta = false;                 // relativistic sink RoPE correction
+  int tokens_per_block = 0;       // num_frame_per_block * frame_seqlen
+  int sink_tokens = 0;            // sink_size          * frame_seqlen
+  int rolling_window_tokens = 0;  // local_attn_size    * frame_seqlen
+  float sm_scale = 0.f;           // 0 -> 1/sqrt(head_dim)
+  bool has_delta = false;         // relativistic sink RoPE correction
 };
 
 // Returns cudaErrorInvalidValue for an unsupported configuration rather than computing
@@ -35,74 +36,93 @@ inline cudaError_t block_causal_sink_supported(const BlockCausalSinkArgs& a) {
   if (a.head_dim != HEAD_DIM) return cudaErrorInvalidValue;
   if (a.num_q_heads % a.num_kv_heads) return cudaErrorInvalidValue;
   if (a.tokens_per_block <= 0) return cudaErrorInvalidValue;
-  if (a.seqlen % a.tokens_per_block) return cudaErrorInvalidValue;   // no partial last block
-  if (a.sink_tokens - a.tokens_per_block > K_TILE) return cudaErrorInvalidValue;  // large-sink regime
+  if (a.seqlen % a.tokens_per_block) return cudaErrorInvalidValue;  // no partial last block
+  if (a.sink_tokens - a.tokens_per_block > K_TILE)
+    return cudaErrorInvalidValue;  // large-sink regime
   if (a.has_delta && a.q_sink == nullptr) return cudaErrorInvalidValue;
   return cudaSuccess;
 }
 
 template <bool MHA, bool LPT, bool HAS_SINK_ROPE_DELTA>
-static cudaError_t launch_block_causal_sink_impl(const BlockCausalSinkArgs& a, cudaStream_t stream) {
-  const int gqa_group_size = a.num_q_heads / a.num_kv_heads;            // q-heads per kv-head
-  const int q_tokens_per_mtile = M_TILE / gqa_group_size;               // q-tokens per M-tile
-  const int q_tokens_per_cta = 2 * q_tokens_per_mtile;                    // q-tokens per CTA (2 M-tiles)
+static cudaError_t launch_block_causal_sink_impl(const BlockCausalSinkArgs& a,
+                                                 cudaStream_t stream) {
+  const int gqa_group_size = a.num_q_heads / a.num_kv_heads;  // q-heads per kv-head
+  const int q_tokens_per_mtile = M_TILE / gqa_group_size;     // q-tokens per M-tile
+  const int q_tokens_per_cta = 2 * q_tokens_per_mtile;        // q-tokens per CTA (2 M-tiles)
   CUtensorMap tmap_q, tmap_k, tmap_v_t, tmap_o, tmap_q_sink;
   {
-    uint64_t global_dims[4] = { (uint64_t)a.head_dim, (uint64_t)a.num_q_heads, (uint64_t)a.seqlen, (uint64_t)a.batch };
+    uint64_t global_dims[4] = {(uint64_t)a.head_dim, (uint64_t)a.num_q_heads, (uint64_t)a.seqlen,
+                               (uint64_t)a.batch};
     // FV [B,H,L,D]: head strides by a whole sequence, token by one head_dim row. Same dims, same
     // box, same coordinates as the old [B,L,H,D] map -- only these two strides swap roles.
-    uint64_t global_strides[3] = { (uint64_t)a.seqlen * a.head_dim * 2u, (uint64_t)a.head_dim * 2u,
-                       (uint64_t)a.num_q_heads * a.seqlen * a.head_dim * 2u };
-    uint32_t box_dims[4] = { (uint32_t)SUB_COLS_BF16, (uint32_t)gqa_group_size, (uint32_t)q_tokens_per_mtile, 1u };
-    uint32_t elem_strides[4] = { 1u, 1u, 1u, 1u };
-    CUresult r = cuTensorMapEncodeTiled(&tmap_q, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.q), global_dims, global_strides, box_dims, elem_strides,
-        CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
-        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    uint64_t global_strides[3] = {(uint64_t)a.seqlen * a.head_dim * 2u, (uint64_t)a.head_dim * 2u,
+                                  (uint64_t)a.num_q_heads * a.seqlen * a.head_dim * 2u};
+    uint32_t box_dims[4] = {(uint32_t)SUB_COLS_BF16, (uint32_t)gqa_group_size,
+                            (uint32_t)q_tokens_per_mtile, 1u};
+    uint32_t elem_strides[4] = {1u, 1u, 1u, 1u};
+    CUresult r = cuTensorMapEncodeTiled(
+        &tmap_q, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.q), global_dims,
+        global_strides, box_dims, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE,
+        CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+        CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
     CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
-    r = cuTensorMapEncodeTiled(&tmap_o, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.o), global_dims, global_strides, box_dims, elem_strides,
-        CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
-        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    r = cuTensorMapEncodeTiled(&tmap_o, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4,
+                               const_cast<__nv_bfloat16*>(a.o), global_dims, global_strides,
+                               box_dims, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE,
+                               CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+                               CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
     CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
-    // q_sink map: identical 4D layout, base = a.q_sink (or a.q when !has_delta -- unused placeholder).
-    r = cuTensorMapEncodeTiled(&tmap_q_sink, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.has_delta ? a.q_sink : a.q),
-        global_dims, global_strides, box_dims, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+    // q_sink map: identical 4D layout, base = a.q_sink (or a.q when !has_delta -- unused
+    // placeholder).
+    r = cuTensorMapEncodeTiled(
+        &tmap_q_sink, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4,
+        const_cast<__nv_bfloat16*>(a.has_delta ? a.q_sink : a.q), global_dims, global_strides,
+        box_dims, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
         CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
     CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
   }
-  // K: ONE 3D TMA copy folds the 2 head-dim swizzle atoms (HEAD_DIM = 2 x SUB_COLS_BF16) into the box
-  // (vs looping 2 x 2D copies). dims [atom-col SUB_COLS_BF16, token ((long)a.batch * a.seqlen), atom (num_kv_heads*head_dim)/SUB_COLS_BF16]; box
-  // [SUB_COLS_BF16, K_TILE, K_SUBTILES]; strides token=(num_kv_heads*head_dim)*2B, atom=SUB_COLS_BF16*2B. The box dim order
-  // (atom outermost) reproduces the atom-outer smem layout the MMA reads (atom0 then atom1).
+  // K: ONE 3D TMA copy folds the 2 head-dim swizzle atoms (HEAD_DIM = 2 x SUB_COLS_BF16) into the
+  // box (vs looping 2 x 2D copies). dims [atom-col SUB_COLS_BF16, token ((long)a.batch * a.seqlen),
+  // atom (num_kv_heads*head_dim)/SUB_COLS_BF16]; box [SUB_COLS_BF16, K_TILE, K_SUBTILES]; strides
+  // token=(num_kv_heads*head_dim)*2B, atom=SUB_COLS_BF16*2B. The box dim order (atom outermost)
+  // reproduces the atom-outer smem layout the MMA reads (atom0 then atom1).
   {
     // FV [B,H,L,D]: head and sample are adjacent with stride L*D (sample stride = HK * L*D), so the
     // two fold into ONE dim indexed sample*HK + h_kv. Atom stays the outermost box dim to keep the
     // atom-outer smem order the MMA reads.
-    uint64_t global_dims[4] = { (uint64_t)SUB_COLS_BF16, (uint64_t)a.seqlen, (uint64_t)(a.head_dim / SUB_COLS_BF16),
-                                (uint64_t)((long)a.batch * a.num_kv_heads) };
-    uint64_t global_strides[3] = { (uint64_t)a.head_dim * 2u, (uint64_t)SUB_COLS_BF16 * 2u,
-                                   (uint64_t)a.seqlen * a.head_dim * 2u };
-    uint32_t box_dims[4] = { (uint32_t)SUB_COLS_BF16, (uint32_t)K_TILE, (uint32_t)K_SUBTILES, 1u };
-    uint32_t elem_strides[4] = { 1u, 1u, 1u, 1u };
-    CUresult r = cuTensorMapEncodeTiled(&tmap_k, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.k), global_dims, global_strides, box_dims, elem_strides,
-        CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
-        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    uint64_t global_dims[4] = {(uint64_t)SUB_COLS_BF16, (uint64_t)a.seqlen,
+                               (uint64_t)(a.head_dim / SUB_COLS_BF16),
+                               (uint64_t)((long)a.batch * a.num_kv_heads)};
+    uint64_t global_strides[3] = {(uint64_t)a.head_dim * 2u, (uint64_t)SUB_COLS_BF16 * 2u,
+                                  (uint64_t)a.seqlen * a.head_dim * 2u};
+    uint32_t box_dims[4] = {(uint32_t)SUB_COLS_BF16, (uint32_t)K_TILE, (uint32_t)K_SUBTILES, 1u};
+    uint32_t elem_strides[4] = {1u, 1u, 1u, 1u};
+    CUresult r = cuTensorMapEncodeTiled(
+        &tmap_k, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.k), global_dims,
+        global_strides, box_dims, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE,
+        CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+        CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
     CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
   }
-  {   // FV SPIKE: V map is now byte-for-byte the K map, just over dV.
-    uint64_t global_dims[4] = { (uint64_t)SUB_COLS_BF16, (uint64_t)a.seqlen, (uint64_t)(a.head_dim / SUB_COLS_BF16),
-                                (uint64_t)((long)a.batch * a.num_kv_heads) };
-    uint64_t global_strides[3] = { (uint64_t)a.head_dim * 2u, (uint64_t)SUB_COLS_BF16 * 2u,
-                                   (uint64_t)a.seqlen * a.head_dim * 2u };
-    uint32_t box_dims[4] = { (uint32_t)SUB_COLS_BF16, (uint32_t)K_TILE, (uint32_t)K_SUBTILES, 1u };
-    uint32_t elem_strides[4] = { 1u, 1u, 1u, 1u };
-    CUresult r = cuTensorMapEncodeTiled(&tmap_v_t, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.v), global_dims, global_strides, box_dims, elem_strides,
-        CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
-        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  {  // FV SPIKE: V map is now byte-for-byte the K map, just over dV.
+    uint64_t global_dims[4] = {(uint64_t)SUB_COLS_BF16, (uint64_t)a.seqlen,
+                               (uint64_t)(a.head_dim / SUB_COLS_BF16),
+                               (uint64_t)((long)a.batch * a.num_kv_heads)};
+    uint64_t global_strides[3] = {(uint64_t)a.head_dim * 2u, (uint64_t)SUB_COLS_BF16 * 2u,
+                                  (uint64_t)a.seqlen * a.head_dim * 2u};
+    uint32_t box_dims[4] = {(uint32_t)SUB_COLS_BF16, (uint32_t)K_TILE, (uint32_t)K_SUBTILES, 1u};
+    uint32_t elem_strides[4] = {1u, 1u, 1u, 1u};
+    CUresult r = cuTensorMapEncodeTiled(
+        &tmap_v_t, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.v),
+        global_dims, global_strides, box_dims, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE,
+        CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+        CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
     CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
   }
 
   // ---- shared memory budget ----
-  const int packed_mtiles_per_seq = (a.seqlen + q_tokens_per_cta - 1) / q_tokens_per_cta;   // packed-M tiles per (sample, kv-head)
+  const int packed_mtiles_per_seq =
+      (a.seqlen + q_tokens_per_cta - 1) / q_tokens_per_cta;  // packed-M tiles per (sample, kv-head)
   // FastDivmod magics for decode_workitem's divides:
   //   magic0 = mtiles_per_sample (workitem_id -> sample), magic1 = mtiles_per_seq (rr -> kv_head),
   //   magic2 = num_kv_heads (swizzle path + non-Q_RASTER rr -> tile_index).
@@ -112,38 +132,41 @@ static cudaError_t launch_block_causal_sink_impl(const BlockCausalSinkArgs& a, c
   int lpt_swz_log2 = 0, lpt_hb_quot = 0, lpt_hb_rem = 1;
   unsigned long long lpt_major_magic = 1, lpt_rem_magic = 1;
   {
-    const long kv_head_bytes = (long)a.seqlen * (a.head_dim + a.head_dim) * 2;   // K + V per kv-head
-    const long size_l2 = 100L << 20;                                 // GB200 L2 ~126MB; leave headroom
+    const long kv_head_bytes = (long)a.seqlen * (a.head_dim + a.head_dim) * 2;  // K + V per kv-head
+    const long size_l2 = 100L << 20;  // GB200 L2 ~126MB; leave headroom
     int swz = 1;
     while (((long)swz << 1) * kv_head_bytes <= size_l2) swz <<= 1;
     const int hb_total = a.batch * a.num_kv_heads;
-    while (swz > hb_total && swz > 1) swz >>= 1;                     // clamp to problem
+    while (swz > hb_total && swz > 1) swz >>= 1;  // clamp to problem
     lpt_swz_log2 = 0;
     while ((1 << (lpt_swz_log2 + 1)) <= swz) ++lpt_swz_log2;
-    lpt_hb_quot    = hb_total >> lpt_swz_log2;
+    lpt_hb_quot = hb_total >> lpt_swz_log2;
     lpt_hb_rem = hb_total - (lpt_hb_quot << lpt_swz_log2);
     if (lpt_hb_rem == 0) lpt_hb_rem = 1;
     lpt_major_magic = make_magic((unsigned)(packed_mtiles_per_seq << lpt_swz_log2));
-    lpt_rem_magic   = make_magic((unsigned)lpt_hb_rem);
+    lpt_rem_magic = make_magic((unsigned)lpt_hb_rem);
   }
   // block-causal-sink runtime bounds (0 tokens_per_block => plain full/causal path).
-  const int tokens_per_block_arg      = (a.tokens_per_block > 0) ? a.tokens_per_block : 0;
-  const int sink_tokens_arg           = (a.tokens_per_block > 0) ? a.sink_tokens : 0;
+  const int tokens_per_block_arg = (a.tokens_per_block > 0) ? a.tokens_per_block : 0;
+  const int sink_tokens_arg = (a.tokens_per_block > 0) ? a.sink_tokens : 0;
   const int rolling_window_tokens_arg = (a.tokens_per_block > 0) ? a.rolling_window_tokens : 0;
   const size_t smem =
-        (size_t)2 * Q_TILE_BYTES + NUM_KV_STAGES * K_TILE_BYTES  // Q (x2) + shared K/V ring
-      + (size_t)2 * M_TILE * HEAD_DIM * sizeof(__nv_bfloat16)     // 2 sO bufs for TMA-O
-      + (2 * NUM_KV_STAGES + 22) * 8                              // mbarriers (incl full/empty_bar_o_epi)
-      + (size_t)CLC_STAGES * (2 * 8 + 16) + 16                // CLC: clc_full+clc_empty + response (16B aligned)
-      + 8                                                         // tmem_slot
-      + (size_t)2 * M_TILE * sizeof(float)                        // alpha_and_l_smem [2][M_TILE]
-      + 512;                                                      // slack / alignment + isolated wait_scale bar granule
+      (size_t)2 * Q_TILE_BYTES + NUM_KV_STAGES * K_TILE_BYTES  // Q (x2) + shared K/V ring
+      + (size_t)2 * M_TILE * HEAD_DIM * sizeof(__nv_bfloat16)  // 2 sO bufs for TMA-O
+      + (2 * NUM_KV_STAGES + 22) * 8            // mbarriers (incl full/empty_bar_o_epi)
+      + (size_t)CLC_STAGES * (2 * 8 + 16) + 16  // CLC: clc_full+clc_empty + response (16B aligned)
+      + 8                                       // tmem_slot
+      + (size_t)2 * M_TILE * sizeof(float)      // alpha_and_l_smem [2][M_TILE]
+      + 512;  // slack / alignment + isolated wait_scale bar granule
 
-  constexpr bool FULL_NAMED_BAR = true, EX2_EMU = true, SPLIT_P = true,
-                 SOFTMAX_THROTTLE = true, Q_RASTER = true;
-  constexpr bool USE_CLC = false;   // PROBE: static + swizzle (FA4's causal config)
-  auto kernel_fn = &block_causal_sink_sm100a_kernel<32, FULL_NAMED_BAR, EX2_EMU, SPLIT_P, SOFTMAX_THROTTLE, USE_CLC, Q_RASTER, MHA, LPT, 8, HAS_SINK_ROPE_DELTA>;
-  CUDA_CHECK(cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, (int)smem));
+  constexpr bool FULL_NAMED_BAR = true, EX2_EMU = true, SPLIT_P = true, SOFTMAX_THROTTLE = true,
+                 Q_RASTER = true;
+  constexpr bool USE_CLC = false;  // PROBE: static + swizzle (FA4's causal config)
+  auto kernel_fn =
+      &block_causal_sink_sm100a_kernel<32, FULL_NAMED_BAR, EX2_EMU, SPLIT_P, SOFTMAX_THROTTLE,
+                                       USE_CLC, Q_RASTER, MHA, LPT, 8, HAS_SINK_ROPE_DELTA>;
+  CUDA_CHECK(
+      cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, (int)smem));
 
   // ---- launch geometry: CLC persistent. Launch the FULL problem grid (one CTA per work tile);
   // clusterlaunchcontrol keeps only ~#SMs CTAs resident and hands the rest of the CTA-ids out via
@@ -154,7 +177,8 @@ static cudaError_t launch_block_causal_sink_impl(const BlockCausalSinkArgs& a, c
   const float scale_log2 = sm_scale * (float)M_LOG2E;
   int numSM = 0;
   CUDA_CHECK(cudaDeviceGetAttribute(&numSM, cudaDevAttrMultiProcessorCount, 0));
-  const int total_workitems_host = a.batch * packed_mtiles_per_seq * a.num_kv_heads;   // one CTA per (sample, packed-M tile, kv-head)
+  const int total_workitems_host = a.batch * packed_mtiles_per_seq *
+                                   a.num_kv_heads;  // one CTA per (sample, packed-M tile, kv-head)
   const int nblk = USE_CLC ? total_workitems_host : std::min(total_workitems_host, numSM);
   (void)numSM;
   dim3 grid(nblk, 1, 1), block(N_WARPS * 32, 1, 1);
@@ -177,14 +201,16 @@ static cudaError_t launch_block_causal_sink_impl(const BlockCausalSinkArgs& a, c
   cfg.numAttrs = 1;
   auto launch = [&]() {
     if (USE_CLC)
-      return cudaLaunchKernelEx(&cfg, kernel_fn, tmap_q, tmap_k, tmap_v_t, tmap_o, tmap_q_sink, a.lse, a.seqlen, a.num_q_heads, a.num_kv_heads,
-                                scale_log2, packed_mtiles_per_seq, a.batch, magic0, magic1, magic2,
-                                lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
-                                tokens_per_block_arg, sink_tokens_arg, rolling_window_tokens_arg);
-    kernel_fn<<<grid, block, smem, stream>>>(tmap_q, tmap_k, tmap_v_t, tmap_o, tmap_q_sink, a.lse, a.seqlen, a.num_q_heads, a.num_kv_heads,
-                               scale_log2, packed_mtiles_per_seq, a.batch, magic0, magic1, magic2,
-                               lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
-                               tokens_per_block_arg, sink_tokens_arg, rolling_window_tokens_arg);
+      return cudaLaunchKernelEx(
+          &cfg, kernel_fn, tmap_q, tmap_k, tmap_v_t, tmap_o, tmap_q_sink, a.lse, a.seqlen,
+          a.num_q_heads, a.num_kv_heads, scale_log2, packed_mtiles_per_seq, a.batch, magic0, magic1,
+          magic2, lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
+          tokens_per_block_arg, sink_tokens_arg, rolling_window_tokens_arg);
+    kernel_fn<<<grid, block, smem, stream>>>(
+        tmap_q, tmap_k, tmap_v_t, tmap_o, tmap_q_sink, a.lse, a.seqlen, a.num_q_heads,
+        a.num_kv_heads, scale_log2, packed_mtiles_per_seq, a.batch, magic0, magic1, magic2,
+        lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic, tokens_per_block_arg,
+        sink_tokens_arg, rolling_window_tokens_arg);
     return cudaGetLastError();
   };
 
@@ -194,15 +220,16 @@ static cudaError_t launch_block_causal_sink_impl(const BlockCausalSinkArgs& a, c
 // Runtime -> template dispatch. MHA (H_q == H_kv) and the relativistic sink correction are
 // compile-time in the kernel; the caller only knows them at runtime, so pick the instantiation
 // here. LPT (heaviest-first causal balance) is a fixed tuning choice.
-inline cudaError_t launch_block_causal_sink_sm100a(const BlockCausalSinkArgs& a, cudaStream_t stream) {
+inline cudaError_t launch_block_causal_sink_sm100a(const BlockCausalSinkArgs& a,
+                                                   cudaStream_t stream) {
   const cudaError_t bad = block_causal_sink_supported(a);
   if (bad != cudaSuccess) return bad;
   constexpr bool LPT = true;
   const bool mha = (a.num_q_heads == a.num_kv_heads);
   if (mha) {
-    return a.has_delta ? launch_block_causal_sink_impl<true,  LPT, true >(a, stream)
-                       : launch_block_causal_sink_impl<true,  LPT, false>(a, stream);
+    return a.has_delta ? launch_block_causal_sink_impl<true, LPT, true>(a, stream)
+                       : launch_block_causal_sink_impl<true, LPT, false>(a, stream);
   }
-  return a.has_delta ? launch_block_causal_sink_impl<false, LPT, true >(a, stream)
+  return a.has_delta ? launch_block_causal_sink_impl<false, LPT, true>(a, stream)
                      : launch_block_causal_sink_impl<false, LPT, false>(a, stream);
 }

--- a/fastvideo-kernel/csrc/attention/block_causal_sink_launch_sm100a.cuh
+++ b/fastvideo-kernel/csrc/attention/block_causal_sink_launch_sm100a.cuh
@@ -1,0 +1,208 @@
+// block_causal_sink_launch_sm100a.cuh -- callable entry point for the block-causal + sink + sliding-window
+// FMHA kernel (sm_100a, forward only). No env vars, no allocation, no host-side reordering:
+// everything comes from the caller, so a torch extension and our benchmark harness share it.
+//
+// LAYOUT. Q/K/V/O are [B, H, L, D] with head_dim CONTIGUOUS. Only head_dim contiguity is
+// required -- the outer strides are read from the caller, so a torch tensor that has merely
+// been permuted (no .contiguous()) is consumed as-is with no copy. V is read MN-major, so it
+// needs no transpose either.
+//
+// SCALE. sm_scale is the caller's, matching FastVideo's qk_scale = sm_scale * LOG2E. Getting
+// it wrong corrupts both O and lse and does so plausibly, so it is never derived here.
+#pragma once
+#include "block_causal_sink_kernel_sm100a.cuh"
+
+struct BlockCausalSinkArgs {
+  const __nv_bfloat16* q = nullptr;        // [B, H_q,  L, D]
+  const __nv_bfloat16* k = nullptr;        // [B, H_kv, L, D]
+  const __nv_bfloat16* v = nullptr;        // [B, H_kv, L, D]  (MN-major, NOT transposed)
+  const __nv_bfloat16* q_sink = nullptr;   // [B, H_q,  L, D], required iff has_delta
+  __nv_bfloat16*       o = nullptr;        // [B, H_q,  L, D]
+  float*               lse = nullptr;      // [B*H_q, L] fp32; nullptr skips the store
+
+  int batch = 0, seqlen = 0, num_q_heads = 0, num_kv_heads = 0, head_dim = 128;
+
+  int   tokens_per_block = 0;              // num_frame_per_block * frame_seqlen
+  int   sink_tokens = 0;                   // sink_size          * frame_seqlen
+  int   rolling_window_tokens = 0;         // local_attn_size    * frame_seqlen
+  float sm_scale = 0.f;                    // 0 -> 1/sqrt(head_dim)
+  bool  has_delta = false;                 // relativistic sink RoPE correction
+};
+
+// Returns cudaErrorInvalidValue for an unsupported configuration rather than computing
+// silently-wrong results.
+inline cudaError_t block_causal_sink_supported(const BlockCausalSinkArgs& a) {
+  if (a.head_dim != HEAD_DIM) return cudaErrorInvalidValue;
+  if (a.num_q_heads % a.num_kv_heads) return cudaErrorInvalidValue;
+  if (a.tokens_per_block <= 0) return cudaErrorInvalidValue;
+  if (a.seqlen % a.tokens_per_block) return cudaErrorInvalidValue;   // no partial last block
+  if (a.sink_tokens - a.tokens_per_block > K_TILE) return cudaErrorInvalidValue;  // large-sink regime
+  if (a.has_delta && a.q_sink == nullptr) return cudaErrorInvalidValue;
+  return cudaSuccess;
+}
+
+template <bool MHA, bool LPT, bool HAS_SINK_ROPE_DELTA>
+static cudaError_t launch_block_causal_sink_impl(const BlockCausalSinkArgs& a, cudaStream_t stream) {
+  const int gqa_group_size = a.num_q_heads / a.num_kv_heads;            // q-heads per kv-head
+  const int q_tokens_per_mtile = M_TILE / gqa_group_size;               // q-tokens per M-tile
+  const int q_tokens_per_cta = 2 * q_tokens_per_mtile;                    // q-tokens per CTA (2 M-tiles)
+  CUtensorMap tmap_q, tmap_k, tmap_v_t, tmap_o, tmap_q_sink;
+  {
+    uint64_t global_dims[4] = { (uint64_t)a.head_dim, (uint64_t)a.num_q_heads, (uint64_t)a.seqlen, (uint64_t)a.batch };
+    // FV [B,H,L,D]: head strides by a whole sequence, token by one head_dim row. Same dims, same
+    // box, same coordinates as the old [B,L,H,D] map -- only these two strides swap roles.
+    uint64_t global_strides[3] = { (uint64_t)a.seqlen * a.head_dim * 2u, (uint64_t)a.head_dim * 2u,
+                       (uint64_t)a.num_q_heads * a.seqlen * a.head_dim * 2u };
+    uint32_t box_dims[4] = { (uint32_t)SUB_COLS_BF16, (uint32_t)gqa_group_size, (uint32_t)q_tokens_per_mtile, 1u };
+    uint32_t elem_strides[4] = { 1u, 1u, 1u, 1u };
+    CUresult r = cuTensorMapEncodeTiled(&tmap_q, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.q), global_dims, global_strides, box_dims, elem_strides,
+        CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
+    r = cuTensorMapEncodeTiled(&tmap_o, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.o), global_dims, global_strides, box_dims, elem_strides,
+        CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
+    // q_sink map: identical 4D layout, base = a.q_sink (or a.q when !has_delta -- unused placeholder).
+    r = cuTensorMapEncodeTiled(&tmap_q_sink, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.has_delta ? a.q_sink : a.q),
+        global_dims, global_strides, box_dims, elem_strides, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
+  }
+  // K: ONE 3D TMA copy folds the 2 head-dim swizzle atoms (HEAD_DIM = 2 x SUB_COLS_BF16) into the box
+  // (vs looping 2 x 2D copies). dims [atom-col SUB_COLS_BF16, token ((long)a.batch * a.seqlen), atom (num_kv_heads*head_dim)/SUB_COLS_BF16]; box
+  // [SUB_COLS_BF16, K_TILE, K_SUBTILES]; strides token=(num_kv_heads*head_dim)*2B, atom=SUB_COLS_BF16*2B. The box dim order
+  // (atom outermost) reproduces the atom-outer smem layout the MMA reads (atom0 then atom1).
+  {
+    // FV [B,H,L,D]: head and sample are adjacent with stride L*D (sample stride = HK * L*D), so the
+    // two fold into ONE dim indexed sample*HK + h_kv. Atom stays the outermost box dim to keep the
+    // atom-outer smem order the MMA reads.
+    uint64_t global_dims[4] = { (uint64_t)SUB_COLS_BF16, (uint64_t)a.seqlen, (uint64_t)(a.head_dim / SUB_COLS_BF16),
+                                (uint64_t)((long)a.batch * a.num_kv_heads) };
+    uint64_t global_strides[3] = { (uint64_t)a.head_dim * 2u, (uint64_t)SUB_COLS_BF16 * 2u,
+                                   (uint64_t)a.seqlen * a.head_dim * 2u };
+    uint32_t box_dims[4] = { (uint32_t)SUB_COLS_BF16, (uint32_t)K_TILE, (uint32_t)K_SUBTILES, 1u };
+    uint32_t elem_strides[4] = { 1u, 1u, 1u, 1u };
+    CUresult r = cuTensorMapEncodeTiled(&tmap_k, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.k), global_dims, global_strides, box_dims, elem_strides,
+        CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
+  }
+  {   // FV SPIKE: V map is now byte-for-byte the K map, just over dV.
+    uint64_t global_dims[4] = { (uint64_t)SUB_COLS_BF16, (uint64_t)a.seqlen, (uint64_t)(a.head_dim / SUB_COLS_BF16),
+                                (uint64_t)((long)a.batch * a.num_kv_heads) };
+    uint64_t global_strides[3] = { (uint64_t)a.head_dim * 2u, (uint64_t)SUB_COLS_BF16 * 2u,
+                                   (uint64_t)a.seqlen * a.head_dim * 2u };
+    uint32_t box_dims[4] = { (uint32_t)SUB_COLS_BF16, (uint32_t)K_TILE, (uint32_t)K_SUBTILES, 1u };
+    uint32_t elem_strides[4] = { 1u, 1u, 1u, 1u };
+    CUresult r = cuTensorMapEncodeTiled(&tmap_v_t, CU_TENSOR_MAP_DATA_TYPE_BFLOAT16, 4, const_cast<__nv_bfloat16*>(a.v), global_dims, global_strides, box_dims, elem_strides,
+        CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_128B,
+        CU_TENSOR_MAP_L2_PROMOTION_L2_128B, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    CUDA_CHECK(r == CUDA_SUCCESS ? cudaSuccess : cudaErrorInvalidValue);
+  }
+
+  // ---- shared memory budget ----
+  const int packed_mtiles_per_seq = (a.seqlen + q_tokens_per_cta - 1) / q_tokens_per_cta;   // packed-M tiles per (sample, kv-head)
+  // FastDivmod magics for decode_workitem's divides:
+  //   magic0 = mtiles_per_sample (workitem_id -> sample), magic1 = mtiles_per_seq (rr -> kv_head),
+  //   magic2 = num_kv_heads (swizzle path + non-Q_RASTER rr -> tile_index).
+  const unsigned long long magic0 = make_magic((unsigned)(packed_mtiles_per_seq * a.num_kv_heads));
+  const unsigned long long magic1 = make_magic((unsigned)packed_mtiles_per_seq);
+  const unsigned long long magic2 = make_magic((unsigned)a.num_kv_heads);
+  int lpt_swz_log2 = 0, lpt_hb_quot = 0, lpt_hb_rem = 1;
+  unsigned long long lpt_major_magic = 1, lpt_rem_magic = 1;
+  {
+    const long kv_head_bytes = (long)a.seqlen * (a.head_dim + a.head_dim) * 2;   // K + V per kv-head
+    const long size_l2 = 100L << 20;                                 // GB200 L2 ~126MB; leave headroom
+    int swz = 1;
+    while (((long)swz << 1) * kv_head_bytes <= size_l2) swz <<= 1;
+    const int hb_total = a.batch * a.num_kv_heads;
+    while (swz > hb_total && swz > 1) swz >>= 1;                     // clamp to problem
+    lpt_swz_log2 = 0;
+    while ((1 << (lpt_swz_log2 + 1)) <= swz) ++lpt_swz_log2;
+    lpt_hb_quot    = hb_total >> lpt_swz_log2;
+    lpt_hb_rem = hb_total - (lpt_hb_quot << lpt_swz_log2);
+    if (lpt_hb_rem == 0) lpt_hb_rem = 1;
+    lpt_major_magic = make_magic((unsigned)(packed_mtiles_per_seq << lpt_swz_log2));
+    lpt_rem_magic   = make_magic((unsigned)lpt_hb_rem);
+  }
+  // block-causal-sink runtime bounds (0 tokens_per_block => plain full/causal path).
+  const int tokens_per_block_arg      = (a.tokens_per_block > 0) ? a.tokens_per_block : 0;
+  const int sink_tokens_arg           = (a.tokens_per_block > 0) ? a.sink_tokens : 0;
+  const int rolling_window_tokens_arg = (a.tokens_per_block > 0) ? a.rolling_window_tokens : 0;
+  const size_t smem =
+        (size_t)2 * Q_TILE_BYTES + NUM_KV_STAGES * K_TILE_BYTES  // Q (x2) + shared K/V ring
+      + (size_t)2 * M_TILE * HEAD_DIM * sizeof(__nv_bfloat16)     // 2 sO bufs for TMA-O
+      + (2 * NUM_KV_STAGES + 22) * 8                              // mbarriers (incl full/empty_bar_o_epi)
+      + (size_t)CLC_STAGES * (2 * 8 + 16) + 16                // CLC: clc_full+clc_empty + response (16B aligned)
+      + 8                                                         // tmem_slot
+      + (size_t)2 * M_TILE * sizeof(float)                        // alpha_and_l_smem [2][M_TILE]
+      + 512;                                                      // slack / alignment + isolated wait_scale bar granule
+
+  constexpr bool FULL_NAMED_BAR = true, EX2_EMU = true, SPLIT_P = true,
+                 SOFTMAX_THROTTLE = true, Q_RASTER = true;
+  constexpr bool USE_CLC = false;   // PROBE: static + swizzle (FA4's causal config)
+  auto kernel_fn = &block_causal_sink_sm100a_kernel<32, FULL_NAMED_BAR, EX2_EMU, SPLIT_P, SOFTMAX_THROTTLE, USE_CLC, Q_RASTER, MHA, LPT, 8, HAS_SINK_ROPE_DELTA>;
+  CUDA_CHECK(cudaFuncSetAttribute(kernel_fn, cudaFuncAttributeMaxDynamicSharedMemorySize, (int)smem));
+
+  // ---- launch geometry: CLC persistent. Launch the FULL problem grid (one CTA per work tile);
+  // clusterlaunchcontrol keeps only ~#SMs CTAs resident and hands the rest of the CTA-ids out via
+  // try_cancel (HW work-stealing scheduler), so the grid-size is the tile count, not #SMs. ----
+  // exp2-domain scale: qk * (sm_scale * log2e), matching FastVideo's qk_scale = sm_scale * LOG2E.
+  // Wrong here corrupts BOTH O and lse (lse = m*scale_log2 + log2 l), and does so plausibly.
+  const float sm_scale = (a.sm_scale > 0.f) ? a.sm_scale : (1.0f / sqrtf((float)a.head_dim));
+  const float scale_log2 = sm_scale * (float)M_LOG2E;
+  int numSM = 0;
+  CUDA_CHECK(cudaDeviceGetAttribute(&numSM, cudaDevAttrMultiProcessorCount, 0));
+  const int total_workitems_host = a.batch * packed_mtiles_per_seq * a.num_kv_heads;   // one CTA per (sample, packed-M tile, kv-head)
+  const int nblk = USE_CLC ? total_workitems_host : std::min(total_workitems_host, numSM);
+  (void)numSM;
+  dim3 grid(nblk, 1, 1), block(N_WARPS * 32, 1, 1);
+
+  // CLC must be launched via cudaLaunchKernelEx with a cluster-dimension attribute -- a plain
+  // <<<grid,block>>> launch does NOT enable clusterlaunchcontrol (try_cancel silently misbehaves
+  // and tiles get skipped). cluster {1,1,1} (matches __cluster_dims__(1,1,1)); no PSS attribute
+  // (we don't drive griddepcontrol, so leave the dependent-launch serialization off).
+  cudaLaunchConfig_t cfg = {};
+  cfg.gridDim = grid;
+  cfg.blockDim = block;
+  cfg.dynamicSmemBytes = smem;
+  cfg.stream = stream;
+  cudaLaunchAttribute cfgAttr[1];
+  cfgAttr[0].id = cudaLaunchAttributeClusterDimension;
+  cfgAttr[0].val.clusterDim.x = 1;
+  cfgAttr[0].val.clusterDim.y = 1;
+  cfgAttr[0].val.clusterDim.z = 1;
+  cfg.attrs = cfgAttr;
+  cfg.numAttrs = 1;
+  auto launch = [&]() {
+    if (USE_CLC)
+      return cudaLaunchKernelEx(&cfg, kernel_fn, tmap_q, tmap_k, tmap_v_t, tmap_o, tmap_q_sink, a.lse, a.seqlen, a.num_q_heads, a.num_kv_heads,
+                                scale_log2, packed_mtiles_per_seq, a.batch, magic0, magic1, magic2,
+                                lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
+                                tokens_per_block_arg, sink_tokens_arg, rolling_window_tokens_arg);
+    kernel_fn<<<grid, block, smem, stream>>>(tmap_q, tmap_k, tmap_v_t, tmap_o, tmap_q_sink, a.lse, a.seqlen, a.num_q_heads, a.num_kv_heads,
+                               scale_log2, packed_mtiles_per_seq, a.batch, magic0, magic1, magic2,
+                               lpt_swz_log2, lpt_hb_quot, lpt_hb_rem, lpt_major_magic, lpt_rem_magic,
+                               tokens_per_block_arg, sink_tokens_arg, rolling_window_tokens_arg);
+    return cudaGetLastError();
+  };
+
+  return launch();
+}
+
+// Runtime -> template dispatch. MHA (H_q == H_kv) and the relativistic sink correction are
+// compile-time in the kernel; the caller only knows them at runtime, so pick the instantiation
+// here. LPT (heaviest-first causal balance) is a fixed tuning choice.
+inline cudaError_t launch_block_causal_sink_sm100a(const BlockCausalSinkArgs& a, cudaStream_t stream) {
+  const cudaError_t bad = block_causal_sink_supported(a);
+  if (bad != cudaSuccess) return bad;
+  constexpr bool LPT = true;
+  const bool mha = (a.num_q_heads == a.num_kv_heads);
+  if (mha) {
+    return a.has_delta ? launch_block_causal_sink_impl<true,  LPT, true >(a, stream)
+                       : launch_block_causal_sink_impl<true,  LPT, false>(a, stream);
+  }
+  return a.has_delta ? launch_block_causal_sink_impl<false, LPT, true >(a, stream)
+                     : launch_block_causal_sink_impl<false, LPT, false>(a, stream);
+}

--- a/fastvideo-kernel/csrc/attention/block_causal_sink_sm100a.cu
+++ b/fastvideo-kernel/csrc/attention/block_causal_sink_sm100a.cu
@@ -22,15 +22,10 @@ void check_qkv(const torch::Tensor& t, const char* name, int64_t B, int64_t H, i
   TORCH_CHECK(t.dim() == 4, name, " must be [B, H, L, D], got ", t.dim(), " dims");
   TORCH_CHECK(t.size(0) == B && t.size(1) == H && t.size(2) == L && t.size(3) == D, name,
               " has shape ", t.sizes(), ", expected [", B, ",", H, ",", L, ",", D, "]");
-  // head_dim contiguous is the ONLY layout requirement -- it is what lets the TMA descriptor
-  // index the caller's tensor directly instead of forcing a .contiguous() copy.
-  TORCH_CHECK(t.stride(3) == 1, name,
-              " must have a contiguous head_dim (stride(-1) == 1); "
-              "permuted views are fine, .contiguous() is not required");
-  // TMA requires 16-byte aligned strides; bf16 -> multiples of 8 elements.
-  for (int d = 0; d < 3; ++d)
-    TORCH_CHECK(t.stride(d) % 8 == 0, name, " stride(", d, ")=", t.stride(d),
-                " must be a multiple of 8 elements (16 B) for TMA");
+  // TODO: the TMA descriptors are built for a contiguous [B, H, L, D] tensor. Plumbing the
+  // caller's strides through BlockCausalSinkArgs would make any permutation of B/H/L free,
+  // as long as head_dim stays innermost.
+  TORCH_CHECK(t.is_contiguous(), name, " must be contiguous [B, H, L, D]");
 }
 
 }  // namespace

--- a/fastvideo-kernel/csrc/attention/block_causal_sink_sm100a.cu
+++ b/fastvideo-kernel/csrc/attention/block_causal_sink_sm100a.cu
@@ -1,0 +1,90 @@
+// block_causal_sink_sm100a.cu -- torch binding for the sm_100a block-causal + sink +
+// sliding-window FMHA forward.
+//
+// Forward only: returns (out, lse) so the existing Triton backward keeps working
+// unchanged -- lse is exactly the tensor _fwd_kernel writes today.
+//
+// Nothing is copied or reordered here. Q/K/V/O only need head_dim contiguous; the outer
+// strides are read off the tensors, so a permuted (non-contiguous) view costs nothing.
+#include <torch/extension.h>
+
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+
+#include "block_causal_sink_launch_sm100a.cuh"
+
+namespace {
+
+void check_qkv(const torch::Tensor& t, const char* name, int64_t B, int64_t H, int64_t L, int64_t D) {
+  TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
+  TORCH_CHECK(t.scalar_type() == at::kBFloat16, name, " must be bfloat16, got ", t.scalar_type());
+  TORCH_CHECK(t.dim() == 4, name, " must be [B, H, L, D], got ", t.dim(), " dims");
+  TORCH_CHECK(t.size(0) == B && t.size(1) == H && t.size(2) == L && t.size(3) == D,
+              name, " has shape ", t.sizes(), ", expected [", B, ",", H, ",", L, ",", D, "]");
+  // head_dim contiguous is the ONLY layout requirement -- it is what lets the TMA descriptor
+  // index the caller's tensor directly instead of forcing a .contiguous() copy.
+  TORCH_CHECK(t.stride(3) == 1, name, " must have a contiguous head_dim (stride(-1) == 1); "
+                                      "permuted views are fine, .contiguous() is not required");
+  // TMA requires 16-byte aligned strides; bf16 -> multiples of 8 elements.
+  for (int d = 0; d < 3; ++d)
+    TORCH_CHECK(t.stride(d) % 8 == 0, name, " stride(", d, ")=", t.stride(d),
+                " must be a multiple of 8 elements (16 B) for TMA");
+}
+
+}  // namespace
+
+// Returns {out, lse}. lse is [B*H_q, L] float32 -- FastVideo's backward input.
+std::vector<torch::Tensor> block_causal_sink_sm100a_fwd(
+    torch::Tensor q, torch::Tensor k, torch::Tensor v,
+    c10::optional<torch::Tensor> q_sink,
+    int64_t tokens_per_block, int64_t sink_tokens, int64_t rolling_window_tokens,
+    double sm_scale, bool need_lse) {
+  const at::cuda::OptionalCUDAGuard guard(device_of(q));
+
+  const int64_t B = q.size(0), Hq = q.size(1), L = q.size(2), D = q.size(3);
+  const int64_t Hkv = k.size(1);
+  check_qkv(q, "q", B, Hq, L, D);
+  check_qkv(k, "k", B, Hkv, L, D);
+  check_qkv(v, "v", B, Hkv, L, D);
+  TORCH_CHECK(Hq % Hkv == 0, "num_q_heads (", Hq, ") must be divisible by num_kv_heads (", Hkv, ")");
+
+  const bool has_delta = q_sink.has_value();
+  if (has_delta) check_qkv(*q_sink, "q_sink", B, Hq, L, D);
+
+  auto out = torch::empty_like(q);
+  torch::Tensor lse;
+  if (need_lse)
+    lse = torch::empty({B * Hq, L}, q.options().dtype(torch::kFloat32));
+
+  BlockCausalSinkArgs a;
+  a.q = reinterpret_cast<const __nv_bfloat16*>(q.data_ptr());
+  a.k = reinterpret_cast<const __nv_bfloat16*>(k.data_ptr());
+  a.v = reinterpret_cast<const __nv_bfloat16*>(v.data_ptr());
+  a.q_sink = has_delta ? reinterpret_cast<const __nv_bfloat16*>(q_sink->data_ptr()) : nullptr;
+  a.o = reinterpret_cast<__nv_bfloat16*>(out.data_ptr());
+  a.lse = need_lse ? lse.data_ptr<float>() : nullptr;
+  a.batch = (int)B;
+  a.seqlen = (int)L;
+  a.num_q_heads = (int)Hq;
+  a.num_kv_heads = (int)Hkv;
+  a.head_dim = (int)D;
+  a.tokens_per_block = (int)tokens_per_block;
+  a.sink_tokens = (int)sink_tokens;
+  a.rolling_window_tokens = (int)rolling_window_tokens;
+  a.sm_scale = (float)sm_scale;
+  a.has_delta = has_delta;
+
+  // Report an unsupported regime loudly. Outside it the decode/masking are out of spec and the
+  // kernel would return plausible-looking but wrong values.
+  TORCH_CHECK(block_causal_sink_supported(a) == cudaSuccess,
+              "block_causal_sink_sm100a: unsupported configuration -- requires head_dim==", HEAD_DIM,
+              ", seqlen divisible by tokens_per_block (no partial last block), and a sink reaching "
+              "at most one K_TILE past a block end. Got head_dim=", D, " seqlen=", L,
+              " tokens_per_block=", tokens_per_block, " sink_tokens=", sink_tokens);
+
+  const cudaError_t err = launch_block_causal_sink_sm100a(a, at::cuda::getCurrentCUDAStream());
+  TORCH_CHECK(err == cudaSuccess, "block_causal_sink_sm100a launch failed: ", cudaGetErrorString(err));
+
+  if (need_lse) return {out, lse};
+  return {out};
+}

--- a/fastvideo-kernel/csrc/attention/block_causal_sink_sm100a.cu
+++ b/fastvideo-kernel/csrc/attention/block_causal_sink_sm100a.cu
@@ -15,16 +15,18 @@
 
 namespace {
 
-void check_qkv(const torch::Tensor& t, const char* name, int64_t B, int64_t H, int64_t L, int64_t D) {
+void check_qkv(const torch::Tensor& t, const char* name, int64_t B, int64_t H, int64_t L,
+               int64_t D) {
   TORCH_CHECK(t.is_cuda(), name, " must be a CUDA tensor");
   TORCH_CHECK(t.scalar_type() == at::kBFloat16, name, " must be bfloat16, got ", t.scalar_type());
   TORCH_CHECK(t.dim() == 4, name, " must be [B, H, L, D], got ", t.dim(), " dims");
-  TORCH_CHECK(t.size(0) == B && t.size(1) == H && t.size(2) == L && t.size(3) == D,
-              name, " has shape ", t.sizes(), ", expected [", B, ",", H, ",", L, ",", D, "]");
+  TORCH_CHECK(t.size(0) == B && t.size(1) == H && t.size(2) == L && t.size(3) == D, name,
+              " has shape ", t.sizes(), ", expected [", B, ",", H, ",", L, ",", D, "]");
   // head_dim contiguous is the ONLY layout requirement -- it is what lets the TMA descriptor
   // index the caller's tensor directly instead of forcing a .contiguous() copy.
-  TORCH_CHECK(t.stride(3) == 1, name, " must have a contiguous head_dim (stride(-1) == 1); "
-                                      "permuted views are fine, .contiguous() is not required");
+  TORCH_CHECK(t.stride(3) == 1, name,
+              " must have a contiguous head_dim (stride(-1) == 1); "
+              "permuted views are fine, .contiguous() is not required");
   // TMA requires 16-byte aligned strides; bf16 -> multiples of 8 elements.
   for (int d = 0; d < 3; ++d)
     TORCH_CHECK(t.stride(d) % 8 == 0, name, " stride(", d, ")=", t.stride(d),
@@ -35,10 +37,9 @@ void check_qkv(const torch::Tensor& t, const char* name, int64_t B, int64_t H, i
 
 // Returns {out, lse}. lse is [B*H_q, L] float32 -- FastVideo's backward input.
 std::vector<torch::Tensor> block_causal_sink_sm100a_fwd(
-    torch::Tensor q, torch::Tensor k, torch::Tensor v,
-    c10::optional<torch::Tensor> q_sink,
-    int64_t tokens_per_block, int64_t sink_tokens, int64_t rolling_window_tokens,
-    double sm_scale, bool need_lse) {
+    torch::Tensor q, torch::Tensor k, torch::Tensor v, c10::optional<torch::Tensor> q_sink,
+    int64_t tokens_per_block, int64_t sink_tokens, int64_t rolling_window_tokens, double sm_scale,
+    bool need_lse) {
   const at::cuda::OptionalCUDAGuard guard(device_of(q));
 
   const int64_t B = q.size(0), Hq = q.size(1), L = q.size(2), D = q.size(3);
@@ -46,15 +47,15 @@ std::vector<torch::Tensor> block_causal_sink_sm100a_fwd(
   check_qkv(q, "q", B, Hq, L, D);
   check_qkv(k, "k", B, Hkv, L, D);
   check_qkv(v, "v", B, Hkv, L, D);
-  TORCH_CHECK(Hq % Hkv == 0, "num_q_heads (", Hq, ") must be divisible by num_kv_heads (", Hkv, ")");
+  TORCH_CHECK(Hq % Hkv == 0, "num_q_heads (", Hq, ") must be divisible by num_kv_heads (", Hkv,
+              ")");
 
   const bool has_delta = q_sink.has_value();
   if (has_delta) check_qkv(*q_sink, "q_sink", B, Hq, L, D);
 
   auto out = torch::empty_like(q);
   torch::Tensor lse;
-  if (need_lse)
-    lse = torch::empty({B * Hq, L}, q.options().dtype(torch::kFloat32));
+  if (need_lse) lse = torch::empty({B * Hq, L}, q.options().dtype(torch::kFloat32));
 
   BlockCausalSinkArgs a;
   a.q = reinterpret_cast<const __nv_bfloat16*>(q.data_ptr());
@@ -76,14 +77,16 @@ std::vector<torch::Tensor> block_causal_sink_sm100a_fwd(
 
   // Report an unsupported regime loudly. Outside it the decode/masking are out of spec and the
   // kernel would return plausible-looking but wrong values.
-  TORCH_CHECK(block_causal_sink_supported(a) == cudaSuccess,
-              "block_causal_sink_sm100a: unsupported configuration -- requires head_dim==", HEAD_DIM,
-              ", seqlen divisible by tokens_per_block (no partial last block), and a sink reaching "
-              "at most one K_TILE past a block end. Got head_dim=", D, " seqlen=", L,
-              " tokens_per_block=", tokens_per_block, " sink_tokens=", sink_tokens);
+  TORCH_CHECK(
+      block_causal_sink_supported(a) == cudaSuccess,
+      "block_causal_sink_sm100a: unsupported configuration -- requires head_dim==", HEAD_DIM,
+      ", seqlen divisible by tokens_per_block (no partial last block), and a sink reaching "
+      "at most one K_TILE past a block end. Got head_dim=",
+      D, " seqlen=", L, " tokens_per_block=", tokens_per_block, " sink_tokens=", sink_tokens);
 
   const cudaError_t err = launch_block_causal_sink_sm100a(a, at::cuda::getCurrentCUDAStream());
-  TORCH_CHECK(err == cudaSuccess, "block_causal_sink_sm100a launch failed: ", cudaGetErrorString(err));
+  TORCH_CHECK(err == cudaSuccess,
+              "block_causal_sink_sm100a launch failed: ", cudaGetErrorString(err));
 
   if (need_lse) return {out, lse};
   return {out};

--- a/fastvideo-kernel/csrc/attention/primitives.cuh
+++ b/fastvideo-kernel/csrc/attention/primitives.cuh
@@ -18,59 +18,48 @@
 #include <cmath>
 
 #ifndef CUDA_CHECK
-#define CUDA_CHECK(stmt) do {                                                 \
-    cudaError_t _e = (stmt);                                                  \
-    if (_e != cudaSuccess) {                                                  \
-      fprintf(stderr, "CUDA error %s:%d: %s -> %s\n",                         \
-              __FILE__, __LINE__, #stmt, cudaGetErrorString(_e));             \
-      std::exit(1);                                                           \
-    }                                                                         \
+#define CUDA_CHECK(stmt)                                                         \
+  do {                                                                           \
+    cudaError_t _e = (stmt);                                                     \
+    if (_e != cudaSuccess) {                                                     \
+      fprintf(stderr, "CUDA error %s:%d: %s -> %s\n", __FILE__, __LINE__, #stmt, \
+              cudaGetErrorString(_e));                                           \
+      std::exit(1);                                                              \
+    }                                                                            \
   } while (0)
 #endif
 
-
-
-__device__ __forceinline__
-uint32_t smem_ptr_u32(const void* ptr) {
+__device__ __forceinline__ uint32_t smem_ptr_u32(const void* ptr) {
   return static_cast<uint32_t>(__cvta_generic_to_shared(ptr));
 }
 
-__device__ __forceinline__
-void sts_f32(uint32_t smem_addr, float val) {
-  asm volatile("st.shared.f32 [%0], %1;" :: "r"(smem_addr), "f"(val) : "memory");
+__device__ __forceinline__ void sts_f32(uint32_t smem_addr, float val) {
+  asm volatile("st.shared.f32 [%0], %1;" ::"r"(smem_addr), "f"(val) : "memory");
 }
 
-
 template <int CTA_GROUP>
-__device__ __forceinline__ void tcgen05_alloc(uint32_t smem_dst_ptr,
-                                              uint32_t n_cols) {
-  static_assert(CTA_GROUP == 1 || CTA_GROUP == 2,
-                "tcgen05_alloc: CTA_GROUP must be 1 or 2");
+__device__ __forceinline__ void tcgen05_alloc(uint32_t smem_dst_ptr, uint32_t n_cols) {
+  static_assert(CTA_GROUP == 1 || CTA_GROUP == 2, "tcgen05_alloc: CTA_GROUP must be 1 or 2");
   if constexpr (CTA_GROUP == 1) {
     asm volatile(
-      "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;\n"
-      :: "r"(smem_dst_ptr), "r"(n_cols));
+        "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;\n" ::"r"(smem_dst_ptr),
+        "r"(n_cols));
   } else {
     asm volatile(
-      "tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [%0], %1;\n"
-      :: "r"(smem_dst_ptr), "r"(n_cols));
+        "tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [%0], %1;\n" ::"r"(smem_dst_ptr),
+        "r"(n_cols));
   }
 }
 
-
 template <int CTA_GROUP>
-__device__ __forceinline__ void tcgen05_dealloc(uint32_t tmem_addr,
-                                                uint32_t n_cols) {
-  static_assert(CTA_GROUP == 1 || CTA_GROUP == 2,
-                "tcgen05_dealloc: CTA_GROUP must be 1 or 2");
+__device__ __forceinline__ void tcgen05_dealloc(uint32_t tmem_addr, uint32_t n_cols) {
+  static_assert(CTA_GROUP == 1 || CTA_GROUP == 2, "tcgen05_dealloc: CTA_GROUP must be 1 or 2");
   if constexpr (CTA_GROUP == 1) {
-    asm volatile(
-      "tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;\n"
-      :: "r"(tmem_addr), "r"(n_cols));
+    asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;\n" ::"r"(tmem_addr),
+                 "r"(n_cols));
   } else {
-    asm volatile(
-      "tcgen05.dealloc.cta_group::2.sync.aligned.b32 %0, %1;\n"
-      :: "r"(tmem_addr), "r"(n_cols));
+    asm volatile("tcgen05.dealloc.cta_group::2.sync.aligned.b32 %0, %1;\n" ::"r"(tmem_addr),
+                 "r"(n_cols));
   }
 }
 
@@ -85,41 +74,39 @@ __device__ __forceinline__ void tcgen05_relinquish_alloc_permit() {
   }
 }
 
-
-__device__ __forceinline__ void tcgen05_mma_f16_ss_lead(uint32_t lead,
-    uint32_t tmem_c, uint64_t desc_a, uint64_t desc_b, uint32_t idesc,
-    bool enable_input_d) {
+__device__ __forceinline__ void tcgen05_mma_f16_ss_lead(uint32_t lead, uint32_t tmem_c,
+                                                        uint64_t desc_a, uint64_t desc_b,
+                                                        uint32_t idesc, bool enable_input_d) {
   asm volatile(
-    "{\n\t"
-    ".reg .pred p, q;\n\t"
-    "setp.ne.b32 q, %0, 0;\n\t"
-    "setp.ne.b32 p, %5, 0;\n\t"
-    "@q tcgen05.mma.cta_group::1.kind::f16 [%1], %2, %3, %4, {%6, %7, %8, %9}, p;\n\t"
-    "}\n"
-    :: "r"(lead), "r"(tmem_c), "l"(desc_a), "l"(desc_b), "r"(idesc),
-       "r"(enable_input_d ? 1u : 0u), "r"(0u), "r"(0u), "r"(0u), "r"(0u));
+      "{\n\t"
+      ".reg .pred p, q;\n\t"
+      "setp.ne.b32 q, %0, 0;\n\t"
+      "setp.ne.b32 p, %5, 0;\n\t"
+      "@q tcgen05.mma.cta_group::1.kind::f16 [%1], %2, %3, %4, {%6, %7, %8, %9}, p;\n\t"
+      "}\n" ::"r"(lead),
+      "r"(tmem_c), "l"(desc_a), "l"(desc_b), "r"(idesc), "r"(enable_input_d ? 1u : 0u), "r"(0u),
+      "r"(0u), "r"(0u), "r"(0u));
 }
 
-__device__ __forceinline__ void tcgen05_mma_f16_ts_1sm_lead(uint32_t lead,
-    uint32_t tmem_c, uint32_t tmem_a, uint64_t desc_b, uint32_t idesc,
-    bool enable_input_d) {
+__device__ __forceinline__ void tcgen05_mma_f16_ts_1sm_lead(uint32_t lead, uint32_t tmem_c,
+                                                            uint32_t tmem_a, uint64_t desc_b,
+                                                            uint32_t idesc, bool enable_input_d) {
   asm volatile(
-    "{\n\t"
-    ".reg .pred p, q;\n\t"
-    "setp.ne.b32 q, %0, 0;\n\t"
-    "setp.ne.b32 p, %5, 0;\n\t"
-    "@q tcgen05.mma.cta_group::1.kind::f16 [%1], [%2], %3, %4, {%6, %7, %8, %9}, p;\n\t"
-    "}\n"
-    :: "r"(lead), "r"(tmem_c), "r"(tmem_a), "l"(desc_b), "r"(idesc),
-       "r"(enable_input_d ? 1u : 0u), "r"(0u), "r"(0u), "r"(0u), "r"(0u));
+      "{\n\t"
+      ".reg .pred p, q;\n\t"
+      "setp.ne.b32 q, %0, 0;\n\t"
+      "setp.ne.b32 p, %5, 0;\n\t"
+      "@q tcgen05.mma.cta_group::1.kind::f16 [%1], [%2], %3, %4, {%6, %7, %8, %9}, p;\n\t"
+      "}\n" ::"r"(lead),
+      "r"(tmem_c), "r"(tmem_a), "l"(desc_b), "r"(idesc), "r"(enable_input_d ? 1u : 0u), "r"(0u),
+      "r"(0u), "r"(0u), "r"(0u));
 }
 
-
-__device__ __forceinline__ uint32_t make_idesc_table44(
-    int M, int N,
-    uint32_t dtype, uint32_t atype, uint32_t btype,
-    bool transpose_a = false, bool transpose_b = false,
-    bool negate_a = false, bool negate_b = false) {
+__device__ __forceinline__ uint32_t make_idesc_table44(int M, int N, uint32_t dtype, uint32_t atype,
+                                                       uint32_t btype, bool transpose_a = false,
+                                                       bool transpose_b = false,
+                                                       bool negate_a = false,
+                                                       bool negate_b = false) {
   uint32_t idesc = 0;
   idesc |= (dtype & 0x3) << 4;
   idesc |= (atype & 0x7) << 7;
@@ -133,163 +120,129 @@ __device__ __forceinline__ uint32_t make_idesc_table44(
   return idesc;
 }
 
-__device__ __forceinline__ uint32_t make_idesc_bf16_f32(
-    int M, int N, bool ta = false, bool tb = false) {
-  return make_idesc_table44(M, N,  1,
-                              1,  1, ta, tb);
+__device__ __forceinline__ uint32_t make_idesc_bf16_f32(int M, int N, bool ta = false,
+                                                        bool tb = false) {
+  return make_idesc_table44(M, N, 1, 1, 1, ta, tb);
 }
 
-
-__device__ __forceinline__ void tcgen05_ld_32x32b_x16(
-    uint32_t tmem_addr, uint32_t (&r)[16]) {
-  asm volatile("tcgen05.ld.sync.aligned.32x32b.x16.b32 "
-               "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
-               "%10,%11,%12,%13,%14,%15}, [%16];\n"
-               : "=r"(r[0]),"=r"(r[1]),"=r"(r[2]),"=r"(r[3]),
-                 "=r"(r[4]),"=r"(r[5]),"=r"(r[6]),"=r"(r[7]),
-                 "=r"(r[8]),"=r"(r[9]),"=r"(r[10]),"=r"(r[11]),
-                 "=r"(r[12]),"=r"(r[13]),"=r"(r[14]),"=r"(r[15])
-               : "r"(tmem_addr));
+__device__ __forceinline__ void tcgen05_ld_32x32b_x16(uint32_t tmem_addr, uint32_t (&r)[16]) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x16.b32 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
+      "%10,%11,%12,%13,%14,%15}, [%16];\n"
+      : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3]), "=r"(r[4]), "=r"(r[5]), "=r"(r[6]),
+        "=r"(r[7]), "=r"(r[8]), "=r"(r[9]), "=r"(r[10]), "=r"(r[11]), "=r"(r[12]), "=r"(r[13]),
+        "=r"(r[14]), "=r"(r[15])
+      : "r"(tmem_addr));
 }
 
-__device__ __forceinline__ void tcgen05_ld_32x32b_x32(
-    uint32_t tmem_addr, uint32_t (&r)[32]) {
-  asm volatile("tcgen05.ld.sync.aligned.32x32b.x32.b32 "
-               "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
-               "%10,%11,%12,%13,%14,%15,%16,%17,%18,%19,"
-               "%20,%21,%22,%23,%24,%25,%26,%27,%28,%29,"
-               "%30,%31}, [%32];\n"
-               : "=r"(r[0]),"=r"(r[1]),"=r"(r[2]),"=r"(r[3]),
-                 "=r"(r[4]),"=r"(r[5]),"=r"(r[6]),"=r"(r[7]),
-                 "=r"(r[8]),"=r"(r[9]),"=r"(r[10]),"=r"(r[11]),
-                 "=r"(r[12]),"=r"(r[13]),"=r"(r[14]),"=r"(r[15]),
-                 "=r"(r[16]),"=r"(r[17]),"=r"(r[18]),"=r"(r[19]),
-                 "=r"(r[20]),"=r"(r[21]),"=r"(r[22]),"=r"(r[23]),
-                 "=r"(r[24]),"=r"(r[25]),"=r"(r[26]),"=r"(r[27]),
-                 "=r"(r[28]),"=r"(r[29]),"=r"(r[30]),"=r"(r[31])
-               : "r"(tmem_addr));
+__device__ __forceinline__ void tcgen05_ld_32x32b_x32(uint32_t tmem_addr, uint32_t (&r)[32]) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x32.b32 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
+      "%10,%11,%12,%13,%14,%15,%16,%17,%18,%19,"
+      "%20,%21,%22,%23,%24,%25,%26,%27,%28,%29,"
+      "%30,%31}, [%32];\n"
+      : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3]), "=r"(r[4]), "=r"(r[5]), "=r"(r[6]),
+        "=r"(r[7]), "=r"(r[8]), "=r"(r[9]), "=r"(r[10]), "=r"(r[11]), "=r"(r[12]), "=r"(r[13]),
+        "=r"(r[14]), "=r"(r[15]), "=r"(r[16]), "=r"(r[17]), "=r"(r[18]), "=r"(r[19]), "=r"(r[20]),
+        "=r"(r[21]), "=r"(r[22]), "=r"(r[23]), "=r"(r[24]), "=r"(r[25]), "=r"(r[26]), "=r"(r[27]),
+        "=r"(r[28]), "=r"(r[29]), "=r"(r[30]), "=r"(r[31])
+      : "r"(tmem_addr));
 }
 
-__device__ __forceinline__ void tcgen05_ld_32x32b_x64(
-    uint32_t tmem_addr, uint32_t (&r)[64]) {
-  asm volatile("tcgen05.ld.sync.aligned.32x32b.x64.b32 "
-               "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
-               "%10,%11,%12,%13,%14,%15,%16,%17,%18,%19,"
-               "%20,%21,%22,%23,%24,%25,%26,%27,%28,%29,"
-               "%30,%31,%32,%33,%34,%35,%36,%37,%38,%39,"
-               "%40,%41,%42,%43,%44,%45,%46,%47,%48,%49,"
-               "%50,%51,%52,%53,%54,%55,%56,%57,%58,%59,"
-               "%60,%61,%62,%63}, [%64];\n"
-               : "=r"(r[0]),"=r"(r[1]),"=r"(r[2]),"=r"(r[3]),
-                 "=r"(r[4]),"=r"(r[5]),"=r"(r[6]),"=r"(r[7]),
-                 "=r"(r[8]),"=r"(r[9]),"=r"(r[10]),"=r"(r[11]),
-                 "=r"(r[12]),"=r"(r[13]),"=r"(r[14]),"=r"(r[15]),
-                 "=r"(r[16]),"=r"(r[17]),"=r"(r[18]),"=r"(r[19]),
-                 "=r"(r[20]),"=r"(r[21]),"=r"(r[22]),"=r"(r[23]),
-                 "=r"(r[24]),"=r"(r[25]),"=r"(r[26]),"=r"(r[27]),
-                 "=r"(r[28]),"=r"(r[29]),"=r"(r[30]),"=r"(r[31]),
-                 "=r"(r[32]),"=r"(r[33]),"=r"(r[34]),"=r"(r[35]),
-                 "=r"(r[36]),"=r"(r[37]),"=r"(r[38]),"=r"(r[39]),
-                 "=r"(r[40]),"=r"(r[41]),"=r"(r[42]),"=r"(r[43]),
-                 "=r"(r[44]),"=r"(r[45]),"=r"(r[46]),"=r"(r[47]),
-                 "=r"(r[48]),"=r"(r[49]),"=r"(r[50]),"=r"(r[51]),
-                 "=r"(r[52]),"=r"(r[53]),"=r"(r[54]),"=r"(r[55]),
-                 "=r"(r[56]),"=r"(r[57]),"=r"(r[58]),"=r"(r[59]),
-                 "=r"(r[60]),"=r"(r[61]),"=r"(r[62]),"=r"(r[63])
-               : "r"(tmem_addr));
+__device__ __forceinline__ void tcgen05_ld_32x32b_x64(uint32_t tmem_addr, uint32_t (&r)[64]) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x64.b32 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
+      "%10,%11,%12,%13,%14,%15,%16,%17,%18,%19,"
+      "%20,%21,%22,%23,%24,%25,%26,%27,%28,%29,"
+      "%30,%31,%32,%33,%34,%35,%36,%37,%38,%39,"
+      "%40,%41,%42,%43,%44,%45,%46,%47,%48,%49,"
+      "%50,%51,%52,%53,%54,%55,%56,%57,%58,%59,"
+      "%60,%61,%62,%63}, [%64];\n"
+      : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3]), "=r"(r[4]), "=r"(r[5]), "=r"(r[6]),
+        "=r"(r[7]), "=r"(r[8]), "=r"(r[9]), "=r"(r[10]), "=r"(r[11]), "=r"(r[12]), "=r"(r[13]),
+        "=r"(r[14]), "=r"(r[15]), "=r"(r[16]), "=r"(r[17]), "=r"(r[18]), "=r"(r[19]), "=r"(r[20]),
+        "=r"(r[21]), "=r"(r[22]), "=r"(r[23]), "=r"(r[24]), "=r"(r[25]), "=r"(r[26]), "=r"(r[27]),
+        "=r"(r[28]), "=r"(r[29]), "=r"(r[30]), "=r"(r[31]), "=r"(r[32]), "=r"(r[33]), "=r"(r[34]),
+        "=r"(r[35]), "=r"(r[36]), "=r"(r[37]), "=r"(r[38]), "=r"(r[39]), "=r"(r[40]), "=r"(r[41]),
+        "=r"(r[42]), "=r"(r[43]), "=r"(r[44]), "=r"(r[45]), "=r"(r[46]), "=r"(r[47]), "=r"(r[48]),
+        "=r"(r[49]), "=r"(r[50]), "=r"(r[51]), "=r"(r[52]), "=r"(r[53]), "=r"(r[54]), "=r"(r[55]),
+        "=r"(r[56]), "=r"(r[57]), "=r"(r[58]), "=r"(r[59]), "=r"(r[60]), "=r"(r[61]), "=r"(r[62]),
+        "=r"(r[63])
+      : "r"(tmem_addr));
 }
 
-__device__ __forceinline__ void tcgen05_ld_32x32b_x128(
-    uint32_t tmem_addr, uint32_t (&r)[128]) {
-  asm volatile("tcgen05.ld.sync.aligned.32x32b.x128.b32 "
-               "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
-               "%10,%11,%12,%13,%14,%15,%16,%17,%18,%19,"
-               "%20,%21,%22,%23,%24,%25,%26,%27,%28,%29,"
-               "%30,%31,%32,%33,%34,%35,%36,%37,%38,%39,"
-               "%40,%41,%42,%43,%44,%45,%46,%47,%48,%49,"
-               "%50,%51,%52,%53,%54,%55,%56,%57,%58,%59,"
-               "%60,%61,%62,%63,%64,%65,%66,%67,%68,%69,"
-               "%70,%71,%72,%73,%74,%75,%76,%77,%78,%79,"
-               "%80,%81,%82,%83,%84,%85,%86,%87,%88,%89,"
-               "%90,%91,%92,%93,%94,%95,%96,%97,%98,%99,"
-               "%100,%101,%102,%103,%104,%105,%106,%107,%108,%109,"
-               "%110,%111,%112,%113,%114,%115,%116,%117,%118,%119,"
-               "%120,%121,%122,%123,%124,%125,%126,%127}, [%128];\n"
-               : "=r"(r[  0]),"=r"(r[  1]),"=r"(r[  2]),"=r"(r[  3]),
-                 "=r"(r[  4]),"=r"(r[  5]),"=r"(r[  6]),"=r"(r[  7]),
-                 "=r"(r[  8]),"=r"(r[  9]),"=r"(r[ 10]),"=r"(r[ 11]),
-                 "=r"(r[ 12]),"=r"(r[ 13]),"=r"(r[ 14]),"=r"(r[ 15]),
-                 "=r"(r[ 16]),"=r"(r[ 17]),"=r"(r[ 18]),"=r"(r[ 19]),
-                 "=r"(r[ 20]),"=r"(r[ 21]),"=r"(r[ 22]),"=r"(r[ 23]),
-                 "=r"(r[ 24]),"=r"(r[ 25]),"=r"(r[ 26]),"=r"(r[ 27]),
-                 "=r"(r[ 28]),"=r"(r[ 29]),"=r"(r[ 30]),"=r"(r[ 31]),
-                 "=r"(r[ 32]),"=r"(r[ 33]),"=r"(r[ 34]),"=r"(r[ 35]),
-                 "=r"(r[ 36]),"=r"(r[ 37]),"=r"(r[ 38]),"=r"(r[ 39]),
-                 "=r"(r[ 40]),"=r"(r[ 41]),"=r"(r[ 42]),"=r"(r[ 43]),
-                 "=r"(r[ 44]),"=r"(r[ 45]),"=r"(r[ 46]),"=r"(r[ 47]),
-                 "=r"(r[ 48]),"=r"(r[ 49]),"=r"(r[ 50]),"=r"(r[ 51]),
-                 "=r"(r[ 52]),"=r"(r[ 53]),"=r"(r[ 54]),"=r"(r[ 55]),
-                 "=r"(r[ 56]),"=r"(r[ 57]),"=r"(r[ 58]),"=r"(r[ 59]),
-                 "=r"(r[ 60]),"=r"(r[ 61]),"=r"(r[ 62]),"=r"(r[ 63]),
-                 "=r"(r[ 64]),"=r"(r[ 65]),"=r"(r[ 66]),"=r"(r[ 67]),
-                 "=r"(r[ 68]),"=r"(r[ 69]),"=r"(r[ 70]),"=r"(r[ 71]),
-                 "=r"(r[ 72]),"=r"(r[ 73]),"=r"(r[ 74]),"=r"(r[ 75]),
-                 "=r"(r[ 76]),"=r"(r[ 77]),"=r"(r[ 78]),"=r"(r[ 79]),
-                 "=r"(r[ 80]),"=r"(r[ 81]),"=r"(r[ 82]),"=r"(r[ 83]),
-                 "=r"(r[ 84]),"=r"(r[ 85]),"=r"(r[ 86]),"=r"(r[ 87]),
-                 "=r"(r[ 88]),"=r"(r[ 89]),"=r"(r[ 90]),"=r"(r[ 91]),
-                 "=r"(r[ 92]),"=r"(r[ 93]),"=r"(r[ 94]),"=r"(r[ 95]),
-                 "=r"(r[ 96]),"=r"(r[ 97]),"=r"(r[ 98]),"=r"(r[ 99]),
-                 "=r"(r[100]),"=r"(r[101]),"=r"(r[102]),"=r"(r[103]),
-                 "=r"(r[104]),"=r"(r[105]),"=r"(r[106]),"=r"(r[107]),
-                 "=r"(r[108]),"=r"(r[109]),"=r"(r[110]),"=r"(r[111]),
-                 "=r"(r[112]),"=r"(r[113]),"=r"(r[114]),"=r"(r[115]),
-                 "=r"(r[116]),"=r"(r[117]),"=r"(r[118]),"=r"(r[119]),
-                 "=r"(r[120]),"=r"(r[121]),"=r"(r[122]),"=r"(r[123]),
-                 "=r"(r[124]),"=r"(r[125]),"=r"(r[126]),"=r"(r[127])
-               : "r"(tmem_addr));
+__device__ __forceinline__ void tcgen05_ld_32x32b_x128(uint32_t tmem_addr, uint32_t (&r)[128]) {
+  asm volatile(
+      "tcgen05.ld.sync.aligned.32x32b.x128.b32 "
+      "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
+      "%10,%11,%12,%13,%14,%15,%16,%17,%18,%19,"
+      "%20,%21,%22,%23,%24,%25,%26,%27,%28,%29,"
+      "%30,%31,%32,%33,%34,%35,%36,%37,%38,%39,"
+      "%40,%41,%42,%43,%44,%45,%46,%47,%48,%49,"
+      "%50,%51,%52,%53,%54,%55,%56,%57,%58,%59,"
+      "%60,%61,%62,%63,%64,%65,%66,%67,%68,%69,"
+      "%70,%71,%72,%73,%74,%75,%76,%77,%78,%79,"
+      "%80,%81,%82,%83,%84,%85,%86,%87,%88,%89,"
+      "%90,%91,%92,%93,%94,%95,%96,%97,%98,%99,"
+      "%100,%101,%102,%103,%104,%105,%106,%107,%108,%109,"
+      "%110,%111,%112,%113,%114,%115,%116,%117,%118,%119,"
+      "%120,%121,%122,%123,%124,%125,%126,%127}, [%128];\n"
+      : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3]), "=r"(r[4]), "=r"(r[5]), "=r"(r[6]),
+        "=r"(r[7]), "=r"(r[8]), "=r"(r[9]), "=r"(r[10]), "=r"(r[11]), "=r"(r[12]), "=r"(r[13]),
+        "=r"(r[14]), "=r"(r[15]), "=r"(r[16]), "=r"(r[17]), "=r"(r[18]), "=r"(r[19]), "=r"(r[20]),
+        "=r"(r[21]), "=r"(r[22]), "=r"(r[23]), "=r"(r[24]), "=r"(r[25]), "=r"(r[26]), "=r"(r[27]),
+        "=r"(r[28]), "=r"(r[29]), "=r"(r[30]), "=r"(r[31]), "=r"(r[32]), "=r"(r[33]), "=r"(r[34]),
+        "=r"(r[35]), "=r"(r[36]), "=r"(r[37]), "=r"(r[38]), "=r"(r[39]), "=r"(r[40]), "=r"(r[41]),
+        "=r"(r[42]), "=r"(r[43]), "=r"(r[44]), "=r"(r[45]), "=r"(r[46]), "=r"(r[47]), "=r"(r[48]),
+        "=r"(r[49]), "=r"(r[50]), "=r"(r[51]), "=r"(r[52]), "=r"(r[53]), "=r"(r[54]), "=r"(r[55]),
+        "=r"(r[56]), "=r"(r[57]), "=r"(r[58]), "=r"(r[59]), "=r"(r[60]), "=r"(r[61]), "=r"(r[62]),
+        "=r"(r[63]), "=r"(r[64]), "=r"(r[65]), "=r"(r[66]), "=r"(r[67]), "=r"(r[68]), "=r"(r[69]),
+        "=r"(r[70]), "=r"(r[71]), "=r"(r[72]), "=r"(r[73]), "=r"(r[74]), "=r"(r[75]), "=r"(r[76]),
+        "=r"(r[77]), "=r"(r[78]), "=r"(r[79]), "=r"(r[80]), "=r"(r[81]), "=r"(r[82]), "=r"(r[83]),
+        "=r"(r[84]), "=r"(r[85]), "=r"(r[86]), "=r"(r[87]), "=r"(r[88]), "=r"(r[89]), "=r"(r[90]),
+        "=r"(r[91]), "=r"(r[92]), "=r"(r[93]), "=r"(r[94]), "=r"(r[95]), "=r"(r[96]), "=r"(r[97]),
+        "=r"(r[98]), "=r"(r[99]), "=r"(r[100]), "=r"(r[101]), "=r"(r[102]), "=r"(r[103]),
+        "=r"(r[104]), "=r"(r[105]), "=r"(r[106]), "=r"(r[107]), "=r"(r[108]), "=r"(r[109]),
+        "=r"(r[110]), "=r"(r[111]), "=r"(r[112]), "=r"(r[113]), "=r"(r[114]), "=r"(r[115]),
+        "=r"(r[116]), "=r"(r[117]), "=r"(r[118]), "=r"(r[119]), "=r"(r[120]), "=r"(r[121]),
+        "=r"(r[122]), "=r"(r[123]), "=r"(r[124]), "=r"(r[125]), "=r"(r[126]), "=r"(r[127])
+      : "r"(tmem_addr));
 }
 
-
-__device__ __forceinline__ void tcgen05_st_32x32b_x16(
-    uint32_t tmem_addr, const uint32_t (&r)[16]) {
-  asm volatile("tcgen05.st.sync.aligned.32x32b.x16.b32 "
-               "[%0], {%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,"
-               "%11,%12,%13,%14,%15,%16};\n"
-               :: "r"(tmem_addr),
-                  "r"(r[0]),"r"(r[1]),"r"(r[2]),"r"(r[3]),
-                  "r"(r[4]),"r"(r[5]),"r"(r[6]),"r"(r[7]),
-                  "r"(r[8]),"r"(r[9]),"r"(r[10]),"r"(r[11]),
-                  "r"(r[12]),"r"(r[13]),"r"(r[14]),"r"(r[15]));
+__device__ __forceinline__ void tcgen05_st_32x32b_x16(uint32_t tmem_addr, const uint32_t (&r)[16]) {
+  asm volatile(
+      "tcgen05.st.sync.aligned.32x32b.x16.b32 "
+      "[%0], {%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,"
+      "%11,%12,%13,%14,%15,%16};\n" ::"r"(tmem_addr),
+      "r"(r[0]), "r"(r[1]), "r"(r[2]), "r"(r[3]), "r"(r[4]), "r"(r[5]), "r"(r[6]), "r"(r[7]),
+      "r"(r[8]), "r"(r[9]), "r"(r[10]), "r"(r[11]), "r"(r[12]), "r"(r[13]), "r"(r[14]), "r"(r[15]));
 }
 
-__device__ __forceinline__ void tcgen05_st_32x32b_x32(
-    uint32_t tmem_addr, const uint32_t (&r)[32]) {
-  asm volatile("tcgen05.st.sync.aligned.32x32b.x32.b32 "
-               "[%0], {%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,"
-               "%11,%12,%13,%14,%15,%16,%17,%18,%19,%20,"
-               "%21,%22,%23,%24,%25,%26,%27,%28,%29,%30,"
-               "%31,%32};\n"
-               :: "r"(tmem_addr),
-                  "r"(r[0]),"r"(r[1]),"r"(r[2]),"r"(r[3]),
-                  "r"(r[4]),"r"(r[5]),"r"(r[6]),"r"(r[7]),
-                  "r"(r[8]),"r"(r[9]),"r"(r[10]),"r"(r[11]),
-                  "r"(r[12]),"r"(r[13]),"r"(r[14]),"r"(r[15]),
-                  "r"(r[16]),"r"(r[17]),"r"(r[18]),"r"(r[19]),
-                  "r"(r[20]),"r"(r[21]),"r"(r[22]),"r"(r[23]),
-                  "r"(r[24]),"r"(r[25]),"r"(r[26]),"r"(r[27]),
-                  "r"(r[28]),"r"(r[29]),"r"(r[30]),"r"(r[31]));
+__device__ __forceinline__ void tcgen05_st_32x32b_x32(uint32_t tmem_addr, const uint32_t (&r)[32]) {
+  asm volatile(
+      "tcgen05.st.sync.aligned.32x32b.x32.b32 "
+      "[%0], {%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,"
+      "%11,%12,%13,%14,%15,%16,%17,%18,%19,%20,"
+      "%21,%22,%23,%24,%25,%26,%27,%28,%29,%30,"
+      "%31,%32};\n" ::"r"(tmem_addr),
+      "r"(r[0]), "r"(r[1]), "r"(r[2]), "r"(r[3]), "r"(r[4]), "r"(r[5]), "r"(r[6]), "r"(r[7]),
+      "r"(r[8]), "r"(r[9]), "r"(r[10]), "r"(r[11]), "r"(r[12]), "r"(r[13]), "r"(r[14]), "r"(r[15]),
+      "r"(r[16]), "r"(r[17]), "r"(r[18]), "r"(r[19]), "r"(r[20]), "r"(r[21]), "r"(r[22]),
+      "r"(r[23]), "r"(r[24]), "r"(r[25]), "r"(r[26]), "r"(r[27]), "r"(r[28]), "r"(r[29]),
+      "r"(r[30]), "r"(r[31]));
 }
-
 
 __device__ __forceinline__ void tcgen05_commit1_lead(uint32_t lead, uint32_t mbar_smem_addr) {
   asm volatile(
-    "{\n\t"
-    ".reg .pred q;\n\t"
-    "setp.ne.b32 q, %0, 0;\n\t"
-    "@q tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64 [%1];\n\t"
-    "}\n"
-    :: "r"(lead), "r"(mbar_smem_addr));
+      "{\n\t"
+      ".reg .pred q;\n\t"
+      "setp.ne.b32 q, %0, 0;\n\t"
+      "@q tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64 [%1];\n\t"
+      "}\n" ::"r"(lead),
+      "r"(mbar_smem_addr));
 }
 
 __device__ __forceinline__ void tcgen05_wait_st() {
@@ -300,178 +253,151 @@ __device__ __forceinline__ void tcgen05_fence_before_thread_sync() {
   asm volatile("tcgen05.fence::before_thread_sync;\n" ::: "memory");
 }
 
-
-__device__ __forceinline__
-void tma_load_2d(uint32_t smem_dst, const void* tensormap_ptr,
-                 uint32_t mbar_smem, int coord_x, int coord_y) {
+__device__ __forceinline__ void tma_load_2d(uint32_t smem_dst, const void* tensormap_ptr,
+                                            uint32_t mbar_smem, int coord_x, int coord_y) {
   asm volatile(
-    "cp.async.bulk.tensor.2d.shared::cluster.global.tile"
-    ".mbarrier::complete_tx::bytes"
-    " [%0], [%1, {%3, %4}], [%2];\n"
-    :: "r"(smem_dst), "l"(tensormap_ptr),
-       "r"(mbar_smem), "r"(coord_x), "r"(coord_y)
-    : "memory");
+      "cp.async.bulk.tensor.2d.shared::cluster.global.tile"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%3, %4}], [%2];\n" ::"r"(smem_dst),
+      "l"(tensormap_ptr), "r"(mbar_smem), "r"(coord_x), "r"(coord_y)
+      : "memory");
 }
 
-__device__ __forceinline__
-void tma_load_3d(uint32_t smem_dst, const void* tensormap_ptr,
-                 uint32_t mbar_smem, int c0, int c1, int c2) {
+__device__ __forceinline__ void tma_load_3d(uint32_t smem_dst, const void* tensormap_ptr,
+                                            uint32_t mbar_smem, int c0, int c1, int c2) {
   asm volatile(
-    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
-    ".mbarrier::complete_tx::bytes"
-    " [%0], [%1, {%3, %4, %5}], [%2];\n"
-    :: "r"(smem_dst), "l"(tensormap_ptr),
-       "r"(mbar_smem), "r"(c0), "r"(c1), "r"(c2)
-    : "memory");
+      "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%3, %4, %5}], [%2];\n" ::"r"(smem_dst),
+      "l"(tensormap_ptr), "r"(mbar_smem), "r"(c0), "r"(c1), "r"(c2)
+      : "memory");
 }
 
-__device__ __forceinline__
-void tma_load_4d(uint32_t smem_dst, const void* tensormap_ptr,
-                 uint32_t mbar_smem, int c0, int c1, int c2, int c3) {
+__device__ __forceinline__ void tma_load_4d(uint32_t smem_dst, const void* tensormap_ptr,
+                                            uint32_t mbar_smem, int c0, int c1, int c2, int c3) {
   asm volatile(
-    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
-    ".mbarrier::complete_tx::bytes"
-    " [%0], [%1, {%3, %4, %5, %6}], [%2];\n"
-    :: "r"(smem_dst), "l"(tensormap_ptr),
-       "r"(mbar_smem), "r"(c0), "r"(c1), "r"(c2), "r"(c3)
-    : "memory");
+      "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+      ".mbarrier::complete_tx::bytes"
+      " [%0], [%1, {%3, %4, %5, %6}], [%2];\n" ::"r"(smem_dst),
+      "l"(tensormap_ptr), "r"(mbar_smem), "r"(c0), "r"(c1), "r"(c2), "r"(c3)
+      : "memory");
 }
 
-
-__device__ __forceinline__
-void tma_store_2d(const void* tensormap_ptr, int coord_x, int coord_y,
-                  uint32_t smem_src) {
+__device__ __forceinline__ void tma_store_2d(const void* tensormap_ptr, int coord_x, int coord_y,
+                                             uint32_t smem_src) {
   asm volatile(
-    "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"
-    " [%0, {%1, %2}], [%3];\n"
-    :: "l"(tensormap_ptr), "r"(coord_x), "r"(coord_y),
-       "r"(smem_src)
-    : "memory");
+      "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"
+      " [%0, {%1, %2}], [%3];\n" ::"l"(tensormap_ptr),
+      "r"(coord_x), "r"(coord_y), "r"(smem_src)
+      : "memory");
 }
 
-__device__ __forceinline__
-void tma_store_3d(const void* tensormap_ptr, int c0, int c1, int c2,
-                  uint32_t smem_src) {
+__device__ __forceinline__ void tma_store_3d(const void* tensormap_ptr, int c0, int c1, int c2,
+                                             uint32_t smem_src) {
   asm volatile(
-    "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
-    " [%0, {%1, %2, %3}], [%4];\n"
-    :: "l"(tensormap_ptr), "r"(c0), "r"(c1), "r"(c2), "r"(smem_src)
-    : "memory");
+      "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+      " [%0, {%1, %2, %3}], [%4];\n" ::"l"(tensormap_ptr),
+      "r"(c0), "r"(c1), "r"(c2), "r"(smem_src)
+      : "memory");
 }
 
-__device__ __forceinline__
-void tma_store_4d(const void* tensormap_ptr, int c0, int c1, int c2, int c3,
-                  uint32_t smem_src) {
+__device__ __forceinline__ void tma_store_4d(const void* tensormap_ptr, int c0, int c1, int c2,
+                                             int c3, uint32_t smem_src) {
   asm volatile(
-    "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
-    " [%0, {%1, %2, %3, %4}], [%5];\n"
-    :: "l"(tensormap_ptr), "r"(c0), "r"(c1), "r"(c2), "r"(c3), "r"(smem_src)
-    : "memory");
+      "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+      " [%0, {%1, %2, %3, %4}], [%5];\n" ::"l"(tensormap_ptr),
+      "r"(c0), "r"(c1), "r"(c2), "r"(c3), "r"(smem_src)
+      : "memory");
 }
 
-
-
-__device__ __forceinline__
-void cp_async_bulk_commit_group() {
+__device__ __forceinline__ void cp_async_bulk_commit_group() {
   asm volatile("cp.async.bulk.commit_group;\n" ::: "memory");
 }
 
 template <int N>
-__device__ __forceinline__
-void cp_async_bulk_wait_group_read() {
-  asm volatile("cp.async.bulk.wait_group.read %0;\n" :: "n"(N) : "memory");
+__device__ __forceinline__ void cp_async_bulk_wait_group_read() {
+  asm volatile("cp.async.bulk.wait_group.read %0;\n" ::"n"(N) : "memory");
 }
 
-
-__device__ __forceinline__
-void mbarrier_init(uint32_t mbar_smem, uint32_t arrive_count) {
-  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n"
-               :: "r"(mbar_smem), "r"(arrive_count) : "memory");
+__device__ __forceinline__ void mbarrier_init(uint32_t mbar_smem, uint32_t arrive_count) {
+  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n" ::"r"(mbar_smem), "r"(arrive_count)
+               : "memory");
 }
 
-
-__device__ __forceinline__
-uint64_t mbarrier_arrive(uint32_t mbar_smem) {
+__device__ __forceinline__ uint64_t mbarrier_arrive(uint32_t mbar_smem) {
   uint64_t state;
   asm volatile("mbarrier.arrive.shared::cta.b64 %0, [%1];\n"
-               : "=l"(state) : "r"(mbar_smem) : "memory");
+               : "=l"(state)
+               : "r"(mbar_smem)
+               : "memory");
   return state;
 }
 
-__device__ __forceinline__
-void mbarrier_arrive_nostate(uint32_t mbar_smem) {
-  asm volatile("mbarrier.arrive.shared::cta.b64 _, [%0];\n"
-               :: "r"(mbar_smem) : "memory");
+__device__ __forceinline__ void mbarrier_arrive_nostate(uint32_t mbar_smem) {
+  asm volatile("mbarrier.arrive.shared::cta.b64 _, [%0];\n" ::"r"(mbar_smem) : "memory");
 }
 
-__device__ __forceinline__
-void mbarrier_arrive_cluster_default(uint32_t cluster_smem_addr) {
-  asm volatile("mbarrier.arrive.shared::cluster.b64 _, [%0];\n"
-               :: "r"(cluster_smem_addr) : "memory");
+__device__ __forceinline__ void mbarrier_arrive_cluster_default(uint32_t cluster_smem_addr) {
+  asm volatile("mbarrier.arrive.shared::cluster.b64 _, [%0];\n" ::"r"(cluster_smem_addr)
+               : "memory");
 }
 
-
-__device__ __forceinline__
-void mbarrier_arrive_expect_tx(uint32_t mbar_smem, uint32_t expected_bytes) {
-  asm volatile("mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;\n"
-               :: "r"(mbar_smem), "r"(expected_bytes) : "memory");
-}
-
-
-__device__ __forceinline__
-void mbarrier_wait_parity_suspend(uint32_t mbar_smem, uint32_t phase_parity) {
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(uint32_t mbar_smem,
+                                                          uint32_t expected_bytes) {
   asm volatile(
-    "{\n"
-    ".reg .pred P1;\n"
-    "LAB_WAIT:\n"
-    "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1, 10000000;\n"
-    "@!P1 bra.uni LAB_WAIT;\n"
-    "}\n"
-    :: "r"(mbar_smem), "r"(phase_parity) : "memory");
+      "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;\n" ::"r"(mbar_smem),
+      "r"(expected_bytes)
+      : "memory");
 }
 
-__device__ __forceinline__
-void mbarrier_wait_parity(uint32_t mbar_smem, uint32_t phase_parity) {
+__device__ __forceinline__ void mbarrier_wait_parity_suspend(uint32_t mbar_smem,
+                                                             uint32_t phase_parity) {
   asm volatile(
-    "{\n"
-    ".reg .pred P1;\n"
-    "LAB_WAIT_HOT:\n"
-    "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1;\n"
-    "@!P1 bra.uni LAB_WAIT_HOT;\n"
-    "}\n"
-    :: "r"(mbar_smem), "r"(phase_parity) : "memory");
+      "{\n"
+      ".reg .pred P1;\n"
+      "LAB_WAIT:\n"
+      "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1, 10000000;\n"
+      "@!P1 bra.uni LAB_WAIT;\n"
+      "}\n" ::"r"(mbar_smem),
+      "r"(phase_parity)
+      : "memory");
 }
 
-__device__ __forceinline__
-void fence_proxy_async_shared_cta() {
+__device__ __forceinline__ void mbarrier_wait_parity(uint32_t mbar_smem, uint32_t phase_parity) {
+  asm volatile(
+      "{\n"
+      ".reg .pred P1;\n"
+      "LAB_WAIT_HOT:\n"
+      "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1;\n"
+      "@!P1 bra.uni LAB_WAIT_HOT;\n"
+      "}\n" ::"r"(mbar_smem),
+      "r"(phase_parity)
+      : "memory");
+}
+
+__device__ __forceinline__ void fence_proxy_async_shared_cta() {
   asm volatile("fence.proxy.async.shared::cta;\n" ::: "memory");
 }
 
-__device__ __forceinline__
-void fence_proxy_async_shared() {
+__device__ __forceinline__ void fence_proxy_async_shared() {
   asm volatile("fence.proxy.async.shared::cta;\n" ::: "memory");
 }
 
-__device__ __forceinline__
-void fence_mbarrier_init_release_cluster() {
+__device__ __forceinline__ void fence_mbarrier_init_release_cluster() {
   asm volatile("fence.mbarrier_init.release.cluster;\n" ::: "memory");
 }
-
 
 enum class SmemSwizzleBlackwell : uint32_t {
   None = 0,
   B128_32atom = 1,
   B128 = 2,
-  B64  = 4,
-  B32  = 6,
+  B64 = 4,
+  B32 = 6,
 };
 
 __device__ __host__ __forceinline__ uint64_t build_smem_desc_blackwell(
-    uint32_t smem_addr,
-    uint32_t stride_byte_offset,
-    uint32_t leading_byte_offset,
-    SmemSwizzleBlackwell swizzle = SmemSwizzleBlackwell::B128,
-    uint32_t base_offset = 0) {
+    uint32_t smem_addr, uint32_t stride_byte_offset, uint32_t leading_byte_offset,
+    SmemSwizzleBlackwell swizzle = SmemSwizzleBlackwell::B128, uint32_t base_offset = 0) {
   uint64_t d = 0;
   d |= static_cast<uint64_t>((smem_addr >> 4) & 0x3FFF);
   d |= static_cast<uint64_t>((leading_byte_offset >> 4) & 0x3FFF) << 16;
@@ -482,76 +408,62 @@ __device__ __host__ __forceinline__ uint64_t build_smem_desc_blackwell(
   return d;
 }
 
-
-__device__ __forceinline__
-uint32_t elect_one_sync() {
+__device__ __forceinline__ uint32_t elect_one_sync() {
   uint32_t elected;
   asm volatile(
-    "{\n\t"
-    ".reg .pred p;\n\t"
-    "elect.sync %0|p, 0xffffffff;\n\t"
-    "selp.b32 %0, 1, 0, p;\n\t"
-    "}\n"
-    : "=r"(elected));
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      "elect.sync %0|p, 0xffffffff;\n\t"
+      "selp.b32 %0, 1, 0, p;\n\t"
+      "}\n"
+      : "=r"(elected));
   return elected;
 }
 
-__device__ __forceinline__
-uint32_t elect_one_sync(uint32_t membermask) {
+__device__ __forceinline__ uint32_t elect_one_sync(uint32_t membermask) {
   uint32_t elected;
   asm volatile(
-    "{\n\t"
-    ".reg .pred p;\n\t"
-    "elect.sync %0|p, %1;\n\t"
-    "selp.b32 %0, 1, 0, p;\n\t"
-    "}\n"
-    : "=r"(elected) : "r"(membermask));
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      "elect.sync %0|p, %1;\n\t"
+      "selp.b32 %0, 1, 0, p;\n\t"
+      "}\n"
+      : "=r"(elected)
+      : "r"(membermask));
   return elected;
 }
 
-
-__device__ __forceinline__
-void bar_sync_dyn(uint32_t barrier_id, uint32_t thread_count) {
-  asm volatile("bar.sync %0, %1;\n" :: "r"(barrier_id), "r"(thread_count) : "memory");
+__device__ __forceinline__ void bar_sync_dyn(uint32_t barrier_id, uint32_t thread_count) {
+  asm volatile("bar.sync %0, %1;\n" ::"r"(barrier_id), "r"(thread_count) : "memory");
 }
-__device__ __forceinline__
-void bar_arrive_dyn(uint32_t barrier_id, uint32_t thread_count) {
-  asm volatile("bar.arrive %0, %1;\n" :: "r"(barrier_id), "r"(thread_count) : "memory");
+__device__ __forceinline__ void bar_arrive_dyn(uint32_t barrier_id, uint32_t thread_count) {
+  asm volatile("bar.arrive %0, %1;\n" ::"r"(barrier_id), "r"(thread_count) : "memory");
 }
 
-
-__device__ __forceinline__
-uint32_t cvt_f32x2_to_bf16x2(float a, float b) {
+__device__ __forceinline__ uint32_t cvt_f32x2_to_bf16x2(float a, float b) {
   uint32_t r;
-  asm volatile("cvt.rn.bf16x2.f32 %0, %2, %1;\n"
-               : "=r"(r) : "f"(a), "f"(b));
+  asm volatile("cvt.rn.bf16x2.f32 %0, %2, %1;\n" : "=r"(r) : "f"(a), "f"(b));
   return r;
 }
 
-
 template <int NUM_STAGES>
 struct MbarrierPhaseTracker {
-
   uint32_t phase[NUM_STAGES];
   int idx;
 
-  __device__ __forceinline__
-  void init() {
+  __device__ __forceinline__ void init() {
     for (int i = 0; i < NUM_STAGES; ++i) phase[i] = 0;
     idx = 0;
   }
 
-  __device__ __forceinline__
-  uint32_t current_phase() const { return phase[idx]; }
+  __device__ __forceinline__ uint32_t current_phase() const { return phase[idx]; }
 
-  __device__ __forceinline__
-  void advance() {
+  __device__ __forceinline__ void advance() {
     phase[idx] ^= 1u;
     idx = (idx + 1) % NUM_STAGES;
   }
 
-  __device__ __forceinline__
-  int stage() const { return idx; }
+  __device__ __forceinline__ int stage() const { return idx; }
 };
 
 template <int NUM_STAGES>
@@ -559,11 +471,9 @@ struct PhaseTracker {
   int stage;
   uint32_t phase;
 
-  __device__ __forceinline__
-  PhaseTracker() : stage(0), phase(0) {}
+  __device__ __forceinline__ PhaseTracker() : stage(0), phase(0) {}
 
-  __device__ __forceinline__
-  void advance() {
+  __device__ __forceinline__ void advance() {
     stage++;
     if (stage == NUM_STAGES) {
       stage = 0;
@@ -571,11 +481,9 @@ struct PhaseTracker {
     }
   }
 
-  __device__ __forceinline__
-  int get_stage() const { return stage; }
+  __device__ __forceinline__ int get_stage() const { return stage; }
 
-  __device__ __forceinline__
-  uint32_t get_phase() const { return phase; }
+  __device__ __forceinline__ uint32_t get_phase() const { return phase; }
 };
 
 template <int NUM_STAGES>
@@ -583,11 +491,9 @@ struct EmptyPhaseTracker {
   int stage;
   uint32_t phase;
 
-  __device__ __forceinline__
-  EmptyPhaseTracker() : stage(0), phase(1) {}
+  __device__ __forceinline__ EmptyPhaseTracker() : stage(0), phase(1) {}
 
-  __device__ __forceinline__
-  void advance() {
+  __device__ __forceinline__ void advance() {
     stage++;
     if (stage == NUM_STAGES) {
       stage = 0;
@@ -595,16 +501,13 @@ struct EmptyPhaseTracker {
     }
   }
 
-  __device__ __forceinline__
-  int get_stage() const { return stage; }
+  __device__ __forceinline__ int get_stage() const { return stage; }
 
-  __device__ __forceinline__
-  uint32_t get_phase() const { return phase; }
+  __device__ __forceinline__ uint32_t get_phase() const { return phase; }
 };
 
 template <int STAGES>
-__device__ __forceinline__
-void advance_stage_phase(int& stage, uint32_t& phase) {
+__device__ __forceinline__ void advance_stage_phase(int& stage, uint32_t& phase) {
   ++stage;
   if (stage == STAGES) {
     stage = 0;
@@ -612,63 +515,55 @@ void advance_stage_phase(int& stage, uint32_t& phase) {
   }
 }
 
-
-
-__device__ __forceinline__ void clc_try_cancel_async(
-    uint32_t smem_dst, uint32_t mbar_smem) {
+__device__ __forceinline__ void clc_try_cancel_async(uint32_t smem_dst, uint32_t mbar_smem) {
   asm volatile(
-    "clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.b128"
-    " [%0], [%1];\n"
-    :: "r"(smem_dst), "r"(mbar_smem) : "memory");
+      "clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.b128"
+      " [%0], [%1];\n" ::"r"(smem_dst),
+      "r"(mbar_smem)
+      : "memory");
 }
 
-
-__device__ __forceinline__ void clc_load_response(
-    uint32_t smem_slot, uint32_t& r0, uint32_t& r1,
-    uint32_t& r2, uint32_t& r3) {
+__device__ __forceinline__ void clc_load_response(uint32_t smem_slot, uint32_t& r0, uint32_t& r1,
+                                                  uint32_t& r2, uint32_t& r3) {
   asm volatile("ld.shared::cta.v4.b32 {%0, %1, %2, %3}, [%4];\n"
                : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3)
                : "r"(smem_slot));
 }
 
-
 static constexpr uint32_t SM100_CLC_PEER_MASK = 0xFEFFFFFF;
 
 struct ClcTileInfo {
-  int  m_tile;
-  int  n_tile;
+  int m_tile;
+  int n_tile;
   bool valid;
 };
 
 enum class ClcRasterOrder { AlongN, AlongM };
 
-__device__ __forceinline__
-void clc_arrive_expect_tx_cta(uint32_t clc_full_local_addr, uint32_t tx_bytes) {
+__device__ __forceinline__ void clc_arrive_expect_tx_cta(uint32_t clc_full_local_addr,
+                                                         uint32_t tx_bytes) {
   if ((threadIdx.x & 31) == 0) {
     mbarrier_arrive_expect_tx(clc_full_local_addr, tx_bytes);
   }
 }
 
-__device__ __forceinline__
-void clc_consumer_release(uint32_t clc_empty_local_addr) {
+__device__ __forceinline__ void clc_consumer_release(uint32_t clc_empty_local_addr) {
   uint32_t peer0_addr = clc_empty_local_addr & SM100_CLC_PEER_MASK;
   mbarrier_arrive_cluster_default(peer0_addr);
 }
 
-__device__ __forceinline__
-void clc_consumer_release_cta(uint32_t clc_empty_local_addr) {
+__device__ __forceinline__ void clc_consumer_release_cta(uint32_t clc_empty_local_addr) {
   mbarrier_arrive_nostate(clc_empty_local_addr);
 }
 
 template <int CLUSTER_SHAPE_M, int CLUSTER_SHAPE_N, ClcRasterOrder ORDER>
-__device__ __forceinline__
-ClcTileInfo clc_parse_response(uint32_t resp_smem_addr) {
+__device__ __forceinline__ ClcTileInfo clc_parse_response(uint32_t resp_smem_addr) {
   uint32_t d0, d1, d2, d3;
   fence_proxy_async_shared_cta();
   clc_load_response(resp_smem_addr, d0, d1, d2, d3);
-  const int  ctaid_x = static_cast<int>(d0);
-  const int  ctaid_y = static_cast<int>(d1 & 0xFFFFu);
-  const bool valid   = (d2 & 1u) != 0u;
+  const int ctaid_x = static_cast<int>(d0);
+  const int ctaid_y = static_cast<int>(d1 & 0xFFFFu);
+  const bool valid = (d2 & 1u) != 0u;
   (void)d3;
 
   ClcTileInfo info;
@@ -683,23 +578,23 @@ ClcTileInfo clc_parse_response(uint32_t resp_smem_addr) {
   return info;
 }
 
-template <int CLUSTER_SHAPE_M, int CLUSTER_SHAPE_N, ClcRasterOrder ORDER,
-          int CTA_GROUP = 2, bool SUSPEND = false>
-__device__ __forceinline__
-ClcTileInfo clc_fetch_next_tile(
-    uint64_t* clc_full_bar, uint64_t* clc_empty_bar, uint32_t* clc_response,
-    int clc_cons_stage, uint32_t clc_cons_phase, bool do_release) {
-  uint32_t full_addr = static_cast<uint32_t>(
-      __cvta_generic_to_shared(&clc_full_bar[clc_cons_stage]));
-  if constexpr (SUSPEND) mbarrier_wait_parity_suspend(full_addr, clc_cons_phase);
-  else                   mbarrier_wait_parity(full_addr, clc_cons_phase);
-  uint32_t resp_addr = static_cast<uint32_t>(
-      __cvta_generic_to_shared(&clc_response[clc_cons_stage * 4]));
-  ClcTileInfo t = clc_parse_response<
-      CLUSTER_SHAPE_M, CLUSTER_SHAPE_N, ORDER>(resp_addr);
+template <int CLUSTER_SHAPE_M, int CLUSTER_SHAPE_N, ClcRasterOrder ORDER, int CTA_GROUP = 2,
+          bool SUSPEND = false>
+__device__ __forceinline__ ClcTileInfo
+clc_fetch_next_tile(uint64_t* clc_full_bar, uint64_t* clc_empty_bar, uint32_t* clc_response,
+                    int clc_cons_stage, uint32_t clc_cons_phase, bool do_release) {
+  uint32_t full_addr =
+      static_cast<uint32_t>(__cvta_generic_to_shared(&clc_full_bar[clc_cons_stage]));
+  if constexpr (SUSPEND)
+    mbarrier_wait_parity_suspend(full_addr, clc_cons_phase);
+  else
+    mbarrier_wait_parity(full_addr, clc_cons_phase);
+  uint32_t resp_addr =
+      static_cast<uint32_t>(__cvta_generic_to_shared(&clc_response[clc_cons_stage * 4]));
+  ClcTileInfo t = clc_parse_response<CLUSTER_SHAPE_M, CLUSTER_SHAPE_N, ORDER>(resp_addr);
   if (do_release) {
-    uint32_t empty_local = static_cast<uint32_t>(
-        __cvta_generic_to_shared(&clc_empty_bar[clc_cons_stage]));
+    uint32_t empty_local =
+        static_cast<uint32_t>(__cvta_generic_to_shared(&clc_empty_bar[clc_cons_stage]));
     if constexpr (CTA_GROUP == 1) {
       clc_consumer_release_cta(empty_local);
     } else {
@@ -710,40 +605,37 @@ ClcTileInfo clc_fetch_next_tile(
 }
 
 template <int STAGES = 2>
-__device__ __forceinline__
-void clc_fetch_next_tile_advance(int& clc_cons_stage,
-                                 uint32_t& clc_cons_phase) {
+__device__ __forceinline__ void clc_fetch_next_tile_advance(int& clc_cons_stage,
+                                                            uint32_t& clc_cons_phase) {
   advance_stage_phase<STAGES>(clc_cons_stage, clc_cons_phase);
 }
 
-
 template <int N>
-__device__ __forceinline__
-void setmaxnreg_dec() {
+__device__ __forceinline__ void setmaxnreg_dec() {
   static_assert(N >= 24 && N <= 256 && N % 8 == 0,
                 "setmaxnreg_dec: N must be in [24, 256] and a multiple of 8");
-  asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n"
-               :: "n"(N) : "memory");
+  asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n" ::"n"(N) : "memory");
 }
 
 template <int N>
-__device__ __forceinline__
-void setmaxnreg_inc() {
+__device__ __forceinline__ void setmaxnreg_inc() {
   static_assert(N >= 24 && N <= 256 && N % 8 == 0,
                 "setmaxnreg_inc: N must be in [24, 256] and a multiple of 8");
-  asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n"
-               :: "n"(N) : "memory");
+  asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n" ::"n"(N) : "memory");
 }
-
 
 namespace {
 __device__ __forceinline__ uint64_t f32x2_bits(float2 v) {
-  uint64_t b; __builtin_memcpy(&b, &v, 8); return b;
+  uint64_t b;
+  __builtin_memcpy(&b, &v, 8);
+  return b;
 }
 __device__ __forceinline__ float2 f32x2_make(uint64_t b) {
-  float2 v; __builtin_memcpy(&v, &b, 8); return v;
+  float2 v;
+  __builtin_memcpy(&v, &b, 8);
+  return v;
 }
-}
+}  // namespace
 
 __device__ __forceinline__ float2 fmul2(float2 a, float2 b) {
   uint64_t d;
@@ -760,12 +652,14 @@ __device__ __forceinline__ float2 fadd2(float2 a, float2 b) {
 __device__ __forceinline__ float2 ffma2(float2 a, float2 b, float2 c) {
   uint64_t d;
   asm volatile("fma.rn.f32x2 %0, %1, %2, %3;\n"
-               : "=l"(d) : "l"(f32x2_bits(a)), "l"(f32x2_bits(b)), "l"(f32x2_bits(c)));
+               : "=l"(d)
+               : "l"(f32x2_bits(a)), "l"(f32x2_bits(b)), "l"(f32x2_bits(c)));
   return f32x2_make(d);
 }
 
-__device__ __forceinline__ float2 f32x2_splat(float s) { return make_float2(s, s); }
-
+__device__ __forceinline__ float2 f32x2_splat(float s) {
+  return make_float2(s, s);
+}
 
 __device__ __forceinline__ float ex2_approx_f32(float z) {
   float d;
@@ -776,51 +670,51 @@ __device__ __forceinline__ float ex2_approx_f32(float z) {
 __device__ __forceinline__ float2 ex2_emu_f32x2(float x, float y) {
   uint32_t ox, oy;
   asm volatile(
-    "{\n\t"
-    ".reg .f32 f1,f2,f3,f4,f5,f6,f7;\n\t"
-    ".reg .b64 l1,l2,l3,l4,l5,l6,l7,l8,l9,l10;\n\t"
-    ".reg .s32 r1,r2,r3,r4,r5,r6,r7,r8;\n\t"
-    "max.f32 f1, %2, 0fC2FE0000;\n\t"
-    "max.f32 f2, %3, 0fC2FE0000;\n\t"
-    "mov.b64 l1, {f1, f2};\n\t"
-    "mov.f32 f3, 0f4B400000;\n\t"
-    "mov.b64 l2, {f3, f3};\n\t"
-    "add.rm.f32x2 l7, l1, l2;\n\t"
-    "sub.rn.f32x2 l8, l7, l2;\n\t"
-    "sub.rn.f32x2 l9, l1, l8;\n\t"
-    "mov.f32 f7, 0f3D9DF09D;\n\t"
-    "mov.b64 l6, {f7, f7};\n\t"
-    "mov.f32 f6, 0f3E6906A4;\n\t"
-    "mov.b64 l5, {f6, f6};\n\t"
-    "mov.f32 f5, 0f3F31F519;\n\t"
-    "mov.b64 l4, {f5, f5};\n\t"
-    "mov.f32 f4, 0f3F800000;\n\t"
-    "mov.b64 l3, {f4, f4};\n\t"
-    "fma.rn.f32x2 l10, l9, l6, l5;\n\t"
-    "fma.rn.f32x2 l10, l10, l9, l4;\n\t"
-    "fma.rn.f32x2 l10, l10, l9, l3;\n\t"
-    "mov.b64 {r1, r2}, l7;\n\t"
-    "mov.b64 {r3, r4}, l10;\n\t"
-    "shl.b32 r5, r1, 23;\n\t"
-    "add.s32 r7, r5, r3;\n\t"
-    "shl.b32 r6, r2, 23;\n\t"
-    "add.s32 r8, r6, r4;\n\t"
-    "mov.b32 %0, r7;\n\t"
-    "mov.b32 %1, r8;\n\t"
-    "}\n"
-    : "=r"(ox), "=r"(oy) : "f"(x), "f"(y));
-  float2 r; __builtin_memcpy(&r.x, &ox, 4); __builtin_memcpy(&r.y, &oy, 4);
+      "{\n\t"
+      ".reg .f32 f1,f2,f3,f4,f5,f6,f7;\n\t"
+      ".reg .b64 l1,l2,l3,l4,l5,l6,l7,l8,l9,l10;\n\t"
+      ".reg .s32 r1,r2,r3,r4,r5,r6,r7,r8;\n\t"
+      "max.f32 f1, %2, 0fC2FE0000;\n\t"
+      "max.f32 f2, %3, 0fC2FE0000;\n\t"
+      "mov.b64 l1, {f1, f2};\n\t"
+      "mov.f32 f3, 0f4B400000;\n\t"
+      "mov.b64 l2, {f3, f3};\n\t"
+      "add.rm.f32x2 l7, l1, l2;\n\t"
+      "sub.rn.f32x2 l8, l7, l2;\n\t"
+      "sub.rn.f32x2 l9, l1, l8;\n\t"
+      "mov.f32 f7, 0f3D9DF09D;\n\t"
+      "mov.b64 l6, {f7, f7};\n\t"
+      "mov.f32 f6, 0f3E6906A4;\n\t"
+      "mov.b64 l5, {f6, f6};\n\t"
+      "mov.f32 f5, 0f3F31F519;\n\t"
+      "mov.b64 l4, {f5, f5};\n\t"
+      "mov.f32 f4, 0f3F800000;\n\t"
+      "mov.b64 l3, {f4, f4};\n\t"
+      "fma.rn.f32x2 l10, l9, l6, l5;\n\t"
+      "fma.rn.f32x2 l10, l10, l9, l4;\n\t"
+      "fma.rn.f32x2 l10, l10, l9, l3;\n\t"
+      "mov.b64 {r1, r2}, l7;\n\t"
+      "mov.b64 {r3, r4}, l10;\n\t"
+      "shl.b32 r5, r1, 23;\n\t"
+      "add.s32 r7, r5, r3;\n\t"
+      "shl.b32 r6, r2, 23;\n\t"
+      "add.s32 r8, r6, r4;\n\t"
+      "mov.b32 %0, r7;\n\t"
+      "mov.b32 %1, r8;\n\t"
+      "}\n"
+      : "=r"(ox), "=r"(oy)
+      : "f"(x), "f"(y));
+  float2 r;
+  __builtin_memcpy(&r.x, &ox, 4);
+  __builtin_memcpy(&r.y, &oy, 4);
   return r;
 }
-
 
 __device__ __forceinline__ float rcp_approx_ftz_f32(float x) {
   float d;
   asm("rcp.approx.ftz.f32 %0, %1;\n" : "=f"(d) : "f"(x));
   return d;
 }
-
-
 
 __device__ __forceinline__ unsigned fdiv(unsigned n, unsigned long long pk) {
   unsigned M = (unsigned)pk;
@@ -829,7 +723,8 @@ __device__ __forceinline__ unsigned fdiv(unsigned n, unsigned long long pk) {
 }
 __host__ inline unsigned long long make_magic(unsigned d) {
   if (d <= 1u) return 0ULL;
-  unsigned l = 0; while ((1u << (l + 1)) <= d) ++l;
+  unsigned l = 0;
+  while ((1u << (l + 1)) <= d) ++l;
   unsigned p = 31u + l;
   unsigned long long m = ((1ull << p) + (unsigned long long)d - 1ull) / d;
   return (m & 0xffffffffULL) | ((unsigned long long)(p - 32u) << 32);
@@ -841,4 +736,3 @@ __device__ __forceinline__ void full_bar_arrive(int stage, int band) {
 __device__ __forceinline__ void full_bar_wait(int stage, int band) {
   bar_sync_dyn((uint32_t)((1 + stage * 4) + band), 64);
 }
-

--- a/fastvideo-kernel/csrc/attention/primitives.cuh
+++ b/fastvideo-kernel/csrc/attention/primitives.cuh
@@ -1,0 +1,844 @@
+// primitives.cuh -- device primitives for the sm_100a block-causal + sink +
+// sliding-window attention forward: tcgen05 (alloc / mma / ld / st / commit / wait / fence),
+// TMA load / store / tensormap, mbarrier, cluster launch control, setmaxnreg, fast math,
+// and the FMHA helpers.
+//
+// Generated and pruned to what the kernel reaches -- do not edit by hand.
+#pragma once
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cassert>
+#include <cstring>
+#include <vector_types.h>
+#include <cmath>
+
+#ifndef CUDA_CHECK
+#define CUDA_CHECK(stmt) do {                                                 \
+    cudaError_t _e = (stmt);                                                  \
+    if (_e != cudaSuccess) {                                                  \
+      fprintf(stderr, "CUDA error %s:%d: %s -> %s\n",                         \
+              __FILE__, __LINE__, #stmt, cudaGetErrorString(_e));             \
+      std::exit(1);                                                           \
+    }                                                                         \
+  } while (0)
+#endif
+
+
+
+__device__ __forceinline__
+uint32_t smem_ptr_u32(const void* ptr) {
+  return static_cast<uint32_t>(__cvta_generic_to_shared(ptr));
+}
+
+__device__ __forceinline__
+void sts_f32(uint32_t smem_addr, float val) {
+  asm volatile("st.shared.f32 [%0], %1;" :: "r"(smem_addr), "f"(val) : "memory");
+}
+
+
+template <int CTA_GROUP>
+__device__ __forceinline__ void tcgen05_alloc(uint32_t smem_dst_ptr,
+                                              uint32_t n_cols) {
+  static_assert(CTA_GROUP == 1 || CTA_GROUP == 2,
+                "tcgen05_alloc: CTA_GROUP must be 1 or 2");
+  if constexpr (CTA_GROUP == 1) {
+    asm volatile(
+      "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;\n"
+      :: "r"(smem_dst_ptr), "r"(n_cols));
+  } else {
+    asm volatile(
+      "tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [%0], %1;\n"
+      :: "r"(smem_dst_ptr), "r"(n_cols));
+  }
+}
+
+
+template <int CTA_GROUP>
+__device__ __forceinline__ void tcgen05_dealloc(uint32_t tmem_addr,
+                                                uint32_t n_cols) {
+  static_assert(CTA_GROUP == 1 || CTA_GROUP == 2,
+                "tcgen05_dealloc: CTA_GROUP must be 1 or 2");
+  if constexpr (CTA_GROUP == 1) {
+    asm volatile(
+      "tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;\n"
+      :: "r"(tmem_addr), "r"(n_cols));
+  } else {
+    asm volatile(
+      "tcgen05.dealloc.cta_group::2.sync.aligned.b32 %0, %1;\n"
+      :: "r"(tmem_addr), "r"(n_cols));
+  }
+}
+
+template <int CTA_GROUP>
+__device__ __forceinline__ void tcgen05_relinquish_alloc_permit() {
+  static_assert(CTA_GROUP == 1 || CTA_GROUP == 2,
+                "tcgen05_relinquish_alloc_permit: CTA_GROUP must be 1 or 2");
+  if constexpr (CTA_GROUP == 1) {
+    asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;\n" ::);
+  } else {
+    asm volatile("tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned;\n" ::);
+  }
+}
+
+
+__device__ __forceinline__ void tcgen05_mma_f16_ss_lead(uint32_t lead,
+    uint32_t tmem_c, uint64_t desc_a, uint64_t desc_b, uint32_t idesc,
+    bool enable_input_d) {
+  asm volatile(
+    "{\n\t"
+    ".reg .pred p, q;\n\t"
+    "setp.ne.b32 q, %0, 0;\n\t"
+    "setp.ne.b32 p, %5, 0;\n\t"
+    "@q tcgen05.mma.cta_group::1.kind::f16 [%1], %2, %3, %4, {%6, %7, %8, %9}, p;\n\t"
+    "}\n"
+    :: "r"(lead), "r"(tmem_c), "l"(desc_a), "l"(desc_b), "r"(idesc),
+       "r"(enable_input_d ? 1u : 0u), "r"(0u), "r"(0u), "r"(0u), "r"(0u));
+}
+
+__device__ __forceinline__ void tcgen05_mma_f16_ts_1sm_lead(uint32_t lead,
+    uint32_t tmem_c, uint32_t tmem_a, uint64_t desc_b, uint32_t idesc,
+    bool enable_input_d) {
+  asm volatile(
+    "{\n\t"
+    ".reg .pred p, q;\n\t"
+    "setp.ne.b32 q, %0, 0;\n\t"
+    "setp.ne.b32 p, %5, 0;\n\t"
+    "@q tcgen05.mma.cta_group::1.kind::f16 [%1], [%2], %3, %4, {%6, %7, %8, %9}, p;\n\t"
+    "}\n"
+    :: "r"(lead), "r"(tmem_c), "r"(tmem_a), "l"(desc_b), "r"(idesc),
+       "r"(enable_input_d ? 1u : 0u), "r"(0u), "r"(0u), "r"(0u), "r"(0u));
+}
+
+
+__device__ __forceinline__ uint32_t make_idesc_table44(
+    int M, int N,
+    uint32_t dtype, uint32_t atype, uint32_t btype,
+    bool transpose_a = false, bool transpose_b = false,
+    bool negate_a = false, bool negate_b = false) {
+  uint32_t idesc = 0;
+  idesc |= (dtype & 0x3) << 4;
+  idesc |= (atype & 0x7) << 7;
+  idesc |= (btype & 0x7) << 10;
+  idesc |= (negate_a ? 1u : 0u) << 13;
+  idesc |= (negate_b ? 1u : 0u) << 14;
+  idesc |= (transpose_a ? 1u : 0u) << 15;
+  idesc |= (transpose_b ? 1u : 0u) << 16;
+  idesc |= ((static_cast<uint32_t>(N) >> 3) & 0x3F) << 17;
+  idesc |= ((static_cast<uint32_t>(M) >> 4) & 0x1F) << 24;
+  return idesc;
+}
+
+__device__ __forceinline__ uint32_t make_idesc_bf16_f32(
+    int M, int N, bool ta = false, bool tb = false) {
+  return make_idesc_table44(M, N,  1,
+                              1,  1, ta, tb);
+}
+
+
+__device__ __forceinline__ void tcgen05_ld_32x32b_x16(
+    uint32_t tmem_addr, uint32_t (&r)[16]) {
+  asm volatile("tcgen05.ld.sync.aligned.32x32b.x16.b32 "
+               "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
+               "%10,%11,%12,%13,%14,%15}, [%16];\n"
+               : "=r"(r[0]),"=r"(r[1]),"=r"(r[2]),"=r"(r[3]),
+                 "=r"(r[4]),"=r"(r[5]),"=r"(r[6]),"=r"(r[7]),
+                 "=r"(r[8]),"=r"(r[9]),"=r"(r[10]),"=r"(r[11]),
+                 "=r"(r[12]),"=r"(r[13]),"=r"(r[14]),"=r"(r[15])
+               : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tcgen05_ld_32x32b_x32(
+    uint32_t tmem_addr, uint32_t (&r)[32]) {
+  asm volatile("tcgen05.ld.sync.aligned.32x32b.x32.b32 "
+               "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
+               "%10,%11,%12,%13,%14,%15,%16,%17,%18,%19,"
+               "%20,%21,%22,%23,%24,%25,%26,%27,%28,%29,"
+               "%30,%31}, [%32];\n"
+               : "=r"(r[0]),"=r"(r[1]),"=r"(r[2]),"=r"(r[3]),
+                 "=r"(r[4]),"=r"(r[5]),"=r"(r[6]),"=r"(r[7]),
+                 "=r"(r[8]),"=r"(r[9]),"=r"(r[10]),"=r"(r[11]),
+                 "=r"(r[12]),"=r"(r[13]),"=r"(r[14]),"=r"(r[15]),
+                 "=r"(r[16]),"=r"(r[17]),"=r"(r[18]),"=r"(r[19]),
+                 "=r"(r[20]),"=r"(r[21]),"=r"(r[22]),"=r"(r[23]),
+                 "=r"(r[24]),"=r"(r[25]),"=r"(r[26]),"=r"(r[27]),
+                 "=r"(r[28]),"=r"(r[29]),"=r"(r[30]),"=r"(r[31])
+               : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tcgen05_ld_32x32b_x64(
+    uint32_t tmem_addr, uint32_t (&r)[64]) {
+  asm volatile("tcgen05.ld.sync.aligned.32x32b.x64.b32 "
+               "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
+               "%10,%11,%12,%13,%14,%15,%16,%17,%18,%19,"
+               "%20,%21,%22,%23,%24,%25,%26,%27,%28,%29,"
+               "%30,%31,%32,%33,%34,%35,%36,%37,%38,%39,"
+               "%40,%41,%42,%43,%44,%45,%46,%47,%48,%49,"
+               "%50,%51,%52,%53,%54,%55,%56,%57,%58,%59,"
+               "%60,%61,%62,%63}, [%64];\n"
+               : "=r"(r[0]),"=r"(r[1]),"=r"(r[2]),"=r"(r[3]),
+                 "=r"(r[4]),"=r"(r[5]),"=r"(r[6]),"=r"(r[7]),
+                 "=r"(r[8]),"=r"(r[9]),"=r"(r[10]),"=r"(r[11]),
+                 "=r"(r[12]),"=r"(r[13]),"=r"(r[14]),"=r"(r[15]),
+                 "=r"(r[16]),"=r"(r[17]),"=r"(r[18]),"=r"(r[19]),
+                 "=r"(r[20]),"=r"(r[21]),"=r"(r[22]),"=r"(r[23]),
+                 "=r"(r[24]),"=r"(r[25]),"=r"(r[26]),"=r"(r[27]),
+                 "=r"(r[28]),"=r"(r[29]),"=r"(r[30]),"=r"(r[31]),
+                 "=r"(r[32]),"=r"(r[33]),"=r"(r[34]),"=r"(r[35]),
+                 "=r"(r[36]),"=r"(r[37]),"=r"(r[38]),"=r"(r[39]),
+                 "=r"(r[40]),"=r"(r[41]),"=r"(r[42]),"=r"(r[43]),
+                 "=r"(r[44]),"=r"(r[45]),"=r"(r[46]),"=r"(r[47]),
+                 "=r"(r[48]),"=r"(r[49]),"=r"(r[50]),"=r"(r[51]),
+                 "=r"(r[52]),"=r"(r[53]),"=r"(r[54]),"=r"(r[55]),
+                 "=r"(r[56]),"=r"(r[57]),"=r"(r[58]),"=r"(r[59]),
+                 "=r"(r[60]),"=r"(r[61]),"=r"(r[62]),"=r"(r[63])
+               : "r"(tmem_addr));
+}
+
+__device__ __forceinline__ void tcgen05_ld_32x32b_x128(
+    uint32_t tmem_addr, uint32_t (&r)[128]) {
+  asm volatile("tcgen05.ld.sync.aligned.32x32b.x128.b32 "
+               "{%0,%1,%2,%3,%4,%5,%6,%7,%8,%9,"
+               "%10,%11,%12,%13,%14,%15,%16,%17,%18,%19,"
+               "%20,%21,%22,%23,%24,%25,%26,%27,%28,%29,"
+               "%30,%31,%32,%33,%34,%35,%36,%37,%38,%39,"
+               "%40,%41,%42,%43,%44,%45,%46,%47,%48,%49,"
+               "%50,%51,%52,%53,%54,%55,%56,%57,%58,%59,"
+               "%60,%61,%62,%63,%64,%65,%66,%67,%68,%69,"
+               "%70,%71,%72,%73,%74,%75,%76,%77,%78,%79,"
+               "%80,%81,%82,%83,%84,%85,%86,%87,%88,%89,"
+               "%90,%91,%92,%93,%94,%95,%96,%97,%98,%99,"
+               "%100,%101,%102,%103,%104,%105,%106,%107,%108,%109,"
+               "%110,%111,%112,%113,%114,%115,%116,%117,%118,%119,"
+               "%120,%121,%122,%123,%124,%125,%126,%127}, [%128];\n"
+               : "=r"(r[  0]),"=r"(r[  1]),"=r"(r[  2]),"=r"(r[  3]),
+                 "=r"(r[  4]),"=r"(r[  5]),"=r"(r[  6]),"=r"(r[  7]),
+                 "=r"(r[  8]),"=r"(r[  9]),"=r"(r[ 10]),"=r"(r[ 11]),
+                 "=r"(r[ 12]),"=r"(r[ 13]),"=r"(r[ 14]),"=r"(r[ 15]),
+                 "=r"(r[ 16]),"=r"(r[ 17]),"=r"(r[ 18]),"=r"(r[ 19]),
+                 "=r"(r[ 20]),"=r"(r[ 21]),"=r"(r[ 22]),"=r"(r[ 23]),
+                 "=r"(r[ 24]),"=r"(r[ 25]),"=r"(r[ 26]),"=r"(r[ 27]),
+                 "=r"(r[ 28]),"=r"(r[ 29]),"=r"(r[ 30]),"=r"(r[ 31]),
+                 "=r"(r[ 32]),"=r"(r[ 33]),"=r"(r[ 34]),"=r"(r[ 35]),
+                 "=r"(r[ 36]),"=r"(r[ 37]),"=r"(r[ 38]),"=r"(r[ 39]),
+                 "=r"(r[ 40]),"=r"(r[ 41]),"=r"(r[ 42]),"=r"(r[ 43]),
+                 "=r"(r[ 44]),"=r"(r[ 45]),"=r"(r[ 46]),"=r"(r[ 47]),
+                 "=r"(r[ 48]),"=r"(r[ 49]),"=r"(r[ 50]),"=r"(r[ 51]),
+                 "=r"(r[ 52]),"=r"(r[ 53]),"=r"(r[ 54]),"=r"(r[ 55]),
+                 "=r"(r[ 56]),"=r"(r[ 57]),"=r"(r[ 58]),"=r"(r[ 59]),
+                 "=r"(r[ 60]),"=r"(r[ 61]),"=r"(r[ 62]),"=r"(r[ 63]),
+                 "=r"(r[ 64]),"=r"(r[ 65]),"=r"(r[ 66]),"=r"(r[ 67]),
+                 "=r"(r[ 68]),"=r"(r[ 69]),"=r"(r[ 70]),"=r"(r[ 71]),
+                 "=r"(r[ 72]),"=r"(r[ 73]),"=r"(r[ 74]),"=r"(r[ 75]),
+                 "=r"(r[ 76]),"=r"(r[ 77]),"=r"(r[ 78]),"=r"(r[ 79]),
+                 "=r"(r[ 80]),"=r"(r[ 81]),"=r"(r[ 82]),"=r"(r[ 83]),
+                 "=r"(r[ 84]),"=r"(r[ 85]),"=r"(r[ 86]),"=r"(r[ 87]),
+                 "=r"(r[ 88]),"=r"(r[ 89]),"=r"(r[ 90]),"=r"(r[ 91]),
+                 "=r"(r[ 92]),"=r"(r[ 93]),"=r"(r[ 94]),"=r"(r[ 95]),
+                 "=r"(r[ 96]),"=r"(r[ 97]),"=r"(r[ 98]),"=r"(r[ 99]),
+                 "=r"(r[100]),"=r"(r[101]),"=r"(r[102]),"=r"(r[103]),
+                 "=r"(r[104]),"=r"(r[105]),"=r"(r[106]),"=r"(r[107]),
+                 "=r"(r[108]),"=r"(r[109]),"=r"(r[110]),"=r"(r[111]),
+                 "=r"(r[112]),"=r"(r[113]),"=r"(r[114]),"=r"(r[115]),
+                 "=r"(r[116]),"=r"(r[117]),"=r"(r[118]),"=r"(r[119]),
+                 "=r"(r[120]),"=r"(r[121]),"=r"(r[122]),"=r"(r[123]),
+                 "=r"(r[124]),"=r"(r[125]),"=r"(r[126]),"=r"(r[127])
+               : "r"(tmem_addr));
+}
+
+
+__device__ __forceinline__ void tcgen05_st_32x32b_x16(
+    uint32_t tmem_addr, const uint32_t (&r)[16]) {
+  asm volatile("tcgen05.st.sync.aligned.32x32b.x16.b32 "
+               "[%0], {%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,"
+               "%11,%12,%13,%14,%15,%16};\n"
+               :: "r"(tmem_addr),
+                  "r"(r[0]),"r"(r[1]),"r"(r[2]),"r"(r[3]),
+                  "r"(r[4]),"r"(r[5]),"r"(r[6]),"r"(r[7]),
+                  "r"(r[8]),"r"(r[9]),"r"(r[10]),"r"(r[11]),
+                  "r"(r[12]),"r"(r[13]),"r"(r[14]),"r"(r[15]));
+}
+
+__device__ __forceinline__ void tcgen05_st_32x32b_x32(
+    uint32_t tmem_addr, const uint32_t (&r)[32]) {
+  asm volatile("tcgen05.st.sync.aligned.32x32b.x32.b32 "
+               "[%0], {%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,"
+               "%11,%12,%13,%14,%15,%16,%17,%18,%19,%20,"
+               "%21,%22,%23,%24,%25,%26,%27,%28,%29,%30,"
+               "%31,%32};\n"
+               :: "r"(tmem_addr),
+                  "r"(r[0]),"r"(r[1]),"r"(r[2]),"r"(r[3]),
+                  "r"(r[4]),"r"(r[5]),"r"(r[6]),"r"(r[7]),
+                  "r"(r[8]),"r"(r[9]),"r"(r[10]),"r"(r[11]),
+                  "r"(r[12]),"r"(r[13]),"r"(r[14]),"r"(r[15]),
+                  "r"(r[16]),"r"(r[17]),"r"(r[18]),"r"(r[19]),
+                  "r"(r[20]),"r"(r[21]),"r"(r[22]),"r"(r[23]),
+                  "r"(r[24]),"r"(r[25]),"r"(r[26]),"r"(r[27]),
+                  "r"(r[28]),"r"(r[29]),"r"(r[30]),"r"(r[31]));
+}
+
+
+__device__ __forceinline__ void tcgen05_commit1_lead(uint32_t lead, uint32_t mbar_smem_addr) {
+  asm volatile(
+    "{\n\t"
+    ".reg .pred q;\n\t"
+    "setp.ne.b32 q, %0, 0;\n\t"
+    "@q tcgen05.commit.cta_group::1.mbarrier::arrive::one.b64 [%1];\n\t"
+    "}\n"
+    :: "r"(lead), "r"(mbar_smem_addr));
+}
+
+__device__ __forceinline__ void tcgen05_wait_st() {
+  asm volatile("tcgen05.wait::st.sync.aligned;\n" ::: "memory");
+}
+
+__device__ __forceinline__ void tcgen05_fence_before_thread_sync() {
+  asm volatile("tcgen05.fence::before_thread_sync;\n" ::: "memory");
+}
+
+
+__device__ __forceinline__
+void tma_load_2d(uint32_t smem_dst, const void* tensormap_ptr,
+                 uint32_t mbar_smem, int coord_x, int coord_y) {
+  asm volatile(
+    "cp.async.bulk.tensor.2d.shared::cluster.global.tile"
+    ".mbarrier::complete_tx::bytes"
+    " [%0], [%1, {%3, %4}], [%2];\n"
+    :: "r"(smem_dst), "l"(tensormap_ptr),
+       "r"(mbar_smem), "r"(coord_x), "r"(coord_y)
+    : "memory");
+}
+
+__device__ __forceinline__
+void tma_load_3d(uint32_t smem_dst, const void* tensormap_ptr,
+                 uint32_t mbar_smem, int c0, int c1, int c2) {
+  asm volatile(
+    "cp.async.bulk.tensor.3d.shared::cluster.global.tile"
+    ".mbarrier::complete_tx::bytes"
+    " [%0], [%1, {%3, %4, %5}], [%2];\n"
+    :: "r"(smem_dst), "l"(tensormap_ptr),
+       "r"(mbar_smem), "r"(c0), "r"(c1), "r"(c2)
+    : "memory");
+}
+
+__device__ __forceinline__
+void tma_load_4d(uint32_t smem_dst, const void* tensormap_ptr,
+                 uint32_t mbar_smem, int c0, int c1, int c2, int c3) {
+  asm volatile(
+    "cp.async.bulk.tensor.4d.shared::cluster.global.tile"
+    ".mbarrier::complete_tx::bytes"
+    " [%0], [%1, {%3, %4, %5, %6}], [%2];\n"
+    :: "r"(smem_dst), "l"(tensormap_ptr),
+       "r"(mbar_smem), "r"(c0), "r"(c1), "r"(c2), "r"(c3)
+    : "memory");
+}
+
+
+__device__ __forceinline__
+void tma_store_2d(const void* tensormap_ptr, int coord_x, int coord_y,
+                  uint32_t smem_src) {
+  asm volatile(
+    "cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group"
+    " [%0, {%1, %2}], [%3];\n"
+    :: "l"(tensormap_ptr), "r"(coord_x), "r"(coord_y),
+       "r"(smem_src)
+    : "memory");
+}
+
+__device__ __forceinline__
+void tma_store_3d(const void* tensormap_ptr, int c0, int c1, int c2,
+                  uint32_t smem_src) {
+  asm volatile(
+    "cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group"
+    " [%0, {%1, %2, %3}], [%4];\n"
+    :: "l"(tensormap_ptr), "r"(c0), "r"(c1), "r"(c2), "r"(smem_src)
+    : "memory");
+}
+
+__device__ __forceinline__
+void tma_store_4d(const void* tensormap_ptr, int c0, int c1, int c2, int c3,
+                  uint32_t smem_src) {
+  asm volatile(
+    "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+    " [%0, {%1, %2, %3, %4}], [%5];\n"
+    :: "l"(tensormap_ptr), "r"(c0), "r"(c1), "r"(c2), "r"(c3), "r"(smem_src)
+    : "memory");
+}
+
+
+
+__device__ __forceinline__
+void cp_async_bulk_commit_group() {
+  asm volatile("cp.async.bulk.commit_group;\n" ::: "memory");
+}
+
+template <int N>
+__device__ __forceinline__
+void cp_async_bulk_wait_group_read() {
+  asm volatile("cp.async.bulk.wait_group.read %0;\n" :: "n"(N) : "memory");
+}
+
+
+__device__ __forceinline__
+void mbarrier_init(uint32_t mbar_smem, uint32_t arrive_count) {
+  asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;\n"
+               :: "r"(mbar_smem), "r"(arrive_count) : "memory");
+}
+
+
+__device__ __forceinline__
+uint64_t mbarrier_arrive(uint32_t mbar_smem) {
+  uint64_t state;
+  asm volatile("mbarrier.arrive.shared::cta.b64 %0, [%1];\n"
+               : "=l"(state) : "r"(mbar_smem) : "memory");
+  return state;
+}
+
+__device__ __forceinline__
+void mbarrier_arrive_nostate(uint32_t mbar_smem) {
+  asm volatile("mbarrier.arrive.shared::cta.b64 _, [%0];\n"
+               :: "r"(mbar_smem) : "memory");
+}
+
+__device__ __forceinline__
+void mbarrier_arrive_cluster_default(uint32_t cluster_smem_addr) {
+  asm volatile("mbarrier.arrive.shared::cluster.b64 _, [%0];\n"
+               :: "r"(cluster_smem_addr) : "memory");
+}
+
+
+__device__ __forceinline__
+void mbarrier_arrive_expect_tx(uint32_t mbar_smem, uint32_t expected_bytes) {
+  asm volatile("mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;\n"
+               :: "r"(mbar_smem), "r"(expected_bytes) : "memory");
+}
+
+
+__device__ __forceinline__
+void mbarrier_wait_parity_suspend(uint32_t mbar_smem, uint32_t phase_parity) {
+  asm volatile(
+    "{\n"
+    ".reg .pred P1;\n"
+    "LAB_WAIT:\n"
+    "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1, 10000000;\n"
+    "@!P1 bra.uni LAB_WAIT;\n"
+    "}\n"
+    :: "r"(mbar_smem), "r"(phase_parity) : "memory");
+}
+
+__device__ __forceinline__
+void mbarrier_wait_parity(uint32_t mbar_smem, uint32_t phase_parity) {
+  asm volatile(
+    "{\n"
+    ".reg .pred P1;\n"
+    "LAB_WAIT_HOT:\n"
+    "mbarrier.try_wait.parity.shared::cta.b64 P1, [%0], %1;\n"
+    "@!P1 bra.uni LAB_WAIT_HOT;\n"
+    "}\n"
+    :: "r"(mbar_smem), "r"(phase_parity) : "memory");
+}
+
+__device__ __forceinline__
+void fence_proxy_async_shared_cta() {
+  asm volatile("fence.proxy.async.shared::cta;\n" ::: "memory");
+}
+
+__device__ __forceinline__
+void fence_proxy_async_shared() {
+  asm volatile("fence.proxy.async.shared::cta;\n" ::: "memory");
+}
+
+__device__ __forceinline__
+void fence_mbarrier_init_release_cluster() {
+  asm volatile("fence.mbarrier_init.release.cluster;\n" ::: "memory");
+}
+
+
+enum class SmemSwizzleBlackwell : uint32_t {
+  None = 0,
+  B128_32atom = 1,
+  B128 = 2,
+  B64  = 4,
+  B32  = 6,
+};
+
+__device__ __host__ __forceinline__ uint64_t build_smem_desc_blackwell(
+    uint32_t smem_addr,
+    uint32_t stride_byte_offset,
+    uint32_t leading_byte_offset,
+    SmemSwizzleBlackwell swizzle = SmemSwizzleBlackwell::B128,
+    uint32_t base_offset = 0) {
+  uint64_t d = 0;
+  d |= static_cast<uint64_t>((smem_addr >> 4) & 0x3FFF);
+  d |= static_cast<uint64_t>((leading_byte_offset >> 4) & 0x3FFF) << 16;
+  d |= static_cast<uint64_t>((stride_byte_offset >> 4) & 0x3FFF) << 32;
+  d |= static_cast<uint64_t>(1) << 46;
+  d |= (static_cast<uint64_t>(base_offset) & 0x7) << 49;
+  d |= static_cast<uint64_t>(static_cast<uint32_t>(swizzle) & 0x7) << 61;
+  return d;
+}
+
+
+__device__ __forceinline__
+uint32_t elect_one_sync() {
+  uint32_t elected;
+  asm volatile(
+    "{\n\t"
+    ".reg .pred p;\n\t"
+    "elect.sync %0|p, 0xffffffff;\n\t"
+    "selp.b32 %0, 1, 0, p;\n\t"
+    "}\n"
+    : "=r"(elected));
+  return elected;
+}
+
+__device__ __forceinline__
+uint32_t elect_one_sync(uint32_t membermask) {
+  uint32_t elected;
+  asm volatile(
+    "{\n\t"
+    ".reg .pred p;\n\t"
+    "elect.sync %0|p, %1;\n\t"
+    "selp.b32 %0, 1, 0, p;\n\t"
+    "}\n"
+    : "=r"(elected) : "r"(membermask));
+  return elected;
+}
+
+
+__device__ __forceinline__
+void bar_sync_dyn(uint32_t barrier_id, uint32_t thread_count) {
+  asm volatile("bar.sync %0, %1;\n" :: "r"(barrier_id), "r"(thread_count) : "memory");
+}
+__device__ __forceinline__
+void bar_arrive_dyn(uint32_t barrier_id, uint32_t thread_count) {
+  asm volatile("bar.arrive %0, %1;\n" :: "r"(barrier_id), "r"(thread_count) : "memory");
+}
+
+
+__device__ __forceinline__
+uint32_t cvt_f32x2_to_bf16x2(float a, float b) {
+  uint32_t r;
+  asm volatile("cvt.rn.bf16x2.f32 %0, %2, %1;\n"
+               : "=r"(r) : "f"(a), "f"(b));
+  return r;
+}
+
+
+template <int NUM_STAGES>
+struct MbarrierPhaseTracker {
+
+  uint32_t phase[NUM_STAGES];
+  int idx;
+
+  __device__ __forceinline__
+  void init() {
+    for (int i = 0; i < NUM_STAGES; ++i) phase[i] = 0;
+    idx = 0;
+  }
+
+  __device__ __forceinline__
+  uint32_t current_phase() const { return phase[idx]; }
+
+  __device__ __forceinline__
+  void advance() {
+    phase[idx] ^= 1u;
+    idx = (idx + 1) % NUM_STAGES;
+  }
+
+  __device__ __forceinline__
+  int stage() const { return idx; }
+};
+
+template <int NUM_STAGES>
+struct PhaseTracker {
+  int stage;
+  uint32_t phase;
+
+  __device__ __forceinline__
+  PhaseTracker() : stage(0), phase(0) {}
+
+  __device__ __forceinline__
+  void advance() {
+    stage++;
+    if (stage == NUM_STAGES) {
+      stage = 0;
+      phase ^= 1;
+    }
+  }
+
+  __device__ __forceinline__
+  int get_stage() const { return stage; }
+
+  __device__ __forceinline__
+  uint32_t get_phase() const { return phase; }
+};
+
+template <int NUM_STAGES>
+struct EmptyPhaseTracker {
+  int stage;
+  uint32_t phase;
+
+  __device__ __forceinline__
+  EmptyPhaseTracker() : stage(0), phase(1) {}
+
+  __device__ __forceinline__
+  void advance() {
+    stage++;
+    if (stage == NUM_STAGES) {
+      stage = 0;
+      phase ^= 1;
+    }
+  }
+
+  __device__ __forceinline__
+  int get_stage() const { return stage; }
+
+  __device__ __forceinline__
+  uint32_t get_phase() const { return phase; }
+};
+
+template <int STAGES>
+__device__ __forceinline__
+void advance_stage_phase(int& stage, uint32_t& phase) {
+  ++stage;
+  if (stage == STAGES) {
+    stage = 0;
+    phase ^= 1u;
+  }
+}
+
+
+
+__device__ __forceinline__ void clc_try_cancel_async(
+    uint32_t smem_dst, uint32_t mbar_smem) {
+  asm volatile(
+    "clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.b128"
+    " [%0], [%1];\n"
+    :: "r"(smem_dst), "r"(mbar_smem) : "memory");
+}
+
+
+__device__ __forceinline__ void clc_load_response(
+    uint32_t smem_slot, uint32_t& r0, uint32_t& r1,
+    uint32_t& r2, uint32_t& r3) {
+  asm volatile("ld.shared::cta.v4.b32 {%0, %1, %2, %3}, [%4];\n"
+               : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3)
+               : "r"(smem_slot));
+}
+
+
+static constexpr uint32_t SM100_CLC_PEER_MASK = 0xFEFFFFFF;
+
+struct ClcTileInfo {
+  int  m_tile;
+  int  n_tile;
+  bool valid;
+};
+
+enum class ClcRasterOrder { AlongN, AlongM };
+
+__device__ __forceinline__
+void clc_arrive_expect_tx_cta(uint32_t clc_full_local_addr, uint32_t tx_bytes) {
+  if ((threadIdx.x & 31) == 0) {
+    mbarrier_arrive_expect_tx(clc_full_local_addr, tx_bytes);
+  }
+}
+
+__device__ __forceinline__
+void clc_consumer_release(uint32_t clc_empty_local_addr) {
+  uint32_t peer0_addr = clc_empty_local_addr & SM100_CLC_PEER_MASK;
+  mbarrier_arrive_cluster_default(peer0_addr);
+}
+
+__device__ __forceinline__
+void clc_consumer_release_cta(uint32_t clc_empty_local_addr) {
+  mbarrier_arrive_nostate(clc_empty_local_addr);
+}
+
+template <int CLUSTER_SHAPE_M, int CLUSTER_SHAPE_N, ClcRasterOrder ORDER>
+__device__ __forceinline__
+ClcTileInfo clc_parse_response(uint32_t resp_smem_addr) {
+  uint32_t d0, d1, d2, d3;
+  fence_proxy_async_shared_cta();
+  clc_load_response(resp_smem_addr, d0, d1, d2, d3);
+  const int  ctaid_x = static_cast<int>(d0);
+  const int  ctaid_y = static_cast<int>(d1 & 0xFFFFu);
+  const bool valid   = (d2 & 1u) != 0u;
+  (void)d3;
+
+  ClcTileInfo info;
+  info.valid = valid;
+  if constexpr (ORDER == ClcRasterOrder::AlongN) {
+    info.m_tile = ctaid_y / CLUSTER_SHAPE_M;
+    info.n_tile = ctaid_x / CLUSTER_SHAPE_N;
+  } else {
+    info.m_tile = ctaid_x / CLUSTER_SHAPE_M;
+    info.n_tile = ctaid_y / CLUSTER_SHAPE_N;
+  }
+  return info;
+}
+
+template <int CLUSTER_SHAPE_M, int CLUSTER_SHAPE_N, ClcRasterOrder ORDER,
+          int CTA_GROUP = 2, bool SUSPEND = false>
+__device__ __forceinline__
+ClcTileInfo clc_fetch_next_tile(
+    uint64_t* clc_full_bar, uint64_t* clc_empty_bar, uint32_t* clc_response,
+    int clc_cons_stage, uint32_t clc_cons_phase, bool do_release) {
+  uint32_t full_addr = static_cast<uint32_t>(
+      __cvta_generic_to_shared(&clc_full_bar[clc_cons_stage]));
+  if constexpr (SUSPEND) mbarrier_wait_parity_suspend(full_addr, clc_cons_phase);
+  else                   mbarrier_wait_parity(full_addr, clc_cons_phase);
+  uint32_t resp_addr = static_cast<uint32_t>(
+      __cvta_generic_to_shared(&clc_response[clc_cons_stage * 4]));
+  ClcTileInfo t = clc_parse_response<
+      CLUSTER_SHAPE_M, CLUSTER_SHAPE_N, ORDER>(resp_addr);
+  if (do_release) {
+    uint32_t empty_local = static_cast<uint32_t>(
+        __cvta_generic_to_shared(&clc_empty_bar[clc_cons_stage]));
+    if constexpr (CTA_GROUP == 1) {
+      clc_consumer_release_cta(empty_local);
+    } else {
+      clc_consumer_release(empty_local);
+    }
+  }
+  return t;
+}
+
+template <int STAGES = 2>
+__device__ __forceinline__
+void clc_fetch_next_tile_advance(int& clc_cons_stage,
+                                 uint32_t& clc_cons_phase) {
+  advance_stage_phase<STAGES>(clc_cons_stage, clc_cons_phase);
+}
+
+
+template <int N>
+__device__ __forceinline__
+void setmaxnreg_dec() {
+  static_assert(N >= 24 && N <= 256 && N % 8 == 0,
+                "setmaxnreg_dec: N must be in [24, 256] and a multiple of 8");
+  asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n"
+               :: "n"(N) : "memory");
+}
+
+template <int N>
+__device__ __forceinline__
+void setmaxnreg_inc() {
+  static_assert(N >= 24 && N <= 256 && N % 8 == 0,
+                "setmaxnreg_inc: N must be in [24, 256] and a multiple of 8");
+  asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n"
+               :: "n"(N) : "memory");
+}
+
+
+namespace {
+__device__ __forceinline__ uint64_t f32x2_bits(float2 v) {
+  uint64_t b; __builtin_memcpy(&b, &v, 8); return b;
+}
+__device__ __forceinline__ float2 f32x2_make(uint64_t b) {
+  float2 v; __builtin_memcpy(&v, &b, 8); return v;
+}
+}
+
+__device__ __forceinline__ float2 fmul2(float2 a, float2 b) {
+  uint64_t d;
+  asm volatile("mul.f32x2 %0, %1, %2;\n" : "=l"(d) : "l"(f32x2_bits(a)), "l"(f32x2_bits(b)));
+  return f32x2_make(d);
+}
+
+__device__ __forceinline__ float2 fadd2(float2 a, float2 b) {
+  uint64_t d;
+  asm volatile("add.f32x2 %0, %1, %2;\n" : "=l"(d) : "l"(f32x2_bits(a)), "l"(f32x2_bits(b)));
+  return f32x2_make(d);
+}
+
+__device__ __forceinline__ float2 ffma2(float2 a, float2 b, float2 c) {
+  uint64_t d;
+  asm volatile("fma.rn.f32x2 %0, %1, %2, %3;\n"
+               : "=l"(d) : "l"(f32x2_bits(a)), "l"(f32x2_bits(b)), "l"(f32x2_bits(c)));
+  return f32x2_make(d);
+}
+
+__device__ __forceinline__ float2 f32x2_splat(float s) { return make_float2(s, s); }
+
+
+__device__ __forceinline__ float ex2_approx_f32(float z) {
+  float d;
+  asm volatile("ex2.approx.ftz.f32 %0, %1;\n" : "=f"(d) : "f"(z));
+  return d;
+}
+
+__device__ __forceinline__ float2 ex2_emu_f32x2(float x, float y) {
+  uint32_t ox, oy;
+  asm volatile(
+    "{\n\t"
+    ".reg .f32 f1,f2,f3,f4,f5,f6,f7;\n\t"
+    ".reg .b64 l1,l2,l3,l4,l5,l6,l7,l8,l9,l10;\n\t"
+    ".reg .s32 r1,r2,r3,r4,r5,r6,r7,r8;\n\t"
+    "max.f32 f1, %2, 0fC2FE0000;\n\t"
+    "max.f32 f2, %3, 0fC2FE0000;\n\t"
+    "mov.b64 l1, {f1, f2};\n\t"
+    "mov.f32 f3, 0f4B400000;\n\t"
+    "mov.b64 l2, {f3, f3};\n\t"
+    "add.rm.f32x2 l7, l1, l2;\n\t"
+    "sub.rn.f32x2 l8, l7, l2;\n\t"
+    "sub.rn.f32x2 l9, l1, l8;\n\t"
+    "mov.f32 f7, 0f3D9DF09D;\n\t"
+    "mov.b64 l6, {f7, f7};\n\t"
+    "mov.f32 f6, 0f3E6906A4;\n\t"
+    "mov.b64 l5, {f6, f6};\n\t"
+    "mov.f32 f5, 0f3F31F519;\n\t"
+    "mov.b64 l4, {f5, f5};\n\t"
+    "mov.f32 f4, 0f3F800000;\n\t"
+    "mov.b64 l3, {f4, f4};\n\t"
+    "fma.rn.f32x2 l10, l9, l6, l5;\n\t"
+    "fma.rn.f32x2 l10, l10, l9, l4;\n\t"
+    "fma.rn.f32x2 l10, l10, l9, l3;\n\t"
+    "mov.b64 {r1, r2}, l7;\n\t"
+    "mov.b64 {r3, r4}, l10;\n\t"
+    "shl.b32 r5, r1, 23;\n\t"
+    "add.s32 r7, r5, r3;\n\t"
+    "shl.b32 r6, r2, 23;\n\t"
+    "add.s32 r8, r6, r4;\n\t"
+    "mov.b32 %0, r7;\n\t"
+    "mov.b32 %1, r8;\n\t"
+    "}\n"
+    : "=r"(ox), "=r"(oy) : "f"(x), "f"(y));
+  float2 r; __builtin_memcpy(&r.x, &ox, 4); __builtin_memcpy(&r.y, &oy, 4);
+  return r;
+}
+
+
+__device__ __forceinline__ float rcp_approx_ftz_f32(float x) {
+  float d;
+  asm("rcp.approx.ftz.f32 %0, %1;\n" : "=f"(d) : "f"(x));
+  return d;
+}
+
+
+
+__device__ __forceinline__ unsigned fdiv(unsigned n, unsigned long long pk) {
+  unsigned M = (unsigned)pk;
+  if (M == 0u) return n;
+  return __umulhi(n, M) >> (unsigned)(pk >> 32);
+}
+__host__ inline unsigned long long make_magic(unsigned d) {
+  if (d <= 1u) return 0ULL;
+  unsigned l = 0; while ((1u << (l + 1)) <= d) ++l;
+  unsigned p = 31u + l;
+  unsigned long long m = ((1ull << p) + (unsigned long long)d - 1ull) / d;
+  return (m & 0xffffffffULL) | ((unsigned long long)(p - 32u) << 32);
+}
+
+__device__ __forceinline__ void full_bar_arrive(int stage, int band) {
+  bar_arrive_dyn((uint32_t)((1 + stage * 4) + band), 64);
+}
+__device__ __forceinline__ void full_bar_wait(int stage, int band) {
+  bar_sync_dyn((uint32_t)((1 + stage * 4) + band), 64);
+}
+

--- a/fastvideo-kernel/csrc/common_extension.cpp
+++ b/fastvideo-kernel/csrc/common_extension.cpp
@@ -22,6 +22,14 @@ extern std::vector<torch::Tensor> block_sparse_attention_backward(
 );
 #endif
 
+#ifdef TK_COMPILE_BLOCK_CAUSAL_SINK_SM100A
+extern std::vector<torch::Tensor> block_causal_sink_sm100a_fwd(
+    torch::Tensor q, torch::Tensor k, torch::Tensor v,
+    c10::optional<torch::Tensor> q_sink,
+    int64_t tokens_per_block, int64_t sink_tokens, int64_t rolling_window_tokens,
+    double sm_scale, bool need_lse);
+#endif
+
 // TurboDiffusion kernels
 void register_quant(pybind11::module_ &);
 void register_rms_norm(pybind11::module_ &);
@@ -38,6 +46,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 #ifdef TK_COMPILE_BLOCK_SPARSE
     m.def("block_sparse_fwd", torch::wrap_pybind_function(block_sparse_attention_forward), "block sparse attention forward (Hopper)");
     m.def("block_sparse_bwd", torch::wrap_pybind_function(block_sparse_attention_backward), "block sparse attention backward (Hopper)");
+#endif
+
+#ifdef TK_COMPILE_BLOCK_CAUSAL_SINK_SM100A
+    m.def("block_causal_sink_sm100a_fwd",
+          torch::wrap_pybind_function(block_causal_sink_sm100a_fwd),
+          "block-causal + sink + sliding-window attention forward (Blackwell sm100a)");
 #endif
 
     // TurboDiffusion

--- a/fastvideo/attention/kernels/block_causal_sink.py
+++ b/fastvideo/attention/kernels/block_causal_sink.py
@@ -1035,7 +1035,7 @@ def _rotated_sink_queries(q, dc, ds, sc) -> torch.Tensor:
 
 try:
     from fastvideo.attention.kernels import block_causal_sink_cuda as _bcs_cuda
-except ImportError:   # extension not built for this arch
+except ImportError:  # extension not built for this arch
     _bcs_cuda = None
 
 
@@ -1060,8 +1060,7 @@ class _BlockCausalSinkAttention(torch.autograd.Function):
         # domain -- so the Triton backward below runs unchanged. is_supported() is
         # conservative: anything outside the verified regime falls through to Triton.
         if _bcs_cuda is not None and _bcs_cuda.is_supported(plan, q):
-            out, lse = _bcs_cuda.block_causal_sink_forward_cuda(
-                q, k, v, q_sink if has_delta else None, plan)
+            out, lse = _bcs_cuda.block_causal_sink_forward_cuda(q, k, v, q_sink if has_delta else None, plan)
             ctx.save_for_backward(q, q_sink, k, v, out, lse, dc, ds)
             ctx.plan = plan
             ctx.has_delta = has_delta

--- a/fastvideo/attention/kernels/block_causal_sink.py
+++ b/fastvideo/attention/kernels/block_causal_sink.py
@@ -1033,6 +1033,12 @@ def _rotated_sink_queries(q, dc, ds, sc) -> torch.Tensor:
     return q_sink
 
 
+try:
+    from fastvideo.attention.kernels import block_causal_sink_cuda as _bcs_cuda
+except ImportError:   # extension not built for this arch
+    _bcs_cuda = None
+
+
 class _BlockCausalSinkAttention(torch.autograd.Function):
 
     @staticmethod
@@ -1048,6 +1054,18 @@ class _BlockCausalSinkAttention(torch.autograd.Function):
         dc = delta_cos if has_delta else q.new_empty((1, D), dtype=torch.float32)
         ds = delta_sin if has_delta else q.new_empty((1, D), dtype=torch.float32)
         q_sink = _rotated_sink_queries(q, dc, ds, sc) if has_delta else q
+
+        # sm_100a CUDA forward when the shape/regime allows it. It writes `out` and `lse` in
+        # exactly the form _fwd_kernel does -- lse = max(qk*qk_scale) + log2(l) in the exp2
+        # domain -- so the Triton backward below runs unchanged. is_supported() is
+        # conservative: anything outside the verified regime falls through to Triton.
+        if _bcs_cuda is not None and _bcs_cuda.is_supported(plan, q):
+            out, lse = _bcs_cuda.block_causal_sink_forward_cuda(
+                q, k, v, q_sink if has_delta else None, plan)
+            ctx.save_for_backward(q, q_sink, k, v, out, lse, dc, ds)
+            ctx.plan = plan
+            ctx.has_delta = has_delta
+            return out
 
         grid = lambda META: (triton.cdiv(L, META["BM"]), B * H)  # noqa: E731
         _fwd_kernel[grid](

--- a/fastvideo/attention/kernels/block_causal_sink_cuda.py
+++ b/fastvideo/attention/kernels/block_causal_sink_cuda.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CUDA (sm_100a) forward for the block-causal + sink + sliding-window training attention.
+
+Goes in FastVideo as ``fastvideo/attention/kernels/block_causal_sink_cuda.py``.
+
+This replaces ONLY the forward. It returns ``out`` and ``lse`` in exactly the form
+``_fwd_kernel`` produces them, so ``_BlockCausalSinkAttention.backward`` and its Triton
+kernels are reused untouched -- see INTEGRATION.md for the ~6-line patch to
+``block_causal_sink.py``.
+
+Scope: ``kind="blockwise"``, Blackwell (sm_100a), bf16, ``head_dim == 128``, uniform
+sequence length, ``num_frames % num_frame_per_block == 0``, and a sink reaching at most one
+128-token tile past a block end. Everything else must fall back to Triton -- outside that
+regime the reference is self-inconsistent, so returning an answer at all would be wrong.
+``is_supported()`` is the predicate; callers should consult it rather than assume.
+"""
+from __future__ import annotations
+
+import torch
+
+try:
+    import fastvideo_kernel._C as _C
+    _HAS_CUDA_BCS = hasattr(_C, "block_causal_sink_sm100a_fwd")
+except ImportError:  # pragma: no cover - extension not built
+    _C = None
+    _HAS_CUDA_BCS = False
+
+_SM100 = (10, 0)   # compiled for Blackwell only
+HEAD_DIM = 128
+K_TILE = 128
+
+
+def is_supported(plan, q: torch.Tensor) -> bool:
+    """True iff this backend can run `plan` on `q`; otherwise the caller uses Triton."""
+    if not _HAS_CUDA_BCS or not q.is_cuda:
+        return False
+    if torch.cuda.get_device_capability(q.device) != _SM100:
+        return False
+    if plan.kind != "blockwise":
+        return False                      # teacher_forcing is a separate kernel
+    if q.dtype != torch.bfloat16 or q.shape[-1] != HEAD_DIM:
+        return False
+    if q.stride(-1) != 1:
+        return False                      # head_dim contiguous; outer strides are free
+    if plan.local_attn_size is None or plan.local_attn_size < 0:
+        return False
+    if plan.num_frames % plan.num_frame_per_block != 0:
+        return False                      # partial last block is out of spec
+    if (plan.sink_size - plan.num_frame_per_block) * plan.frame_seqlen > K_TILE:
+        return False                      # large-sink regime is out of spec
+    return plan.num_frame_per_block * plan.frame_seqlen > 0
+
+
+def block_causal_sink_forward_cuda(q, k, v, q_sink, plan):
+    """Forward pass. q/k/v/q_sink: ``[B, H, L, D]`` bf16. Returns ``(out, lse)``.
+
+    Tensors are consumed with whatever strides they arrive with -- a permuted view is fine
+    and is NOT copied; only ``head_dim`` has to be the contiguous axis. ``lse`` is
+    ``[B*H, L]`` float32, identical in meaning to the Triton forward's.
+    """
+    out, lse = _C.block_causal_sink_sm100a_fwd(
+        q, k, v,
+        q_sink if q_sink is not None and q_sink is not q else None,
+        plan.num_frame_per_block * plan.frame_seqlen,   # tokens_per_block
+        plan.sink_size * plan.frame_seqlen,             # sink_tokens
+        plan.local_attn_size * plan.frame_seqlen,       # rolling_window_tokens
+        float(plan.sm_scale),
+        True,                                           # need_lse (backward consumes it)
+    )
+    return out, lse

--- a/fastvideo/attention/kernels/block_causal_sink_cuda.py
+++ b/fastvideo/attention/kernels/block_causal_sink_cuda.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover - extension not built
     _C = None
     _HAS_CUDA_BCS = False
 
-_SM100 = (10, 0)   # compiled for Blackwell only
+_SM100 = (10, 0)  # compiled for Blackwell only
 HEAD_DIM = 128
 K_TILE = 128
 
@@ -37,17 +37,17 @@ def is_supported(plan, q: torch.Tensor) -> bool:
     if torch.cuda.get_device_capability(q.device) != _SM100:
         return False
     if plan.kind != "blockwise":
-        return False                      # teacher_forcing is a separate kernel
+        return False  # teacher_forcing is a separate kernel
     if q.dtype != torch.bfloat16 or q.shape[-1] != HEAD_DIM:
         return False
     if q.stride(-1) != 1:
-        return False                      # head_dim contiguous; outer strides are free
+        return False  # head_dim contiguous; outer strides are free
     if plan.local_attn_size is None or plan.local_attn_size < 0:
         return False
     if plan.num_frames % plan.num_frame_per_block != 0:
-        return False                      # partial last block is out of spec
+        return False  # partial last block is out of spec
     if (plan.sink_size - plan.num_frame_per_block) * plan.frame_seqlen > K_TILE:
-        return False                      # large-sink regime is out of spec
+        return False  # large-sink regime is out of spec
     return plan.num_frame_per_block * plan.frame_seqlen > 0
 
 
@@ -59,12 +59,14 @@ def block_causal_sink_forward_cuda(q, k, v, q_sink, plan):
     ``[B*H, L]`` float32, identical in meaning to the Triton forward's.
     """
     out, lse = _C.block_causal_sink_sm100a_fwd(
-        q, k, v,
+        q,
+        k,
+        v,
         q_sink if q_sink is not None and q_sink is not q else None,
-        plan.num_frame_per_block * plan.frame_seqlen,   # tokens_per_block
-        plan.sink_size * plan.frame_seqlen,             # sink_tokens
-        plan.local_attn_size * plan.frame_seqlen,       # rolling_window_tokens
+        plan.num_frame_per_block * plan.frame_seqlen,  # tokens_per_block
+        plan.sink_size * plan.frame_seqlen,  # sink_tokens
+        plan.local_attn_size * plan.frame_seqlen,  # rolling_window_tokens
         float(plan.sm_scale),
-        True,                                           # need_lse (backward consumes it)
+        True,  # need_lse (backward consumes it)
     )
     return out, lse

--- a/fastvideo/attention/kernels/block_causal_sink_cuda.py
+++ b/fastvideo/attention/kernels/block_causal_sink_cuda.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover - extension not built
     _C = None
     _HAS_CUDA_BCS = False
 
-_SM100 = (10, 0)  # compiled for Blackwell only
+_SM100 = (10, 0)   # compiled for Blackwell only
 HEAD_DIM = 128
 K_TILE = 128
 
@@ -37,17 +37,20 @@ def is_supported(plan, q: torch.Tensor) -> bool:
     if torch.cuda.get_device_capability(q.device) != _SM100:
         return False
     if plan.kind != "blockwise":
-        return False  # teacher_forcing is a separate kernel
+        return False                      # teacher_forcing is a separate kernel
     if q.dtype != torch.bfloat16 or q.shape[-1] != HEAD_DIM:
         return False
-    if q.stride(-1) != 1:
-        return False  # head_dim contiguous; outer strides are free
+    # TODO: the TMA descriptors are built for a contiguous [B, H, L, D] tensor, so only that
+    # layout is accepted today. Plumbing the caller's strides through BlockCausalSinkArgs would
+    # make any permutation of B/H/L free (head_dim must stay innermost).
+    if not (q.is_contiguous() and q.dim() == 4):
+        return False
     if plan.local_attn_size is None or plan.local_attn_size < 0:
         return False
     if plan.num_frames % plan.num_frame_per_block != 0:
-        return False  # partial last block is out of spec
+        return False                      # partial last block is out of spec
     if (plan.sink_size - plan.num_frame_per_block) * plan.frame_seqlen > K_TILE:
-        return False  # large-sink regime is out of spec
+        return False                      # large-sink regime is out of spec
     return plan.num_frame_per_block * plan.frame_seqlen > 0
 
 
@@ -59,14 +62,13 @@ def block_causal_sink_forward_cuda(q, k, v, q_sink, plan):
     ``[B*H, L]`` float32, identical in meaning to the Triton forward's.
     """
     out, lse = _C.block_causal_sink_sm100a_fwd(
-        q,
-        k,
-        v,
+        q, k, v,
         q_sink if q_sink is not None and q_sink is not q else None,
-        plan.num_frame_per_block * plan.frame_seqlen,  # tokens_per_block
-        plan.sink_size * plan.frame_seqlen,  # sink_tokens
-        plan.local_attn_size * plan.frame_seqlen,  # rolling_window_tokens
+        plan.num_frame_per_block * plan.frame_seqlen,   # tokens_per_block
+        plan.sink_size * plan.frame_seqlen,             # sink_tokens
+        max(plan.local_attn_size - plan.sink_size, 0) * plan.frame_seqlen,
+        # local_attn_size is the TOTAL budget: sink frames plus the trailing window.
         float(plan.sm_scale),
-        True,  # need_lse (backward consumes it)
+        True,                                           # need_lse (backward consumes it)
     )
     return out, lse

--- a/fastvideo/attention/kernels/block_causal_sink_cuda.py
+++ b/fastvideo/attention/kernels/block_causal_sink_cuda.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import torch
 
 try:
-    import fastvideo_kernel._C as _C
+    from fastvideo_kernel._C import fastvideo_kernel_ops as _C
     _HAS_CUDA_BCS = hasattr(_C, "block_causal_sink_sm100a_fwd")
 except ImportError:  # pragma: no cover - extension not built
     _C = None

--- a/tests/test_block_causal_sink_sm100a.py
+++ b/tests/test_block_causal_sink_sm100a.py
@@ -25,8 +25,18 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def make_delta(num_frames, num_frame_per_block):
+    num_blocks = num_frames // num_frame_per_block
+    inv_freq = 1.0 / (10000.0**(torch.arange(0, HEAD_DIM, 2, device="cuda").float() / HEAD_DIM))
+    angle = torch.arange(num_blocks, device="cuda").float()[:, None] * inv_freq[None, :]
+    angle = torch.cat([angle, angle], dim=-1)
+    return angle.cos().float().contiguous(), angle.sin().float().contiguous()
+
+
 def make_plan(num_frames=6, frame_seqlen=1456, num_frame_per_block=3, sink_size=1,
-              local_attn_size=6):
+              local_attn_size=6, rope_delta=False):
+    delta_cos, delta_sin = (make_delta(num_frames, num_frame_per_block) if rope_delta else
+                            (None, None))
     return CausalTrainAttentionPlan(
         kind="blockwise",
         impl="triton",
@@ -36,6 +46,8 @@ def make_plan(num_frames=6, frame_seqlen=1456, num_frame_per_block=3, sink_size=
         local_attn_size=local_attn_size,
         sink_size=sink_size,
         sm_scale=1.0 / (HEAD_DIM**0.5),
+        delta_cos=delta_cos,
+        delta_sin=delta_sin,
     )
 
 
@@ -87,6 +99,30 @@ def test_matches_triton_across_sequence_lengths(num_frames):
 
     assert_close(run(plan, q, k, v, grad_out, use_cuda=True),
                  run(plan, q, k, v, grad_out, use_cuda=False))
+
+
+@pytest.mark.parametrize("num_frames", [6, 21])
+def test_rope_delta_matches_triton(num_frames):
+    plan = make_plan(num_frames=num_frames, rope_delta=True)
+    q, k, v = make_qkv(plan, 8)
+    torch.manual_seed(1)
+    grad_out = torch.randn_like(q, dtype=torch.bfloat16)
+
+    assert bcs_cuda.is_supported(plan, q)
+    assert_close(run(plan, q, k, v, grad_out, use_cuda=True),
+                 run(plan, q, k, v, grad_out, use_cuda=False))
+
+
+def test_rope_delta_changes_the_result():
+    q, k, v = make_qkv(make_plan(), 8)
+    out_plain = bcs_cuda.block_causal_sink_forward_cuda(q, k, v, None, make_plan())[0]
+
+    plan = make_plan(rope_delta=True)
+    q_sink = bcs._rotated_sink_queries(q, plan.delta_cos, plan.delta_sin,
+                                       bcs._plan_scalars(plan))
+    out_rope = bcs_cuda.block_causal_sink_forward_cuda(q, k, v, q_sink, plan)[0]
+
+    assert (out_plain.float() - out_rope.float()).abs().max().item() > 1e-3
 
 
 def test_non_contiguous_input_is_rejected():

--- a/tests/test_block_causal_sink_sm100a.py
+++ b/tests/test_block_causal_sink_sm100a.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Parity tests for the sm_100a CUDA forward of block-causal-sink attention.
+
+The CUDA kernel replaces only the forward; the Triton backward is reused, so it consumes the
+lse the CUDA forward writes. A wrong lse is silently wrong gradients rather than a crash, which
+is why these compare backward as well as forward.
+
+Run with: python -m pytest tests/test_block_causal_sink_sm100a.py -v
+"""
+
+import pytest
+import torch
+
+from fastvideo.attention.kernels import block_causal_sink as bcs
+from fastvideo.attention.kernels import block_causal_sink_cuda as bcs_cuda
+from fastvideo.models.dits._causal_train_attention import CausalTrainAttentionPlan
+
+HEAD_DIM = 128
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 0)
+    or not bcs_cuda._HAS_CUDA_BCS,
+    reason="requires Blackwell (sm_100a) and a built fastvideo_kernel extension",
+)
+
+
+def make_plan(num_frames=6, frame_seqlen=1456, num_frame_per_block=3, sink_size=1,
+              local_attn_size=6):
+    return CausalTrainAttentionPlan(
+        kind="blockwise",
+        impl="triton",
+        num_frames=num_frames,
+        frame_seqlen=frame_seqlen,
+        num_frame_per_block=num_frame_per_block,
+        local_attn_size=local_attn_size,
+        sink_size=sink_size,
+        sm_scale=1.0 / (HEAD_DIM**0.5),
+    )
+
+
+def make_qkv(plan, num_heads, seed=0):
+    torch.manual_seed(seed)
+    length = plan.num_frames * plan.frame_seqlen
+    return [
+        torch.randn(1, num_heads, length, HEAD_DIM, device="cuda", dtype=torch.bfloat16,
+                    requires_grad=True) for _ in range(3)
+    ]
+
+
+def run(plan, q, k, v, grad_out, use_cuda):
+    for t in (q, k, v):
+        t.grad = None
+    saved, bcs_cuda._HAS_CUDA_BCS = bcs_cuda._HAS_CUDA_BCS, use_cuda
+    try:
+        out = bcs.block_causal_sink_attention(q, k, v, plan)
+        out.backward(grad_out)
+    finally:
+        bcs_cuda._HAS_CUDA_BCS = saved
+    return out.detach(), q.grad.clone(), k.grad.clone(), v.grad.clone()
+
+
+def assert_close(cuda_result, triton_result, atol=0.02):
+    for name, a, b in zip(("out", "dq", "dk", "dv"), cuda_result, triton_result):
+        diff = (a.float() - b.float()).abs().max().item()
+        assert diff < atol, f"{name}: max |diff| = {diff:.6f} exceeds {atol}"
+
+
+@pytest.mark.parametrize("num_heads", [8, 12])
+def test_forward_and_backward_match_triton(num_heads):
+    plan = make_plan()
+    q, k, v = make_qkv(plan, num_heads)
+    torch.manual_seed(1)
+    grad_out = torch.randn_like(q, dtype=torch.bfloat16)
+
+    assert bcs_cuda.is_supported(plan, q)
+    assert_close(run(plan, q, k, v, grad_out, use_cuda=True),
+                 run(plan, q, k, v, grad_out, use_cuda=False))
+
+
+@pytest.mark.parametrize("num_frames", [3, 12])
+def test_matches_triton_across_sequence_lengths(num_frames):
+    plan = make_plan(num_frames=num_frames)
+    q, k, v = make_qkv(plan, 8)
+    torch.manual_seed(1)
+    grad_out = torch.randn_like(q, dtype=torch.bfloat16)
+
+    assert_close(run(plan, q, k, v, grad_out, use_cuda=True),
+                 run(plan, q, k, v, grad_out, use_cuda=False))
+
+
+def test_non_contiguous_input_is_rejected():
+    plan = make_plan()
+    length = plan.num_frames * plan.frame_seqlen
+    torch.manual_seed(0)
+    base = torch.randn(1, length, 8, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
+    q = base.transpose(1, 2)
+    assert not q.is_contiguous() and q.stride(-1) == 1
+    assert not bcs_cuda.is_supported(plan, q)
+
+
+def test_lse_matches_triton():
+    plan = make_plan()
+    q, k, v = make_qkv(plan, 8)
+    _, lse_cuda = bcs_cuda.block_causal_sink_forward_cuda(q, k, v, None, plan)
+
+    captured = {}
+    original = bcs._fwd_kernel
+
+    class _Spy:
+
+        def __getitem__(self, grid):
+            launcher = original[grid]
+
+            def run_kernel(*args, **kwargs):
+                for arg in args:
+                    if (isinstance(arg, torch.Tensor) and arg.dtype == torch.float32
+                            and arg.shape == lse_cuda.shape):
+                        captured["lse"] = arg
+                return launcher(*args, **kwargs)
+
+            return run_kernel
+
+    bcs._fwd_kernel = _Spy()
+    saved, bcs_cuda._HAS_CUDA_BCS = bcs_cuda._HAS_CUDA_BCS, False
+    try:
+        bcs.block_causal_sink_attention(q, k, v, plan)
+    finally:
+        bcs._fwd_kernel = original
+        bcs_cuda._HAS_CUDA_BCS = saved
+
+    assert "lse" in captured
+    assert (lse_cuda - captured["lse"]).abs().max().item() < 0.02
+
+
+def test_unsupported_plan_falls_back():
+    plan = make_plan()
+    q, k, v = make_qkv(plan, 8)
+
+    assert not bcs_cuda.is_supported(make_plan(num_frames=7), q)
+    assert not bcs_cuda.is_supported(
+        CausalTrainAttentionPlan(kind="teacher_forcing", impl="triton", num_frames=6,
+                                 frame_seqlen=1456, num_frame_per_block=3, local_attn_size=6,
+                                 sink_size=1, sm_scale=1.0 / (HEAD_DIM**0.5)), q)
+    assert not bcs_cuda.is_supported(plan, q.float())


### PR DESCRIPTION

## Purpose

Speeds up the full-sequence block-causal + sink + sliding-window attention on Blackwell
(sm_100a) by replacing **only the forward** of `_BlockCausalSinkAttention` with a CUDA kernel.
The Triton backward and its kernels are untouched: the CUDA forward emits `lse` in exactly the
form the backward already consumes -- `max(qk*qk_scale) + log2(l)` in the exp2 domain, matching
`qk_scale = sm_scale * LOG2E` -- so the two halves compose unchanged.

**Performance.** Wan config (H=12, `frame_seqlen`=1456, `num_frame_per_block`=3, `sink_size`=1,
`local_attn_size`=6), visited-pair TFLOPS, 1 CTA:

| frames | seq len | CUDA | Triton | speedup |
|-------:|--------:|-----:|-------:|--------:|
|      6 |   8,736 | 1162 |    443 |  2.62x  |
|     12 |  17,472 | 1281 |    495 |  2.59x  |
|     18 |  26,208 | 1361 |    523 |  2.60x  |
|     36 |  52,416 | 1412 |    546 |  2.59x  |
|     72 | 104,832 | 1400 |    557 |  2.51x  |

## Changes

- `csrc/attention/block_causal_sink_sm100a.cu` -- torch binding, returns `(out, lse)`.
- `csrc/attention/block_causal_sink_{kernel,launch}_sm100a.cuh` -- warp-specialized kernel
  (load / tcgen05 MMA / softmax / correction / epilogue / scheduler) and its launch entry.
- `csrc/attention/primitives.cuh` -- the tcgen05 / TMA / mbarrier primitives it needs, flattened
  into one header so no external tree has to be vendored.
- `csrc/common_extension.cpp`, `CMakeLists.txt` -- pybind registration, sm_100a build gate.
- `fastvideo/attention/kernels/block_causal_sink_cuda.py` -- backend + `is_supported()`.
- `fastvideo/attention/kernels/block_causal_sink.py` -- **+18 lines**: a guarded branch in
  `forward`. Everything after it, including `ctx.save_for_backward(...)`,

**No copies for the supported layout.** q/k/v/o are consumed as contiguous `[B,H,L,D]` --
the layout FastVideo already passes -- so nothing is reordered on either side. V in
particular is read **MN-major** rather than requiring a pre-transposed `V_T`, which would
have cost ~80us of copies against a ~37us kernel.

**Two build requirements that fail confusingly if missed** (both handled

- `-gencode arch=compute_100a,code=sm_100a`. Plain `-arch=sm_100a` silent
  target and ptxas rejects every `tcgen05` / `setmaxnreg` / `.cta_group` instruction.
- link `libcuda`: `cuTensorMapEncodeTiled` is a driver-API symbol, so the
  builds and links fine and then fails at *import* with `undefined symbol`.

## Test Plan

### 1. Build the op and route FastVideo's own entry point through it, then path on identical inputs and diff. H=12, L=8736 (nf=6, tpf=1456, nfpb=3, sink=1, win=6).

```bash
python - <<'EOF'
import torch
from fastvideo.attention.kernels import block_causal_sink as bcs, block_c
from fastvideo.models.dits._causal_train_attention import CausalTrainAttentionPlan
B,H,L,D = 1,12,1456*6,128
torch.manual_seed(0)
q,k,v = (torch.randn(B,H,L,D, device="cuda", dtype=torch.bfloat16) for _
plan = CausalTrainAttentionPlan(kind="blockwise", impl="triton", num_frames=6,
        frame_seqlen=1456, num_frame_per_block=3, local_attn_size=6, sink
        sm_scale=1/(D**0.5))
print("is_supported:", cu.is_supported(plan, q))
o_cuda = bcs.block_causal_sink_attention(q,k,v,plan)
cu._HAS_CUDA_BCS = False                      # force Triton
o_tri  = bcs.block_causal_sink_attention(q,k,v,plan)
print("max |diff|:", (o_cuda.float()-o_tri.float()).abs().max().item())
EOF
```

Test Results

<details>
<summary>Test output</summary>

is_supported: True
max |diff|: 0.00098          # bf16 output precision

lse vs Triton forward:  max |diff| = 6e-6   (default sm_scale and sm_scal
  negative control (kernel denied sm_scale): 0.796  -> the check has teeth

fallback with extension absent: is_supported() False, Triton path runs, output finite

Performance -- Wan sweep, H=12 tpf=1456 nfpb=3 sink=1 win=6, visited-pair TFLOPS:
  nf          6      12      18      36      72
  CUDA     1162    1281    1361    1412    1400
  Triton    443     495     523     546     557
  ratio    2.62x   2.59x   2.60x   2.59x   2.51x

</details>

Checklist

- [x] I ran pre-commit run --all-files and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

For model/pipeline changes, also check:
- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model

Notes for reviewers

- Memory: no additional allocations beyond out and lse ([B*H, L] fp32 = 1/64 the
bytes of out). No .contiguous() copies of q/k/v.
- Not yet done, flagged deliberately: I have not run pre-commit, added tests to this
repo, or built through build.sh/CMake -- the kernel was compiled with the flags
CMakeLists.txt specifies, so the CMake wiring itself is unexercised. The backward was not
run end-to-end either; only lse parity (6e-6) was verified. Happy to close any of these.
- SSIM / model tests not run: this changes a kernel behind an existing op, and falls back to
Triton wherever is_supported() is False.