### PR TITLE
[bugfix]: keep _resolved_attention_backend out of the positional config signature

### DIFF
--- a/fastvideo/configs/models/base.py
+++ b/fastvideo/configs/models/base.py
@@ -36,7 +36,9 @@ class ModelConfig:
     # This is the component-level decision, not a promise about the kernel any
     # single layer ends up running: a layer that does not declare support for
     # this backend still falls back (see ``fastvideo/attention/selector.py``).
-    _resolved_attention_backend: "AttentionBackendEnum | None" = None
+    # Keyword-only: the loader writes this by attribute assignment, so it must not
+    # take a slot in the positional signature that subclasses' fields inherit.
+    _resolved_attention_backend: "AttentionBackendEnum | None" = field(default=None, kw_only=True)
 
     def __getattr__(self, name):
         # Only called if 'name' is not found in ModelConfig directly


### PR DESCRIPTION
## Problem

`fastvideo/tests/stages/test_text_encoding.py::test_chat_template_thinking_is_keyword_only_and_preserves_subclass_positions`
has been failing on main since #1657.

That PR added `_resolved_attention_backend` to `ModelConfig` as a regular
dataclass field. It sits second in the base class, so it shifted the positional
slot of every field subclasses declare after it. For `CLIPTextConfig`, the 7th
positional argument now binds to `treat_empty_as_dot` instead of
`num_hidden_layers_override` — silently, since the types are compatible.

## Why this is a production fix, not a stale test

The test is doing its job. It was added to guard the positional-layout contract
after `chat_template_enable_thinking` was deliberately made `kw_only=True` for
exactly this reason — note the `pytest.raises(TypeError)` assertion at the end.
Updating the test to match the shifted layout would paper over the regression
and retire the guard.

`_resolved_attention_backend` is internal: `record_resolved_attention_backend`
writes it by attribute assignment (`selector.py:152`) and
`get_resolved_attention_backend` reads it with `getattr`. No caller passes it to
a constructor, so it should never have occupied a positional slot.

## Fix

Mark the field `kw_only=True`. One line, no call-site changes.

## Test

`pytest fastvideo/tests/api/ fastvideo/tests/stages/ fastvideo/tests/layers/ fastvideo/tests/attention/`
→ **369 passed, 13 skipped**

Covers both the regression test above and `test_attention_selector_resolution.py`
introduced by #1657. `pre-commit run --files fastvideo/configs/models/base.py` passes.
