### PR TITLE
[bugfix]: add GB200 to the inline SSIM device tables #1676 missed

### DIFF
--- a/fastvideo/tests/ssim/test_flux_t2i_similarity.py
+++ b/fastvideo/tests/ssim/test_flux_t2i_similarity.py
@@ -34,6 +34,7 @@ device_reference_folder = resolve_device_reference_folder(
         ("A40", "A40"),
         ("L40S", "L40S"),
         ("H100", "H100"),
+        ("GB200", "GB200"),
         ("H200", "H200"),
         ("RTX 4090", "RTX4090"),
         ("4090", "RTX4090"),

--- a/fastvideo/tests/ssim/test_gamecraft_similarity.py
+++ b/fastvideo/tests/ssim/test_gamecraft_similarity.py
@@ -46,6 +46,7 @@ device_reference_folder = resolve_device_reference_folder(
         ("L40S", "L40S"),
         ("A100", "A100"),
         ("H100", "H100"),
+        ("GB200", "GB200"),
         ("H200", "H200"),
     ),
     device_name=get_cuda_device_name(),

--- a/fastvideo/tests/ssim/test_gen3c_similarity.py
+++ b/fastvideo/tests/ssim/test_gen3c_similarity.py
@@ -57,6 +57,10 @@ if "A40" in device_name:
     device_reference_folder = "A40" + device_reference_folder_suffix
 elif "L40S" in device_name:
     device_reference_folder = "L40S" + device_reference_folder_suffix
+elif "GB200" in device_name:
+    # must be checked before any future bare-"B200" branch: these are
+    # substring tests and "B200" is a substring of "NVIDIA GB200"
+    device_reference_folder = "GB200" + device_reference_folder_suffix
 else:
     device_reference_folder = None
     logger.warning(f"Unsupported device for GEN3C SSIM tests: {device_name}")

--- a/fastvideo/tests/ssim/test_lingbot_similarity.py
+++ b/fastvideo/tests/ssim/test_lingbot_similarity.py
@@ -54,6 +54,9 @@ device_reference_folder = resolve_device_reference_folder(
         ("A40", "A40"),
         ("L40S", "L40S"),
         ("H100", "H100"),
+        # GB200 must precede any bare "B200" pattern: the lookup is a
+        # substring scan and "B200" is a substring of "NVIDIA GB200"
+        ("GB200", "GB200"),
         ("H200", "H200"),
     ),
     device_name=device_name,

--- a/fastvideo/tests/ssim/test_longcat_similarity.py
+++ b/fastvideo/tests/ssim/test_longcat_similarity.py
@@ -41,6 +41,7 @@ device_reference_folder = resolve_device_reference_folder(
         ("A40", "A40"),
         ("L40S", "L40S"),
         ("H100", "H100"),
+        ("GB200", "GB200"),
         ("H200", "H200"),
     ),
     device_name=get_cuda_device_name(),

--- a/fastvideo/tests/ssim/test_matrixgame2_similarity.py
+++ b/fastvideo/tests/ssim/test_matrixgame2_similarity.py
@@ -29,6 +29,7 @@ device_reference_folder = resolve_device_reference_folder(
     (
         ("A40", "A40"),
         ("L40S", "L40S"),
+        ("GB200", "GB200"),
         ("H200", "H200"),
     ),
     device_name=get_cuda_device_name(),

--- a/fastvideo/tests/ssim/test_matrixgame3_similarity.py
+++ b/fastvideo/tests/ssim/test_matrixgame3_similarity.py
@@ -27,6 +27,7 @@ device_reference_folder = resolve_device_reference_folder(
     (
         ("A40", "A40"),
         ("L40S", "L40S"),
+        ("GB200", "GB200"),
         ("H200", "H200"),
     ),
     device_name=get_cuda_device_name(),

--- a/fastvideo/tests/ssim/test_sd35_similarity.py
+++ b/fastvideo/tests/ssim/test_sd35_similarity.py
@@ -30,6 +30,7 @@ device_reference_folder = resolve_device_reference_folder(
         ("A40", "A40"),
         ("L40S", "L40S"),
         ("H100", "H100"),
+        ("GB200", "GB200"),
         ("H200", "H200"),
         ("RTX 4090", "RTX4090"),
         ("4090", "RTX4090"),


### PR DESCRIPTION
## What

#1676 gave GB200 its own reference folder in the shared `DEVICE_MAPPINGS` table (plus the glm/zimage inline copies), but seven more SSIM tests carry private inline device tables and gen3c uses a hand-rolled if/elif chain. On GB200 hosts these resolved to the `L40S`/`Unknown` fallback — or would be captured by a future bare-`B200` entry, since the lookup is a substring scan and `B200` is a substring of `"NVIDIA GB200"`.

13 insertions across 8 files: a `("GB200", "GB200")` entry in each inline table (ordered before any `B200` pattern) and a GB200 branch in gen3c's chain.

## Validation

- Full ssim suite run on a GB200 tray at this commit: **37 passed / 1 skipped** (the upstream-disabled TurboWan2.2-A14B) in 56:53 — every test resolved its reference folder through the patched paths and compared against the GB200 references in `FastVideo/ssim-reference-videos` (seeded 2026-08-05 with FA4 enabled, matching `ssim_test.py`'s env).
- The ordering assertion in `test_device_reference_folder.py` (from #1676) covers the shared table; the inline copies here carry the same GB200-before-B200 order with a comment.

Follow-up (separate PR): unify gen3c onto the shared resolver so the table exists in one place.