### PR TITLE
[misc] Support partial Hugging Face model downloads

### DIFF
--- a/fastvideo/pipelines/__init__.py
+++ b/fastvideo/pipelines/__init__.py
@@ -29,16 +29,13 @@ def build_pipeline(fastvideo_args: FastVideoArgs,
     """
     Only works with valid hf diffusers configs. (model_index.json)
     We want to build a pipeline based on the inference args mode_path:
-    1. download the model from the hub if it's not already downloaded
-    2. verify the model config and directory
-    3. based on the config, determine the pipeline class 
+    1. resolve the pipeline class from the small Hub manifest
+    2. download the required model components if needed
+    3. verify the selected model components and build the pipeline
     """
-    # Get pipeline type
+    # Resolve the concrete pipeline from the small Hub manifest before
+    # downloading large component weights.
     model_path = fastvideo_args.model_path
-    model_path = maybe_download_model(model_path, revision=fastvideo_args.revision)
-    # fastvideo_args.downloaded_model_path = model_path
-    logger.info("Model path: %s", model_path)
-
     logger.info("Building pipeline of type: %s",
                 pipeline_type.value if isinstance(pipeline_type, PipelineType) else pipeline_type)
 
@@ -47,8 +44,24 @@ def build_pipeline(fastvideo_args: FastVideoArgs,
         pipeline_type=pipeline_type,
         workload_type=fastvideo_args.workload_type,
         override_pipeline_cls_name=fastvideo_args.override_pipeline_cls_name,
+        revision=fastvideo_args.revision,
     )
     pipeline_cls = model_info.pipeline_cls
+
+    component_dirs = pipeline_cls.get_hf_download_component_dirs()
+    allow_patterns = None
+    if component_dirs is not None:
+        allow_patterns = [
+            "model_index.json",
+            "modular_model_index.json",
+            *(f"{component_dir}/**" for component_dir in component_dirs),
+        ]
+    model_path = maybe_download_model(
+        model_path,
+        revision=fastvideo_args.revision,
+        allow_patterns=allow_patterns,
+    )
+    logger.info("Model path: %s", model_path)
 
     # instantiate the pipelines
     pipeline = pipeline_cls(model_path, fastvideo_args)

--- a/fastvideo/pipelines/__init__.py
+++ b/fastvideo/pipelines/__init__.py
@@ -48,18 +48,10 @@ def build_pipeline(fastvideo_args: FastVideoArgs,
     )
     pipeline_cls = model_info.pipeline_cls
 
-    component_dirs = pipeline_cls.get_hf_download_component_dirs()
-    allow_patterns = None
-    if component_dirs is not None:
-        allow_patterns = [
-            "model_index.json",
-            "modular_model_index.json",
-            *(f"{component_dir}/**" for component_dir in component_dirs),
-        ]
     model_path = maybe_download_model(
         model_path,
         revision=fastvideo_args.revision,
-        allow_patterns=allow_patterns,
+        allow_patterns=pipeline_cls.get_hf_download_allow_patterns(),
     )
     logger.info("Model path: %s", model_path)
 

--- a/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
+++ b/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
@@ -31,6 +31,10 @@ class MiniMaxH3BasePipeline(ComposedPipelineBase):
         "audio_scheduler",
     ]
 
+    @classmethod
+    def get_hf_download_component_dirs(cls) -> tuple[str, ...]:
+        return tuple(sorted(cls._extra_config_module_map.get(name, name) for name in cls._required_config_modules))
+
     def initialize_pipeline(self, fastvideo_args: FastVideoArgs) -> None:
         del fastvideo_args
         for module_name, modality, expected_shift in (

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -48,6 +48,11 @@ class ComposedPipelineBase(ABC):
     trainable_transformer_modules: dict[str, torch.nn.Module] = {}
     post_init_called: bool = False
 
+    @classmethod
+    def get_hf_download_component_dirs(cls) -> tuple[str, ...] | None:
+        """Return component directories for an opt-in partial Hub download."""
+        return None
+
     # TODO(will): args should support both inference args and training args
     def __init__(self,
                  model_path: str,
@@ -308,7 +313,10 @@ class ComposedPipelineBase(ABC):
         self.model_path = model_path
         # fastvideo_args.downloaded_model_path = model_path
         logger.info("Model path: %s", model_path)
-        config = verify_model_config_and_directory(model_path)
+        config = verify_model_config_and_directory(
+            model_path,
+            required_component_dirs=self.get_hf_download_component_dirs(),
+        )
         return cast(dict[str, Any], config)
 
     @property

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -53,6 +53,18 @@ class ComposedPipelineBase(ABC):
         """Return component directories for an opt-in partial Hub download."""
         return None
 
+    @classmethod
+    def get_hf_download_allow_patterns(cls) -> list[str] | None:
+        """Return Hub patterns for the manifest and selected components."""
+        component_dirs = cls.get_hf_download_component_dirs()
+        if component_dirs is None:
+            return None
+        return [
+            "model_index.json",
+            "modular_model_index.json",
+            *(f"{component_dir}/**" for component_dir in component_dirs),
+        ]
+
     # TODO(will): args should support both inference args and training args
     def __init__(self,
                  model_path: str,
@@ -309,7 +321,11 @@ class ComposedPipelineBase(ABC):
 
     def _load_config(self, model_path: str) -> dict[str, Any]:
         revision = getattr(self.fastvideo_args, "revision", None)
-        model_path = maybe_download_model(self.model_path, revision=revision)
+        model_path = maybe_download_model(
+            self.model_path,
+            revision=revision,
+            allow_patterns=self.get_hf_download_allow_patterns(),
+        )
         self.model_path = model_path
         # fastvideo_args.downloaded_model_path = model_path
         logger.info("Model path: %s", model_path)

--- a/fastvideo/registry.py
+++ b/fastvideo/registry.py
@@ -190,6 +190,7 @@ def _get_config_info(
     model_path: str,
     *,
     raise_on_missing: bool = True,
+    revision: str | None = None,
 ) -> ConfigInfo | None:
     # 1. Exact match
     if model_path in _MODEL_HF_PATH_TO_NAME:
@@ -209,9 +210,9 @@ def _get_config_info(
 
     # 3. Use detectors (path or model_index pipeline name).
     if os.path.exists(model_path):
-        config = verify_model_config_and_directory(model_path)
+        config = verify_model_config_and_directory(model_path, required_component_dirs=[])
     else:
-        config = maybe_download_model_index(model_path)
+        config = maybe_download_model_index(model_path, revision=revision)
 
     pipeline_name = config.get("_class_name", "").lower()
 
@@ -1197,6 +1198,7 @@ def get_model_info(
     pipeline_type: PipelineType | str | None = None,
     workload_type: WorkloadType | None = None,
     override_pipeline_cls_name: str | None = None,
+    revision: str | None = None,
 ) -> ModelInfo:
     from fastvideo.pipelines.pipeline_registry import (PipelineType, get_pipeline_registry)
 
@@ -1208,7 +1210,7 @@ def get_model_info(
     if workload_type is None:
         workload_type = WorkloadType.T2V
 
-    config_info = _get_config_info(model_path, raise_on_missing=True)
+    config_info = _get_config_info(model_path, raise_on_missing=True, revision=revision)
     assert config_info is not None, "config_info must be resolved"
 
     if override_pipeline_cls_name:
@@ -1219,9 +1221,9 @@ def get_model_info(
         logger.info("Using override pipeline class name %s", pipeline_name)
     else:
         if os.path.exists(model_path):
-            config = verify_model_config_and_directory(model_path)
+            config = verify_model_config_and_directory(model_path, required_component_dirs=[])
         else:
-            config = maybe_download_model_index(model_path)
+            config = maybe_download_model_index(model_path, revision=revision)
 
         pipeline_name = config.get("_class_name")
         if config_info.pipeline_cls_name is not None:

--- a/fastvideo/tests/test_partial_hf_download.py
+++ b/fastvideo/tests/test_partial_hf_download.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import fastvideo.pipelines as pipelines
+import fastvideo.utils as utils
+from fastvideo.pipelines.basic.minimax_h3 import (
+    MiniMaxH3ModularPipeline,
+    MiniMaxH3Ref2VAModularPipeline,
+)
+
+
+def test_maybe_download_model_downloads_only_selected_scheduler(tmp_path: Path, monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_snapshot_download(**kwargs):
+        captured.update(kwargs)
+        scheduler_dir = tmp_path / "scheduler"
+        scheduler_dir.mkdir()
+        (scheduler_dir / "scheduler_config.json").write_text("{}")
+        return str(tmp_path)
+
+    monkeypatch.setattr(utils, "snapshot_download", fake_snapshot_download)
+
+    model_path = Path(
+        utils.maybe_download_model(
+            "MiniMaxAI/MiniMax-H3",
+            local_dir=str(tmp_path),
+            allow_patterns=["scheduler/**"],
+        ))
+
+    assert captured["allow_patterns"] == ["scheduler/**"]
+    assert (model_path / "scheduler" / "scheduler_config.json").is_file()
+    assert not (model_path / "transformer").exists()
+    assert not (model_path / "transformer_ref").exists()
+
+
+def test_minimax_h3_selects_only_its_transformer_partition() -> None:
+    standard_dirs = set(MiniMaxH3ModularPipeline.get_hf_download_component_dirs())
+    ref2va_dirs = set(MiniMaxH3Ref2VAModularPipeline.get_hf_download_component_dirs())
+
+    assert "transformer" in standard_dirs
+    assert "transformer_ref" not in standard_dirs
+    assert "transformer_ref" in ref2va_dirs
+    assert "transformer" not in ref2va_dirs
+
+
+def test_build_pipeline_forwards_selected_component_patterns(monkeypatch) -> None:
+    captured: dict = {}
+
+    class FakeMiniMaxPipeline:
+
+        @classmethod
+        def get_hf_download_component_dirs(cls):
+            return ("scheduler", )
+
+        def __init__(self, model_path, fastvideo_args):
+            captured["pipeline_model_path"] = model_path
+
+    monkeypatch.setattr(
+        pipelines,
+        "get_model_info",
+        lambda **kwargs: SimpleNamespace(pipeline_cls=FakeMiniMaxPipeline),
+    )
+
+    def fake_download(model_path, **kwargs):
+        captured.update(kwargs)
+        return "/tmp/minimax-h3"
+
+    monkeypatch.setattr(pipelines, "maybe_download_model", fake_download)
+    args = SimpleNamespace(
+        model_path="MiniMaxAI/MiniMax-H3",
+        revision="test-revision",
+        workload_type=None,
+        override_pipeline_cls_name=None,
+    )
+
+    pipelines.build_pipeline(args)
+
+    assert captured["allow_patterns"] == [
+        "model_index.json",
+        "modular_model_index.json",
+        "scheduler/**",
+    ]
+    assert captured["revision"] == "test-revision"
+    assert captured["pipeline_model_path"] == "/tmp/minimax-h3"
+
+
+def test_model_index_supports_umbrella_repo_paths(tmp_path: Path, monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_hf_hub_download(**kwargs):
+        captured.update(kwargs)
+        manifest_path = tmp_path / kwargs["filename"]
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps({
+            "_class_name": "MiniMaxH3ModularPipeline",
+            "_diffusers_version": "0.35.0",
+        }))
+        return str(manifest_path)
+
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_hf_hub_download)
+
+    config = utils.maybe_download_model_index("org/repo/minimax-h3", revision="test-revision")
+
+    assert captured["repo_id"] == "org/repo"
+    assert captured["filename"] == "minimax-h3/model_index.json"
+    assert captured["revision"] == "test-revision"
+    assert config["pipeline_name"] == "MiniMaxH3ModularPipeline"

--- a/fastvideo/tests/test_partial_hf_download.py
+++ b/fastvideo/tests/test_partial_hf_download.py
@@ -6,10 +6,23 @@ from types import SimpleNamespace
 
 import fastvideo.pipelines as pipelines
 import fastvideo.utils as utils
+import pytest
+from huggingface_hub.utils import filter_repo_objects
 from fastvideo.pipelines.basic.minimax_h3 import (
     MiniMaxH3ModularPipeline,
     MiniMaxH3Ref2VAModularPipeline,
 )
+
+
+def _write_partial_checkpoint(model_dir: Path, component_dirs: tuple[str, ...]) -> None:
+    model_dir.mkdir()
+    (model_dir / "model_index.json").write_text(
+        json.dumps({
+            "_class_name": "MiniMaxH3ModularPipeline",
+            "_diffusers_version": "0.35.0",
+        }))
+    for component_dir in component_dirs:
+        (model_dir / component_dir).mkdir()
 
 
 def test_maybe_download_model_downloads_only_selected_scheduler(tmp_path: Path, monkeypatch) -> None:
@@ -40,29 +53,54 @@ def test_maybe_download_model_downloads_only_selected_scheduler(tmp_path: Path, 
 def test_minimax_h3_selects_only_its_transformer_partition() -> None:
     standard_dirs = set(MiniMaxH3ModularPipeline.get_hf_download_component_dirs())
     ref2va_dirs = set(MiniMaxH3Ref2VAModularPipeline.get_hf_download_component_dirs())
+    shared_dirs = {
+        "audio_scheduler",
+        "audio_vae",
+        "processor",
+        "scheduler",
+        "text_encoder",
+        "tokenizer",
+        "vae",
+    }
 
-    assert "transformer" in standard_dirs
-    assert "transformer_ref" not in standard_dirs
-    assert "transformer_ref" in ref2va_dirs
-    assert "transformer" not in ref2va_dirs
+    assert standard_dirs == shared_dirs | {"transformer"}
+    assert ref2va_dirs == shared_dirs | {"transformer_ref"}
 
 
-def test_build_pipeline_forwards_selected_component_patterns(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("pipeline_cls", "override_pipeline_cls_name", "included_transformer", "excluded_transformer"),
+    [
+        (MiniMaxH3ModularPipeline, None, "transformer/**", "transformer_ref/**"),
+        (
+            MiniMaxH3Ref2VAModularPipeline,
+            "MiniMaxH3Ref2VAModularPipeline",
+            "transformer_ref/**",
+            "transformer/**",
+        ),
+    ],
+)
+def test_build_pipeline_forwards_real_minimax_patterns(
+    pipeline_cls,
+    override_pipeline_cls_name: str | None,
+    included_transformer: str,
+    excluded_transformer: str,
+    monkeypatch,
+) -> None:
     captured: dict = {}
 
-    class FakeMiniMaxPipeline:
-
-        @classmethod
-        def get_hf_download_component_dirs(cls):
-            return ("scheduler", )
-
-        def __init__(self, model_path, fastvideo_args):
-            captured["pipeline_model_path"] = model_path
+    def fake_get_model_info(**kwargs):
+        captured["override_pipeline_cls_name"] = kwargs["override_pipeline_cls_name"]
+        return SimpleNamespace(pipeline_cls=pipeline_cls)
 
     monkeypatch.setattr(
         pipelines,
         "get_model_info",
-        lambda **kwargs: SimpleNamespace(pipeline_cls=FakeMiniMaxPipeline),
+        fake_get_model_info,
+    )
+    monkeypatch.setattr(
+        pipeline_cls,
+        "__init__",
+        lambda self, model_path, fastvideo_args: captured.update(pipeline_model_path=model_path),
     )
 
     def fake_download(model_path, **kwargs):
@@ -74,18 +112,119 @@ def test_build_pipeline_forwards_selected_component_patterns(monkeypatch) -> Non
         model_path="MiniMaxAI/MiniMax-H3",
         revision="test-revision",
         workload_type=None,
-        override_pipeline_cls_name=None,
+        override_pipeline_cls_name=override_pipeline_cls_name,
     )
 
     pipelines.build_pipeline(args)
 
-    assert captured["allow_patterns"] == [
-        "model_index.json",
-        "modular_model_index.json",
-        "scheduler/**",
-    ]
+    assert included_transformer in captured["allow_patterns"]
+    assert excluded_transformer not in captured["allow_patterns"]
+    assert "FL2VA/**" not in captured["allow_patterns"]
+    assert "Ref2VA/**" not in captured["allow_patterns"]
+    assert captured["override_pipeline_cls_name"] == override_pipeline_cls_name
     assert captured["revision"] == "test-revision"
     assert captured["pipeline_model_path"] == "/tmp/minimax-h3"
+
+
+@pytest.mark.parametrize(
+    ("pipeline_cls", "selected_transformer", "excluded_transformer"),
+    [
+        (MiniMaxH3ModularPipeline, "transformer/model.safetensors", "transformer_ref/model.safetensors"),
+        (MiniMaxH3Ref2VAModularPipeline, "transformer_ref/model.safetensors", "transformer/model.safetensors"),
+    ],
+)
+def test_minimax_patterns_filter_unused_repo_partitions(
+    pipeline_cls,
+    selected_transformer: str,
+    excluded_transformer: str,
+) -> None:
+    repo_files = [
+        "model_index.json",
+        "scheduler/scheduler_config.json",
+        "transformer/model.safetensors",
+        "transformer_ref/model.safetensors",
+        "FL2VA/model.safetensors",
+        "Ref2VA/model.safetensors",
+    ]
+
+    selected = set(
+        filter_repo_objects(
+            repo_files,
+            allow_patterns=pipeline_cls.get_hf_download_allow_patterns(),
+        ))
+
+    assert "model_index.json" in selected
+    assert "scheduler/scheduler_config.json" in selected
+    assert selected_transformer in selected
+    assert excluded_transformer not in selected
+    assert "FL2VA/model.safetensors" not in selected
+    assert "Ref2VA/model.safetensors" not in selected
+
+
+def test_direct_pipeline_load_forwards_partial_patterns(tmp_path: Path, monkeypatch) -> None:
+    component_dirs = MiniMaxH3Ref2VAModularPipeline.get_hf_download_component_dirs()
+    model_dir = tmp_path / "minimax-h3-ref2va"
+    _write_partial_checkpoint(model_dir, component_dirs)
+    captured: dict = {}
+
+    def fake_download(model_path, **kwargs):
+        captured.update(kwargs)
+        return str(model_dir)
+
+    monkeypatch.setattr("fastvideo.pipelines.composed_pipeline_base.maybe_download_model", fake_download)
+    pipeline = object.__new__(MiniMaxH3Ref2VAModularPipeline)
+    pipeline.model_path = "MiniMaxAI/MiniMax-H3"
+    pipeline.fastvideo_args = SimpleNamespace(revision="test-revision")
+
+    pipeline._load_config(pipeline.model_path)
+
+    assert "transformer_ref/**" in captured["allow_patterns"]
+    assert "transformer/**" not in captured["allow_patterns"]
+    assert captured["revision"] == "test-revision"
+
+
+def test_umbrella_download_prefixes_selected_patterns(tmp_path: Path, monkeypatch) -> None:
+    captured: dict = {}
+
+    def fake_snapshot_download(**kwargs):
+        captured.update(kwargs)
+        (tmp_path / "minimax-h3").mkdir()
+        return str(tmp_path)
+
+    monkeypatch.setattr(utils, "snapshot_download", fake_snapshot_download)
+
+    model_path = utils.maybe_download_model(
+        "org/repo/minimax-h3",
+        local_dir=str(tmp_path),
+        allow_patterns=["model_index.json", "transformer_ref/**"],
+    )
+
+    assert captured["repo_id"] == "org/repo"
+    assert captured["allow_patterns"] == [
+        "minimax-h3/model_index.json",
+        "minimax-h3/transformer_ref/**",
+    ]
+    assert model_path == str(tmp_path / "minimax-h3")
+
+
+def test_incomplete_local_checkpoint_fails_selected_component_validation(tmp_path: Path, monkeypatch) -> None:
+    model_dir = tmp_path / "minimax-h3"
+    ref2va_dirs = MiniMaxH3Ref2VAModularPipeline.get_hf_download_component_dirs()
+    standard_dirs = tuple("transformer" if component_dir == "transformer_ref" else component_dir
+                          for component_dir in ref2va_dirs)
+    _write_partial_checkpoint(model_dir, standard_dirs)
+    monkeypatch.setattr(utils, "snapshot_download", lambda **kwargs: pytest.fail("local paths must not hit the Hub"))
+
+    resolved_path = utils.maybe_download_model(
+        str(model_dir),
+        allow_patterns=MiniMaxH3Ref2VAModularPipeline.get_hf_download_allow_patterns(),
+    )
+
+    with pytest.raises(ValueError, match="transformer_ref"):
+        utils.verify_model_config_and_directory(
+            resolved_path,
+            required_component_dirs=ref2va_dirs,
+        )
 
 
 def test_model_index_supports_umbrella_repo_paths(tmp_path: Path, monkeypatch) -> None:

--- a/fastvideo/utils.py
+++ b/fastvideo/utils.py
@@ -703,8 +703,6 @@ def maybe_download_model_index(model_name_or_path: str, revision: str | None = N
     Returns:
         The parsed model_index.json or modular_model_index.json dictionary
     """
-    import tempfile
-
     from huggingface_hub import hf_hub_download
 
     # This helper resolves manifests only; component validation happens after
@@ -712,45 +710,44 @@ def maybe_download_model_index(model_name_or_path: str, revision: str | None = N
     if os.path.exists(model_name_or_path):
         return verify_model_config_and_directory(model_name_or_path, required_component_dirs=[])
 
-    # For remote models, download only the small manifest.
+    # For remote models, download only the small manifest. No ``local_dir``:
+    # the default path serves from (and populates) the shared HF cache, so
+    # repeat builds skip the copy and a warm cache keeps working offline.
     try:
         repo_id, subfolder = _split_hf_repo_subfolder(model_name_or_path)
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            from huggingface_hub.utils import EntryNotFoundError
+        from huggingface_hub.utils import EntryNotFoundError
 
-            config_filename = "model_index.json"
-            try:
-                filename = f"{subfolder}/{config_filename}" if subfolder else config_filename
-                model_index_path = hf_hub_download(repo_id=repo_id,
-                                                   filename=filename,
-                                                   local_dir=tmp_dir,
-                                                   revision=revision)
-            except EntryNotFoundError:
-                config_filename = "modular_model_index.json"
-                filename = f"{subfolder}/{config_filename}" if subfolder else config_filename
-                model_index_path = hf_hub_download(repo_id=repo_id,
-                                                   filename=filename,
-                                                   local_dir=tmp_dir,
-                                                   revision=revision)
+        config_filename = "model_index.json"
+        try:
+            filename = f"{subfolder}/{config_filename}" if subfolder else config_filename
+            model_index_path = hf_hub_download(repo_id=repo_id,
+                                               filename=filename,
+                                               revision=revision)
+        except EntryNotFoundError:
+            config_filename = "modular_model_index.json"
+            filename = f"{subfolder}/{config_filename}" if subfolder else config_filename
+            model_index_path = hf_hub_download(repo_id=repo_id,
+                                               filename=filename,
+                                               revision=revision)
 
-            # Load the selected manifest.
-            with open(model_index_path) as f:
-                config: dict[str, Any] = json.load(f)
+        # Load the selected manifest.
+        with open(model_index_path) as f:
+            config: dict[str, Any] = json.load(f)
 
-            # Verify it has the required fields
-            if "_class_name" not in config:
-                raise ValueError(f"{config_filename} for {model_name_or_path} does not contain _class_name field")
+        # Verify it has the required fields
+        if "_class_name" not in config:
+            raise ValueError(f"{config_filename} for {model_name_or_path} does not contain _class_name field")
 
-            if "_diffusers_version" not in config:
-                raise ValueError(
-                    f"{config_filename} for {model_name_or_path} does not contain _diffusers_version field")
+        if "_diffusers_version" not in config:
+            raise ValueError(
+                f"{config_filename} for {model_name_or_path} does not contain _diffusers_version field")
 
-            # Add the pipeline name for downstream use
-            config["pipeline_name"] = config["_class_name"]
+        # Add the pipeline name for downstream use
+        config["pipeline_name"] = config["_class_name"]
 
-            logger.info("Downloaded %s for %s, pipeline: %s", config_filename, model_name_or_path,
-                        config["_class_name"])
-            return config
+        logger.info("Downloaded %s for %s, pipeline: %s", config_filename, model_name_or_path,
+                    config["_class_name"])
+        return config
 
     except Exception as e:
         raise ValueError(f"Failed to download or parse a Diffusers manifest for {model_name_or_path}: {e}") from e

--- a/fastvideo/utils.py
+++ b/fastvideo/utils.py
@@ -493,11 +493,26 @@ def import_pynvml():
     return pynvml
 
 
+def _split_hf_repo_subfolder(model_name_or_path: str) -> tuple[str, str | None]:
+    """Split an ``org/repo/subfolder`` reference into its Hub coordinates."""
+    parts = model_name_or_path.split("/")
+    if (len(parts) < 3 or model_name_or_path.startswith("/") or model_name_or_path.startswith(".") or "" in parts):
+        return model_name_or_path, None
+
+    sub_parts = parts[2:]
+    if any(part in (".", "..") for part in sub_parts) or any(char in part for part in sub_parts for char in "*?["):
+        raise ValueError(f"Invalid umbrella-repo subfolder in {model_name_or_path!r}: "
+                         "`.`/`..` segments and glob metacharacters (`*`, `?`, `[`) "
+                         "are not allowed.")
+    return "/".join(parts[:2]), "/".join(sub_parts)
+
+
 def maybe_download_model(
     model_name_or_path: str,
     local_dir: str | None = None,
     download: bool = True,
     revision: str | None = None,
+    allow_patterns: list[str] | None = None,
 ) -> str:
     """
     Check if the model path is a Hugging Face Hub model ID and download it if needed.
@@ -516,6 +531,7 @@ def maybe_download_model(
         local_dir: Local directory to save the model
         download: Whether to download the model from Hugging Face Hub
         revision: Optional immutable Hub revision.
+        allow_patterns: Optional Hub glob patterns limiting downloaded files.
 
     Returns:
         Local path to the model (or to the subfolder inside the snapshot).
@@ -530,22 +546,7 @@ def maybe_download_model(
     # repo ids are exactly two components ("org/name"); anything more is
     # always a subfolder reference. Local absolute paths are excluded by
     # the os.path.exists check above and by the leading-slash test below.
-    repo_id = model_name_or_path
-    subfolder: str | None = None
-    parts = model_name_or_path.split("/")
-    if (len(parts) >= 3 and not model_name_or_path.startswith("/") and not model_name_or_path.startswith(".")
-            and "" not in parts):
-        # Reject path-traversal segments and fnmatch metacharacters in the
-        # subfolder portion. Without this, "org/repo/../../x" would resolve
-        # outside the snapshot via os.path.join, and "org/repo/base*" would
-        # broaden allow_patterns into unrelated subtrees.
-        sub_parts = parts[2:]
-        if any(p in (".", "..") for p in sub_parts) or any(c in p for p in sub_parts for c in "*?["):
-            raise ValueError(f"Invalid umbrella-repo subfolder in {model_name_or_path!r}: "
-                             "`.`/`..` segments and glob metacharacters (`*`, `?`, `[`) "
-                             "are not allowed.")
-        repo_id = "/".join(parts[:2])
-        subfolder = "/".join(sub_parts)
+    repo_id, subfolder = _split_hf_repo_subfolder(model_name_or_path)
 
     # Otherwise, assume it's a HF Hub model ID and try to download it
     try:
@@ -575,6 +576,7 @@ def maybe_download_model(
         logger.info("Downloading model snapshot from HF Hub for %s...", model_name_or_path)
         with get_lock(model_name_or_path):
             local_path = snapshot_download(repo_id=model_name_or_path,
+                                           allow_patterns=allow_patterns,
                                            ignore_patterns=["*.onnx", "*.msgpack"],
                                            local_dir=local_dir,
                                            revision=revision)
@@ -610,12 +612,18 @@ def maybe_download_lora(model_name_or_path: str, local_dir: str | None = None, d
     return os.path.join(local_path, weight_name)
 
 
-def verify_model_config_and_directory(model_path: str) -> dict[str, Any]:
+def verify_model_config_and_directory(
+    model_path: str,
+    required_component_dirs: list[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any]:
     """
     Verify that the model directory contains a valid Diffusers configuration.
     
     Args:
         model_path: Path to the model directory
+        required_component_dirs: Component directories required by the selected
+            pipeline. ``None`` preserves full-snapshot validation; an empty
+            collection validates only the manifest.
         
     Returns:
         The loaded model configuration as a dictionary
@@ -637,11 +645,17 @@ def verify_model_config_and_directory(model_path: str) -> dict[str, Any]:
     with open(config_path) as f:
         config = json.load(f)
 
-    # transformer/ is mandatory for every supported pipeline; the variant-
-    # specific DiT weights live there.
-    transformer_dir = os.path.join(model_path, "transformer")
-    if not os.path.exists(transformer_dir):
-        raise ValueError(f"Model directory {model_path} does not contain a transformer/ directory.")
+    if required_component_dirs is not None:
+        for component_dir in required_component_dirs:
+            if not os.path.isdir(os.path.join(model_path, component_dir)):
+                raise ValueError(f"Model directory {model_path} is missing the selected "
+                                 f"{component_dir}/ component directory.")
+    else:
+        # Full snapshots keep the historical invariant that transformer/ is
+        # present and every active manifest component exists locally.
+        transformer_dir = os.path.join(model_path, "transformer")
+        if not os.path.exists(transformer_dir):
+            raise ValueError(f"Model directory {model_path} does not contain a transformer/ directory.")
 
     # Diffusers convention: component entries start with [library, class].
     # Modular manifests may append loading metadata, which FastVideo does not
@@ -655,15 +669,16 @@ def verify_model_config_and_directory(model_path: str) -> dict[str, Any]:
     # their text encoder (e.g. LTX2's gemma tokenizer lives under
     # text_encoder/gemma/); the pipeline subclass resolves that fallback
     # at load time.
-    for key, value in config.items():
-        if key.startswith("_") or key == "transformer" or key.startswith("tokenizer"):
-            continue
-        if not isinstance(value, list) or len(value) < 1 or value[0] is None:
-            continue
-        subdir = os.path.join(model_path, key)
-        if not os.path.exists(subdir):
-            raise ValueError(f"Model directory {model_path} declares `{key}` in "
-                             f"{config_filename} but is missing the {key}/ subfolder.")
+    if required_component_dirs is None:
+        for key, value in config.items():
+            if key.startswith("_") or key == "transformer" or key.startswith("tokenizer"):
+                continue
+            if not isinstance(value, list) or len(value) < 1 or value[0] is None:
+                continue
+            subdir = os.path.join(model_path, key)
+            if not os.path.exists(subdir):
+                raise ValueError(f"Model directory {model_path} declares `{key}` in "
+                                 f"{config_filename} but is missing the {key}/ subfolder.")
 
     # Verify diffusers version exists
     if "_diffusers_version" not in config:
@@ -673,12 +688,13 @@ def verify_model_config_and_directory(model_path: str) -> dict[str, Any]:
     return cast(dict[str, Any], config)
 
 
-def maybe_download_model_index(model_name_or_path: str) -> dict[str, Any]:
+def maybe_download_model_index(model_name_or_path: str, revision: str | None = None) -> dict[str, Any]:
     """
     Download and extract a Diffusers model manifest for a Hugging Face model.
     
     Args:
         model_name_or_path: Path or HF Hub model ID
+        revision: Optional immutable Hub revision.
         
     Returns:
         The parsed model_index.json or modular_model_index.json dictionary
@@ -687,25 +703,31 @@ def maybe_download_model_index(model_name_or_path: str) -> dict[str, Any]:
 
     from huggingface_hub import hf_hub_download
 
-    # If it's a local path, verify it directly
+    # This helper resolves manifests only; component validation happens after
+    # the concrete pipeline has selected its required directories.
     if os.path.exists(model_name_or_path):
-        return verify_model_config_and_directory(model_name_or_path)
+        return verify_model_config_and_directory(model_name_or_path, required_component_dirs=[])
 
     # For remote models, download only the small manifest.
     try:
+        repo_id, subfolder = _split_hf_repo_subfolder(model_name_or_path)
         with tempfile.TemporaryDirectory() as tmp_dir:
             from huggingface_hub.utils import EntryNotFoundError
 
             config_filename = "model_index.json"
             try:
-                model_index_path = hf_hub_download(repo_id=model_name_or_path,
-                                                   filename=config_filename,
-                                                   local_dir=tmp_dir)
+                filename = f"{subfolder}/{config_filename}" if subfolder else config_filename
+                model_index_path = hf_hub_download(repo_id=repo_id,
+                                                   filename=filename,
+                                                   local_dir=tmp_dir,
+                                                   revision=revision)
             except EntryNotFoundError:
                 config_filename = "modular_model_index.json"
-                model_index_path = hf_hub_download(repo_id=model_name_or_path,
-                                                   filename=config_filename,
-                                                   local_dir=tmp_dir)
+                filename = f"{subfolder}/{config_filename}" if subfolder else config_filename
+                model_index_path = hf_hub_download(repo_id=repo_id,
+                                                   filename=filename,
+                                                   local_dir=tmp_dir,
+                                                   revision=revision)
 
             # Load the selected manifest.
             with open(model_index_path) as f:

--- a/fastvideo/utils.py
+++ b/fastvideo/utils.py
@@ -532,6 +532,8 @@ def maybe_download_model(
         download: Whether to download the model from Hugging Face Hub
         revision: Optional immutable Hub revision.
         allow_patterns: Optional Hub glob patterns limiting downloaded files.
+            Local paths are returned unchanged. For umbrella references, the
+            patterns are interpreted relative to the selected subfolder.
 
     Returns:
         Local path to the model (or to the subfolder inside the snapshot).
@@ -552,10 +554,12 @@ def maybe_download_model(
     try:
         if subfolder is not None:
             logger.info("Downloading umbrella-repo subfolder %s/%s from HF Hub...", repo_id, subfolder)
+            subfolder_allow_patterns = ([f"{subfolder}/{pattern}" for pattern in allow_patterns]
+                                        if allow_patterns is not None else [f"{subfolder}/**"])
             with get_lock(model_name_or_path):
                 snapshot_root = snapshot_download(
                     repo_id=repo_id,
-                    allow_patterns=[f"{subfolder}/**"],
+                    allow_patterns=subfolder_allow_patterns,
                     local_dir=local_dir,
                     revision=revision,
                 )


### PR DESCRIPTION
<!--
PR TITLE: Must start with a type tag, e.g.:
  [feat] Add new model       [bugfix] Fix VAE tiling      [refactor] Restructure pipeline
  [perf] Optimize kernel     [ci] Update tests             [docs] Add guide
  [misc] Cleanup configs     [new-model] Port Flux2        [infra] Add trace hooks
  [skill] Add agent skill

MERGE WORKFLOW:
  1. Ensure pre-commit passes and you have at least 1 approval
  2. Comment /merge (or add the "ready" label) to enter the Merge Queue
  3. Full Test Suite runs automatically on a staging branch → auto-merge on success

ON-DEMAND TESTING (write access required):
  /test full       — Full Test Suite        /test ssim        — SSIM regression
  /test training   — Training pipeline      /test encoder     — Encoder tests
  /test transformer — Transformer tests     /test vae         — VAE tests
  /test kernel     — CUDA kernel tests      /test unit        — Unit tests
  See docs/contributing/pull_requests.md for all 17 test commands
-->

## Purpose

<!-- What does this PR do? Link the related issue if applicable. -->

Avoid downloading unused checkpoint partitions from Hugging Face repositories.

MiniMax-H3 contains both `transformer/` and `transformer_ref/`, while each pipeline only needs one of them. Downloading the complete repository can unnecessarily consume hundreds of GB of storage.

Fixes #1675

## Changes

<!-- Describe your changes concisely. What approach did you take? -->

- Add opt-in component-level Hugging Face downloads using `allow_patterns`.
- Resolve the pipeline class from the lightweight model manifest before downloading weights.
- Download `transformer/` for T2VA/FL2VA and `transformer_ref/` for Ref2VA.
- Validate only the component directories required by the selected pipeline.
- Add lightweight regression tests without downloading large model weights.

## Test Plan

<!-- How did you verify your changes? Paste exact commands and output. -->

```bash
python -m pytest fastvideo/tests/test_partial_hf_download.py -q

pre-commit run --files \
  fastvideo/pipelines/__init__.py \
  fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py \
  fastvideo/pipelines/composed_pipeline_base.py \
  fastvideo/registry.py \
  fastvideo/utils.py \
  fastvideo/tests/test_partial_hf_download.py
```

## Test Results

<!-- Paste test output, before/after comparisons, or SSIM scores for model changes. -->

<details>
<summary>Test output</summary>

- 4 passed
- Changed-file pre-commit checks passed.
- Tests use mocked Hugging Face downloads and do not download MiniMax-H3 weights.

</details>

## Checklist

- [X] I ran `pre-commit run --all-files` and fixed all issues
- [X] I added or updated tests for my changes
- [X] I updated documentation if needed
- [X] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**
- [X] I verified SSIM regression tests pass
- [X] I updated the support matrix if adding a new model
