### PR TITLE
[perf]: remove per-step host syncs and repeated work from causal inference

### DIFF
--- a/fastvideo/entrypoints/video_generator.py
+++ b/fastvideo/entrypoints/video_generator.py
@@ -860,12 +860,21 @@ class VideoGenerator:
             frames = None
         else:
             videos = rearrange(samples, "b c t h w -> t b c h w")
-            frames = []
-            for x in videos:
+            # Transfer the frames in one copy. Reading them back individually
+            # blocks on the device once per frame, which serializes the
+            # remaining frames' device-side work behind each transfer.
+            # Each frame is written straight into one preallocated buffer
+            # rather than collected in a list and stacked afterwards, so only
+            # one full-size copy of the frames is ever live on the device.
+            stacked_frames = None
+            for frame_index, x in enumerate(videos):
                 x = torchvision.utils.make_grid(x, nrow=6)
                 x = x.permute(1, 2, 0).squeeze(-1)
                 x = (x * 255).to(torch.uint8)
-                frames.append(x.contiguous().cpu().numpy())
+                if stacked_frames is None:
+                    stacked_frames = torch.empty((videos.shape[0], *x.shape), dtype=torch.uint8, device=x.device)
+                stacked_frames[frame_index] = x
+            frames = (list(stacked_frames.cpu().numpy()) if stacked_frames is not None else [])
         postprocess_time = time.perf_counter() - postprocess_start
         logger.info("PostDecodeFrameProcessStage completed in %.3f s", postprocess_time)
         if logging_info is not None:

--- a/fastvideo/models/dits/causal_wanvideo.py
+++ b/fastvideo/models/dits/causal_wanvideo.py
@@ -322,7 +322,9 @@ class CausalWanTransformerBlock(nn.Module):
         attn_output, _ = self.to_out(attn_output)
         attn_output = attn_output.squeeze(1)
 
-        null_shift = null_scale = torch.tensor([0], device=hidden_states.device)
+        # torch.zeros(...) allocates straight on the device; torch.tensor([0],
+        # device=...) builds on the host and copies, once per block per step.
+        null_shift = null_scale = torch.zeros(1, device=hidden_states.device, dtype=torch.long)
         norm_hidden_states, hidden_states = self.self_attn_residual_norm(hidden_states, attn_output, gate_msa,
                                                                          null_shift, null_scale)
         norm_hidden_states, hidden_states = norm_hidden_states.to(orig_dtype), hidden_states.to(orig_dtype)

--- a/fastvideo/models/dits/causal_wanvideo.py
+++ b/fastvideo/models/dits/causal_wanvideo.py
@@ -346,7 +346,9 @@ class CausalWanTransformerBlock(nn.Module):
         attn_output, _ = self.to_out(attn_output)
         attn_output = attn_output.squeeze(1)
 
-        null_shift = null_scale = torch.tensor([0], device=hidden_states.device)
+        # torch.zeros(...) allocates straight on the device; torch.tensor([0],
+        # device=...) builds on the host and copies, once per block per step.
+        null_shift = null_scale = torch.zeros(1, device=hidden_states.device, dtype=torch.long)
         norm_hidden_states, hidden_states = self.self_attn_residual_norm(
             hidden_states, attn_output, gate_msa, null_shift, null_scale)
         norm_hidden_states, hidden_states = norm_hidden_states.to(

--- a/fastvideo/models/utils.py
+++ b/fastvideo/models/utils.py
@@ -135,7 +135,38 @@ def modulate(x: torch.Tensor, shift: torch.Tensor | None = None, scale: torch.Te
         return x * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)  # type: ignore[union-attr]
 
 
-def pred_noise_to_pred_video(pred_noise: torch.Tensor, noise_input_latent: torch.Tensor, timestep: torch.Tensor,
+_FLOAT64_SCHEDULE_ATTR = "_fastvideo_float64_schedule"
+
+
+def get_float64_schedule(scheduler: Any,
+                         device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Return the scheduler's sigma and timestep tables as float64 on ``device``.
+
+    The result is memoized on the scheduler and reused until it swaps the
+    tables out, which ``set_timesteps`` does. Callers run once per denoising
+    step, so converting on every call would recast and re-upload the whole
+    schedule for values that do not change within a schedule.
+    """
+    sigmas = scheduler.sigmas
+    timesteps = scheduler.timesteps
+    cached = getattr(scheduler, _FLOAT64_SCHEDULE_ATTR, None)
+    if cached is not None:
+        cached_sigmas, cached_timesteps, sigmas_f64, timesteps_f64 = cached
+        if (cached_sigmas is sigmas and cached_timesteps is timesteps
+                and sigmas_f64.device == device):
+            return sigmas_f64, timesteps_f64
+
+    sigmas_f64 = sigmas.to(device=device, dtype=torch.float64)
+    timesteps_f64 = timesteps.to(device=device, dtype=torch.float64)
+    setattr(scheduler, _FLOAT64_SCHEDULE_ATTR,
+            (sigmas, timesteps, sigmas_f64, timesteps_f64))
+    return sigmas_f64, timesteps_f64
+
+
+def pred_noise_to_pred_video(pred_noise: torch.Tensor,
+                             noise_input_latent: torch.Tensor,
+                             timestep: torch.Tensor,
                              scheduler: Any) -> torch.Tensor:
     """
     Convert predicted noise to clean latent.
@@ -167,8 +198,7 @@ def pred_noise_to_pred_video(pred_noise: torch.Tensor, noise_input_latent: torch
     device = pred_noise.device
     pred_noise = pred_noise.double().to(device)
     noise_input_latent = noise_input_latent.double().to(device)
-    sigmas = scheduler.sigmas.double().to(device)
-    timesteps = scheduler.timesteps.double().to(device)
+    sigmas, timesteps = get_float64_schedule(scheduler, device)
     timestep_id = torch.argmin((timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
     sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1)
     pred_video = noise_input_latent - sigma_t * pred_noise
@@ -208,8 +238,7 @@ def pred_noise_to_x_bound(pred_noise: torch.Tensor, noise_input_latent: torch.Te
     device = pred_noise.device
     pred_noise = pred_noise.double().to(device)
     noise_input_latent = noise_input_latent.double().to(device)
-    sigmas = scheduler.sigmas.double().to(device)
-    timesteps = scheduler.timesteps.double().to(device)
+    sigmas, timesteps = get_float64_schedule(scheduler, device)
     timestep_id = torch.argmin((timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
     sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1)
 

--- a/fastvideo/models/utils.py
+++ b/fastvideo/models/utils.py
@@ -139,6 +139,35 @@ def modulate(x: torch.Tensor,
             1)  # type: ignore[union-attr]
 
 
+_FLOAT64_SCHEDULE_ATTR = "_fastvideo_float64_schedule"
+
+
+def get_float64_schedule(scheduler: Any,
+                         device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Return the scheduler's sigma and timestep tables as float64 on ``device``.
+
+    The result is memoized on the scheduler and reused until it swaps the
+    tables out, which ``set_timesteps`` does. Callers run once per denoising
+    step, so converting on every call would recast and re-upload the whole
+    schedule for values that do not change within a schedule.
+    """
+    sigmas = scheduler.sigmas
+    timesteps = scheduler.timesteps
+    cached = getattr(scheduler, _FLOAT64_SCHEDULE_ATTR, None)
+    if cached is not None:
+        cached_sigmas, cached_timesteps, sigmas_f64, timesteps_f64 = cached
+        if (cached_sigmas is sigmas and cached_timesteps is timesteps
+                and sigmas_f64.device == device):
+            return sigmas_f64, timesteps_f64
+
+    sigmas_f64 = sigmas.to(device=device, dtype=torch.float64)
+    timesteps_f64 = timesteps.to(device=device, dtype=torch.float64)
+    setattr(scheduler, _FLOAT64_SCHEDULE_ATTR,
+            (sigmas, timesteps, sigmas_f64, timesteps_f64))
+    return sigmas_f64, timesteps_f64
+
+
 def pred_noise_to_pred_video(pred_noise: torch.Tensor,
                              noise_input_latent: torch.Tensor,
                              timestep: torch.Tensor,
@@ -173,8 +202,7 @@ def pred_noise_to_pred_video(pred_noise: torch.Tensor,
     device = pred_noise.device
     pred_noise = pred_noise.double().to(device)
     noise_input_latent = noise_input_latent.double().to(device)
-    sigmas = scheduler.sigmas.double().to(device)
-    timesteps = scheduler.timesteps.double().to(device)
+    sigmas, timesteps = get_float64_schedule(scheduler, device)
     timestep_id = torch.argmin(
         (timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
     sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1)
@@ -217,8 +245,7 @@ def pred_noise_to_x_bound(pred_noise: torch.Tensor,
     device = pred_noise.device
     pred_noise = pred_noise.double().to(device)
     noise_input_latent = noise_input_latent.double().to(device)
-    sigmas = scheduler.sigmas.double().to(device)
-    timesteps = scheduler.timesteps.double().to(device)
+    sigmas, timesteps = get_float64_schedule(scheduler, device)
     timestep_id = torch.argmin(
         (timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
     sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1)

--- a/fastvideo/pipelines/stages/causal_denoising.py
+++ b/fastvideo/pipelines/stages/causal_denoising.py
@@ -358,6 +358,10 @@ class CausalDMDDenosingStage(DenoisingStage):
     def _initialize_kv_cache(self, batch_size, dtype, device) -> list[dict]:
         """
         Initialize a Per-GPU KV cache aligned with the Wan model assumptions.
+
+        The window offsets are plain Python ints rather than device tensors.
+        The attention block reads them back on every layer to slice the cache,
+        so keeping them on device would force a host sync per layer per step.
         """
         kv_cache1 = []
         num_attention_heads = self.transformer.num_attention_heads
@@ -378,9 +382,9 @@ class CausalDMDDenosingStage(DenoisingStage):
                             dtype=dtype,
                             device=device),
                 "global_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
+                0,
                 "local_end_index":
-                torch.tensor([0], dtype=torch.long, device=device),
+                0,
             })
 
         return kv_cache1

--- a/fastvideo/tests/ops/test_flow_schedule_cache.py
+++ b/fastvideo/tests/ops/test_flow_schedule_cache.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the float64 schedule memoization in fastvideo.models.utils."""
+
+import pytest
+import torch
+
+from fastvideo.models.utils import (
+    _FLOAT64_SCHEDULE_ATTR,
+    get_float64_schedule,
+    pred_noise_to_pred_video,
+    pred_noise_to_x_bound,
+)
+
+
+class FakeScheduler:
+    """Minimal stand-in exposing the sigma and timestep tables the helper reads."""
+
+    def __init__(self, num_steps: int = 4) -> None:
+        self.set_timesteps(num_steps)
+
+    def set_timesteps(self, num_steps: int) -> None:
+        """Rebuild the schedule tables the way a real scheduler does per call."""
+        self.timesteps = torch.linspace(1000.0, 0.0, num_steps)
+        self.sigmas = self.timesteps / 1000.0
+
+
+def _reference_schedule(scheduler: FakeScheduler,
+                        device: torch.device) -> tuple[torch.Tensor, torch.Tensor]:
+    """Convert the schedule the way the call sites did before memoization."""
+    return (scheduler.sigmas.double().to(device),
+            scheduler.timesteps.double().to(device))
+
+
+def test_repeated_call_returns_cached_tensors():
+    """A second call for the same schedule reuses the same tensor objects."""
+    scheduler = FakeScheduler()
+    device = torch.device("cpu")
+    sigmas_first, timesteps_first = get_float64_schedule(scheduler, device)
+    sigmas_second, timesteps_second = get_float64_schedule(scheduler, device)
+    assert sigmas_first is sigmas_second
+    assert timesteps_first is timesteps_second
+
+
+def test_cached_values_match_direct_conversion():
+    """Memoized tables are bitwise-equal to converting the schedule directly."""
+    scheduler = FakeScheduler()
+    device = torch.device("cpu")
+    sigmas, timesteps = get_float64_schedule(scheduler, device)
+    sigmas_reference, timesteps_reference = _reference_schedule(scheduler, device)
+    assert torch.equal(sigmas, sigmas_reference)
+    assert torch.equal(timesteps, timesteps_reference)
+
+
+def test_tables_are_float64():
+    """Both tables are promoted to float64 regardless of the source dtype."""
+    scheduler = FakeScheduler()
+    scheduler.sigmas = scheduler.sigmas.to(torch.float32)
+    scheduler.timesteps = scheduler.timesteps.to(torch.float32)
+    sigmas, timesteps = get_float64_schedule(scheduler, torch.device("cpu"))
+    assert sigmas.dtype == torch.float64
+    assert timesteps.dtype == torch.float64
+
+
+def test_set_timesteps_invalidates_cache():
+    """Swapping the schedule tables rebuilds them instead of serving stale ones."""
+    scheduler = FakeScheduler(num_steps=4)
+    device = torch.device("cpu")
+    sigmas_before, _ = get_float64_schedule(scheduler, device)
+
+    scheduler.set_timesteps(8)
+    sigmas_after, timesteps_after = get_float64_schedule(scheduler, device)
+
+    assert sigmas_after is not sigmas_before
+    assert sigmas_after.shape[0] == 8
+    sigmas_reference, timesteps_reference = _reference_schedule(scheduler, device)
+    assert torch.equal(sigmas_after, sigmas_reference)
+    assert torch.equal(timesteps_after, timesteps_reference)
+
+
+def test_cache_is_stored_on_the_scheduler():
+    """The memo lives on the scheduler, so separate schedulers stay independent."""
+    first, second = FakeScheduler(), FakeScheduler()
+    device = torch.device("cpu")
+    assert getattr(first, _FLOAT64_SCHEDULE_ATTR, None) is None
+
+    first_sigmas, _ = get_float64_schedule(first, device)
+    assert getattr(first, _FLOAT64_SCHEDULE_ATTR, None) is not None
+    assert getattr(second, _FLOAT64_SCHEDULE_ATTR, None) is None
+
+    second_sigmas, _ = get_float64_schedule(second, device)
+    assert second_sigmas is not first_sigmas
+
+
+def _reference_pred_noise_to_pred_video(pred_noise: torch.Tensor,
+                                        noise_input_latent: torch.Tensor,
+                                        timestep: torch.Tensor,
+                                        scheduler: FakeScheduler) -> torch.Tensor:
+    """Reproduce the pre-memoization conversion for a numerical parity check."""
+    dtype = pred_noise.dtype
+    device = pred_noise.device
+    pred_noise = pred_noise.double().to(device)
+    noise_input_latent = noise_input_latent.double().to(device)
+    sigmas, timesteps = _reference_schedule(scheduler, device)
+    timestep_id = torch.argmin(
+        (timesteps.unsqueeze(0) - timestep.unsqueeze(1)).abs(), dim=1)
+    sigma_t = sigmas[timestep_id].reshape(-1, 1, 1, 1)
+    return (noise_input_latent - sigma_t * pred_noise).to(dtype)
+
+
+@pytest.mark.parametrize("num_steps", [2, 4, 8])
+def test_pred_noise_to_pred_video_matches_reference(num_steps):
+    """Memoizing the schedule leaves the converted latents bitwise unchanged."""
+    torch.manual_seed(0)
+    scheduler = FakeScheduler(num_steps=num_steps)
+    timestep = scheduler.timesteps[:min(3, num_steps)].clone()
+    batch_size = timestep.numel()
+    pred_noise = torch.randn(batch_size, 4, 8, 8)
+    noise_input_latent = torch.randn(batch_size, 4, 8, 8)
+
+    expected = _reference_pred_noise_to_pred_video(pred_noise, noise_input_latent,
+                                                   timestep, scheduler)
+    actual = pred_noise_to_pred_video(pred_noise, noise_input_latent, timestep,
+                                      scheduler)
+    assert torch.equal(actual, expected)
+
+
+def test_pred_noise_to_pred_video_is_stable_across_repeated_calls():
+    """Reusing a cached schedule across steps keeps results identical."""
+    torch.manual_seed(0)
+    scheduler = FakeScheduler()
+    pred_noise = torch.randn(2, 4, 8, 8)
+    noise_input_latent = torch.randn(2, 4, 8, 8)
+    timestep = scheduler.timesteps[:2].clone()
+
+    first = pred_noise_to_pred_video(pred_noise, noise_input_latent, timestep,
+                                     scheduler)
+    second = pred_noise_to_pred_video(pred_noise, noise_input_latent, timestep,
+                                      scheduler)
+    assert torch.equal(first, second)
+
+
+def test_pred_noise_to_x_bound_uses_the_same_schedule():
+    """The boundary variant reads the memoized tables without altering them."""
+    torch.manual_seed(0)
+    scheduler = FakeScheduler()
+    pred_noise = torch.randn(2, 4, 8, 8)
+    noise_input_latent = torch.randn(2, 4, 8, 8)
+    timestep = scheduler.timesteps[:2].clone()
+    boundary_timestep = torch.full_like(timestep, float(scheduler.timesteps[-1]))
+
+    sigmas_before, _ = get_float64_schedule(scheduler, pred_noise.device)
+    result = pred_noise_to_x_bound(pred_noise, noise_input_latent, timestep,
+                                   boundary_timestep, scheduler)
+    sigmas_after, _ = get_float64_schedule(scheduler, pred_noise.device)
+
+    assert sigmas_after is sigmas_before
+    assert result.shape == pred_noise.shape


### PR DESCRIPTION
## Problem
 
The causal Wan denoising loop calls the transformer once per step, and each step repeated work that does not change between steps:
 
- The KV cache stored its two position counters as device tensors. The attention block reads them back on every layer to slice the cache, and reading a device tensor makes the CPU wait for the GPU. That is one wait per layer per denoising step, around 2,100 waits per generation.
- The flow-match schedule was cast to float64 and re-uploaded to the device on every denoising step, although it only changes when the scheduler replaces it.
- Decoded frames were copied to the host one at a time. Each copy made the CPU wait for the GPU, so the remaining frames' GPU work queued up behind every copy.
## Changes
 
- Store the KV cache counters as plain Python ints. Both the read and write sites already accepted either type, so only the initializer changed. The training initializers still use tensors, which `wan_causal.py` needs for its gradient-checkpoint snapshots.
- Memoize the float64 schedule on the scheduler. The memo is keyed on the identity of the scheduler's tables, so it rebuilds when `set_timesteps` replaces them.
- Copy decoded frames to the host in one transfer. Each frame is written straight into one preallocated buffer as it is built, so the batched copy never holds a second full-size copy of the frames.
- Build the causal Wan block's null shift/scale with `torch.zeros(...)` instead of `torch.tensor([0], device=...)`, which built the value on the host and copied it every step. Same dtype, shape, and value.
This is inference-path only. No behavior or output changes.
 
## Results
 
Measured on GB200, CUDA 13.0, torch 2.12, `wlsaidhi/SFWan2.1-T2V-1.3B-Diffusers`, 480x832, 81 frames, 4 DMD steps, seed 1024. Base and branch alternated in one session, 3 generations each, 4 rounds.
 
| Metric | Change |
| --- | --- |
| Denoise | -16% to -34%, median -26% |
| End to end | -11% to -25%, median -19% |
 
The branch held 4471-4659 ms across all 12 generations; the base ranged 5316-7010 ms.
 
## Test evidence
 
- Output is byte-identical to before: 0 differing values out of 97,044,480, reproduced independently on separate hardware.
- `pytest fastvideo/tests/ops/test_flow_schedule_cache.py`: 10 passed. New file, covers cache reuse, invalidation on `set_timesteps`, per-scheduler isolation, and bitwise parity with the previous conversion.
- `pytest fastvideo/tests/entrypoints/test_video_generator.py`: 29 passed. Existing tests, they cover the frame-building path.
- `pytest fastvideo/tests/ops fastvideo/tests/stages fastvideo/tests/layers fastvideo/tests/entrypoints fastvideo/tests/api`: 613 passed, 4 skipped, 1 failed. The failure is `test_typed_quant_flow.py::test_typed_transformer_quant_resolves_to_nvfp4_instance`, which fails the same way on `main` with none of these changes applied. It passes when its file runs alone, so it is a pre-existing test-ordering issue, not a regression from this PR.
- `pre-commit run --files <changed files>`: passed.
## Notes
 
This was split out of #1660. The CUDA graph capture work from that PR is not included here and follows separately; these three changes do not depend on it.