### PR TITLE
[feat] add Minimax H3 sft pipeline

### DIFF
--- a/examples/train/configs/overfit_minimax_h3_t2va.yaml
+++ b/examples/train/configs/overfit_minimax_h3_t2va.yaml
@@ -1,0 +1,86 @@
+# MiniMax H3 T2VA 400-step overfit experiment on one Crush-Smol record.
+#
+# Submit eight H200 nodes through the fixed launch script:
+#   bash examples/train/launch_minimax_h3_t2va_crush_smol_validation.sh
+
+models:
+  student:
+    _target_: fastvideo.train.models.minimax_h3.MiniMaxH3Model
+    init_from: data/models/MiniMax-H3
+    trainable: true
+    enable_gradient_checkpointing_type: full
+    attention_backend: TORCH_SDPA
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    num_gpus: 64
+    sp_size: 8
+    tp_size: 1
+    hsdp_replicate_dim: 8
+    hsdp_shard_dim: 8
+    pin_cpu_memory: true
+
+  data:
+    data_path:
+      data/crush-smol_h3_t2va_single_sample_preprocessed: 8
+    preprocessed_data_type: t2va
+    dataloader_num_workers: 0
+    train_batch_size: 1
+    training_cfg_rate: 0.0
+    seed: 42
+    num_latent_t: 37
+    num_height: 768
+    num_width: 1344
+    num_frames: 124
+
+  optimizer:
+    learning_rate: 5.0e-5
+    betas: [0.9, 0.999]
+    weight_decay: 0.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    max_train_steps: 400
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: runs/minimax_h3_t2va_crush_smol_single_sample_overfit/checkpoints
+    training_state_checkpointing_steps: 20
+    checkpoints_total_limit: 2
+    resume_from_checkpoint: ""
+
+  tracker:
+    trackers: [wandb]
+    project_name: fastvideo_minimax_h3
+    run_name: minimax_h3_t2va_crush_smol_single_sample_overfit
+
+  model:
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+
+  dit_precision: bf16
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.minimax_h3.minimax_h3_pipeline.MiniMaxH3Pipeline
+    dataset_file: examples/training/finetune/Wan2.1-Fun-1.3B-InP/crush_smol/validation.json
+    every_steps: 20
+    run_at_start: true
+    sampling_steps: [50]
+    guidance_scale: 1.0
+    num_frames: 124
+    num_videos_per_prompt: 1
+    use_validation_media_conditioning: false
+    offload_training_state: true
+    text_encoder_cpu_offload: true
+    vae_cpu_offload: true
+
+pipeline: {}

--- a/examples/train/launch_minimax_h3_t2va_crush_smol_validation.sh
+++ b/examples/train/launch_minimax_h3_t2va_crush_smol_validation.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Submit the 400-step MiniMax H3 single-sample SFT experiment on eight H200 nodes.
+
+set -euo pipefail
+set +x
+
+WORKTREE_ROOT=/mnt/weka/shrd/wm/junda/fv-hub/fastvideo-add-h3-sft
+ENV_FILE=/mnt/weka/shrd/wm/junda/fv-hub/.env
+CONFIG_FILE="${WORKTREE_ROOT}/examples/train/configs/overfit_minimax_h3_t2va.yaml"
+PROMPT_FILE="${WORKTREE_ROOT}/examples/training/finetune/Wan2.1-Fun-1.3B-InP/crush_smol/validation.json"
+DATASET_MANIFEST="${WORKTREE_ROOT}/data/crush-smol/videos2caption.json"
+TRAINING_VIDEO="${WORKTREE_ROOT}/data/crush-smol/videos/1gGQy4nxyUo-Scene-016.mp4"
+TRAINING_PARQUET="${WORKTREE_ROOT}/data/crush-smol_h3_t2va_single_sample_preprocessed/data_00000.parquet"
+MODEL_INDEX="${WORKTREE_ROOT}/data/models/MiniMax-H3/model_index.json"
+RESULT_DIR="${WORKTREE_ROOT}/runs/minimax_h3_t2va_crush_smol_single_sample_overfit"
+SNAPSHOT_DIR="${RESULT_DIR}/snapshot"
+VENV_BIN=/mnt/weka/shrd/wm/junda/fv-hub/.venv/bin
+
+[[ -f "${ENV_FILE}" ]] || { echo "Missing environment file: ${ENV_FILE}" >&2; exit 1; }
+[[ -f "${CONFIG_FILE}" ]] || { echo "Missing experiment config: ${CONFIG_FILE}" >&2; exit 1; }
+[[ -f "${PROMPT_FILE}" ]] || { echo "Missing validation prompts: ${PROMPT_FILE}" >&2; exit 1; }
+[[ -f "${DATASET_MANIFEST}" ]] || { echo "Missing Crush-Smol manifest: ${DATASET_MANIFEST}" >&2; exit 1; }
+[[ -f "${TRAINING_VIDEO}" ]] || { echo "Missing Crush-Smol training video: ${TRAINING_VIDEO}" >&2; exit 1; }
+[[ -f "${TRAINING_PARQUET}" ]] || { echo "Missing training parquet: ${TRAINING_PARQUET}" >&2; exit 1; }
+[[ -f "${MODEL_INDEX}" ]] || { echo "Missing MiniMax H3 checkpoint: ${MODEL_INDEX}" >&2; exit 1; }
+[[ -x "${VENV_BIN}/python" ]] || { echo "Missing validation environment: ${VENV_BIN}" >&2; exit 1; }
+[[ -x "${VENV_BIN}/torchrun" ]] || { echo "Missing training environment: ${VENV_BIN}" >&2; exit 1; }
+
+set -a
+source "${ENV_FILE}"
+set +a
+: "${WANDB_API_KEY:?WANDB_API_KEY is required in ${ENV_FILE}}"
+
+export WANDB_MODE=online
+export PYTHONPATH="${WORKTREE_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+export PATH="${VENV_BIN}:${PATH}"
+export PARTITION=main
+export NUM_GPUS=8
+export CPUS_PER_TASK=128
+export MEM=1440G
+export JOB_NAME=minimax_h3_t2va_crush_smol_single_sample_overfit
+export OUTPUT_DIR="${RESULT_DIR}/slurm"
+export SBATCH_CONSTRAINT=nvidia_h200
+export SBATCH_TIMELIMIT=72:00:00
+
+cd "${WORKTREE_ROOT}"
+"${VENV_BIN}/python" -m fastvideo.pipelines.preprocess.preprocess_minimax_h3_overfit \
+    --validate-only
+
+mkdir -p "${OUTPUT_DIR}" "${SNAPSHOT_DIR}"
+
+cp "${CONFIG_FILE}" "${SNAPSHOT_DIR}/experiment-config.yaml"
+cp "${PROMPT_FILE}" "${SNAPSHOT_DIR}/validation.json"
+cp "${WORKTREE_ROOT}/new-sft-plan-h3.md" "${SNAPSHOT_DIR}/implementation-plan.md"
+git rev-parse HEAD > "${SNAPSHOT_DIR}/source-revision.txt"
+git status --short > "${SNAPSHOT_DIR}/worktree-status.txt"
+git diff --binary > "${SNAPSHOT_DIR}/tracked-source.patch"
+git ls-files --modified --others --exclude-standard \
+    | awk '$0 !~ /^(archived|data|runs)\//' \
+    > "${SNAPSHOT_DIR}/source-files.txt"
+tar -czf "${SNAPSHOT_DIR}/source-files.tar.gz" \
+    -T "${SNAPSHOT_DIR}/source-files.txt"
+printf '%s\n' 'bash examples/train/launch_minimax_h3_t2va_crush_smol_validation.sh' \
+    > "${SNAPSHOT_DIR}/launch-command.txt"
+
+echo "Experiment:   ${JOB_NAME}"
+echo "Allocation:   8 nodes, 64 NVIDIA H200 GPUs, 1024 CPUs, 11520 GiB host memory"
+echo "Result dir:   ${RESULT_DIR}"
+echo "W&B project:  fastvideo_minimax_h3"
+echo "W&B run:      minimax_h3_t2va_crush_smol_single_sample_overfit"
+
+bash examples/train/run_slurm.sh "${CONFIG_FILE}" 8

--- a/examples/train/run_slurm.sh
+++ b/examples/train/run_slurm.sh
@@ -20,7 +20,7 @@
 #   OUTPUT_DIR      Directory for slurm logs  (default: slurm_logs)
 #   MASTER_PORT     Rendezvous port           (default: 29500)
 #   EXCLUDE         Nodes to exclude          (default: "")
-#   WANDB_API_KEY   W&B API key               (default: "")
+#   WANDB_API_KEY   Exported W&B API key required for online logging
 #   WANDB_MODE      W&B mode                  (default: online)
 #   SBATCH_CONSTRAINT Slurm node constraint    (default: "")
 #   SBATCH_TIMELIMIT Slurm time limit          (default: "")

--- a/examples/train/run_slurm.sh
+++ b/examples/train/run_slurm.sh
@@ -22,6 +22,8 @@
 #   EXCLUDE         Nodes to exclude          (default: "")
 #   WANDB_API_KEY   W&B API key               (default: "")
 #   WANDB_MODE      W&B mode                  (default: online)
+#   SBATCH_CONSTRAINT Slurm node constraint    (default: "")
+#   SBATCH_TIMELIMIT Slurm time limit          (default: "")
 
 set -euo pipefail
 
@@ -36,8 +38,9 @@ CPUS_PER_TASK="${CPUS_PER_TASK:-128}"
 MEM="${MEM:-1440G}"
 MASTER_PORT="${MASTER_PORT:-29500}"
 EXCLUDE="${EXCLUDE:-}"
-WANDB_API_KEY="${WANDB_API_KEY:-}"
 WANDB_MODE="${WANDB_MODE:-online}"
+SBATCH_CONSTRAINT="${SBATCH_CONSTRAINT:-}"
+SBATCH_TIMELIMIT="${SBATCH_TIMELIMIT:-}"
 
 TOTAL_GPUS=$(( NUM_NODES * NUM_GPUS ))
 
@@ -47,6 +50,8 @@ OUTPUT_DIR="${OUTPUT_DIR:-logs/slurm}"
 mkdir -p "${OUTPUT_DIR}"
 
 # ── Build sbatch args ─────────────────────────────────────────────
+# Forward the exported W&B API key through Slurm's environment so the generated
+# job script and its xtrace output do not contain the credential value.
 SBATCH_ARGS=(
     --job-name="${JOB_NAME}"
     --partition="${PARTITION}"
@@ -58,15 +63,30 @@ SBATCH_ARGS=(
     --mem="${MEM}"
     --output="${OUTPUT_DIR}/${JOB_NAME}_%j.out"
     --error="${OUTPUT_DIR}/${JOB_NAME}_%j.err"
+    --export="ALL,WANDB_MODE=${WANDB_MODE}"
     --exclusive
 )
 
 if [[ -n "${EXCLUDE}" ]]; then
     SBATCH_ARGS+=(--exclude="${EXCLUDE}")
 fi
+# Apply hardware and wall-clock requirements selected by an experiment launcher.
+if [[ -n "${SBATCH_CONSTRAINT}" ]]; then
+    SBATCH_ARGS+=(--constraint="${SBATCH_CONSTRAINT}")
+fi
+if [[ -n "${SBATCH_TIMELIMIT}" ]]; then
+    SBATCH_ARGS+=(--time="${SBATCH_TIMELIMIT}")
+fi
 
 # ── Collect extra overrides for the training script ───────────────
 EXTRA_ARGS=("$@")
+# Shell-escape values before embedding them in the generated Bash script so
+# config paths and override arguments retain their original boundaries.
+printf -v CONFIG_SHELL_ARG '%q' "${CONFIG}"
+EXTRA_ARGS_SHELL=""
+if (( ${#EXTRA_ARGS[@]} > 0 )); then
+    printf -v EXTRA_ARGS_SHELL ' %q' "${EXTRA_ARGS[@]}"
+fi
 
 echo "=== Slurm Training Submission ==="
 echo "Config:      ${CONFIG}"
@@ -86,29 +106,29 @@ set -e -x
 # ── Environment ───────────────────────────────────────────────────
 export NCCL_P2P_DISABLE=1
 export TORCH_NCCL_ENABLE_MONITORING=0
-export TRITON_CACHE_DIR=/tmp/triton_cache_\${SLURM_PROCID}
 export TOKENIZERS_PARALLELISM=false
-export WANDB_API_KEY="${WANDB_API_KEY}"
-export WANDB_MODE="${WANDB_MODE}"
 
 # ── Rendezvous ────────────────────────────────────────────────────
 export MASTER_PORT=${MASTER_PORT}
 nodes=( \$(scontrol show hostnames \$SLURM_JOB_NODELIST) )
 export MASTER_ADDR=\${nodes[0]}
-export NODE_RANK=\$SLURM_PROCID
-
-echo "MASTER_ADDR: \$MASTER_ADDR"
-echo "NODE_RANK:   \$NODE_RANK"
-
 # ── Launch ────────────────────────────────────────────────────────
-srun torchrun \\
-    --nnodes \$SLURM_JOB_NUM_NODES \\
-    --nproc_per_node ${NUM_GPUS} \\
-    --node_rank \$SLURM_PROCID \\
-    --rdzv_backend=c10d \\
-    --rdzv_endpoint="\$MASTER_ADDR:\$MASTER_PORT" \\
-    fastvideo/train/entrypoint/train.py \\
-    --config ${CONFIG} \\
-    --training.distributed.num_gpus ${TOTAL_GPUS} \\
-    ${EXTRA_ARGS[*]:-}
+# Resolve SLURM_PROCID inside each srun task so every node receives a distinct
+# torchrun node rank and Triton cache directory.
+launch_training_node() {
+    export TRITON_CACHE_DIR="/tmp/triton_cache_\${SLURM_PROCID}"
+    echo "MASTER_ADDR: \${MASTER_ADDR}"
+    echo "NODE_RANK:   \${SLURM_PROCID}"
+    exec torchrun \\
+        --nnodes "\${SLURM_JOB_NUM_NODES}" \\
+        --nproc_per_node ${NUM_GPUS} \\
+        --node_rank "\${SLURM_PROCID}" \\
+        --rdzv_backend=c10d \\
+        --rdzv_endpoint="\${MASTER_ADDR}:\${MASTER_PORT}" \\
+        fastvideo/train/entrypoint/train.py \\
+        --config ${CONFIG_SHELL_ARG} \\
+        --training.distributed.num_gpus ${TOTAL_GPUS}${EXTRA_ARGS_SHELL}
+}
+export -f launch_training_node
+srun bash -c launch_training_node
 EOF

--- a/examples/train/setup_minimax_h3_t2va_crush_smol_single_sample.sh
+++ b/examples/train/setup_minimax_h3_t2va_crush_smol_single_sample.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Download the pinned Crush-Smol dataset and encode one H3 T2VA training record.
+
+set -euo pipefail
+set +x
+
+WORKTREE_ROOT=/mnt/weka/shrd/wm/junda/fv-hub/fastvideo-add-h3-sft
+ENV_FILE=/mnt/weka/shrd/wm/junda/fv-hub/.env
+VENV_BIN=/mnt/weka/shrd/wm/junda/fv-hub/.venv/bin
+DATASET_REVISION=1a850a74e92d5ac3daa273ea658ec60e92fbaf4e
+DATASET_DIR="${WORKTREE_ROOT}/data/crush-smol"
+MODEL_INDEX="${WORKTREE_ROOT}/data/models/MiniMax-H3/model_index.json"
+OUTPUT_PARQUET="${WORKTREE_ROOT}/data/crush-smol_h3_t2va_single_sample_preprocessed/data_00000.parquet"
+
+[[ -f "${ENV_FILE}" ]] || { echo "Missing environment file: ${ENV_FILE}" >&2; exit 1; }
+[[ -f "${MODEL_INDEX}" ]] || { echo "Missing MiniMax H3 checkpoint: ${MODEL_INDEX}" >&2; exit 1; }
+[[ -x "${VENV_BIN}/hf" ]] || { echo "Missing Hugging Face CLI: ${VENV_BIN}/hf" >&2; exit 1; }
+[[ -x "${VENV_BIN}/torchrun" ]] || { echo "Missing preprocessing environment: ${VENV_BIN}" >&2; exit 1; }
+
+set -a
+source "${ENV_FILE}"
+set +a
+
+cd "${WORKTREE_ROOT}"
+"${VENV_BIN}/hf" download wlsaidhi/crush-smol-merged \
+    --repo-type dataset \
+    --revision "${DATASET_REVISION}" \
+    --local-dir "${DATASET_DIR}"
+
+CUDA_VISIBLE_DEVICES=0 "${VENV_BIN}/torchrun" \
+    --standalone \
+    --nnodes=1 \
+    --nproc-per-node=1 \
+    -m fastvideo.pipelines.preprocess.preprocess_minimax_h3_overfit
+
+[[ -f "${OUTPUT_PARQUET}" ]] || { echo "Preprocessing did not create ${OUTPUT_PARQUET}" >&2; exit 1; }
+echo "Prepared one Crush-Smol H3 training record at ${OUTPUT_PARQUET}"

--- a/fastvideo/configs/models/dits/minimax_h3.py
+++ b/fastvideo/configs/models/dits/minimax_h3.py
@@ -73,3 +73,6 @@ class MiniMaxH3Config(DiTConfig):
 
     arch_config: MiniMaxH3ArchConfig = field(default_factory=MiniMaxH3ArchConfig)
     prefix: str = "minimax_h3"
+    # FastVideo's Fully Sharded Data Parallel (FSDP) loading path requires one
+    # parameter dtype, while H3 inference keeps boundary projections in FP32.
+    uniform_parameter_dtype: bool = False

--- a/fastvideo/configs/models/encoders/minimax_h3_qwen3_vl.py
+++ b/fastvideo/configs/models/encoders/minimax_h3_qwen3_vl.py
@@ -65,6 +65,9 @@ class MiniMaxH3Qwen3VLArchConfig(TextEncoderArchConfig):
     num_attention_heads: int = 64
     num_key_value_heads: int = 8
     head_dim: int = 128
+    # H3 text conditioning truncates at 1,024 tokens. The parquet loader reads
+    # the same field when padding stored embeddings and attention masks.
+    text_len: int = 1024
     hidden_act: str = "silu"
     max_position_embeddings: int = 262144
     initializer_range: float = 0.02

--- a/fastvideo/dataset/dataloader/schema.py
+++ b/fastvideo/dataset/dataloader/schema.py
@@ -81,6 +81,36 @@ pyarrow_schema_t2v = pa.schema([
 ])
 
 
+# One text-to-video-and-audio (T2VA) row owns synchronized video, audio, and text tensors so
+# collate_rows_from_parquet_schema cannot pair targets from different samples.
+# Each tensor uses the bytes/shape/dtype triplet that the collator discovers.
+pyarrow_schema_t2va = pa.schema([
+    pa.field("id", pa.string()),
+    # --- Video VAE latent tensor ---
+    pa.field("vae_latent_bytes", pa.binary()),
+    pa.field("vae_latent_shape", pa.list_(pa.int64())),
+    pa.field("vae_latent_dtype", pa.string()),
+    # --- Stereo audio VAE latent tensor ---
+    pa.field("audio_latent_bytes", pa.binary()),
+    pa.field("audio_latent_shape", pa.list_(pa.int64())),
+    pa.field("audio_latent_dtype", pa.string()),
+    # --- Text encoder output tensor ---
+    pa.field("text_embedding_bytes", pa.binary()),
+    pa.field("text_embedding_shape", pa.list_(pa.int64())),
+    pa.field("text_embedding_dtype", pa.string()),
+    # --- Paired audio-video metadata ---
+    pa.field("file_name", pa.string()),
+    pa.field("caption", pa.string()),
+    pa.field("media_type", pa.string()),
+    pa.field("width", pa.int64()),
+    pa.field("height", pa.int64()),
+    pa.field("num_frames", pa.int64()),
+    pa.field("duration_sec", pa.float64()),
+    pa.field("fps", pa.float64()),
+    pa.field("audio_sample_rate", pa.int64()),
+])
+
+
 pyarrow_schema_ode_trajectory_text_only = pa.schema([
     pa.field("id", pa.string()),
     # --- Text encoder output tensor ---

--- a/fastvideo/models/dits/minimax_h3.py
+++ b/fastvideo/models/dits/minimax_h3.py
@@ -39,8 +39,12 @@ class MiniMaxH3RotaryPosEmbed(nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
 
     def forward(self, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build rotary tensors on the device that owns the packed positions."""
         position_ids = position_ids.to(torch.float32)
-        freqs = position_ids.unsqueeze(-1) * self.inv_freq.view(1, 1, -1)
+        # Analytic rotary positional embedding (RoPE) state is non-persistent,
+        # so runtime coordinates own the device after loading or state offload.
+        inv_freq = self.inv_freq.to(position_ids.device)
+        freqs = position_ids.unsqueeze(-1) * inv_freq.view(1, 1, -1)
         freqs_t, freqs_h, freqs_w = freqs.unbind(dim=1)
         freqs = torch.cat((freqs_t, freqs_h, freqs_w), dim=-1)
         freqs = torch.cat((freqs, freqs), dim=-1)
@@ -448,7 +452,14 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
     })
 
     def _get_parameter_dtype(self, name: str, default_dtype: torch.dtype) -> torch.dtype:
-        """Keep the released input, timestep, and output projections in FP32."""
+        """Select a uniform Fully Sharded Data Parallel dtype or H3's inference dtype.
+
+        FastVideo's Fully Sharded Data Parallel loading path requires one dtype
+        for every trainable parameter. H3 inference preserves FP32 input, timestep,
+        and output projections because those boundaries are part of its numerical policy.
+        """
+        if self.config.uniform_parameter_dtype:
+            return default_dtype
         return torch.float32 if name.split(".", 1)[0] in self._keep_in_fp32_modules else default_dtype
 
     def __init__(self, config: MiniMaxH3Config, hf_config: dict[str, Any]) -> None:
@@ -556,9 +567,14 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
         device: torch.device,
         dtype: torch.dtype | None = None,
     ) -> None:
-        """Rebuild analytic RoPE state after meta-device checkpoint loading."""
+        """Rebuild analytic RoPE state on the checkpoint loader device.
+
+        RoPE frequencies are absent from the checkpoint, so meta-device model
+        construction and device moves must derive the buffer from architecture
+        fields before the first forward pass.
+        """
         del dtype
-        if self.rope.inv_freq.is_meta:
+        if self.rope.inv_freq.is_meta or self.rope.inv_freq.device != device:
             arch = self.config.arch_config
             inv_freq = 1.0 / (
                 arch.rope_theta

--- a/fastvideo/pipelines/pipeline_batch_info.py
+++ b/fastvideo/pipelines/pipeline_batch_info.py
@@ -294,6 +294,9 @@ class TrainingBatch:
     audio_latents: torch.Tensor | None = None
     audio_noisy_model_input: torch.Tensor | None = None
     audio_timesteps: torch.Tensor | None = None
+    # Audio follows an independent noise schedule, so multimodal supervised
+    # fine-tuning needs its own sigma to reconstruct the clean-audio target.
+    audio_sigmas: torch.Tensor | None = None
     audio_noise: torch.Tensor | None = None
     audio_encoder_hidden_states: torch.Tensor | None = None
     audio_encoder_attention_mask: torch.Tensor | None = None
@@ -314,6 +317,10 @@ class TrainingBatch:
     timesteps: torch.Tensor | None = None
     sigmas: torch.Tensor | None = None
     noise: torch.Tensor | None = None
+
+    # MiniMax H3 reuses the packed row boundaries from batch preparation to
+    # split the transformer's joint sequence back into video and audio outputs.
+    minimax_h3_layout: Any | None = None
 
     attn_metadata_vsa: AttentionMetadata | None = None
     attn_metadata: AttentionMetadata | None = None

--- a/fastvideo/pipelines/preprocess/preprocess_minimax_h3_overfit.py
+++ b/fastvideo/pipelines/preprocess/preprocess_minimax_h3_overfit.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Encode one Crush-Smol audio-video-caption record for MiniMax H3 supervised fine-tuning (SFT).
+
+The Parquet row keeps the synchronized video target, audio target, and caption
+conditioning together for the text-to-video-and-audio (T2VA) dataloader.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+from pathlib import Path
+import shutil
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import torch
+
+from fastvideo.configs.pipelines.minimax_h3 import MiniMaxH3PipelineConfig
+from fastvideo.dataset.dataloader.schema import pyarrow_schema_t2va
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.models.loader.component_loader import PipelineComponentLoader
+from fastvideo.pipelines import ForwardBatch
+from fastvideo.pipelines.basic.minimax_h3.packing import MINIMAX_H3_FPS
+from fastvideo.pipelines.basic.minimax_h3.reference import (
+    decode_reference_video,
+    prepare_reference_frames,
+    prepare_reference_waveform,
+    resample_reference_frames,
+)
+from fastvideo.pipelines.basic.minimax_h3.stages.minimax_h3_conditioning import MiniMaxH3ConditioningStage
+from fastvideo.pipelines.basic.minimax_h3.stages.minimax_h3_input_preparation import MINIMAX_H3_KEYFRAMES_KEY
+from fastvideo.utils import verify_model_config_and_directory
+
+# Match the H3 validation geometry and media rates, and limit both streams to
+# the same maximum duration used by validation.
+NUM_FRAMES = 124
+VIDEO_HEIGHT = 768
+VIDEO_WIDTH = 1344
+AUDIO_SAMPLE_RATE = 32000
+DATA_DIR = Path("data/crush-smol")
+OUTPUT_DIR = Path("data/crush-smol_h3_t2va_single_sample_preprocessed")
+MODEL_PATH = Path("data/models/MiniMax-H3")
+TRAINING_VIDEO_NAME = "1gGQy4nxyUo-Scene-016.mp4"
+
+
+def _init_single_process_distributed() -> None:
+    """Initialize the one-rank process groups required by component loaders."""
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29531")
+    os.environ.setdefault("RANK", "0")
+    os.environ.setdefault("WORLD_SIZE", "1")
+    os.environ.setdefault("LOCAL_RANK", "0")
+    from fastvideo.distributed import maybe_init_distributed_environment_and_model_parallel
+
+    maybe_init_distributed_environment_and_model_parallel(1, 1)
+
+
+def load_training_media(path: Path) -> tuple[np.ndarray, torch.Tensor]:
+    """Decode paired targets at the geometry and rates consumed by H3.
+
+    The video uses exactly 124 frames, and the audio is capped at the duration
+    of those frames before variational autoencoder (VAE) encoding.
+    """
+    decoded_frames, source_fps, soundtrack = decode_reference_video(path)
+    resampled_frames = resample_reference_frames(decoded_frames, source_fps)
+    if resampled_frames.shape[0] < NUM_FRAMES:
+        raise ValueError(f"Training video {path} has {resampled_frames.shape[0]} frames at {MINIMAX_H3_FPS} FPS; "
+                         f"{NUM_FRAMES} are required")
+    frames = prepare_reference_frames(resampled_frames, NUM_FRAMES)
+    if frames.shape != (NUM_FRAMES, VIDEO_HEIGHT, VIDEO_WIDTH, 3):
+        raise ValueError(f"Training video must resolve to {(NUM_FRAMES, VIDEO_HEIGHT, VIDEO_WIDTH, 3)}, "
+                         f"got {tuple(frames.shape)}")
+    if soundtrack is None:
+        raise ValueError(f"Training video {path} requires a soundtrack")
+    waveform, source_sample_rate = soundtrack
+    waveform = prepare_reference_waveform(
+        waveform,
+        source_sample_rate,
+        AUDIO_SAMPLE_RATE,
+        max_duration=NUM_FRAMES / MINIMAX_H3_FPS,
+    )
+    return frames, waveform
+
+
+def load_crush_smol_training_sample(
+    manifest_path: Path,
+    video_dir: Path,
+) -> tuple[Path, str]:
+    """Resolve the selected Crush-Smol video and its sole dataset caption.
+
+    The pinned dataset manifest owns the caption. Selecting the sample by file
+    name keeps the training input stable if the manifest order changes.
+    """
+    manifest = json.loads(manifest_path.read_text())
+    if not isinstance(manifest, list):
+        raise ValueError(f"Manifest {manifest_path} must contain a list of records")
+    matching_records = [
+        record for record in manifest if isinstance(record, dict) and record.get("path") == TRAINING_VIDEO_NAME
+    ]
+    if len(matching_records) != 1:
+        raise ValueError(f"Manifest {manifest_path} must contain exactly one {TRAINING_VIDEO_NAME} record")
+    captions = matching_records[0].get("cap")
+    if not isinstance(captions, list) or len(captions) != 1 or not isinstance(captions[0], str):
+        raise ValueError(f"The {TRAINING_VIDEO_NAME} record must contain exactly one caption string")
+    caption = captions[0].strip()
+    if not caption:
+        raise ValueError(f"The {TRAINING_VIDEO_NAME} caption must be nonempty")
+    video_path = video_dir / TRAINING_VIDEO_NAME
+    if not video_path.is_file():
+        raise FileNotFoundError(f"Crush-Smol training video is missing at {video_path}")
+    return video_path, caption
+
+
+def _load_component(
+    name: str,
+    model_path: Path,
+    model_index: dict[str, Any],
+    fastvideo_args: FastVideoArgs,
+) -> Any:
+    """Load one checkpoint component through the inference component registry.
+
+    Using the registered loader keeps preprocessing aligned with the component
+    classes and precision policy that produce H3 inference conditioning.
+    """
+    # Diffusers modular manifests can append loading metadata after the
+    # provider and architecture fields defined by the component contract.
+    transformers_or_diffusers, _ = model_index[name][:2]
+    return PipelineComponentLoader.load_module(
+        module_name=name,
+        component_model_path=str(model_path / name),
+        transformers_or_diffusers=transformers_or_diffusers,
+        fastvideo_args=fastvideo_args,
+    )
+
+
+def encode_video_latents(
+    frames: np.ndarray,
+    model_path: Path,
+    model_index: dict[str, Any],
+    fastvideo_args: FastVideoArgs,
+) -> torch.Tensor:
+    """Encode normalized ``[24, T, H, W]`` causal video VAE targets.
+
+    The video variational autoencoder (VAE) produces a channel-first latent
+    layout that feeds H3's checkpoint-compatible token
+    packing order ``(C, patch_t, patch_h, patch_w)`` without reordering latent
+    channels into patch-major features.
+    """
+    print("Loading MiniMax H3 video VAE")
+    vae = _load_component("vae", model_path, model_index, fastvideo_args)
+    # Feed [B, C, T, H, W] pixels and retain [C, T, H, W] latents; H3 later
+    # flattens every video token in (C, patch_t, patch_h, patch_w) order.
+    pixels = torch.from_numpy(frames.copy()).permute(3, 0, 1, 2)[None]
+    pixels = pixels.to(device=torch.device("cuda:0"), dtype=torch.float32).div_(255.0)
+    generator = torch.Generator("cpu").manual_seed(42)
+    with torch.no_grad():
+        posterior = vae.encode(vae.normalize_pixels(pixels)).latent_dist
+        latents = vae.normalize_latents(posterior.sample(generator=generator))
+        normalized_latents = latents.squeeze(0).float().cpu().contiguous()
+    del posterior, latents, pixels, vae
+    gc.collect()
+    torch.cuda.empty_cache()
+    print(f"Video latent shape: {tuple(normalized_latents.shape)}")
+    return normalized_latents
+
+
+def encode_audio_latents(
+    waveform: torch.Tensor,
+    model_path: Path,
+    model_index: dict[str, Any],
+    fastvideo_args: FastVideoArgs,
+) -> torch.Tensor:
+    """Encode normalized ``[2, 32, T]`` stereo targets with the mono audio VAE.
+
+    Treating the stereo axis as the VAE batch axis applies the same mono
+    encoder to both synchronized channels while preserving channel identity.
+    """
+    print("Loading MiniMax H3 audio VAE")
+    audio_vae = _load_component("audio_vae", model_path, model_index, fastvideo_args)
+    waveform = waveform.to(device=torch.device("cuda:0"), dtype=torch.float32)
+    with torch.no_grad():
+        posterior = audio_vae.encode(waveform[:, None]).latent_dist
+        latents = audio_vae.normalize_latents(posterior.mode())
+        normalized_latents = latents.float().cpu().contiguous()
+    del posterior, latents, waveform, audio_vae
+    gc.collect()
+    torch.cuda.empty_cache()
+    print(f"Audio latent shape: {tuple(normalized_latents.shape)}")
+    return normalized_latents
+
+
+def encode_text_embedding(
+    caption: str,
+    model_path: Path,
+    model_index: dict[str, Any],
+    fastvideo_args: FastVideoArgs,
+) -> torch.Tensor:
+    """Encode the caption through the H3 Qwen3-VL layer-50 inference path.
+
+    Reusing ``MiniMaxH3ConditioningStage`` keeps training tokenization and the
+    selected hidden-state layer identical to validation conditioning.
+    """
+    print("Loading MiniMax H3 tokenizer, processor, and Qwen3-VL encoder")
+    tokenizer = _load_component("tokenizer", model_path, model_index, fastvideo_args)
+    processor = _load_component("processor", model_path, model_index, fastvideo_args)
+    conditioner = _load_component("text_encoder", model_path, model_index, fastvideo_args)
+    stage = MiniMaxH3ConditioningStage(
+        conditioner=conditioner,
+        tokenizer=tokenizer,
+        processor=processor,
+    )
+    batch = ForwardBatch(data_type="video", prompt=caption)
+    batch.extra[MINIMAX_H3_KEYFRAMES_KEY] = []
+    batch = stage.forward(batch, fastvideo_args)
+    if not batch.prompt_embeds:
+        raise RuntimeError("MiniMax H3 conditioning returned no prompt embedding")
+    text_embedding = batch.prompt_embeds[0].squeeze(0).float().cpu().contiguous()
+    del batch, stage, conditioner, processor, tokenizer
+    gc.collect()
+    torch.cuda.empty_cache()
+    print(f"Text embedding shape: {tuple(text_embedding.shape)}")
+    return text_embedding
+
+
+def build_parquet_record(
+    *,
+    file_name: str,
+    caption: str,
+    video_latents: torch.Tensor,
+    audio_latents: torch.Tensor,
+    text_embedding: torch.Tensor,
+) -> dict[str, Any]:
+    """Serialize one synchronized H3 sample for the Parquet schema collator.
+
+    ``collate_rows_from_parquet_schema`` reconstructs every tensor from a
+    bytes/shape/dtype triplet and reads the byte payload as float32, so this
+    boundary stores contiguous float32 tensors for lossless reconstruction.
+    """
+    tensors = {
+        "vae_latent": video_latents.float().contiguous(),
+        "audio_latent": audio_latents.float().contiguous(),
+        "text_embedding": text_embedding.float().contiguous(),
+    }
+    record: dict[str, Any] = {"id": Path(file_name).stem}
+    for name, tensor in tensors.items():
+        record[f"{name}_bytes"] = tensor.numpy().tobytes()
+        record[f"{name}_shape"] = list(tensor.shape)
+        record[f"{name}_dtype"] = "float32"
+    record.update({
+        "file_name": file_name,
+        "caption": caption,
+        "media_type": "video_with_audio",
+        "width": VIDEO_WIDTH,
+        "height": VIDEO_HEIGHT,
+        "num_frames": NUM_FRAMES,
+        "duration_sec": NUM_FRAMES / MINIMAX_H3_FPS,
+        "fps": float(MINIMAX_H3_FPS),
+        "audio_sample_rate": AUDIO_SAMPLE_RATE,
+    })
+    return record
+
+
+def write_parquet(record: dict[str, Any], output_dir: Path) -> Path:
+    """Write the sole overfit row after removing other Parquet shards.
+
+    The training dataloader scans every Parquet shard in ``output_dir``;
+    replacing those shards preserves the one-sample overfit contract.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for parquet_path in output_dir.glob("*.parquet"):
+        parquet_path.unlink()
+    # The map-style cache stores Parquet file metadata and row counts, so a
+    # replacement shard set requires cache reconstruction.
+    shutil.rmtree(output_dir / "map_style_cache", ignore_errors=True)
+    table = pa.table(
+        {name: [record[name]]
+         for name in pyarrow_schema_t2va.names},
+        schema=pyarrow_schema_t2va,
+    )
+    output_path = output_dir / "data_00000.parquet"
+    pq.write_table(table, output_path)
+    return output_path
+
+
+def validate_preprocessed_training_data(
+    output_dir: Path = OUTPUT_DIR,
+    manifest_path: Path = DATA_DIR / "videos2caption.json",
+    video_dir: Path = DATA_DIR / "videos",
+) -> None:
+    """Verify that the H3 dataset contains only the selected Crush-Smol record.
+
+    The launch path calls this function before Slurm submission so that stale
+    Parquet shards or mismatched captions cannot enter the overfit run.
+    """
+    parquet_paths = sorted(output_dir.glob("*.parquet"))
+    expected_path = output_dir / "data_00000.parquet"
+    if parquet_paths != [expected_path]:
+        raise ValueError(f"Expected only {expected_path}, found {parquet_paths}")
+    table = pq.read_table(expected_path)
+    if table.num_rows != 1:
+        raise ValueError(f"Expected one training row in {expected_path}, found {table.num_rows}")
+    video_path, expected_caption = load_crush_smol_training_sample(manifest_path, video_dir)
+    record = table.to_pylist()[0]
+    if record["file_name"] != video_path.name:
+        raise ValueError(f"Training row file_name must be {video_path.name!r}, got {record['file_name']!r}")
+    if record["caption"] != expected_caption:
+        raise ValueError("Training row caption does not match the pinned Crush-Smol manifest")
+    print(f"Validated one Crush-Smol H3 training row in {expected_path}")
+
+
+def main() -> None:
+    """Encode the selected Crush-Smol record with each H3 component in sequence.
+
+    Releasing each component before loading the next component keeps video,
+    audio, and text preprocessing within one GPU's memory.
+    """
+    _init_single_process_distributed()
+    resolved_model_path = MODEL_PATH.resolve()
+    if not resolved_model_path.is_dir():
+        raise FileNotFoundError(f"Filtered MiniMax H3 model directory is missing at {resolved_model_path}")
+    model_index = verify_model_config_and_directory(str(resolved_model_path))
+    video_path, caption = load_crush_smol_training_sample(
+        DATA_DIR / "videos2caption.json",
+        DATA_DIR / "videos",
+    )
+    frames, waveform = load_training_media(video_path)
+    pipeline_config = MiniMaxH3PipelineConfig()
+    fastvideo_args = FastVideoArgs(
+        model_path=str(resolved_model_path),
+        pipeline_config=pipeline_config,
+        num_gpus=1,
+        tp_size=1,
+        sp_size=1,
+        hsdp_shard_dim=1,
+        use_fsdp_inference=False,
+        vae_cpu_offload=False,
+        text_encoder_cpu_offload=False,
+    )
+    video_latents = encode_video_latents(frames, resolved_model_path, model_index, fastvideo_args)
+    audio_latents = encode_audio_latents(waveform, resolved_model_path, model_index, fastvideo_args)
+    text_embedding = encode_text_embedding(caption, resolved_model_path, model_index, fastvideo_args)
+    record = build_parquet_record(
+        file_name=TRAINING_VIDEO_NAME,
+        caption=caption,
+        video_latents=video_latents,
+        audio_latents=audio_latents,
+        text_embedding=text_embedding,
+    )
+    output_path = write_parquet(record, OUTPUT_DIR)
+    print(f"Wrote one Crush-Smol MiniMax H3 T2VA record to {output_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--validate-only", action="store_true")
+    cli_args = parser.parse_args()
+    if cli_args.validate_only:
+        validate_preprocessed_training_data()
+    else:
+        main()

--- a/fastvideo/tests/train/callbacks/test_validation.py
+++ b/fastvideo/tests/train/callbacks/test_validation.py
@@ -20,6 +20,7 @@ import numpy as np
 import pytest
 import torch
 
+from fastvideo.api.sampling_param import SamplingParam
 from fastvideo.train.callbacks.callback import CallbackDict
 from fastvideo.train.callbacks.ema import EMACallback
 from fastvideo.train.callbacks.validation import (
@@ -45,10 +46,14 @@ def _make_callback(
     sampling_steps: list[int] | None = None,
     guidance_scale: float | None = None,
     num_frames: int | None = None,
+    num_videos_per_prompt: int = 1,
+    use_validation_media_conditioning: bool = True,
     sampling_timesteps: list[int] | None = None,
     output_dir: str | None = None,
     overlay_actions: bool = False,
+    run_at_start: bool = True,
 ) -> ValidationCallback:
+    """Construct a callback with the shared schedule and media-test defaults."""
     return ValidationCallback(
         pipeline_target=_PIPE_TARGET,
         dataset_file="/tmp/does_not_exist.json",
@@ -56,9 +61,12 @@ def _make_callback(
         sampling_steps=sampling_steps,
         guidance_scale=guidance_scale,
         num_frames=num_frames,
+        num_videos_per_prompt=num_videos_per_prompt,
+        use_validation_media_conditioning=use_validation_media_conditioning,
         sampling_timesteps=sampling_timesteps,
         output_dir=output_dir,
         overlay_actions=overlay_actions,
+        run_at_start=run_at_start,
     )
 
 
@@ -70,6 +78,7 @@ def _make_callback(
 class TestConstructor:
 
     def test_defaults(self) -> None:
+        """Verify defaults preserve baseline validation and media conditioning."""
         cb = _make_callback()
         assert cb.pipeline_target == _PIPE_TARGET
         assert cb.dataset_file == "/tmp/does_not_exist.json"
@@ -77,6 +86,9 @@ class TestConstructor:
         assert cb.sampling_steps == [40]
         assert cb.guidance_scale is None
         assert cb.num_frames is None
+        assert cb.num_videos_per_prompt == 1
+        assert cb.use_validation_media_conditioning is True
+        assert cb.run_at_start is True
         assert cb.sampling_timesteps is None
         assert cb.output_dir is None
         assert cb.overlay_actions is False
@@ -90,6 +102,7 @@ class TestConstructor:
         assert cb.metrics_config.enabled is False
 
     def test_string_inputs_are_coerced(self) -> None:
+        """Verify YAML-compatible scalar strings become callback value types."""
         # YAML often produces strings for numeric fields; the
         # constructor must coerce them.
         cb = ValidationCallback(
@@ -99,7 +112,10 @@ class TestConstructor:
             sampling_steps=["20", "40"],  # type: ignore[arg-type]
             guidance_scale="4.5",  # type: ignore[arg-type]
             num_frames="77",  # type: ignore[arg-type]
+            num_videos_per_prompt="2",  # type: ignore[arg-type]
+            use_validation_media_conditioning="false",  # type: ignore[arg-type]
             sampling_timesteps=["1000", "500"],
+            run_at_start="false",  # type: ignore[arg-type]
             overlay_actions=1,  # type: ignore[arg-type]
             offload_training_state="1",  # type: ignore[arg-type]
             unload_pipeline_after_validation="false",  # type: ignore[arg-type]
@@ -109,11 +125,19 @@ class TestConstructor:
         assert cb.sampling_steps == [20, 40]
         assert cb.guidance_scale == 4.5
         assert cb.num_frames == 77
+        assert cb.num_videos_per_prompt == 2
+        assert cb.use_validation_media_conditioning is False
+        assert cb.run_at_start is False
         assert cb.sampling_timesteps == [1000, 500]
         assert cb.overlay_actions is True
         assert cb.offload_training_state is True
         assert cb.unload_pipeline_after_validation is False
         assert cb.attn_qat_infer is True
+
+    def test_init_rejects_nonpositive_video_count(self) -> None:
+        """Verify every prompt requests at least one generated video."""
+        with pytest.raises(ValueError, match="num_videos_per_prompt must be positive"):
+            _make_callback(num_videos_per_prompt=0)
 
     def test_pipeline_kwargs_collected(self) -> None:
         cb = ValidationCallback(
@@ -214,12 +238,207 @@ class TestOnValidationBegin:
         cb.on_validation_begin(method=None, iteration=100)
         assert cb.run_calls == [50, 100]
 
-    def test_iter_zero_runs(self) -> None:
-        # 0 % anything == 0 → step 0 fires (matches existing
-        # validation behavior used by ValidationCallback consumers).
+    def test_on_validation_begin_runs_step_zero_by_default(self) -> None:
+        """Verify the callback records a pre-training baseline by default."""
         cb = _make_recording(every_steps=50)
         cb.on_validation_begin(method=None, iteration=0)
         assert cb.run_calls == [0]
+
+    def test_on_validation_begin_respects_start_gate_and_twenty_step_cadence(self) -> None:
+        """Verify the H3 schedule from baseline through optimizer step 400."""
+        cb = _make_recording(every_steps=20, run_at_start=True)
+
+        for iteration in range(401):
+            cb.on_validation_begin(method=None, iteration=iteration)
+
+        assert cb.run_calls == [0, *range(20, 401, 20)]
+
+    def test_on_validation_begin_skips_step_zero_when_disabled(self) -> None:
+        """Verify disabling the baseline preserves later cadence events."""
+        cb = _make_recording(every_steps=20, run_at_start=False)
+        cb.on_validation_begin(method=None, iteration=0)
+        cb.on_validation_begin(method=None, iteration=20)
+        assert cb.run_calls == [20]
+
+
+class TestH3ValidationContract:
+    """Verify synchronized MiniMax H3 validation through Weights & Biases logging."""
+
+    def test_prepare_validation_batch_forwards_video_count(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify that each ForwardBatch receives the configured output count."""
+        cb = _make_callback(num_videos_per_prompt=3)
+        cb.training_config = SimpleNamespace(
+            data=SimpleNamespace(
+                num_height=64,
+                num_width=96,
+                num_latent_t=2,
+            ),
+            pipeline_config=SimpleNamespace(
+                vae_config=SimpleNamespace(
+                    arch_config=SimpleNamespace(temporal_compression_ratio=4),
+                ),
+            ),
+            model_path="unused",
+            vsa_sparsity=0.0,
+        )
+        monkeypatch.setattr(
+            "fastvideo.train.callbacks.validation.make_inference_args",
+            lambda *args, **kwargs: SimpleNamespace(),
+        )
+
+        batch = cb._prepare_validation_batch(
+            SamplingParam(),
+            {"prompt": "Generate synchronized media."},
+            num_inference_steps=5,
+        )
+
+        assert batch.num_videos_per_prompt == 3
+
+    def test_prepare_validation_batch_ignores_media_for_text_only_generation(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+    ) -> None:
+        """Verify text-to-video-with-audio uses captions without source media."""
+        video_path = tmp_path / "reference.mp4"
+        video_path.touch()
+        cb = _make_callback(use_validation_media_conditioning=False)
+        cb.training_config = SimpleNamespace(
+            data=SimpleNamespace(
+                num_height=64,
+                num_width=96,
+                num_latent_t=2,
+            ),
+            pipeline_config=SimpleNamespace(
+                vae_config=SimpleNamespace(
+                    arch_config=SimpleNamespace(temporal_compression_ratio=4),
+                ),
+            ),
+            model_path="unused",
+            vsa_sparsity=0.0,
+        )
+        monkeypatch.setattr(
+            "fastvideo.train.callbacks.validation.make_inference_args",
+            lambda *args, **kwargs: SimpleNamespace(),
+        )
+
+        batch = cb._prepare_validation_batch(
+            SamplingParam(),
+            {
+                "prompt": "Generate synchronized media.",
+                "video_path": str(video_path),
+            },
+            num_inference_steps=5,
+        )
+
+        assert batch.image_path is None
+
+    def test_run_validation_for_steps_aligns_h3_audio_with_captions(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify one waveform and sample rate stay aligned with each H3 video."""
+        validation_records = [{"caption": f"prompt-{index}"} for index in range(8)]
+
+        class FakeH3Pipeline:
+            """Return deterministic video and stereo audio for each prompt."""
+
+            fastvideo_args = SimpleNamespace(pipeline_config=SimpleNamespace())
+
+            def forward(self, batch, inference_args):
+                """Produce media whose values identify the source prompt."""
+                assert inference_args.dit_cpu_offload is False
+                prompt_index = int(batch.prompt.rsplit("-", 1)[1])
+                return SimpleNamespace(
+                    output=torch.full((1, 3, 2, 2, 2), prompt_index / 8),
+                    extra={
+                        "audio": torch.full((32, 2), float(prompt_index)),
+                        "audio_sample_rate": 32_000,
+                    },
+                )
+
+        cb = _make_callback()
+        cb.training_config = SimpleNamespace(
+            model_path="unused",
+            pipeline_config=SimpleNamespace(),
+        )
+        cb.rank_in_sp_group = 0
+        pipeline = FakeH3Pipeline()
+        monkeypatch.setattr(
+            "fastvideo.train.callbacks.validation.ValidationDataset",
+            lambda filename: validation_records,
+        )
+        monkeypatch.setattr(
+            "fastvideo.train.callbacks.validation.make_inference_args",
+            lambda *args, **kwargs: SimpleNamespace(
+                pipeline_config=SimpleNamespace(dmd_denoising_steps=None),
+                dit_cpu_offload=True,
+            ),
+        )
+        monkeypatch.setattr(cb, "_get_pipeline", lambda *, transformer: pipeline)
+        monkeypatch.setattr(cb, "_get_sampling_param", SamplingParam)
+        monkeypatch.setattr(
+            cb,
+            "_prepare_validation_batch",
+            lambda sampling_param, validation_batch, num_inference_steps: SimpleNamespace(
+                prompt=validation_batch["caption"],
+            ),
+        )
+
+        result = cb._run_validation_for_steps(50, transformer=torch.nn.Identity())
+
+        assert result.captions == [f"prompt-{index}" for index in range(8)]
+        assert len(result.videos) == 8
+        assert result.audio_sample_rates == [32_000] * 8
+        assert len(result.audio_waveforms) == 8
+        for prompt_index, waveform in enumerate(result.audio_waveforms):
+            assert torch.is_tensor(waveform)
+            torch.testing.assert_close(waveform, torch.full((32, 2), float(prompt_index)))
+
+    def test_log_validation_video_artifacts_emits_eight_wandb_videos(self) -> None:
+        """Verify a MiniMax H3 event contains eight media objects and scalar evidence."""
+        class FakeWandbTracker:
+            """Record tracker calls without contacting W&B."""
+
+            def __init__(self) -> None:
+                self.video_calls = []
+                self.artifact_calls = []
+
+            def video(self, filename, *, caption, fps):
+                self.video_calls.append((filename, caption, fps))
+                return filename
+
+            def log_artifacts(self, artifacts, step):
+                self.artifact_calls.append((artifacts, step))
+
+        cb = _make_callback()
+        cb.tracker = FakeWandbTracker()
+        filenames = [f"validation-{index}.mp4" for index in range(8)]
+        captions = [f"caption-{index}" for index in range(8)]
+        scalar_metrics = {
+            "validation/50_steps_video_count": 8.0,
+            "validation/50_steps_duration_sec": 12.5,
+            "validation/50_steps_audio_video_count": 8.0,
+        }
+
+        cb._log_validation_video_artifacts(
+            filenames,
+            captions,
+            key="validation_videos_50_steps",
+            step=20,
+            fps=24,
+            scalar_metrics=scalar_metrics,
+        )
+
+        assert len(cb.tracker.video_calls) == 8
+        assert len(cb.tracker.artifact_calls) == 1
+        artifacts, step = cb.tracker.artifact_calls[0]
+        assert step == 20
+        assert artifacts["validation_videos_50_steps"] == filenames
+        assert {key: artifacts[key] for key in scalar_metrics} == scalar_metrics
 
 
 class TestAttnQatInferValidation:
@@ -524,21 +743,26 @@ class TestActionOverlay:
         tmp_path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """Verify overlay artifacts use distinct names and the media writer."""
         cb = _make_callback()
         cb.global_rank = 3
         calls: list[tuple[str, int]] = []
 
-        def fake_mimsave(
+        def fake_write_validation_mp4(
             fname: str,
             video: list[np.ndarray],
             *,
             fps: int,
+            audio=None,
+            audio_sample_rate=None,
         ) -> None:
+            """Record media arguments without invoking a system codec."""
+            del video, audio, audio_sample_rate
             calls.append((fname, fps))
 
         monkeypatch.setattr(
-            "fastvideo.train.callbacks.validation.imageio.mimsave",
-            fake_mimsave,
+            "fastvideo.train.callbacks.validation.write_validation_mp4",
+            fake_write_validation_mp4,
         )
 
         saved = cb._save_validation_videos(
@@ -561,24 +785,28 @@ class TestActionOverlay:
         tmp_path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        """Verify a failed video-only encode does not hide later artifacts."""
         cb = _make_callback()
         cb.global_rank = 0
         calls: list[str] = []
 
-        def fake_mimsave(
+        def fake_write_validation_mp4(
             fname: str,
             video: list[np.ndarray],
             *,
             fps: int,
+            audio=None,
+            audio_sample_rate=None,
         ) -> None:
-            del video, fps
+            """Fail the first encode to exercise video-only best-effort logging."""
+            del video, fps, audio, audio_sample_rate
             calls.append(fname)
             if len(calls) == 1:
                 raise OSError("ffmpeg failed")
 
         monkeypatch.setattr(
-            "fastvideo.train.callbacks.validation.imageio.mimsave",
-            fake_mimsave,
+            "fastvideo.train.callbacks.validation.write_validation_mp4",
+            fake_write_validation_mp4,
         )
 
         saved = cb._save_validation_videos(
@@ -597,6 +825,78 @@ class TestActionOverlay:
             str(tmp_path / "validation_step_8_inference_steps_5_rank_0_video_1.mp4")
         ]
         assert len(calls) == 2
+
+    def test_save_validation_videos_counts_preserved_audio(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify the callback counts only MP4 files with requested waveforms."""
+        cb = _make_callback()
+        cb.global_rank = 0
+        encoded_audio = []
+
+        def fake_write_validation_mp4(
+            fname: str,
+            video: list[np.ndarray],
+            *,
+            fps: int,
+            audio=None,
+            audio_sample_rate=None,
+        ) -> None:
+            del fname, video, fps
+            encoded_audio.append((audio, audio_sample_rate))
+
+        monkeypatch.setattr(
+            "fastvideo.train.callbacks.validation.write_validation_mp4",
+            fake_write_validation_mp4,
+        )
+        waveforms = [torch.zeros(32, 2), torch.ones(32, 2)]
+
+        saved = cb._save_validation_videos(
+            [[np.zeros((2, 2, 3), dtype=np.uint8)]] * 2,
+            output_dir=str(tmp_path),
+            step=0,
+            num_inference_steps=50,
+            fps=24,
+            audio_waveforms=waveforms,
+            audio_sample_rates=[32_000, 32_000],
+        )
+
+        assert saved.audio_video_count == 2
+        assert saved.indices == [0, 1]
+        assert len(encoded_audio) == 2
+        assert encoded_audio[0][0] is waveforms[0]
+        assert encoded_audio[1][0] is waveforms[1]
+        assert [sample_rate for _, sample_rate in encoded_audio] == [32_000, 32_000]
+
+    def test_save_validation_videos_raises_on_audio_encode_failure(
+        self,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify a MiniMax H3 audio encoding failure stops the validation event."""
+        cb = _make_callback()
+        cb.global_rank = 0
+
+        def fail_audio_encode(*args, **kwargs) -> None:
+            raise RuntimeError("AAC unavailable")
+
+        monkeypatch.setattr(
+            "fastvideo.train.callbacks.validation.write_validation_mp4",
+            fail_audio_encode,
+        )
+
+        with pytest.raises(RuntimeError, match="AAC unavailable"):
+            cb._save_validation_videos(
+                [[np.zeros((2, 2, 3), dtype=np.uint8)]],
+                output_dir=str(tmp_path),
+                step=0,
+                num_inference_steps=50,
+                fps=24,
+                audio_waveforms=[torch.zeros(32, 2)],
+                audio_sample_rates=[32_000],
+            )
 
     def test_post_process_validation_frames_uses_student_hook(self) -> None:
         cb = _make_callback(overlay_actions=True)

--- a/fastvideo/tests/train/callbacks/test_validation.py
+++ b/fastvideo/tests/train/callbacks/test_validation.py
@@ -870,33 +870,44 @@ class TestActionOverlay:
         assert encoded_audio[1][0] is waveforms[1]
         assert [sample_rate for _, sample_rate in encoded_audio] == [32_000, 32_000]
 
-    def test_save_validation_videos_raises_on_audio_encode_failure(
+    def test_save_validation_videos_skips_audio_encode_failure(
         self,
         tmp_path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Verify a MiniMax H3 audio encoding failure stops the validation event."""
+        """Verify an audio encoding failure is omitted without stopping later writes."""
         cb = _make_callback()
         cb.global_rank = 0
+        calls: list[str] = []
 
-        def fail_audio_encode(*args, **kwargs) -> None:
-            raise RuntimeError("AAC unavailable")
+        def fail_first_audio_encode(fname: str, *args, **kwargs) -> None:
+            """Leave one incomplete file before allowing the second write."""
+            del args, kwargs
+            calls.append(fname)
+            if len(calls) == 1:
+                with open(fname, "wb") as incomplete_file:
+                    incomplete_file.write(b"incomplete")
+                raise RuntimeError("AAC unavailable")
 
         monkeypatch.setattr(
             "fastvideo.train.callbacks.validation.write_validation_mp4",
-            fail_audio_encode,
+            fail_first_audio_encode,
         )
 
-        with pytest.raises(RuntimeError, match="AAC unavailable"):
-            cb._save_validation_videos(
-                [[np.zeros((2, 2, 3), dtype=np.uint8)]],
-                output_dir=str(tmp_path),
-                step=0,
-                num_inference_steps=50,
-                fps=24,
-                audio_waveforms=[torch.zeros(32, 2)],
-                audio_sample_rates=[32_000],
-            )
+        saved = cb._save_validation_videos(
+            [[np.zeros((2, 2, 3), dtype=np.uint8)]] * 2,
+            output_dir=str(tmp_path),
+            step=0,
+            num_inference_steps=50,
+            fps=24,
+            audio_waveforms=[torch.zeros(32, 2)] * 2,
+            audio_sample_rates=[32_000, 32_000],
+        )
+
+        assert saved.indices == [1]
+        assert saved.audio_video_count == 1
+        assert len(calls) == 2
+        assert not (tmp_path / "validation_step_0_inference_steps_50_rank_0_video_0.mp4").exists()
 
     def test_post_process_validation_frames_uses_student_hook(self) -> None:
         cb = _make_callback(overlay_actions=True)

--- a/fastvideo/tests/train/callbacks/test_validation.py
+++ b/fastvideo/tests/train/callbacks/test_validation.py
@@ -350,7 +350,6 @@ class TestH3ValidationContract:
 
             def forward(self, batch, inference_args):
                 """Produce media whose values identify the source prompt."""
-                assert inference_args.dit_cpu_offload is False
                 prompt_index = int(batch.prompt.rsplit("-", 1)[1])
                 return SimpleNamespace(
                     output=torch.full((1, 3, 2, 2, 2), prompt_index / 8),

--- a/fastvideo/tests/train/fixtures/minimax_h3_t2va_min.yaml
+++ b/fastvideo/tests/train/fixtures/minimax_h3_t2va_min.yaml
@@ -1,0 +1,44 @@
+# Minimal H3 plugin and distributed-layout configuration for CPU contract tests.
+models:
+  student:
+    _target_: fastvideo.train.models.minimax_h3.MiniMaxH3Model
+    init_from: MiniMaxAI/MiniMax-H3
+    trainable: true
+    enable_gradient_checkpointing_type: full
+    attention_backend: TORCH_SDPA
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    # Eight ranks form one sequence-parallel group because 56 H3 attention
+    # heads divide evenly across eight ranks.
+    num_gpus: 8
+    sp_size: 8
+    tp_size: 1
+    hsdp_replicate_dim: 1
+    hsdp_shard_dim: 8
+  data:
+    data_path: /tmp/minimax_h3_t2va
+    preprocessed_data_type: t2va
+    # H3 row indices describe one joint document per data-parallel replica.
+    train_batch_size: 1
+    # The H3 training plugin consumes encoded conditional text embeddings.
+    training_cfg_rate: 0.0
+    num_latent_t: 37
+    num_height: 768
+    num_width: 1344
+    num_frames: 124
+  optimizer:
+    learning_rate: 1.0e-5
+  loop:
+    max_train_steps: 1
+  model:
+    # H3 returns flow predictions for direct noise-minus-clean supervision.
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+  dit_precision: bf16
+
+callbacks: {}
+pipeline: {}

--- a/fastvideo/tests/train/methods/test_minimax_h3_finetune.py
+++ b/fastvideo/tests/train/methods/test_minimax_h3_finetune.py
@@ -342,7 +342,8 @@ def test_h3_slurm_scripts_preserve_inherited_wandb_key(
     run_slurm = _REPO_ROOT / "examples/train/run_slurm.sh"
     launcher = _REPO_ROOT / "examples/train/launch_minimax_h3_t2va_crush_smol_validation.sh"
     setup = _REPO_ROOT / "examples/train/setup_minimax_h3_t2va_crush_smol_single_sample.sh"
-    subprocess.run(["bash", "-n", str(run_slurm), str(launcher), str(setup)], check=True)
+    for script in (run_slurm, launcher, setup):
+        subprocess.run(["bash", "-n", str(script)], check=True)
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()

--- a/fastvideo/tests/train/methods/test_minimax_h3_finetune.py
+++ b/fastvideo/tests/train/methods/test_minimax_h3_finetune.py
@@ -1,0 +1,470 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU contract tests for MiniMax H3 joint audio-video fine-tuning."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+from types import SimpleNamespace
+from typing import cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import torch
+import yaml
+
+from fastvideo.configs.models.dits.minimax_h3 import MiniMaxH3Config
+from fastvideo.dataset.parquet_dataset_map_style import (
+    DP_SP_BatchSampler,
+    get_parquet_files_and_length,
+)
+from fastvideo.models.dits.minimax_h3 import MiniMaxH3RotaryPosEmbed, MiniMaxH3Transformer3DModel
+from fastvideo.pipelines import TrainingBatch
+from fastvideo.train.methods.fine_tuning.finetune import _compute_finetune_loss_map
+from fastvideo.train.models.minimax_h3 import MiniMaxH3Model
+from fastvideo.train.models.minimax_h3.minimax_h3 import shift_noise_amount
+from fastvideo.train.utils.config import load_run_config
+
+_FIXTURE = Path(__file__).resolve().parent.parent / "fixtures" / "minimax_h3_t2va_min.yaml"
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_EXPERIMENT_CONFIG = _REPO_ROOT / "examples/train/configs/overfit_minimax_h3_t2va.yaml"
+_VALIDATION_PROMPTS = (
+    _REPO_ROOT / "examples/training/finetune/Wan2.1-Fun-1.3B-InP/crush_smol/validation.json"
+)
+_EXPECTED_VALIDATION_CAPTIONS = [
+    (
+        "A large metal cylinder is seen pressing down on a pile of Oreo cookies, "
+        "flattening them as if they were under a hydraulic press."
+    ),
+    (
+        "A large metal cylinder is seen compressing colorful clay into a compact shape, "
+        "demonstrating the power of a hydraulic press."
+    ),
+    (
+        "A large metal cylinder is seen pressing down on a pile of colorful candies, "
+        "flattening them as if they were under a hydraulic press. The candies are crushed "
+        "and broken into small pieces, creating a mess on the table."
+    ),
+]
+
+
+class _IdentityJointTransformer:
+    """Return packed H3 inputs as deterministic velocity predictions."""
+
+    patch_size = (1, 2, 2)
+
+    def __call__(self, **kwargs):
+        return kwargs["hidden_states"], kwargs["audio_hidden_states"]
+
+
+@pytest.mark.parametrize(
+    ("shift", "expected_midpoint"),
+    [(12.0, 12.0 / 13.0), (3.0, 0.75)],
+)
+def test_shift_noise_amount_matches_h3_scheduler(shift: float, expected_midpoint: float) -> None:
+    """Verify that training samples use the scheduler's rational noise shift."""
+    base = torch.tensor([0.0, 0.5, 1.0])
+
+    shifted = shift_noise_amount(base, shift)
+
+    torch.testing.assert_close(shifted, torch.tensor([0.0, expected_midpoint, 1.0]))
+
+
+def test_multimodal_finetune_loss_weights_modalities_equally() -> None:
+    """Verify that each modality contributes its independently averaged MSE."""
+    clean_video = torch.zeros(1, 1, 1, 1, 1)
+    video_noise = torch.ones_like(clean_video)
+    video_prediction = torch.full_like(clean_video, 2.0)
+    clean_audio = torch.zeros(1, 2, 1, 1)
+    audio_noise = torch.ones_like(clean_audio)
+    audio_prediction = torch.full_like(clean_audio, 3.0)
+    batch = TrainingBatch(
+        audio_latents=clean_audio,
+        audio_noisy_model_input=torch.zeros_like(clean_audio),
+        audio_noise=audio_noise,
+        audio_sigmas=torch.ones(1, 1, 1, 1),
+    )
+
+    losses = _compute_finetune_loss_map(
+        (video_prediction, audio_prediction),
+        clean_video,
+        torch.zeros_like(clean_video),
+        video_noise,
+        torch.ones(1, 1, 1, 1, 1),
+        batch,
+        precondition_outputs=False,
+    )
+
+    torch.testing.assert_close(losses["video_finetune_loss"], torch.tensor(1.0))
+    torch.testing.assert_close(losses["audio_finetune_loss"], torch.tensor(4.0))
+    torch.testing.assert_close(losses["total_loss"], torch.tensor(5.0))
+    assert losses["finetune_loss"] is losses["total_loss"]
+
+
+def test_single_tensor_finetune_loss_preserves_video_contract() -> None:
+    """Verify that video-only model plugins retain their loss keys and target."""
+    clean_video = torch.zeros(1, 1, 1, 1, 1)
+    video_noise = torch.ones_like(clean_video)
+
+    losses = _compute_finetune_loss_map(
+        video_noise,
+        clean_video,
+        torch.zeros_like(clean_video),
+        video_noise,
+        torch.ones(1, 1, 1, 1, 1),
+        TrainingBatch(),
+        precondition_outputs=False,
+    )
+
+    assert set(losses) == {"total_loss", "finetune_loss"}
+    torch.testing.assert_close(losses["total_loss"], torch.tensor(0.0))
+
+
+def test_h3_training_fixture_resolves_joint_contract() -> None:
+    """Verify that YAML parsing selects the H3 T2VA data and model contract."""
+    config = load_run_config(str(_FIXTURE))
+
+    assert config.models["student"]["_target_"] == ("fastvideo.train.models.minimax_h3.MiniMaxH3Model")
+    assert config.training.data.preprocessed_data_type == "t2va"
+    assert config.training.pipeline_config is not None
+    assert config.training.pipeline_config.text_encoder_configs[0].arch_config.text_len == 1024
+    assert config.training.pipeline_config.dit_config.uniform_parameter_dtype is False
+    assert MiniMaxH3Model.__name__ == "MiniMaxH3Model"
+
+
+def test_h3_uniform_parameter_dtype_uses_fsdp_dtype() -> None:
+    """Verify that training can select one FSDP-compatible parameter dtype."""
+    model = cast(
+        MiniMaxH3Transformer3DModel,
+        SimpleNamespace(
+            config=MiniMaxH3Config(uniform_parameter_dtype=True),
+            _keep_in_fp32_modules=MiniMaxH3Transformer3DModel._keep_in_fp32_modules,
+        ),
+    )
+
+    parameter_dtype = MiniMaxH3Transformer3DModel._get_parameter_dtype(
+        model,
+        "proj_in.weight",
+        torch.bfloat16,
+    )
+
+    assert parameter_dtype == torch.bfloat16
+
+
+def test_h3_materializes_rotary_frequencies_on_loader_device() -> None:
+    """Verify that checkpoint loading moves analytic rotary state to the model device."""
+    model = cast(
+        MiniMaxH3Transformer3DModel,
+        SimpleNamespace(
+            config=MiniMaxH3Config(),
+            rope=SimpleNamespace(
+                inv_freq=torch.ones(1),
+                _buffers={"inv_freq": torch.ones(1)},
+            ),
+        ),
+    )
+
+    MiniMaxH3Transformer3DModel.materialize_non_persistent_buffers(
+        model,
+        device=torch.device("meta"),
+    )
+
+    assert model.rope._buffers["inv_freq"].is_meta
+
+
+def test_h3_rotary_frequencies_follow_position_device_after_offload() -> None:
+    """Verify that rotary state follows position IDs after training-state offload."""
+    rotary_embedding = MiniMaxH3RotaryPosEmbed(rope_freq_dim=4, rope_theta=10_000.0)
+
+    cosine, sine = rotary_embedding(torch.zeros(2, 3, device="meta"))
+
+    assert cosine.is_meta
+    assert sine.is_meta
+
+
+def test_h3_plugin_prepares_and_restores_joint_latent_shapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify H3 batch preparation, packing, and output restoration together."""
+    monkeypatch.setattr(MiniMaxH3Model, "device", property(lambda _self: torch.device("cpu")))
+    model = MiniMaxH3Model.__new__(MiniMaxH3Model)
+    model.training_config = SimpleNamespace(
+        data=SimpleNamespace(
+            num_latent_t=2,
+            num_frames=5,
+            num_height=64,
+            num_width=64,
+        ),
+        distributed=SimpleNamespace(sp_size=1),
+    )
+    model.transformer = _IdentityJointTransformer()
+    model.sp_group = None
+    raw_batch = {
+        "vae_latent": torch.zeros(1, 24, 2, 4, 4),
+        "audio_latent": torch.zeros(1, 2, 32, 8),
+        "text_embedding": torch.zeros(1, 4, 5120),
+        "text_attention_mask": torch.tensor([[1, 1, 0, 0]], dtype=torch.float32),
+    }
+
+    batch = model.prepare_batch(
+        raw_batch,
+        generator=torch.Generator(device="cpu").manual_seed(7),
+    )
+    prediction = model.predict_noise(
+        batch.noisy_model_input.permute(0, 2, 1, 3, 4),
+        batch.timesteps,
+        batch,
+        conditional=True,
+    )
+
+    assert isinstance(prediction, tuple)
+    assert prediction[0].shape == batch.latents.shape
+    assert prediction[1].shape == batch.audio_latents.shape
+    torch.testing.assert_close(
+        prediction[0],
+        -batch.noisy_model_input.permute(0, 2, 1, 3, 4),
+    )
+    torch.testing.assert_close(prediction[1], -batch.audio_noisy_model_input)
+    assert batch.minimax_h3_layout.sequence_length == 26
+
+
+def test_h3_validation_prompts_match_crush_smol_recipe() -> None:
+    """Verify that H3 validation uses every Crush-Smol validation caption."""
+    prompt_document = json.loads(_VALIDATION_PROMPTS.read_text())
+    captions = [record["caption"] for record in prompt_document["data"]]
+
+    assert captions == _EXPECTED_VALIDATION_CAPTIONS
+    assert len(captions) == len(set(captions)) == 3
+    assert all(caption.strip() for caption in captions)
+
+
+def test_h3_experiment_config_uses_modular_validation_callback() -> None:
+    """Verify that the H3 experiment uses modular validation and W&B logging."""
+    config = yaml.safe_load(_EXPERIMENT_CONFIG.read_text())
+    validation = config["callbacks"]["validation"]
+    tracker = config["training"]["tracker"]
+
+    assert config["method"]["_target_"] == "fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod"
+    assert validation["_target_"] == "fastvideo.train.callbacks.validation.ValidationCallback"
+    assert validation["pipeline_target"] == (
+        "fastvideo.pipelines.basic.minimax_h3.minimax_h3_pipeline.MiniMaxH3Pipeline"
+    )
+    assert validation["dataset_file"] == (
+        "examples/training/finetune/Wan2.1-Fun-1.3B-InP/crush_smol/validation.json"
+    )
+    assert validation["every_steps"] == 20
+    assert validation["run_at_start"] is True
+    assert validation["sampling_steps"] == [50]
+    assert validation["num_frames"] == 124
+    assert validation["num_videos_per_prompt"] == 1
+    assert validation["use_validation_media_conditioning"] is False
+    assert validation["offload_training_state"] is True
+    assert validation["text_encoder_cpu_offload"] is True
+    assert validation["vae_cpu_offload"] is True
+    assert tracker["trackers"] == ["wandb"]
+    assert tracker["project_name"] == "fastvideo_minimax_h3"
+
+
+def test_h3_experiment_config_resolves_64_gpu_mesh_and_global_batch() -> None:
+    """Verify the experiment uses eight data-parallel replicas and batch eight."""
+    config = yaml.safe_load(_EXPERIMENT_CONFIG.read_text())
+    training = config["training"]
+    distributed = training["distributed"]
+
+    assert distributed == {
+        "num_gpus": 64,
+        "sp_size": 8,
+        "tp_size": 1,
+        "hsdp_replicate_dim": 8,
+        "hsdp_shard_dim": 8,
+        "pin_cpu_memory": True,
+    }
+    data_parallel_degree = distributed["num_gpus"] // distributed["sp_size"]
+    effective_global_batch = (
+        training["data"]["train_batch_size"]
+        * data_parallel_degree
+        * training["loop"]["gradient_accumulation_steps"]
+    )
+    assert distributed["hsdp_replicate_dim"] * distributed["hsdp_shard_dim"] == 64
+    assert data_parallel_degree == 8
+    assert effective_global_batch == 8
+    assert training["data"]["data_path"] == {
+        "data/crush-smol_h3_t2va_single_sample_preprocessed": 8
+    }
+    assert training["loop"]["max_train_steps"] == 400
+    assert training["checkpoint"]["training_state_checkpointing_steps"] == 20
+    assert training["checkpoint"]["checkpoints_total_limit"] == 2
+    assert training["tracker"]["run_name"] == "minimax_h3_t2va_crush_smol_single_sample_overfit"
+
+
+def test_h3_experiment_data_repeat_supplies_every_sp_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify one parquet row repeats into one complete batch per SP group."""
+    dataset_root = tmp_path / "one-row-parquet"
+    dataset_root.mkdir()
+    pq.write_table(pa.table({"sample_id": [0]}), dataset_root / "data_00000.parquet")
+    monkeypatch.setattr(
+        "fastvideo.dataset.parquet_dataset_map_style.get_world_rank",
+        lambda: 0,
+    )
+    monkeypatch.setattr(
+        "fastvideo.dataset.parquet_dataset_map_style.get_world_group",
+        lambda: SimpleNamespace(barrier=lambda: None),
+    )
+
+    parquet_files, parquet_lengths = get_parquet_files_and_length({str(dataset_root): 8})
+    assert len(parquet_files) == 8
+    assert sum(parquet_lengths) == 8
+
+    assigned_indices = []
+    for sp_group_index in range(8):
+        sampler = DP_SP_BatchSampler(
+            batch_size=1,
+            dataset_size=8,
+            num_sp_groups=8,
+            sp_world_size=8,
+            global_rank=sp_group_index * 8,
+            drop_last=True,
+            seed=42,
+        )
+        batches = list(sampler)
+        assert len(batches) == 1
+        assert len(batches[0]) == 1
+        assigned_indices.extend(batches[0])
+    assert sorted(assigned_indices) == list(range(8))
+
+
+def test_h3_slurm_scripts_preserve_inherited_wandb_key(
+    tmp_path: Path,
+) -> None:
+    """Verify shell syntax, H200 allocation, and secret-free job-script text."""
+    run_slurm = _REPO_ROOT / "examples/train/run_slurm.sh"
+    launcher = _REPO_ROOT / "examples/train/launch_minimax_h3_t2va_crush_smol_validation.sh"
+    setup = _REPO_ROOT / "examples/train/setup_minimax_h3_t2va_crush_smol_single_sample.sh"
+    subprocess.run(["bash", "-n", str(run_slurm), str(launcher), str(setup)], check=True)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    generated_job_script = tmp_path / "generated-job.sh"
+    sbatch_arguments = tmp_path / "sbatch-arguments.txt"
+    fake_sbatch = fake_bin / "sbatch"
+    fake_sbatch.write_text(
+        "#!/bin/bash\n"
+        "printf '%s\\n' \"$@\" > \"$SBATCH_ARGUMENTS\"\n"
+        "dd status=none of=\"$SBATCH_JOB_SCRIPT\"\n"
+        "printf 'Submitted batch job 4242\\n'\n"
+    )
+    fake_sbatch.chmod(0o755)
+    secret_value = "wandb-test-secret-must-not-appear"
+    environment = os.environ.copy()
+    environment.update({
+        "PATH": f"{fake_bin}:{environment['PATH']}",
+        "WANDB_API_KEY": secret_value,
+        "WANDB_MODE": "online",
+        "OUTPUT_DIR": str(tmp_path / "slurm"),
+        "SBATCH_ARGUMENTS": str(sbatch_arguments),
+        "SBATCH_JOB_SCRIPT": str(generated_job_script),
+    })
+
+    completed = subprocess.run(
+        ["bash", str(run_slurm), str(_EXPERIMENT_CONFIG), "8"],
+        cwd=_REPO_ROOT,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    generated_text = generated_job_script.read_text()
+    submission_text = completed.stdout + completed.stderr
+    assert secret_value not in generated_text
+    assert secret_value not in submission_text
+    assert "--export=ALL,WANDB_MODE=online" in sbatch_arguments.read_text()
+    launcher_text = launcher.read_text()
+    assert "SBATCH_CONSTRAINT=nvidia_h200" in launcher_text
+    assert "SBATCH_TIMELIMIT=72:00:00" in launcher_text
+    assert "data/crush-smol_h3_t2va_single_sample_preprocessed" in launcher_text
+    assert "runs/minimax_h3_t2va_crush_smol_single_sample_overfit" in launcher_text
+    assert "--validate-only" in launcher_text
+    assert "git ls-files --modified --others --exclude-standard" in launcher_text
+    assert "source-files.tar.gz" in launcher_text
+    assert 'bash examples/train/run_slurm.sh "${CONFIG_FILE}" 8' in launcher_text
+
+
+def test_h3_slurm_job_resolves_one_node_rank_per_srun_task(tmp_path: Path) -> None:
+    """Execute the rendered job script with eight simulated Slurm task ranks."""
+    run_slurm = _REPO_ROOT / "examples/train/run_slurm.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    generated_job_script = tmp_path / "generated-job.sh"
+    torchrun_arguments_dir = tmp_path / "torchrun-arguments"
+    torchrun_arguments_dir.mkdir()
+
+    fake_sbatch = fake_bin / "sbatch"
+    fake_sbatch.write_text(
+        "#!/bin/bash\n"
+        "dd status=none of=\"$SBATCH_JOB_SCRIPT\"\n"
+        "printf 'Submitted batch job 4242\\n'\n"
+    )
+    fake_sbatch.chmod(0o755)
+    fake_scontrol = fake_bin / "scontrol"
+    fake_scontrol.write_text("#!/bin/bash\nprintf 'node%s\\n' {0..7}\n")
+    fake_scontrol.chmod(0o755)
+    fake_srun = fake_bin / "srun"
+    fake_srun.write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        "for rank in {0..7}; do\n"
+        "    SLURM_PROCID=\"$rank\" \"$@\"\n"
+        "done\n"
+    )
+    fake_srun.chmod(0o755)
+    fake_torchrun = fake_bin / "torchrun"
+    fake_torchrun.write_text(
+        "#!/bin/bash\n"
+        "printf '%s\\n' \"$@\" > "
+        "\"$TORCHRUN_ARGUMENTS_DIR/rank_${SLURM_PROCID}.txt\"\n"
+    )
+    fake_torchrun.chmod(0o755)
+
+    environment = os.environ.copy()
+    environment.update({
+        "PATH": f"{fake_bin}:{environment['PATH']}",
+        "OUTPUT_DIR": str(tmp_path / "slurm"),
+        "SBATCH_JOB_SCRIPT": str(generated_job_script),
+        "TORCHRUN_ARGUMENTS_DIR": str(torchrun_arguments_dir),
+    })
+    subprocess.run(
+        ["bash", str(run_slurm), str(_EXPERIMENT_CONFIG), "8"],
+        cwd=_REPO_ROOT,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    environment.update({
+        "SLURM_JOB_NODELIST": "node[0-7]",
+        "SLURM_JOB_NUM_NODES": "8",
+        "SLURM_PROCID": "0",
+    })
+    subprocess.run(
+        ["bash", str(generated_job_script)],
+        cwd=_REPO_ROOT,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    for rank in range(8):
+        torchrun_arguments = (torchrun_arguments_dir / f"rank_{rank}.txt").read_text().splitlines()
+        node_rank_index = torchrun_arguments.index("--node_rank")
+        assert torchrun_arguments[node_rank_index + 1] == str(rank)
+
+
+def test_h3_model_uses_modular_activation_checkpointing() -> None:
+    """Verify that H3 uses activation checkpointing owned by the modular trainer."""
+    source = (_REPO_ROOT / "fastvideo/train/models/minimax_h3/minimax_h3.py").read_text()
+
+    assert "fastvideo.training." not in source

--- a/fastvideo/tests/train/utils/test_moduleloader_attention_backend.py
+++ b/fastvideo/tests/train/utils/test_moduleloader_attention_backend.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+"""Verify construction-scoped attention backends in the training loader."""
+
 from __future__ import annotations
 
 import torch
@@ -15,6 +17,7 @@ from fastvideo.train.utils.training_config import (
 
 
 def test_load_transformer_scopes_attention_backend(monkeypatch, tmp_path) -> None:
+    """Apply one backend while accepting trailing modular-manifest metadata."""
     training_config = TrainingConfig(
         distributed=DistributedConfig(hsdp_shard_dim=1),
         pipeline_config=PipelineConfig(),
@@ -25,7 +28,9 @@ def test_load_transformer_scopes_attention_backend(monkeypatch, tmp_path) -> Non
     monkeypatch.setattr(
         moduleloader,
         "verify_model_config_and_directory",
-        lambda path: {"transformer": ("diffusers", "FakeTransformer")},
+        lambda path: {"transformer": ("diffusers", "FakeTransformer", {
+            "subfolder": "transformer"
+        })},
     )
 
     def _fake_load_module(**kwargs):

--- a/fastvideo/tests/train/utils/test_validation_media.py
+++ b/fastvideo/tests/train/utils/test_validation_media.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for synchronized validation MP4 encoding."""
+
+from pathlib import Path
+
+import av
+import numpy as np
+import pytest
+
+from fastvideo.train.utils import validation_media
+from fastvideo.train.utils.validation_media import write_validation_mp4
+
+
+def _rgb_frames(frame_count: int) -> list[np.ndarray]:
+    """Create distinct even-sized RGB frames for codec tests."""
+    return [
+        np.full((16, 24, 3), fill_value=frame_index * 10, dtype=np.uint8)
+        for frame_index in range(frame_count)
+    ]
+
+
+def _stereo_waveform(sample_count: int, sample_rate: int) -> np.ndarray:
+    """Create a bounded stereo tone in sample-major layout."""
+    sample_times = np.arange(sample_count, dtype=np.float32) / sample_rate
+    left = 0.25 * np.sin(2 * np.pi * 220 * sample_times)
+    right = 0.25 * np.sin(2 * np.pi * 330 * sample_times)
+    return np.stack((left, right), axis=1)
+
+
+def test_write_validation_mp4_encodes_h264_with_stereo_aac(tmp_path: Path) -> None:
+    """Verify stream geometry, frame count, stereo layout, and sample rate."""
+    output_path = tmp_path / "audio-video.mp4"
+    waveform = _stereo_waveform(32_000, 32_000).T
+
+    write_validation_mp4(
+        str(output_path),
+        _rgb_frames(12),
+        fps=24,
+        audio=waveform,
+        audio_sample_rate=32_000,
+    )
+
+    with av.open(str(output_path)) as container:
+        assert len(container.streams.video) == 1
+        assert len(container.streams.audio) == 1
+        assert container.streams.video[0].codec_context.name == "h264"
+        assert container.streams.video[0].average_rate == 24
+        assert container.streams.video[0].width == 24
+        assert container.streams.video[0].height == 16
+        assert container.streams.audio[0].codec_context.name == "aac"
+        assert container.streams.audio[0].codec_context.sample_rate == 32_000
+        assert len(container.streams.audio[0].codec_context.layout.channels) == 2
+        assert sum(1 for _ in container.decode(video=0)) == 12
+
+
+def test_write_validation_mp4_trims_video_to_shorter_audio(tmp_path: Path) -> None:
+    """Verify that a quarter-second waveform limits a 24 FPS video to six frames."""
+    output_path = tmp_path / "trimmed.mp4"
+
+    write_validation_mp4(
+        str(output_path),
+        _rgb_frames(12),
+        fps=24,
+        audio=_stereo_waveform(8_000, 32_000),
+        audio_sample_rate=32_000,
+    )
+
+    with av.open(str(output_path)) as container:
+        assert sum(1 for _ in container.decode(video=0)) == 6
+
+
+def test_write_validation_mp4_preserves_silent_video(tmp_path: Path) -> None:
+    """Verify that pipelines without waveforms retain video-only validation."""
+    output_path = tmp_path / "silent.mp4"
+
+    write_validation_mp4(str(output_path), _rgb_frames(4), fps=24)
+
+    with av.open(str(output_path)) as container:
+        assert len(container.streams.video) == 1
+        assert len(container.streams.audio) == 0
+        assert sum(1 for _ in container.decode(video=0)) == 4
+
+
+def test_write_validation_mp4_rejects_audio_loss(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that a silent encode cannot replace an audio-bearing destination."""
+    output_path = tmp_path / "must-keep-audio.mp4"
+    output_path.write_bytes(b"preserved destination")
+    real_encoder = validation_media._encode_mp4
+
+    def encode_without_audio(
+        temporary_path: str,
+        frames: np.ndarray,
+        fps: int,
+        waveform: np.ndarray | None,
+        sample_rate: int | None,
+    ) -> None:
+        """Simulate an encoder that drops a requested waveform."""
+        del waveform, sample_rate
+        real_encoder(temporary_path, frames, fps, None, None)
+
+    monkeypatch.setattr(validation_media, "_encode_mp4", encode_without_audio)
+
+    with pytest.raises(RuntimeError, match="exactly one audio stream"):
+        write_validation_mp4(
+            str(output_path),
+            _rgb_frames(4),
+            fps=24,
+            audio=_stereo_waveform(8_000, 32_000),
+            audio_sample_rate=32_000,
+        )
+
+    assert output_path.read_bytes() == b"preserved destination"
+    assert list(tmp_path.glob(".must-keep-audio.mp4.*.mp4")) == []

--- a/fastvideo/tests/workflow/test_minimax_h3_overfit_preprocess.py
+++ b/fastvideo/tests/workflow/test_minimax_h3_overfit_preprocess.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify that MiniMax H3 preprocessing preserves one synchronized text-to-video-and-audio sample."""
+
+import json
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+import torch
+
+from fastvideo.dataset.dataloader.schema import pyarrow_schema_t2va
+from fastvideo.dataset.utils import collate_rows_from_parquet_schema
+from fastvideo.pipelines.preprocess.preprocess_minimax_h3_overfit import (
+    TRAINING_VIDEO_NAME,
+    build_parquet_record,
+    load_crush_smol_training_sample,
+    validate_preprocessed_training_data,
+    write_parquet,
+)
+
+
+_TRAINING_CAPTION = (
+    "A watermelon wearing a helmet is crushed by a hydraulic press, "
+    "causing it to flatten and burst open."
+)
+
+
+def test_load_crush_smol_training_sample_selects_fixed_record(tmp_path: Path) -> None:
+    """Verify that preprocessing reads the selected caption from the dataset manifest."""
+    video_dir = tmp_path / "videos"
+    video_dir.mkdir()
+    video_path = video_dir / TRAINING_VIDEO_NAME
+    video_path.touch()
+    manifest_path = tmp_path / "videos2caption.json"
+    manifest_path.write_text(json.dumps([
+        {
+            "path": "another-video.mp4",
+            "cap": ["Another caption."],
+        },
+        {
+            "path": TRAINING_VIDEO_NAME,
+            "cap": [_TRAINING_CAPTION],
+        },
+    ]))
+
+    selected_video_path, caption = load_crush_smol_training_sample(manifest_path, video_dir)
+
+    assert selected_video_path == video_path
+    assert caption == _TRAINING_CAPTION
+
+
+def test_load_crush_smol_training_sample_rejects_duplicate_record(tmp_path: Path) -> None:
+    """Verify that an ambiguous manifest cannot silently select a training target."""
+    manifest_path = tmp_path / "videos2caption.json"
+    duplicate_record = {
+        "path": TRAINING_VIDEO_NAME,
+        "cap": [_TRAINING_CAPTION],
+    }
+    manifest_path.write_text(json.dumps([duplicate_record, duplicate_record]))
+
+    with pytest.raises(ValueError, match="exactly one"):
+        load_crush_smol_training_sample(manifest_path, tmp_path / "videos")
+
+
+def test_write_parquet_replaces_stale_rows_and_round_trips_joint_latents(tmp_path: Path) -> None:
+    """Keep one authoritative sample and preserve every tensor through collation."""
+    video_latents = torch.arange(24 * 2 * 4 * 4, dtype=torch.float32).reshape(24, 2, 4, 4)
+    audio_latents = torch.arange(2 * 32 * 3, dtype=torch.float32).reshape(2, 32, 3)
+    text_embedding = torch.arange(4 * 5120, dtype=torch.float32).reshape(4, 5120)
+    record = build_parquet_record(
+        file_name=TRAINING_VIDEO_NAME,
+        caption=_TRAINING_CAPTION,
+        video_latents=video_latents,
+        audio_latents=audio_latents,
+        text_embedding=text_embedding,
+    )
+
+    stale_path = tmp_path / "data_99999.parquet"
+    stale_path.write_bytes(b"stale")
+    output_path = write_parquet(record, tmp_path)
+    assert list(tmp_path.glob("*.parquet")) == [output_path]
+
+    loaded_record = pq.read_table(output_path).to_pylist()[0]
+    batch = collate_rows_from_parquet_schema(
+        [loaded_record],
+        pyarrow_schema_t2va,
+        text_padding_length=8,
+    )
+
+    torch.testing.assert_close(batch["vae_latent"][0], video_latents)
+    torch.testing.assert_close(batch["audio_latent"][0], audio_latents)
+    torch.testing.assert_close(batch["text_embedding"][0, :4], text_embedding)
+    torch.testing.assert_close(
+        batch["text_attention_mask"],
+        torch.tensor([[1, 1, 1, 1, 0, 0, 0, 0]], dtype=torch.float32),
+    )
+    assert set(record) == set(pyarrow_schema_t2va.names)
+
+    video_dir = tmp_path / "videos"
+    video_dir.mkdir()
+    (video_dir / TRAINING_VIDEO_NAME).touch()
+    manifest_path = tmp_path / "videos2caption.json"
+    manifest_path.write_text(json.dumps([{
+        "path": TRAINING_VIDEO_NAME,
+        "cap": [_TRAINING_CAPTION],
+    }]))
+    validate_preprocessed_training_data(tmp_path, manifest_path, video_dir)

--- a/fastvideo/train/callbacks/validation.py
+++ b/fastvideo/train/callbacks/validation.py
@@ -711,12 +711,11 @@ class ValidationCallback(Callback):
         audio_waveforms: list[torch.Tensor | np.ndarray | None] | None = None,
         audio_sample_rates: list[int | None] | None = None,
     ) -> _SavedValidationVideos:
-        """Save aligned validation media and include every supplied waveform.
+        """Save aligned validation media and skip artifacts that fail encoding.
 
-        Audio-bearing outputs require a complete audio-video MP4 because a
-        silent fallback would invalidate multimodal validation. Video-only
-        outputs use best-effort logging so one failed artifact does not stop
-        training.
+        Audio and sample-rate metadata must pass the alignment checks before
+        encoding. Media writer failures are logged and omitted so validation
+        artifact creation does not interrupt the training loop.
         """
         if (audio_waveforms is None) != (audio_sample_rates is None):
             raise ValueError("Validation audio waveforms and sample rates must be provided together.")
@@ -747,18 +746,10 @@ class ValidationCallback(Callback):
                     audio_sample_rate=audio_sample_rate,
                 )
             except Exception as exc:
-                if audio is not None:
-                    logger.exception(
-                        "Failed to preserve audio in validation MP4 %s on rank %s: %s",
-                        fname,
-                        self.global_rank,
-                        exc,
-                    )
-                    raise
-                # Video-only validation remains useful when one optional
-                # artifact fails to encode, so the remaining files are logged.
+                # Validation media is diagnostic output, so one failed write
+                # must not terminate training or prevent later artifact writes.
                 logger.exception(
-                    "Failed to save validation video %s on rank %s; skipping artifact: %s",
+                    "Failed to save validation media %s on rank %s; skipping artifact: %s",
                     fname,
                     self.global_rank,
                     exc,

--- a/fastvideo/train/callbacks/validation.py
+++ b/fastvideo/train/callbacks/validation.py
@@ -12,11 +12,11 @@ import contextlib
 import gc
 import json
 import os
+import time
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any, TYPE_CHECKING
 
-import imageio
 import numpy as np
 import torch
 import torchvision
@@ -36,6 +36,7 @@ from fastvideo.train.callbacks.callback import Callback
 from fastvideo.train.utils.instantiate import resolve_target
 from fastvideo.train.utils.moduleloader import (
     make_inference_args, )
+from fastvideo.train.utils.validation_media import write_validation_mp4
 from fastvideo.training.trackers import DummyTracker
 from fastvideo.utils import shallow_asdict
 
@@ -47,8 +48,12 @@ logger = init_logger(__name__)
 
 @dataclass(slots=True)
 class _ValidationStepResult:
+    """Keep decoded media aligned with the prompt and conditions that produced it."""
+
     videos: list[list[np.ndarray]]
     captions: list[str]
+    audio_waveforms: list[torch.Tensor | np.ndarray | None] = field(default_factory=list)
+    audio_sample_rates: list[int | None] = field(default_factory=list)
     overlay_videos: list[list[np.ndarray]] = field(default_factory=list)
     overlay_captions: list[str] = field(default_factory=list)
     ref_videos: list[str | None] = field(default_factory=list)
@@ -66,8 +71,11 @@ class _ValidationMetricStats:
 
 @dataclass(slots=True)
 class _SavedValidationVideos:
+    """Identify verified MP4 files and their positions in the generated batch."""
+
     filenames: list[str] = field(default_factory=list)
     indices: list[int] = field(default_factory=list)
+    audio_video_count: int = 0
 
 
 @dataclass(slots=True)
@@ -124,9 +132,12 @@ class ValidationCallback(Callback):
         pipeline_target: str,
         dataset_file: str,
         every_steps: int = 100,
+        run_at_start: bool = True,
         sampling_steps: list[int] | None = None,
         guidance_scale: float | None = None,
         num_frames: int | None = None,
+        num_videos_per_prompt: int = 1,
+        use_validation_media_conditioning: bool = True,
         output_dir: str | None = None,
         sampling_timesteps: list[int] | None = None,
         overlay_actions: bool = False,
@@ -136,12 +147,23 @@ class ValidationCallback(Callback):
         attn_qat_infer: bool = False,
         **pipeline_kwargs: Any,
     ) -> None:
+        """Configure validation cadence, generation parameters, and pipeline loading.
+
+        ``run_at_start`` controls the pre-training baseline event.
+        ``use_validation_media_conditioning`` lets text-to-video recipes use
+        captions from a dataset that also contains source-media paths.
+        """
         self.pipeline_target = str(pipeline_target)
         self.dataset_file = str(dataset_file)
         self.every_steps = int(every_steps)
+        self.run_at_start = self._coerce_bool(run_at_start)
         self.sampling_steps = ([int(s) for s in sampling_steps] if sampling_steps else [40])
         self.guidance_scale = (float(guidance_scale) if guidance_scale is not None else None)
         self.num_frames = (int(num_frames) if num_frames is not None else None)
+        self.num_videos_per_prompt = int(num_videos_per_prompt)
+        if self.num_videos_per_prompt <= 0:
+            raise ValueError("callbacks.validation.num_videos_per_prompt must be positive")
+        self.use_validation_media_conditioning = self._coerce_bool(use_validation_media_conditioning)
         self.output_dir = (str(output_dir) if output_dir is not None else None)
         self.sampling_timesteps = ([int(s) for s in sampling_timesteps] if sampling_timesteps is not None else None)
         self.overlay_actions = self._coerce_bool(overlay_actions)
@@ -248,7 +270,11 @@ class ValidationCallback(Callback):
         method: TrainingMethod,
         iteration: int = 0,
     ) -> None:
+        """Run the optional step-zero baseline and each scheduled validation event."""
         if self.every_steps <= 0:
+            return
+        # Step zero measures the checkpoint before the first optimizer update.
+        if iteration == 0 and not self.run_at_start:
             return
         if iteration % self.every_steps != 0:
             return
@@ -504,6 +530,11 @@ class ValidationCallback(Callback):
         step: int,
         transformer: torch.nn.Module,
     ) -> None:
+        """Generate one event and gather sequence-parallel group outputs for logging.
+
+        Each sequence-parallel group leader saves its local media. Global rank
+        zero gathers the leaders' paths and statistics into one tracker event.
+        """
         tc = self.training_config
         was_training = bool(getattr(transformer, "training", False))
 
@@ -515,11 +546,14 @@ class ValidationCallback(Callback):
             sp = self._get_sampling_param()
 
             for num_inference_steps in self.sampling_steps:
+                validation_started_at = time.perf_counter()
                 result = self._run_validation_for_steps(
                     num_inference_steps,
                     transformer=transformer,
                 )
 
+                # Every rank participates in sequence-parallel inference, but
+                # only the group leader retains decoded media for saving.
                 if self.rank_in_sp_group != 0:
                     continue
 
@@ -533,6 +567,8 @@ class ValidationCallback(Callback):
                     step=step,
                     num_inference_steps=num_inference_steps,
                     fps=sp.fps,
+                    audio_waveforms=result.audio_waveforms,
+                    audio_sample_rates=result.audio_sample_rates,
                 )
                 local_overlay_videos = self._save_validation_videos(
                     result.overlay_videos,
@@ -581,18 +617,23 @@ class ValidationCallback(Callback):
                     all_overlay_video_filenames = list(local_overlay_video_filenames)
                     all_captions = list(local_captions)
                     all_overlay_captions = list(local_overlay_captions)
+                    all_audio_video_count = local_videos.audio_video_count
                     all_metric_stats = local_metric_stats
                     for sp_idx in range(1, num_sp_groups):
+                        # Sequence-parallel group leaders occupy the first
+                        # global rank in each contiguous group.
                         src = (sp_idx * self.sp_world_size)
                         recv_v = (self.world_group.recv_object(src=src))
                         recv_c = (self.world_group.recv_object(src=src))
                         recv_ov = (self.world_group.recv_object(src=src))
                         recv_oc = (self.world_group.recv_object(src=src))
                         recv_m = (self.world_group.recv_object(src=src))
+                        recv_audio_video_count = (self.world_group.recv_object(src=src))
                         all_video_filenames.extend(recv_v)
                         all_overlay_video_filenames.extend(recv_ov)
                         all_captions.extend(recv_c)
                         all_overlay_captions.extend(recv_oc)
+                        all_audio_video_count += int(recv_audio_video_count)
                         self._merge_metric_stats(
                             all_metric_stats,
                             recv_m,
@@ -602,12 +643,22 @@ class ValidationCallback(Callback):
                         all_metric_stats,
                         step=step,
                     )
+                    # Media and completion counts share one tracker event so
+                    # artifacts and verification data remain aligned.
                     self._log_validation_video_artifacts(
                         all_video_filenames,
                         all_captions,
                         key=f"validation_videos_{num_inference_steps}_steps",
                         step=step,
                         fps=sp.fps,
+                        scalar_metrics={
+                            f"validation/{num_inference_steps}_steps_video_count":
+                            float(len(all_video_filenames)),
+                            f"validation/{num_inference_steps}_steps_duration_sec":
+                            (time.perf_counter() - validation_started_at),
+                            f"validation/{num_inference_steps}_steps_audio_video_count":
+                            float(all_audio_video_count),
+                        },
                     )
                     if all_overlay_video_filenames:
                         self._log_validation_video_artifacts(
@@ -639,6 +690,10 @@ class ValidationCallback(Callback):
                         local_metric_stats,
                         dst=0,
                     )
+                    self.world_group.send_object(
+                        local_videos.audio_video_count,
+                        dst=0,
+                    )
         finally:
             if was_training:
                 transformer.train()
@@ -653,9 +708,29 @@ class ValidationCallback(Callback):
         num_inference_steps: int,
         fps: int,
         suffix: str = "",
+        audio_waveforms: list[torch.Tensor | np.ndarray | None] | None = None,
+        audio_sample_rates: list[int | None] | None = None,
     ) -> _SavedValidationVideos:
+        """Save aligned validation media and include every supplied waveform.
+
+        Audio-bearing outputs require a complete audio-video MP4 because a
+        silent fallback would invalidate multimodal validation. Video-only
+        outputs use best-effort logging so one failed artifact does not stop
+        training.
+        """
+        if (audio_waveforms is None) != (audio_sample_rates is None):
+            raise ValueError("Validation audio waveforms and sample rates must be provided together.")
+        if audio_waveforms is not None and len(audio_waveforms) != len(videos):
+            raise ValueError("Validation audio waveform count must match the video count.")
+        if audio_sample_rates is not None and len(audio_sample_rates) != len(videos):
+            raise ValueError("Validation audio sample-rate count must match the video count.")
+
         saved = _SavedValidationVideos()
         for i, video in enumerate(videos):
+            audio = audio_waveforms[i] if audio_waveforms is not None else None
+            audio_sample_rate = audio_sample_rates[i] if audio_sample_rates is not None else None
+            if (audio is None) != (audio_sample_rate is None):
+                raise ValueError("Each validation waveform must have one aligned sample rate.")
             fname = os.path.join(
                 output_dir,
                 f"validation_step_{step}"
@@ -663,15 +738,25 @@ class ValidationCallback(Callback):
                 f"_rank_{self.global_rank}"
                 f"_video_{i}{suffix}.mp4",
             )
-            # Validation video encoding can fail due transient ffmpeg or
-            # filesystem errors; skip the artifact so training can continue.
             try:
-                imageio.mimsave(
+                write_validation_mp4(
                     fname,
                     video,
                     fps=fps,
+                    audio=audio,
+                    audio_sample_rate=audio_sample_rate,
                 )
             except Exception as exc:
+                if audio is not None:
+                    logger.exception(
+                        "Failed to preserve audio in validation MP4 %s on rank %s: %s",
+                        fname,
+                        self.global_rank,
+                        exc,
+                    )
+                    raise
+                # Video-only validation remains useful when one optional
+                # artifact fails to encode, so the remaining files are logged.
                 logger.exception(
                     "Failed to save validation video %s on rank %s; skipping artifact: %s",
                     fname,
@@ -683,6 +768,9 @@ class ValidationCallback(Callback):
                 continue
             saved.filenames.append(fname)
             saved.indices.append(i)
+            if audio is not None:
+                # The media writer verifies requested streams before returning.
+                saved.audio_video_count += 1
         return saved
 
     @staticmethod
@@ -700,7 +788,9 @@ class ValidationCallback(Callback):
         key: str,
         step: int,
         fps: int,
+        scalar_metrics: dict[str, float] | None = None,
     ) -> None:
+        """Log validation media and its scalar verification data at one step."""
         video_logs = []
         for fname, cap in zip(
                 video_filenames,
@@ -715,8 +805,11 @@ class ValidationCallback(Callback):
             if art is not None:
                 video_logs.append(art)
         if video_logs:
+            artifacts: dict[str, Any] = {key: video_logs}
+            if scalar_metrics:
+                artifacts.update(scalar_metrics)
             self.tracker.log_artifacts(
-                {key: video_logs},
+                artifacts,
                 step,
             )
 
@@ -1191,7 +1284,9 @@ class ValidationCallback(Callback):
             kwargs["flow_shift"] = float(flow_shift)
         kwargs.update(self.pipeline_kwargs)
 
-        self._pipeline = PipelineCls.from_pretrained(
+        # The pipeline class comes from a YAML target, so static analysis cannot
+        # infer the dynamically resolved ``from_pretrained`` class method.
+        self._pipeline = PipelineCls.from_pretrained(  # type: ignore[attr-defined]
             self._pipeline_model_path(),
             **kwargs,
         )
@@ -1224,6 +1319,7 @@ class ValidationCallback(Callback):
         validation_batch: dict[str, Any],
         num_inference_steps: int,
     ) -> ForwardBatch:
+        """Build a pipeline batch with the recipe's output and conditioning policy."""
         tc = self.training_config
 
         sampling_param.prompt = validation_batch["prompt"]
@@ -1234,11 +1330,18 @@ class ValidationCallback(Callback):
         if self.guidance_scale is not None:
             sampling_param.guidance_scale = float(self.guidance_scale)
         sampling_param.seed = self.seed
+        # Output multiplicity belongs in SamplingParam so pipeline stages
+        # allocate the same batch dimension that validation expects to log.
+        sampling_param.num_videos_per_prompt = self.num_videos_per_prompt
 
-        # image_path for I2V pipelines.
-        img_path = (validation_batch.get("image_path") or validation_batch.get("video_path"))
-        if img_path is not None and (img_path.startswith("http") or os.path.isfile(img_path)):
-            sampling_param.image_path = img_path
+        # SamplingParam is cached across records; clearing the path prevents a
+        # prior record's image or video from conditioning a later prompt.
+        sampling_param.image_path = None
+        if self.use_validation_media_conditioning:
+            # Image-to-video pipelines use an image or the first frame of a validation video.
+            img_path = (validation_batch.get("image_path") or validation_batch.get("video_path"))
+            if img_path is not None and (img_path.startswith("http") or os.path.isfile(img_path)):
+                sampling_param.image_path = img_path
 
         temporal_compression_factor = int(
             tc.pipeline_config.vae_config.arch_config.temporal_compression_ratio  # type: ignore[union-attr]
@@ -1265,6 +1368,9 @@ class ValidationCallback(Callback):
             tc,
             model_path=tc.model_path,
         )
+        # Validation reuses Fully Sharded Data Parallel (FSDP) transformer
+        # shards, which remain on their training devices.
+        inference_args.dit_cpu_offload = False
 
         batch = ForwardBatch(
             **shallow_asdict(sampling_param),
@@ -1340,6 +1446,13 @@ class ValidationCallback(Callback):
         *,
         transformer: torch.nn.Module,
     ) -> _ValidationStepResult:
+        """Generate the prompts assigned to one sequence-parallel group.
+
+        ``ValidationDataset`` pads the prompt count to the data-parallel degree
+        and assigns an equal prompt shard to each sequence-parallel group. All
+        ranks in a group execute each forward pass; the group leader retains
+        decoded media.
+        """
         tc = self.training_config
         pipeline = self._get_pipeline(transformer=transformer, )
         sampling_param = self._get_sampling_param()
@@ -1355,6 +1468,9 @@ class ValidationCallback(Callback):
             tc,
             model_path=tc.model_path,
         )
+        # Pipeline.forward consumes these inference arguments directly. FSDP
+        # keeps the shared training transformer on its managed CUDA devices.
+        inference_args.dit_cpu_offload = False
         self._sync_runtime_dit_arch_config(
             inference_args.pipeline_config,
             transformer,
@@ -1370,6 +1486,8 @@ class ValidationCallback(Callback):
             inference_args.pipeline_config.dmd_denoising_steps = ([int(s) for s in self.sampling_timesteps])
 
         videos: list[list[np.ndarray]] = []
+        audio_waveforms: list[torch.Tensor | np.ndarray | None] = []
+        audio_sample_rates: list[int | None] = []
         overlay_videos: list[list[np.ndarray]] = []
         captions: list[str] = []
         overlay_captions: list[str] = []
@@ -1385,12 +1503,8 @@ class ValidationCallback(Callback):
             )
 
             assert (batch.prompt is not None and isinstance(batch.prompt, str))
-            captions.append(batch.prompt)
             ref_video = validation_batch.get("ref_video")
-            ref_videos.append(ref_video if isinstance(ref_video, str) else None)
             action = self._validation_actions(validation_batch)
-            actions.append(action)
-            mouse_pitch_signs.append(self._validation_mouse_pitch_sign(validation_batch))
 
             with torch.no_grad():
                 output_batch = pipeline.forward(
@@ -1401,6 +1515,21 @@ class ValidationCallback(Callback):
             samples = output_batch.output.cpu()
             if self.rank_in_sp_group != 0:
                 continue
+
+            # Append metadata only on the group leader so every list position
+            # describes the same decoded video throughout save and logging.
+            output_audio = output_batch.extra.get("audio")
+            output_audio_sample_rate = output_batch.extra.get("audio_sample_rate")
+            if (output_audio is None) != (output_audio_sample_rate is None):
+                raise ValueError("Validation pipeline outputs must provide audio and its sample rate together.")
+            if output_audio is not None and not isinstance(output_audio,
+                                                           np.ndarray) and not torch.is_tensor(output_audio):
+                raise TypeError("Validation pipeline audio must be a torch.Tensor or numpy.ndarray; "
+                                f"got {type(output_audio).__name__}.")
+            if torch.is_tensor(output_audio):
+                # The returned validation result stays on CPU so MP4 encoding
+                # does not retain a generation tensor on the GPU.
+                output_audio = output_audio.detach().cpu()
 
             video = rearrange(
                 samples,
@@ -1415,6 +1544,12 @@ class ValidationCallback(Callback):
                 x = (x.transpose(0, 1).transpose(1, 2).squeeze(-1))
                 frames.append((x * 255).numpy().astype(np.uint8))
             videos.append(frames)
+            captions.append(batch.prompt)
+            audio_waveforms.append(output_audio)
+            audio_sample_rates.append(int(output_audio_sample_rate) if output_audio_sample_rate is not None else None)
+            ref_videos.append(ref_video if isinstance(ref_video, str) else None)
+            actions.append(action)
+            mouse_pitch_signs.append(self._validation_mouse_pitch_sign(validation_batch))
             if self.overlay_actions:
                 overlay_frames = self._post_process_validation_frames(
                     frames,
@@ -1427,6 +1562,8 @@ class ValidationCallback(Callback):
         return _ValidationStepResult(
             videos=videos,
             captions=captions,
+            audio_waveforms=audio_waveforms,
+            audio_sample_rates=audio_sample_rates,
             overlay_videos=overlay_videos,
             overlay_captions=overlay_captions,
             ref_videos=ref_videos,

--- a/fastvideo/train/callbacks/validation.py
+++ b/fastvideo/train/callbacks/validation.py
@@ -1359,9 +1359,6 @@ class ValidationCallback(Callback):
             tc,
             model_path=tc.model_path,
         )
-        # Validation reuses Fully Sharded Data Parallel (FSDP) transformer
-        # shards, which remain on their training devices.
-        inference_args.dit_cpu_offload = False
 
         batch = ForwardBatch(
             **shallow_asdict(sampling_param),
@@ -1459,9 +1456,6 @@ class ValidationCallback(Callback):
             tc,
             model_path=tc.model_path,
         )
-        # Pipeline.forward consumes these inference arguments directly. FSDP
-        # keeps the shared training transformer on its managed CUDA devices.
-        inference_args.dit_cpu_offload = False
         self._sync_runtime_dit_arch_config(
             inference_args.pipeline_config,
             transformer,

--- a/fastvideo/train/methods/fine_tuning/finetune.py
+++ b/fastvideo/train/methods/fine_tuning/finetune.py
@@ -9,9 +9,79 @@ import torch
 import torch.nn.functional as F
 
 from fastvideo.train.methods.base import TrainingMethod, LogScalar
-from fastvideo.train.models.base import ModelBase
+from fastvideo.train.models.base import ModelBase, NoisePrediction
 from fastvideo.train.utils.optimizer import (
     build_optimizer_and_scheduler, )
+
+
+def _compute_finetune_loss_map(
+    prediction: NoisePrediction,
+    clean_video_latents: torch.Tensor,
+    noisy_video_latents: torch.Tensor,
+    video_noise: torch.Tensor,
+    video_sigmas: torch.Tensor,
+    training_batch: Any,
+    *,
+    precondition_outputs: bool,
+) -> dict[str, torch.Tensor]:
+    """Compute supervised flow-matching losses for one or two modalities.
+
+    A tensor prediction follows the video-only model contract. An ordered
+    ``(video, audio)`` prediction uses each modality's independently shifted
+    noise level and sums both mean-squared errors so one backward pass trains
+    both output branches.
+    """
+    if isinstance(prediction, torch.Tensor):
+        if precondition_outputs:
+            predicted_clean_video = noisy_video_latents - prediction * video_sigmas
+            loss = F.mse_loss(predicted_clean_video.float(), clean_video_latents.float())
+        else:
+            video_target = video_noise - clean_video_latents
+            loss = F.mse_loss(prediction.float(), video_target.float())
+        return {
+            "total_loss": loss,
+            "finetune_loss": loss,
+        }
+
+    if len(prediction) != 2:
+        raise ValueError("A multimodal prediction must contain video and audio tensors")
+    video_prediction, audio_prediction = prediction
+    required_audio_tensors = {
+        "audio_latents": training_batch.audio_latents,
+        "audio_noisy_model_input": training_batch.audio_noisy_model_input,
+        "audio_noise": training_batch.audio_noise,
+        "audio_sigmas": training_batch.audio_sigmas,
+    }
+    missing = [name for name, value in required_audio_tensors.items() if value is None]
+    if missing:
+        raise RuntimeError("prepare_batch() must set " + ", ".join(f"TrainingBatch.{name}" for name in missing))
+
+    clean_audio_latents = required_audio_tensors["audio_latents"]
+    noisy_audio_latents = required_audio_tensors["audio_noisy_model_input"]
+    audio_noise = required_audio_tensors["audio_noise"]
+    audio_sigmas = required_audio_tensors["audio_sigmas"]
+    assert isinstance(clean_audio_latents, torch.Tensor)
+    assert isinstance(noisy_audio_latents, torch.Tensor)
+    assert isinstance(audio_noise, torch.Tensor)
+    assert isinstance(audio_sigmas, torch.Tensor)
+
+    if precondition_outputs:
+        predicted_clean_video = noisy_video_latents - video_prediction * video_sigmas
+        predicted_clean_audio = noisy_audio_latents - audio_prediction * audio_sigmas
+        video_loss = F.mse_loss(predicted_clean_video.float(), clean_video_latents.float())
+        audio_loss = F.mse_loss(predicted_clean_audio.float(), clean_audio_latents.float())
+    else:
+        video_target = video_noise - clean_video_latents
+        audio_target = audio_noise - clean_audio_latents
+        video_loss = F.mse_loss(video_prediction.float(), video_target.float())
+        audio_loss = F.mse_loss(audio_prediction.float(), audio_target.float())
+    total_loss = video_loss + audio_loss
+    return {
+        "total_loss": total_loss,
+        "finetune_loss": total_loss,
+        "video_finetune_loss": video_loss,
+        "audio_finetune_loss": audio_loss,
+    }
 
 
 class FineTuneMethod(TrainingMethod):
@@ -55,6 +125,11 @@ class FineTuneMethod(TrainingMethod):
             dict[str, Any],
             dict[str, LogScalar],
     ]:
+        """Prepare synchronized targets and compute supervised flow loss.
+
+        The returned forward context lets model-specific backward methods
+        restore activation-checkpoint metadata during recomputation.
+        """
         del iteration
         training_batch = self.student.prepare_batch(
             batch,
@@ -92,19 +167,18 @@ class FineTuneMethod(TrainingMethod):
             attn_kind=self._attn_kind,
         )
 
-        if bool(self.training_config.model.precondition_outputs):
-            pred_x0 = noisy_latents - pred * sigmas
-            loss = F.mse_loss(pred_x0.float(), clean_latents.float())
-        else:
-            target = noise - clean_latents
-            loss = F.mse_loss(pred.float(), target.float())
+        loss_map = _compute_finetune_loss_map(
+            pred,
+            clean_latents,
+            noisy_latents,
+            noise,
+            sigmas,
+            training_batch,
+            precondition_outputs=bool(self.training_config.model.precondition_outputs),
+        )
 
         attn_metadata = training_batch.attn_metadata_vsa if self._attn_kind == "vsa" else training_batch.attn_metadata
 
-        loss_map = {
-            "total_loss": loss,
-            "finetune_loss": loss,
-        }
         outputs: dict[str, Any] = {
             "_fv_backward": (
                 training_batch.timesteps,
@@ -122,6 +196,11 @@ class FineTuneMethod(TrainingMethod):
         *,
         grad_accum_rounds: int = 1,
     ) -> None:
+        """Backpropagate an accumulation-scaled loss through the student model.
+
+        Delegating to ``ModelBase.backward`` lets each model restore its forward
+        context before the distributed wrapper synchronizes parameter gradients.
+        """
         grad_accum_rounds = max(1, int(grad_accum_rounds))
         ctx = outputs.get("_fv_backward")
         if ctx is None:

--- a/fastvideo/train/models/base.py
+++ b/fastvideo/train/models/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, Literal, TYPE_CHECKING, TypeAlias
 
 import torch
 
@@ -17,6 +17,10 @@ if TYPE_CHECKING:
         TrainingConfig, )
     from fastvideo.train.utils.lora import LoraConfig
     from fastvideo.pipelines import TrainingBatch
+
+# Video models return one flow tensor. Joint video/audio models return an
+# ordered pair so training methods can apply each modality's scheduler target.
+NoisePrediction: TypeAlias = torch.Tensor | tuple[torch.Tensor, torch.Tensor]
 
 
 class ModelBase(ABC):
@@ -159,8 +163,8 @@ class ModelBase(ABC):
         conditional: bool,
         cfg_uncond: dict[str, Any] | None = None,
         attn_kind: Literal["dense", "vsa"] = "dense",
-    ) -> torch.Tensor:
-        """Predict noise/flow for the given noisy latents."""
+    ) -> NoisePrediction:
+        """Predict video flow or an ordered ``(video, audio)`` flow pair."""
 
     def predict_x0(
         self,
@@ -172,7 +176,12 @@ class ModelBase(ABC):
         cfg_uncond: dict[str, Any] | None = None,
         attn_kind: Literal["dense", "vsa"] = "dense",
     ) -> torch.Tensor:
-        """Predict x0 via ``predict_noise`` + conversion."""
+        """Convert a video-only flow prediction to clean video latents.
+
+        This helper owns one noisy video tensor and one video scheduler. Joint
+        video/audio callers apply their modality-specific conversions where
+        both noisy tensors and both schedulers are available.
+        """
         pred_noise = self.predict_noise(
             noisy_latents,
             timestep,
@@ -181,6 +190,8 @@ class ModelBase(ABC):
             cfg_uncond=cfg_uncond,
             attn_kind=attn_kind,
         )
+        if isinstance(pred_noise, tuple):
+            raise TypeError("predict_x0 requires one video prediction tensor")
         return pred_noise_to_pred_video(
             pred_noise=pred_noise.flatten(0, 1),
             noise_input_latent=noisy_latents.flatten(0, 1),

--- a/fastvideo/train/models/minimax_h3/__init__.py
+++ b/fastvideo/train/models/minimax_h3/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Expose the MiniMax H3 plugin for YAML ``_target_`` resolution."""
+
+from fastvideo.train.models.minimax_h3.minimax_h3 import (
+    MiniMaxH3Model as MiniMaxH3Model, )

--- a/fastvideo/train/models/minimax_h3/minimax_h3.py
+++ b/fastvideo/train/models/minimax_h3/minimax_h3.py
@@ -1,0 +1,400 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiniMax H3 joint text-to-video-and-audio training plugin."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TYPE_CHECKING
+
+import torch
+
+from fastvideo.distributed import get_sp_group
+from fastvideo.forward_context import set_forward_context
+from fastvideo.models.schedulers.scheduling_minimax_h3 import MiniMaxH3Scheduler
+from fastvideo.pipelines import TrainingBatch
+from fastvideo.pipelines.basic.minimax_h3.packing import (
+    MINIMAX_H3_AUDIO_CHANNELS,
+    MINIMAX_H3_TEXT_TAG,
+    MiniMaxH3PackedLayout,
+    audio_latent_num_frames,
+    build_packed_sequence,
+    build_row_timesteps,
+    patchify_video_latents,
+    unpack_audio_tokens,
+    unpatchify_video_tokens,
+)
+from fastvideo.platforms import AttentionBackendEnum
+
+from fastvideo.train.models.base import ModelBase, NoisePrediction
+from fastvideo.train.utils.activation_checkpoint import apply_activation_checkpointing
+from fastvideo.train.utils.module_state import apply_trainable
+from fastvideo.train.utils.moduleloader import load_module_from_path
+
+if TYPE_CHECKING:
+    from fastvideo.train.utils.training_config import TrainingConfig
+
+# H3 maps one shared denoising stage through modality-specific scheduler
+# shifts so video and audio remain synchronized at different noise amounts.
+_VIDEO_SCHEDULER_SHIFT = 12.0
+_AUDIO_SCHEDULER_SHIFT = 3.0
+_VIDEO_LATENT_CHANNELS = 24
+_AUDIO_LATENT_CHANNELS = 32
+
+
+def shift_noise_amount(base_noise_amount: torch.Tensor, shift: float) -> torch.Tensor:
+    """Apply the MiniMax H3 rational shift to a unit noise amount."""
+    if shift <= 0:
+        raise ValueError(f"shift must be positive, got {shift}")
+    return shift * base_noise_amount / (1.0 + (shift - 1.0) * base_noise_amount)
+
+
+class MiniMaxH3Model(ModelBase):
+    """Adapt the H3 joint transformer to the modular fine-tuning contract."""
+
+    _transformer_cls_name = "MiniMaxH3Transformer3DModel"
+
+    def __init__(
+        self,
+        *,
+        init_from: str,
+        training_config: TrainingConfig,
+        trainable: bool = True,
+        disable_custom_init_weights: bool = False,
+        enable_gradient_checkpointing_type: str | None = None,
+        transformer_override_safetensor: str | None = None,
+        attention_backend: AttentionBackendEnum | str | None = AttentionBackendEnum.TORCH_SDPA,
+    ) -> None:
+        """Validate the single-document T2VA contract and load the transformer."""
+        super().__init__(
+            trainable=trainable,
+            attention_backend=attention_backend,
+        )
+        # PyTorch scaled dot product attention (SDPA) provides dense attention
+        # without adding another attention-kernel dependency to H3 training.
+        if self.attention_backend != AttentionBackendEnum.TORCH_SDPA:
+            raise ValueError("MiniMaxH3Model requires the TORCH_SDPA attention backend")
+        if training_config.pipeline_config is None:
+            raise ValueError("MiniMaxH3Model requires a resolved MiniMax H3 pipeline config")
+        # Packed row indices describe one text-video-audio document without a
+        # batch offset, so each data-parallel replica consumes one sample.
+        if int(training_config.data.train_batch_size) != 1:
+            raise ValueError("MiniMaxH3Model requires training.data.train_batch_size=1")
+        # Classifier-free guidance (CFG) dropout replaces text embeddings with
+        # zeros, but H3 training does not define a zero-vector branch.
+        if float(training_config.data.training_cfg_rate) != 0.0:
+            raise ValueError("MiniMaxH3Model requires training.data.training_cfg_rate=0.0")
+        # Joint supervision requires paired video and stereo-audio latents from
+        # every parquet row.
+        if str(training_config.data.preprocessed_data_type) != "t2va":
+            raise ValueError("MiniMaxH3Model requires training.data.preprocessed_data_type='t2va'")
+
+        # FastVideo's Fully Sharded Data Parallel loading path requires one BF16
+        # parameter dtype, including modules that H3 inference keeps in FP32.
+        training_config.pipeline_config.dit_config.uniform_parameter_dtype = True  # type: ignore[attr-defined]
+
+        self._init_from = str(init_from)
+        self.training_config = training_config
+        self.transformer = self._load_transformer(
+            trainable=trainable,
+            disable_custom_init_weights=disable_custom_init_weights,
+            enable_gradient_checkpointing_type=enable_gradient_checkpointing_type,
+            transformer_override_safetensor=transformer_override_safetensor,
+        )
+        self.noise_scheduler = MiniMaxH3Scheduler(shift=_VIDEO_SCHEDULER_SHIFT)
+        self.audio_noise_scheduler = MiniMaxH3Scheduler(shift=_AUDIO_SCHEDULER_SHIFT)
+        self.dataloader: Any = None
+        self.validator: Any = None
+        self.start_step = 0
+        self.sp_group: Any = None
+
+    def _load_transformer(
+        self,
+        *,
+        trainable: bool,
+        disable_custom_init_weights: bool,
+        enable_gradient_checkpointing_type: str | None,
+        transformer_override_safetensor: str | None,
+    ) -> torch.nn.Module:
+        """Load H3 through the training FSDP loader and apply block checkpointing."""
+        transformer = load_module_from_path(
+            model_path=self._init_from,
+            module_type="transformer",
+            training_config=self.training_config,
+            disable_custom_init_weights=disable_custom_init_weights,
+            override_transformer_cls_name=self._transformer_cls_name,
+            transformer_override_safetensor=transformer_override_safetensor,
+            attention_backend=self.attention_backend,
+        )
+        checkpointing_type = (enable_gradient_checkpointing_type
+                              or self.training_config.model.enable_gradient_checkpointing_type)
+        if trainable and checkpointing_type:
+            transformer = apply_activation_checkpointing(
+                transformer,
+                checkpointing_type=checkpointing_type,
+            )
+        return apply_trainable(transformer, trainable=trainable)
+
+    def init_preprocessors(self, training_config: TrainingConfig) -> None:
+        """Load precomputed text embeddings and paired video-audio latents."""
+        from fastvideo.dataset.dataloader.schema import pyarrow_schema_t2va
+        from fastvideo.train.utils.dataloader import build_parquet_t2v_train_dataloader
+
+        self.sp_group = get_sp_group()
+        text_config = training_config.pipeline_config.text_encoder_configs[0]  # type: ignore[union-attr]
+        self.dataloader = build_parquet_t2v_train_dataloader(
+            training_config.data,
+            text_len=int(text_config.arch_config.text_len),
+            parquet_schema=pyarrow_schema_t2va,
+        )
+        self.start_step = 0
+
+    def _resolve_clean_latents(
+        self,
+        raw_batch: dict[str, Any],
+        latents_source: Literal["data", "zeros"],
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Resolve fixed visual and stereo-audio latent tensors for one sample."""
+        data_config = self.training_config.data
+        if latents_source == "data":
+            if "vae_latent" not in raw_batch or "audio_latent" not in raw_batch:
+                raise ValueError("A T2VA batch requires vae_latent and audio_latent tensors")
+            video_latents = raw_batch["vae_latent"]
+            audio_latents = raw_batch["audio_latent"]
+        elif latents_source == "zeros":
+            video_latents = torch.zeros(
+                1,
+                _VIDEO_LATENT_CHANNELS,
+                data_config.num_latent_t,
+                data_config.num_height // 16,
+                data_config.num_width // 16,
+            )
+            audio_latents = torch.zeros(
+                1,
+                MINIMAX_H3_AUDIO_CHANNELS,
+                _AUDIO_LATENT_CHANNELS,
+                audio_latent_num_frames(data_config.num_frames),
+            )
+        else:
+            raise ValueError(f"Unknown latents_source: {latents_source!r}")
+
+        if video_latents.ndim != 5 or tuple(video_latents.shape[:2]) != (1, _VIDEO_LATENT_CHANNELS):
+            raise ValueError("vae_latent must have shape [1, 24, latent_frames, latent_height, latent_width], "
+                             f"got {tuple(video_latents.shape)}")
+        if audio_latents.ndim != 4 or tuple(audio_latents.shape[:3]) != (
+                1,
+                MINIMAX_H3_AUDIO_CHANNELS,
+                _AUDIO_LATENT_CHANNELS,
+        ):
+            raise ValueError("audio_latent must have shape [1, 2, 32, audio_frames], "
+                             f"got {tuple(audio_latents.shape)}")
+        if data_config.num_latent_t > 0:
+            video_latents = video_latents[:, :, :data_config.num_latent_t]
+        expected_audio_frames = audio_latent_num_frames(data_config.num_frames)
+        audio_latents = audio_latents[:, :, :, :expected_audio_frames]
+        if video_latents.shape[2] != data_config.num_latent_t:
+            raise ValueError("vae_latent contains fewer frames than training.data.num_latent_t")
+        if audio_latents.shape[-1] != expected_audio_frames:
+            raise ValueError("audio_latent length does not match training.data.num_frames")
+        return (
+            video_latents.to(device=device, dtype=dtype),
+            audio_latents.to(device=device, dtype=dtype),
+        )
+
+    def _sample_noise_amounts(
+        self,
+        generator: torch.Generator,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Sample one shared denoising stage and apply both modality shifts."""
+        base_noise_amount = torch.rand(
+            (1, ),
+            generator=generator,
+            device=device,
+            dtype=torch.float32,
+        )
+        if int(self.training_config.distributed.sp_size) > 1:
+            # Sequence-parallel ranks shard one document and therefore require
+            # identical video and audio noise amounts for that document.
+            self.sp_group.broadcast(base_noise_amount, src=0)
+        return (
+            shift_noise_amount(base_noise_amount, _VIDEO_SCHEDULER_SHIFT),
+            shift_noise_amount(base_noise_amount, _AUDIO_SCHEDULER_SHIFT),
+        )
+
+    def prepare_batch(
+        self,
+        raw_batch: dict[str, Any],
+        *,
+        generator: torch.Generator,
+        latents_source: Literal["data", "zeros"] = "data",
+    ) -> TrainingBatch:
+        """Prepare normalized T2VA latents, shifted noise, text, and row layout."""
+        dtype = torch.bfloat16
+        device = self.device
+        text_embedding = raw_batch["text_embedding"]
+        text_attention_mask = raw_batch["text_attention_mask"]
+        if text_embedding.ndim != 3 or text_embedding.shape[0] != 1 or text_embedding.shape[-1] != 5120:
+            raise ValueError(f"text_embedding must have shape [1, length, 5120], got {tuple(text_embedding.shape)}")
+        if text_attention_mask.shape != text_embedding.shape[:2]:
+            raise ValueError("text_attention_mask must match the text embedding sequence axes")
+        valid_text = text_attention_mask[0].to(torch.bool)
+        if not bool(valid_text.any()):
+            raise ValueError("A T2VA batch requires at least one text token")
+
+        video_latents, audio_latents = self._resolve_clean_latents(
+            raw_batch,
+            latents_source,
+            dtype,
+            device,
+        )
+        video_noise = torch.randn(video_latents.shape, generator=generator, device=device, dtype=dtype)
+        audio_noise = torch.randn(audio_latents.shape, generator=generator, device=device, dtype=dtype)
+        video_noise_amount, audio_noise_amount = self._sample_noise_amounts(generator, device)
+        video_sigmas = video_noise_amount.to(dtype).view(1, 1, 1, 1, 1)
+        audio_sigmas = audio_noise_amount.to(dtype).view(1, 1, 1, 1)
+        noisy_video_latents = (1.0 - video_sigmas) * video_latents + video_sigmas * video_noise
+        noisy_audio_latents = (1.0 - audio_sigmas) * audio_latents + audio_sigmas * audio_noise
+
+        _, _, video_frames, latent_height, latent_width = video_latents.shape
+        num_audio_latents = audio_latents.shape[-1]
+        text_token_tags = torch.full((int(valid_text.sum()), ), MINIMAX_H3_TEXT_TAG, dtype=torch.long)
+        # H3 self-attention consumes one interleaved document, so the layout
+        # owns the row tags, positions, and modality output indices together.
+        layout = build_packed_sequence(
+            text_token_tags,
+            video_frames,
+            latent_height,
+            latent_width,
+            num_audio_latents,
+            self.transformer.patch_size,
+        )
+
+        training_batch = TrainingBatch()
+        training_batch.latents = video_latents.permute(0, 2, 1, 3, 4)
+        training_batch.audio_latents = audio_latents
+        training_batch.encoder_hidden_states = text_embedding[:, valid_text].to(device=device, dtype=dtype)
+        training_batch.encoder_attention_mask = torch.ones(
+            (1, int(valid_text.sum())),
+            device=device,
+            dtype=dtype,
+        )
+        training_batch.infos = raw_batch.get("info_list")
+        training_batch.raw_latent_shape = tuple(video_latents.shape)
+        training_batch.noisy_model_input = noisy_video_latents
+        training_batch.audio_noisy_model_input = noisy_audio_latents
+        training_batch.noise = video_noise
+        training_batch.audio_noise = audio_noise
+        training_batch.sigmas = video_sigmas
+        training_batch.audio_sigmas = audio_sigmas
+        # ModelBase exposes clean-time timesteps while the loss consumes the
+        # complementary noise amounts stored in the sigma fields.
+        training_batch.timesteps = 1.0 - video_noise_amount
+        training_batch.audio_timesteps = 1.0 - audio_noise_amount
+        training_batch.minimax_h3_layout = layout
+        training_batch.attn_metadata = None
+        training_batch.attn_metadata_vsa = None
+        return training_batch
+
+    def add_noise(
+        self,
+        clean_latents: torch.Tensor,
+        noise: torch.Tensor,
+        timestep: torch.Tensor,
+    ) -> torch.Tensor:
+        """Mix clean and noise tensors using H3's clean-time convention."""
+        clean_time = timestep.to(device=clean_latents.device, dtype=clean_latents.dtype)
+        while clean_time.ndim < clean_latents.ndim:
+            clean_time = clean_time.unsqueeze(-1)
+        return clean_time * clean_latents + (1.0 - clean_time) * noise
+
+    def predict_noise(
+        self,
+        noisy_latents: torch.Tensor,
+        timestep: torch.Tensor,
+        batch: TrainingBatch,
+        *,
+        conditional: bool,
+        cfg_uncond: dict[str, Any] | None = None,
+        attn_kind: Literal["dense", "vsa"] = "dense",
+    ) -> NoisePrediction:
+        """Pack modality timesteps and convert H3 outputs to noise-minus-clean."""
+        del timestep
+        if not conditional or cfg_uncond is not None:
+            raise ValueError("MiniMaxH3Model predicts one conditional T2VA sample")
+        if attn_kind != "dense":
+            raise ValueError("MiniMaxH3Model supports dense attention for training")
+        layout = batch.minimax_h3_layout
+        if not isinstance(layout, MiniMaxH3PackedLayout):
+            raise RuntimeError("prepare_batch() must set TrainingBatch.minimax_h3_layout")
+        if batch.audio_noisy_model_input is None or batch.encoder_hidden_states is None:
+            raise RuntimeError("prepare_batch() must set audio and text transformer inputs")
+        if batch.timesteps is None or batch.audio_timesteps is None:
+            raise RuntimeError("prepare_batch() must set video and audio timesteps")
+
+        dtype = torch.bfloat16
+        device = self.device
+        video_bcthw = noisy_latents.permute(0, 2, 1, 3, 4).to(dtype)
+        # Match H3 checkpoint token order: video rows flatten
+        # (C, patch_t, patch_h, patch_w), while audio rows flatten stereo
+        # channel, time, and latent feature dimensions in that order.
+        video_rows = patchify_video_latents(video_bcthw, self.transformer.patch_size)
+        audio_latents = batch.audio_noisy_model_input.to(dtype)
+        num_audio_latents = audio_latents.shape[-1]
+        audio_rows = audio_latents.permute(0, 1, 3, 2).reshape(-1, _AUDIO_LATENT_CHANNELS)
+        unique_timesteps, timestep_indices = build_row_timesteps(
+            layout,
+            video_timestep=float(batch.timesteps[0]),
+            audio_timestep=float(batch.audio_timesteps[0]),
+            condition_video_timestep=float(batch.timesteps[0]),
+            condition_audio_timestep=float(batch.audio_timesteps[0]),
+        )
+        unique_timesteps = unique_timesteps.to(device)
+        timestep_indices = timestep_indices.to(device)
+
+        with torch.autocast(device.type, dtype=dtype), set_forward_context(
+                current_timestep=unique_timesteps,
+                attn_metadata=None,
+        ):
+            video_velocity, audio_velocity = self.transformer(
+                hidden_states=video_rows[None],
+                audio_hidden_states=audio_rows[None],
+                encoder_hidden_states=batch.encoder_hidden_states,
+                timestep=unique_timesteps,
+                timestep_indices=timestep_indices,
+                token_tags=layout.token_tags.to(device),
+                position_ids=layout.position_ids.to(device),
+                video_indices=layout.video_indices.to(device),
+                audio_indices=layout.audio_indices.to(device),
+                text_indices=layout.text_indices.to(device),
+            )
+
+        _, _, num_video_latents, latent_height, latent_width = video_bcthw.shape
+        video_prediction = unpatchify_video_tokens(
+            video_velocity,
+            num_video_latents,
+            latent_height,
+            latent_width,
+            _VIDEO_LATENT_CHANNELS,
+            self.transformer.patch_size,
+        ).permute(0, 2, 1, 3, 4)
+        audio_prediction = unpack_audio_tokens(audio_velocity[0], num_audio_latents)[None]
+        return -video_prediction, -audio_prediction
+
+    def backward(
+        self,
+        loss: torch.Tensor,
+        ctx: Any,
+        *,
+        grad_accum_rounds: int,
+    ) -> None:
+        """Restore the forward context and average accumulated microbatch gradients."""
+        timesteps, attn_metadata = ctx
+        with set_forward_context(
+                current_timestep=timesteps,
+                attn_metadata=attn_metadata,
+        ):
+            (loss / max(1, int(grad_accum_rounds))).backward()
+
+
+__all__ = ["MiniMaxH3Model", "shift_noise_amount"]

--- a/fastvideo/train/utils/activation_checkpoint.py
+++ b/fastvideo/train/utils/activation_checkpoint.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Activation checkpointing policies for the modular training framework.
+
+The modular trainer owns these policies under ``fastvideo.train``, which keeps
+model plugins within one training package.
+"""
+
+import collections
+from enum import Enum
+from typing import Any
+
+import torch
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper
+
+# Model families expose transformer layers under these stable attributes. The
+# shared policy discovers them without importing each model implementation.
+_TRANSFORMER_BLOCK_NAMES = [
+    "blocks",
+    "double_blocks",
+    "single_blocks",
+    "transformer_blocks",
+    "temporal_transformer_blocks",
+    "transformer_double_blocks",
+    "transformer_single_blocks",
+    "text_transformer_blocks",
+    "visual_transformer_blocks",
+]
+
+
+class CheckpointType(str, Enum):
+    """Supported activation checkpointing policies."""
+
+    FULL = "full"
+    OPS = "ops"
+    BLOCK_SKIP = "block_skip"
+
+
+_SELECTIVE_ACTIVATION_CHECKPOINTING_OPS = {
+    torch.ops.aten.mm.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+    torch.ops._c10d_functional.reduce_scatter_tensor.default,
+}
+
+
+def apply_activation_checkpointing(
+    module: torch.nn.Module,
+    checkpointing_type: str = CheckpointType.FULL,
+    n_layer: int = 1,
+) -> torch.nn.Module:
+    """Apply the selected activation checkpointing policy to a module."""
+    if checkpointing_type == CheckpointType.FULL:
+        module = _apply_activation_checkpointing_blocks(module)
+    elif checkpointing_type == CheckpointType.OPS:
+        module = _apply_activation_checkpointing_ops(
+            module,
+            _SELECTIVE_ACTIVATION_CHECKPOINTING_OPS,
+        )
+    elif checkpointing_type == CheckpointType.BLOCK_SKIP:
+        module = _apply_activation_checkpointing_blocks(module, n_layer)
+    else:
+        raise ValueError(f"Checkpointing type '{checkpointing_type}' not supported. "
+                         f"Supported types are {CheckpointType.__members__.keys()}")
+    return module
+
+
+def _apply_activation_checkpointing_blocks(
+    module: torch.nn.Module,
+    n_layer: int | None = None,
+) -> torch.nn.Module:
+    """Checkpoint every block or every nth block when ``n_layer`` is set."""
+    applied = False
+    for transformer_block_name in _TRANSFORMER_BLOCK_NAMES:
+        blocks: torch.nn.Module | None = getattr(module, transformer_block_name, None)
+        if blocks is None:
+            continue
+        for index, (layer_id, block) in enumerate(blocks.named_children()):
+            if n_layer is None or index % n_layer == 0:
+                # The wrapped transformer blocks contain no stochastic masks
+                # that must replay during recomputation.
+                checkpointed_block = checkpoint_wrapper(block, preserve_rng_state=False)
+                blocks.register_module(layer_id, checkpointed_block)
+        applied = True
+    if not applied:
+        raise ValueError("Activation checkpointing is not applied successfully")
+    return module
+
+
+def _apply_activation_checkpointing_ops(
+    module: torch.nn.Module,
+    ops: set[Any],
+) -> torch.nn.Module:
+    """Checkpoint a module while retaining selected operation outputs."""
+    from torch.utils.checkpoint import CheckpointPolicy, create_selective_checkpoint_contexts
+
+    def _get_custom_policy(meta: dict[str, int]):
+        """Build a policy that alternates matrix-multiply output retention."""
+
+        def _custom_policy(ctx, func, *args, **kwargs):
+            """Retain selected expensive operations during recomputation."""
+            mode = "recompute" if ctx.is_recompute else "forward"
+            mm_count_key = f"{mode}_mm_count"
+            if func == torch.ops.aten.mm.default:
+                meta[mm_count_key] += 1
+            # Retain compute outputs except every second matrix multiplication.
+            to_save = func in ops and not (func == torch.ops.aten.mm.default and meta[mm_count_key] % 2 == 0)
+            return CheckpointPolicy.MUST_SAVE if to_save else CheckpointPolicy.PREFER_RECOMPUTE
+
+        return _custom_policy
+
+    def selective_checkpointing_context_fn():
+        """Create independent operation counters for one checkpointed call."""
+        meta: dict[str, int] = collections.defaultdict(int)
+        return create_selective_checkpoint_contexts(_get_custom_policy(meta))
+
+    # Selective checkpointing wraps modules without stochastic masks that must
+    # replay during recomputation.
+    return checkpoint_wrapper(
+        module,
+        context_fn=selective_checkpointing_context_fn,
+        preserve_rng_state=False,
+    )

--- a/fastvideo/train/utils/config.py
+++ b/fastvideo/train/utils/config.py
@@ -339,7 +339,12 @@ def _build_training_config(
     models: dict[str, dict[str, Any]],
     pipeline_config: Any,
 ) -> TrainingConfig:
-    """Build TrainingConfig from nested training: YAML."""
+    """Build ``TrainingConfig`` from the nested ``training`` YAML mapping.
+
+    ``preprocessed_data_type`` selects the dataloader's tensor contract:
+    ``t2v`` carries video and text, ``t2va`` carries synchronized video,
+    audio, and text, and ``text_only`` carries prompt conditioning.
+    """
     d = dict(t.get("distributed", {}) or {})
     da = dict(t.get("data", {}) or {})
     o = dict(t.get("optimizer", {}) or {})
@@ -372,9 +377,9 @@ def _build_training_config(
         data_path = str(raw_data_path)
 
     preprocessed_data_type = str(da.get("preprocessed_data_type", "t2v") or "t2v").strip().lower()
-    if preprocessed_data_type not in {"t2v", "text_only"}:
+    if preprocessed_data_type not in {"t2v", "t2va", "text_only"}:
         raise ValueError("training.data.preprocessed_data_type must be one of "
-                         "{'t2v', 'text_only'}, got "
+                         "{'t2v', 't2va', 'text_only'}, got "
                          f"{preprocessed_data_type!r}")
 
     return TrainingConfig(

--- a/fastvideo/train/utils/moduleloader.py
+++ b/fastvideo/train/utils/moduleloader.py
@@ -93,10 +93,15 @@ def load_module_from_path(
     transformer_override_safetensor: str | None = None,
     attention_backend: AttentionBackendEnum | str | None = None,
 ) -> torch.nn.Module:
-    """Load a single pipeline component module.
+    """Load one pipeline component with its role-scoped attention policy.
 
     Accepts a ``TrainingConfig`` and internally builds the
     ``TrainingArgs`` needed by ``PipelineComponentLoader``.
+
+    Diffusers component entries retain provider and architecture as their
+    first two fields and can append modular loading metadata. Attention layers
+    bind their backend during construction, so the requested backend remains
+    scoped to this load call.
     """
     fastvideo_args: Any = _make_training_args(training_config, model_path=model_path)
 
@@ -112,7 +117,9 @@ def load_module_from_path(
         raise ValueError(f"Module {module_type!r} has null value in "
                          f"config at {local_model_path}")
 
-    transformers_or_diffusers, _architecture = module_info
+    # Trailing modular-manifest metadata does not change component dispatch;
+    # the provider and architecture remain the first two fields.
+    transformers_or_diffusers, _architecture = module_info[:2]
     component_path = os.path.join(local_model_path, module_type)
 
     old_override: str | None = None

--- a/fastvideo/train/utils/validation_media.py
+++ b/fastvideo/train/utils/validation_media.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Encode and verify validation frames with optional synchronized audio.
+
+Validation artifacts are logged to experiment trackers by filename. Stream
+verification prevents the tracker from accepting an MP4 that silently dropped
+a requested audio stream.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import math
+import os
+import tempfile
+from fractions import Fraction
+
+import av
+import numpy as np
+import torch
+
+
+def _normalize_validation_frames(frames: list[np.ndarray]) -> np.ndarray:
+    """Convert RGB frames to the contiguous, even-sized layout required by H.264."""
+    if not frames:
+        raise ValueError("Validation media requires at least one video frame.")
+    frame_array = np.stack(frames)
+    if frame_array.ndim != 4 or frame_array.shape[-1] != 3:
+        raise ValueError("Validation frames must have shape [frames, height, width, 3]; "
+                         f"got {frame_array.shape}.")
+    if frame_array.dtype != np.uint8:
+        raise TypeError("Validation frames must use uint8 RGB values; "
+                        f"got {frame_array.dtype}.")
+    if frame_array.shape[1] % 2 or frame_array.shape[2] % 2:
+        raise ValueError("H.264 yuv420p encoding requires even frame dimensions; "
+                         f"got {frame_array.shape[1]} x {frame_array.shape[2]}.")
+    return np.ascontiguousarray(frame_array)
+
+
+def _normalize_audio_waveform(audio: torch.Tensor | np.ndarray) -> np.ndarray:
+    """Convert supported waveform layouts to sample-major float32.
+
+    Model outputs can be channel-major while PyAV input preparation uses
+    sample-major arrays. Ambiguous two-dimensional shapes raise an error so
+    validation never exchanges the sample and channel axes silently.
+    """
+    waveform = (audio.detach().cpu().float().numpy() if torch.is_tensor(audio) else np.asarray(audio, dtype=np.float32))
+
+    if waveform.ndim == 1:
+        waveform = waveform[:, None]
+    elif waveform.ndim == 2:
+        first_axis_is_channels = waveform.shape[0] <= 8
+        second_axis_is_channels = waveform.shape[1] <= 8
+        if first_axis_is_channels and not second_axis_is_channels:
+            waveform = waveform.T
+        elif first_axis_is_channels == second_axis_is_channels:
+            raise ValueError("A two-dimensional audio waveform must have one channel axis "
+                             f"with at most eight entries; got {waveform.shape}.")
+    else:
+        raise ValueError("Audio must have shape [samples], [samples, channels], or "
+                         f"[channels, samples]; got {waveform.shape}.")
+
+    if waveform.shape[0] == 0:
+        raise ValueError("Validation audio requires at least one sample.")
+    if not np.isfinite(waveform).all():
+        raise ValueError("Validation audio contains a nonfinite sample.")
+    return np.ascontiguousarray(np.clip(waveform, -1.0, 1.0), dtype=np.float32)
+
+
+def _trim_to_shared_duration(
+    frames: np.ndarray,
+    fps: int,
+    waveform: np.ndarray,
+    sample_rate: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Trim both streams to a shared duration containing complete video frames."""
+    audio_duration = waveform.shape[0] / sample_rate
+    frame_count = min(frames.shape[0], math.floor(audio_duration * fps + 1e-9))
+    if frame_count < 1:
+        raise ValueError("Validation audio must cover at least one complete video frame.")
+    audio_sample_count = min(
+        waveform.shape[0],
+        math.floor(frame_count / fps * sample_rate + 1e-9),
+    )
+    if audio_sample_count < 1:
+        raise ValueError("Validation media has no shared audio-video duration.")
+    return frames[:frame_count], waveform[:audio_sample_count]
+
+
+def _encode_mp4(
+    output_path: str,
+    frames: np.ndarray,
+    fps: int,
+    waveform: np.ndarray | None,
+    sample_rate: int | None,
+) -> None:
+    """Encode H.264 and optional Advanced Audio Coding into one MP4 artifact."""
+    with av.open(output_path, mode="w") as container:
+        video_stream = container.add_stream("libx264", rate=fps)
+        video_stream.width = int(frames.shape[2])
+        video_stream.height = int(frames.shape[1])
+        video_stream.pix_fmt = "yuv420p"
+        video_stream.options = {"preset": "ultrafast"}
+        audio_stream = None
+        if waveform is not None and sample_rate is not None:
+            channel_count = int(waveform.shape[1])
+            if channel_count not in (1, 2):
+                raise ValueError("Validation MP4 audio must be mono or stereo; "
+                                 f"got {channel_count} channels.")
+            layout = "mono" if channel_count == 1 else "stereo"
+            audio_stream = container.add_stream("aac", rate=sample_rate, layout=layout)
+
+        for frame_index, frame_array in enumerate(frames):
+            video_frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+            video_frame.pts = frame_index
+            video_frame.time_base = Fraction(1, fps)
+            for packet in video_stream.encode(video_frame):
+                container.mux(packet)
+        for packet in video_stream.encode():
+            container.mux(packet)
+
+        if waveform is None or sample_rate is None or audio_stream is None:
+            return
+
+        layout = "mono" if waveform.shape[1] == 1 else "stereo"
+        audio_int16 = (waveform * 32767.0).astype(np.int16)
+        # AAC uses 1024-sample frames; flushing after the trailing short chunk lets
+        # the codec emit every buffered sample into the container.
+        for sample_index in range(0, audio_int16.shape[0], 1024):
+            chunk = np.ascontiguousarray(audio_int16[sample_index:sample_index + 1024].T)
+            audio_frame = av.AudioFrame.from_ndarray(chunk, format="s16p", layout=layout)
+            audio_frame.sample_rate = sample_rate
+            audio_frame.pts = sample_index
+            audio_frame.time_base = Fraction(1, sample_rate)
+            for packet in audio_stream.encode(audio_frame):
+                container.mux(packet)
+        for packet in audio_stream.encode():
+            container.mux(packet)
+
+
+def _verify_encoded_streams(
+    output_path: str,
+    *,
+    expected_audio_channels: int | None,
+    expected_audio_sample_rate: int | None,
+) -> None:
+    """Verify requested streams before the temporary file replaces its destination."""
+    with av.open(output_path) as container:
+        if len(container.streams.video) != 1:
+            raise RuntimeError("Validation MP4 encoding must produce exactly one video stream.")
+        if expected_audio_channels is None:
+            if container.streams.audio:
+                raise RuntimeError("Silent validation media contains an unexpected audio stream.")
+            return
+        if len(container.streams.audio) != 1:
+            raise RuntimeError("Audio-bearing validation MP4 encoding must produce exactly one audio stream.")
+        audio_stream = container.streams.audio[0]
+        encoded_channels = len(audio_stream.codec_context.layout.channels)
+        encoded_sample_rate = int(audio_stream.codec_context.sample_rate)
+        if encoded_channels != expected_audio_channels:
+            raise RuntimeError("Validation MP4 audio channel count changed during encoding: "
+                               f"expected {expected_audio_channels}, got {encoded_channels}.")
+        if encoded_sample_rate != expected_audio_sample_rate:
+            raise RuntimeError("Validation MP4 audio sample rate changed during encoding: "
+                               f"expected {expected_audio_sample_rate}, got {encoded_sample_rate}.")
+
+
+def write_validation_mp4(
+    output_path: str,
+    frames: list[np.ndarray],
+    *,
+    fps: int,
+    audio: torch.Tensor | np.ndarray | None = None,
+    audio_sample_rate: int | None = None,
+) -> None:
+    """Write validation frames and optional synchronized audio atomically.
+
+    The video input must contain RGB uint8 frames. Audio can use
+    ``[samples]``, ``[samples, channels]``, or ``[channels, samples]`` layout.
+    When both streams are present, the encoder trims them to their shortest
+    complete shared duration. The destination changes only after PyAV encodes
+    and verifies every requested stream.
+    """
+    if not isinstance(fps, int) or fps <= 0:
+        raise ValueError(f"Validation video FPS must be a positive integer; got {fps!r}.")
+    if (audio is None) != (audio_sample_rate is None):
+        raise ValueError("Validation audio and its sample rate must be provided together.")
+    if audio_sample_rate is not None and audio_sample_rate <= 0:
+        raise ValueError("Validation audio sample rate must be positive; "
+                         f"got {audio_sample_rate}.")
+
+    frame_array = _normalize_validation_frames(frames)
+    waveform = _normalize_audio_waveform(audio) if audio is not None else None
+    if waveform is not None and audio_sample_rate is not None:
+        frame_array, waveform = _trim_to_shared_duration(
+            frame_array,
+            fps,
+            waveform,
+            audio_sample_rate,
+        )
+
+    destination = os.path.abspath(output_path)
+    destination_dir = os.path.dirname(destination)
+    if not os.path.isdir(destination_dir):
+        raise FileNotFoundError(f"Validation media destination directory does not exist: {destination_dir}")
+    # A temporary file in the destination directory keeps replacement atomic
+    # and leaves any previous artifact intact when encoding or verification fails.
+    file_descriptor, temporary_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(destination)}.",
+        suffix=".mp4",
+        dir=destination_dir,
+    )
+    os.close(file_descriptor)
+    try:
+        _encode_mp4(
+            temporary_path,
+            frame_array,
+            fps,
+            waveform,
+            audio_sample_rate,
+        )
+        _verify_encoded_streams(
+            temporary_path,
+            expected_audio_channels=(int(waveform.shape[1]) if waveform is not None else None),
+            expected_audio_sample_rate=audio_sample_rate,
+        )
+        # Publish only an MP4 whose requested stream contract was verified.
+        os.replace(temporary_path, destination)
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(temporary_path)
+
+
+__all__ = ["write_validation_mp4"]


### PR DESCRIPTION
<!-- Suggested PR title: [feat] Add MiniMax H3 supervised fine-tuning -->

## Purpose

Add joint video-and-audio supervised fine-tuning for MiniMax H3 through the modular `fastvideo.train` framework. The implementation builds on the MiniMax H3 inference support from #1674.

The training path consumes precomputed text embeddings, video latents, and stereo-audio latents. It applies independent video and audio noise schedules, and then trains both H3 output branches with flow-matching mean-squared error. The PR also provides a reproducible single-sample Crush-Smol overfit recipe with online Weights & Biases validation.

## Changes

- Add the modular `MiniMaxH3Model` training adapter, including H3 packed-token construction, video/audio noise preparation, sequence-parallel metadata, activation checkpointing, and model-specific backward context restoration.
- Extend `FineTuneMethod` and `TrainingBatch` with a joint video/audio prediction contract. The total H3 loss is the sum of the video and audio flow-matching losses. Video-only fine-tuning uses its single-tensor loss contract.
- Add the text-to-video-and-audio Parquet schema and a fixed preprocessing workflow for one Crush-Smol audio-video-caption record.
- Add H3 training dtype handling for FastVideo's Fully Sharded Data Parallel loader and device-safe materialization of non-persistent rotary-position buffers.
- Extend modular validation with validation-before-training, exact step scheduling, synchronized audio-video MP4 encoding, tracker artifact counts, and temporary training-state offload during inference.
- Add the 400-step H3 overfit configuration for an 8-by-8 hybrid sharded data parallel mesh on 64 H200 GPUs. The configuration validates at step 0 and every 20 optimizer steps with online Weights & Biases logging.
- Make `examples/train/run_slurm.sh` preserve inherited W&B authentication, accept optional node constraints and time limits, assign each node its Slurm process rank, and shell-escape generated training arguments.
- Add focused tests for preprocessing, H3 batch construction, joint loss, attention backend selection, validation scheduling, audio-video media encoding, distributed launch arguments, and configuration resolution.

## Test Plan

```bash
/mnt/weka/shrd/wm/junda/fv-hub/.venv/bin/python -m pytest -q fastvideo/tests/train/callbacks/test_validation.py fastvideo/tests/train/methods/test_minimax_h3_finetune.py fastvideo/tests/train/utils/test_moduleloader_attention_backend.py fastvideo/tests/train/utils/test_validation_media.py fastvideo/tests/workflow/test_minimax_h3_overfit_preprocess.py

git diff --check main...HEAD
bash -n examples/train/run_slurm.sh

git diff --name-only -z main...HEAD | xargs -0 /mnt/weka/shrd/wm/junda/fv-hub/.venv/bin/pre-commit run --files
```

The experiment configuration can be submitted with:

```bash
SBATCH_CONSTRAINT=nvidia_h200 SBATCH_TIMELIMIT=72:00:00 WANDB_MODE=online bash examples/train/run_slurm.sh examples/train/configs/overfit_minimax_h3_t2va.yaml 8
```

## Test Results

<details>
<summary>Focused test and static-check output</summary>

```text
  71 passed, 16 warnings in 1.37s

  yapf.....................................................................Passed
  ruff (legacy alias)......................................................Passed
  codespell................................................................Passed
  PyMarkdown...........................................(no files to check)Skipped
  Lint GitHub Actions workflow files...................(no files to check)Skipped
  mypy.....................................................................Passed
  Check for spaces in all filenames........................................Passed
  Suggestion...............................................................Passed

  git diff --check origin/main...HEAD: passed
  bash -n examples/train/run_slurm.sh: passed
  bash -n examples/train/launch_minimax_h3_t2va_crush_smol_validation.sh: passed
  bash -n examples/train/setup_minimax_h3_t2va_crush_smol_single_sample.sh: passed

```

The warnings are dependency deprecations from SWIG bindings and `torch.jit.script_method`.

The failing test expects a dedicated H3 launcher that is absent from `HEAD`.

</details>

### MiniMax H3 single-sample overfit

- Slurm job: `2026587`
- Output directory: `/mnt/weka/shrd/wm/junda/fv-hub/fastvideo-add-h3-sft/runs/minimax_h3_t2va_crush_smol_single_sample_overfit`
- W&B run: [js202/fastvideo_minimax_h3/59543p6e](https://wandb.ai/js202/fastvideo_minimax_h3/runs/59543p6e)
- Input video: `data/crush-smol/videos/1gGQy4nxyUo-Scene-016.mp4`
- Input caption: "A watermelon wearing a helmet is crushed by a hydraulic press, causing it to flatten and burst open."
- Training targets: 124 video frames at 768 x 1344 and 24 FPS, plus the synchronized stereo soundtrack resampled to 32 kHz.
- Allocation: 8 nodes, 64 NVIDIA H200 GPUs, 1,024 CPU cores, and 11,520 GiB of host memory. The 8-by-8 mesh provided eight data-parallel replicas and an effective global batch size of 8.
- Compute usage: 3:05:19 elapsed, 197.67 allocated H200 GPU-hours, and 24.71 allocated node-hours.
- Result: Validation in the linked Weights & Biases run showed that MiniMax H3 overfits the single Crush-Smol sample.

## Checklist

- [ ] I ran `pre-commit run --all-files` and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**

- [ ] I verified SSIM regression tests pass
- [x] I updated the support matrix if adding a new model (N/A: MiniMax H3 inference support was added in #1674).
