### PR TITLE
[bugfix]: condition HunyuanVideo 1.5 i2v on the reference image

### DIFF
--- a/fastvideo/configs/pipelines/hunyuan15.py
+++ b/fastvideo/configs/pipelines/hunyuan15.py
@@ -112,7 +112,7 @@ class Hunyuan15T2V480PConfig(PipelineConfig):
 
     vae_tiling: bool = True
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self.vae_config.load_encoder = False
         self.vae_config.load_decoder = True
         if self.text_encoder_configs:
@@ -127,6 +127,15 @@ class Hunyuan15I2V480PStepDistilledConfig(Hunyuan15T2V480PConfig):
     # The i2v checkpoints ship a SigLIP vision tower; declaring it here is what
     # makes the loader build one.
     image_encoder_config: EncoderConfig = field(default_factory=SiglipVisionConfig)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.vae_config.load_encoder = True
+
+    def check_pipeline_config(self) -> None:
+        super().check_pipeline_config()
+        if not self.vae_config.load_encoder:
+            raise ValueError("HunyuanVideo 1.5 I2V requires the VAE encoder.")
 
 
 @dataclass
@@ -145,6 +154,15 @@ class Hunyuan15I2V720PConfig(Hunyuan15T2V720PConfig):
     flow_shift: int = 7
 
     image_encoder_config: EncoderConfig = field(default_factory=SiglipVisionConfig)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.vae_config.load_encoder = True
+
+    def check_pipeline_config(self) -> None:
+        super().check_pipeline_config()
+        if not self.vae_config.load_encoder:
+            raise ValueError("HunyuanVideo 1.5 I2V requires the VAE encoder.")
 
 
 @dataclass

--- a/fastvideo/configs/pipelines/hunyuan15.py
+++ b/fastvideo/configs/pipelines/hunyuan15.py
@@ -8,7 +8,7 @@ import torch
 
 from fastvideo.configs.models import DiTConfig, EncoderConfig, VAEConfig
 from fastvideo.configs.models.dits import HunyuanVideo15Config
-from fastvideo.configs.models.encoders import (BaseEncoderOutput, Qwen2_5_VLConfig, T5Config)
+from fastvideo.configs.models.encoders import (BaseEncoderOutput, Qwen2_5_VLConfig, SiglipVisionConfig, T5Config)
 from fastvideo.configs.models.vaes import Hunyuan15VAEConfig
 from fastvideo.configs.models.upsamplers import SRTo720pUpsamplerConfig, SRTo1080pUpsamplerConfig
 from fastvideo.configs.pipelines.base import PipelineConfig, UpsamplerConfig
@@ -124,6 +124,10 @@ class Hunyuan15T2V480PConfig(PipelineConfig):
 class Hunyuan15I2V480PStepDistilledConfig(Hunyuan15T2V480PConfig):
     flow_shift: int = 7
 
+    # The i2v checkpoints ship a SigLIP vision tower; declaring it here is what
+    # makes the loader build one.
+    image_encoder_config: EncoderConfig = field(default_factory=SiglipVisionConfig)
+
 
 @dataclass
 class Hunyuan15T2V720PConfig(Hunyuan15T2V480PConfig):
@@ -139,6 +143,8 @@ class Hunyuan15I2V720PConfig(Hunyuan15T2V720PConfig):
 
     # HunyuanConfig-specific parameters with defaults
     flow_shift: int = 7
+
+    image_encoder_config: EncoderConfig = field(default_factory=SiglipVisionConfig)
 
 
 @dataclass

--- a/fastvideo/pipelines/basic/hunyuan15/hunyuan15_i2v_pipeline.py
+++ b/fastvideo/pipelines/basic/hunyuan15/hunyuan15_i2v_pipeline.py
@@ -20,8 +20,12 @@ logger = init_logger(__name__)
 
 class HunyuanVideo15ImageToVideoPipeline(ComposedPipelineBase):
 
+    # image_encoder and feature_extractor are the SigLIP pair the i2v
+    # checkpoints ship; without them the reference image has no route into the
+    # transformer and the run is text-to-video wearing an i2v label.
     _required_config_modules = [
-        "text_encoder", "text_encoder_2", "tokenizer", "tokenizer_2", "vae", "transformer", "scheduler"
+        "text_encoder", "text_encoder_2", "tokenizer", "tokenizer_2", "vae", "transformer", "scheduler",
+        "image_encoder", "feature_extractor"
     ]
 
     def create_pipeline_stages(self, fastvideo_args: FastVideoArgs):
@@ -47,7 +51,9 @@ class HunyuanVideo15ImageToVideoPipeline(ComposedPipelineBase):
                                                     transformer=self.get_module("transformer")))
 
         self.add_stage(stage_name="image_encoding_stage",
-                       stage=Hy15ImageEncodingStage(image_encoder=None, image_processor=None))
+                       stage=Hy15ImageEncodingStage(image_encoder=self.get_module("image_encoder"),
+                                                    image_processor=self.get_module("feature_extractor"),
+                                                    vae=self.get_module("vae")))
 
         self.add_stage(stage_name="denoising_stage",
                        stage=DenoisingStage(transformer=self.get_module("transformer"),

--- a/fastvideo/pipelines/stages/image_encoding.py
+++ b/fastvideo/pipelines/stages/image_encoding.py
@@ -119,9 +119,10 @@ class Hy15ImageEncodingStage(ImageEncodingStage):
         Encode the prompt into image encoder hidden states.
         """
         device = get_local_torch_device()
+        batch_size = batch.raw_latent_shape[0]
 
         if batch.pil_image is None:
-            batch.image_embeds = [torch.zeros(1, 729, 1152, device=device)]
+            batch.image_embeds = [torch.zeros(batch_size, 729, 1152, device=device)]
             raw_latent_shape = list(batch.raw_latent_shape)
             raw_latent_shape[1] = 1
             batch.video_latent = torch.zeros(tuple(raw_latent_shape), device=device)
@@ -145,7 +146,15 @@ class Hy15ImageEncodingStage(ImageEncodingStage):
             return_tensors="pt",
         ).to(device=device, dtype=encoder_dtype)
         with set_forward_context(current_timestep=0, attn_metadata=None):
-            batch.image_embeds = [self.image_encoder(**image_inputs).last_hidden_state]
+            image_embeds = self.image_encoder(**image_inputs).last_hidden_state
+        # The public input is one reference image. Encode it once, then reuse
+        # the conditioning for every latent requested from that image.
+        if image_embeds.shape[0] == 1:
+            image_embeds = image_embeds.repeat(batch_size, 1, 1)
+        elif image_embeds.shape[0] != batch_size:
+            raise ValueError(f"HunyuanVideo 1.5 image embeddings have batch size {image_embeds.shape[0]}, "
+                             f"but the latent batch size is {batch_size}.")
+        batch.image_embeds = [image_embeds]
         if fastvideo_args.image_encoder_cpu_offload:
             self.image_encoder.to("cpu")
 
@@ -155,22 +164,48 @@ class Hy15ImageEncodingStage(ImageEncodingStage):
         vae_dtype = PRECISION_TO_TYPE[fastvideo_args.pipeline_config.vae_precision]
         vae_autocast_enabled = (vae_dtype != torch.float32) and not fastvideo_args.disable_autocast
 
-        image_processor = ImageProcessor(vae_scale_factor=8)
+        # The HunyuanVideo 1.5 VAE compresses space by 16 and latent
+        # preparation divides by the same ratio, so aligning the reference
+        # image to 8 lets a height like 552 reach the encoder and fail
+        # inside its reshape.
+        image_processor = ImageProcessor(
+            vae_scale_factor=fastvideo_args.pipeline_config.vae_config.arch_config.spatial_compression_ratio)
         pixels = image_processor.preprocess(batch.pil_image, batch.height, batch.width)
         pixels = pixels.unsqueeze(2).to(device=device, dtype=vae_dtype)
 
         self.vae = self.vae.to(device)
         with torch.autocast(device_type="cuda", dtype=vae_dtype, enabled=vae_autocast_enabled):
+            # The decoding stage turns tiling on and nothing turns it back off,
+            # and both stages hold the same VAE. Without this the first
+            # generation in a process encodes the reference image untiled and
+            # every later one encodes it tiled, so the same image and seed give
+            # different conditioning. Decide from the config, as the other
+            # VAE-encoding stages in this file do.
+            if fastvideo_args.pipeline_config.vae_tiling:
+                self.vae.enable_tiling()
             cond_latents = self.vae.encode(pixels).mode()
             cond_latents = cond_latents * self.vae.config.scaling_factor
         if fastvideo_args.vae_cpu_offload:
             self.vae.to("cpu")
 
-        cond_latents = cond_latents.repeat(1, 1, latent_temporal, 1, 1)
-        cond_latents[:, :, 1:] = 0.0
+        if cond_latents.shape[0] == 1:
+            cond_latents = cond_latents.repeat(batch_size, 1, 1, 1, 1)
+        elif cond_latents.shape[0] != batch_size:
+            raise ValueError(f"HunyuanVideo 1.5 conditioning latents have batch size {cond_latents.shape[0]}, "
+                             f"but the requested latent batch size is {batch_size}.")
+
+        first_frame_latents = cond_latents[:, :, :1]
+        cond_latents = cond_latents.new_zeros(
+            batch_size,
+            latent_channels,
+            latent_temporal,
+            latent_height,
+            latent_width,
+        )
+        cond_latents[:, :, :1] = first_frame_latents
 
         mask = torch.zeros(
-            1,
+            batch_size,
             1,
             latent_temporal,
             latent_height,

--- a/fastvideo/pipelines/stages/image_encoding.py
+++ b/fastvideo/pipelines/stages/image_encoding.py
@@ -15,6 +15,7 @@ import torch
 from fastvideo.distributed import get_local_torch_device
 from fastvideo.fastvideo_args import ExecutionMode, FastVideoArgs
 from fastvideo.forward_context import set_forward_context
+from fastvideo.image_processor import ImageProcessor
 from fastvideo.logger import init_logger
 from fastvideo.models.vaes.common import ParallelTiledVAE
 from fastvideo.models.vision_utils import (get_default_height_width, normalize, numpy_to_pt, pil_to_numpy, resize,
@@ -97,22 +98,94 @@ class ImageEncodingStage(PipelineStage):
 class Hy15ImageEncodingStage(ImageEncodingStage):
     """
     Stage for encoding image prompts into embeddings for HunyuanVideo1.5 models.
+
+    Without a reference image (T2V and the super-resolution pipelines) the
+    conditioning slots are zero-filled and the transformer takes its T2V branch.
+    With one, SigLIP supplies ``image_embeds`` and the VAE supplies the first
+    frame of the conditioning latent, which is what turns that branch off.
     """
+
+    def __init__(self, image_encoder=None, image_processor=None, vae=None):
+        super().__init__(image_encoder=image_encoder, image_processor=image_processor)
+        self.vae = vae
 
     def verify_input(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> VerificationResult:
         """Verify image encoding stage inputs."""
         return VerificationResult()
 
+    @torch.no_grad()
     def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
         """
         Encode the prompt into image encoder hidden states.
         """
-        if batch.pil_image is None:
-            batch.image_embeds = [torch.zeros(1, 729, 1152, device=get_local_torch_device())]
+        device = get_local_torch_device()
 
-        raw_latent_shape = list(batch.raw_latent_shape)
-        raw_latent_shape[1] = 1
-        batch.video_latent = torch.zeros(tuple(raw_latent_shape), device=get_local_torch_device())
+        if batch.pil_image is None:
+            batch.image_embeds = [torch.zeros(1, 729, 1152, device=device)]
+            raw_latent_shape = list(batch.raw_latent_shape)
+            raw_latent_shape[1] = 1
+            batch.video_latent = torch.zeros(tuple(raw_latent_shape), device=device)
+            return batch
+
+        if self.image_encoder is None or self.image_processor is None or self.vae is None:
+            raise ValueError("HunyuanVideo 1.5 needs an image encoder, its processor and the VAE to condition on a "
+                             "reference image, but this pipeline was built without them. Image-to-video requires "
+                             "HunyuanVideo15ImageToVideoPipeline and an i2v checkpoint.")
+
+        _, latent_channels, latent_temporal, latent_height, latent_width = batch.raw_latent_shape
+
+        # 1. SigLIP hidden states. The transformer reads all-zero image
+        # embeddings as "this is T2V", so this is what selects the I2V branch.
+        self.image_encoder = self.image_encoder.to(device)
+        encoder_dtype = next(self.image_encoder.parameters()).dtype
+        image_inputs = self.image_processor.preprocess(
+            images=batch.pil_image,
+            do_resize=True,
+            do_convert_rgb=True,
+            return_tensors="pt",
+        ).to(device=device, dtype=encoder_dtype)
+        with set_forward_context(current_timestep=0, attn_metadata=None):
+            batch.image_embeds = [self.image_encoder(**image_inputs).last_hidden_state]
+        if fastvideo_args.image_encoder_cpu_offload:
+            self.image_encoder.to("cpu")
+
+        # 2. The reference image occupies the first latent frame of the
+        # conditioning stream; every later frame is zero and the mask channel
+        # marks which one is real.
+        vae_dtype = PRECISION_TO_TYPE[fastvideo_args.pipeline_config.vae_precision]
+        vae_autocast_enabled = (vae_dtype != torch.float32) and not fastvideo_args.disable_autocast
+
+        image_processor = ImageProcessor(vae_scale_factor=8)
+        pixels = image_processor.preprocess(batch.pil_image, batch.height, batch.width)
+        pixels = pixels.unsqueeze(2).to(device=device, dtype=vae_dtype)
+
+        self.vae = self.vae.to(device)
+        with torch.autocast(device_type="cuda", dtype=vae_dtype, enabled=vae_autocast_enabled):
+            cond_latents = self.vae.encode(pixels).mode()
+            cond_latents = cond_latents * self.vae.config.scaling_factor
+        if fastvideo_args.vae_cpu_offload:
+            self.vae.to("cpu")
+
+        cond_latents = cond_latents.repeat(1, 1, latent_temporal, 1, 1)
+        cond_latents[:, :, 1:] = 0.0
+
+        mask = torch.zeros(
+            1,
+            1,
+            latent_temporal,
+            latent_height,
+            latent_width,
+            device=device,
+            dtype=cond_latents.dtype,
+        )
+        mask[:, :, 0] = 1.0
+
+        # Latents, then conditioning, then mask: the denoising stage appends
+        # ``image_latent`` as one block, so the channel order has to be built
+        # here. Leaving ``video_latent`` unset keeps it out of the earlier
+        # branch, which would append the mask before the conditioning.
+        batch.image_latent = torch.cat([cond_latents, mask], dim=1)
+        assert batch.image_latent.shape[1] == latent_channels + 1
         return batch
 
 

--- a/fastvideo/tests/stages/test_hy15_image_encoding_stage.py
+++ b/fastvideo/tests/stages/test_hy15_image_encoding_stage.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for ``Hy15ImageEncodingStage``.
+
+The failure this guards against is quiet: with no reference image conditioning,
+HunyuanVideo 1.5 still trains and still samples, it just ignores the image. So
+these assert the channel layout rather than only that a tensor came back.
+
+Ordering matters and is invisible in T2V. ``DenoisingStage`` appends
+``image_latent`` as one block, so the 65 channel input is
+``[latents 32][conditioning 32][mask 1]``. For T2V the last 33 are all zero and
+either order produces the same tensor, which is why a swapped layout would go
+unnoticed until an image is actually supplied.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import PIL.Image
+import pytest
+import torch
+
+from fastvideo.pipelines.stages.image_encoding import Hy15ImageEncodingStage
+
+LATENT_SHAPE = (1, 32, 5, 8, 12)  # B, C, T, H, W
+REFERENCE_IMAGE = PIL.Image.new("RGB", (LATENT_SHAPE[4] * 8, LATENT_SHAPE[3] * 8), (120, 60, 30))
+VISION_TOKENS = 729
+VISION_DIM = 1152
+
+
+class _FakeSiglip(torch.nn.Module):
+    """Returns a constant non-zero hidden state, which is all the stage reads."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.marker = torch.nn.Parameter(torch.ones(1))
+
+    def forward(self, pixel_values: torch.Tensor):
+        batch = pixel_values.shape[0]
+        return SimpleNamespace(last_hidden_state=torch.full((batch, VISION_TOKENS, VISION_DIM), 0.5))
+
+
+class _FakeProcessor:
+
+    def preprocess(self, images, **kwargs):
+        return SimpleNamespace(to=lambda **_: {"pixel_values": torch.zeros(1, 3, 384, 384)})
+
+
+class _FakeVAE(torch.nn.Module):
+    """Encodes to a constant so the first frame is distinguishable from zero."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.config = SimpleNamespace(scaling_factor=2.0)
+
+    def encode(self, pixels: torch.Tensor):
+        _, _, _, height, width = pixels.shape
+        latent = torch.full((1, LATENT_SHAPE[1], 1, height // 8, width // 8), 3.0)
+        return SimpleNamespace(mode=lambda: latent)
+
+    def to(self, *args, **kwargs):
+        return self
+
+
+def _batch(pil_image):
+    return SimpleNamespace(
+        pil_image=pil_image,
+        raw_latent_shape=LATENT_SHAPE,
+        image_embeds=[],
+        image_latent=None,
+        video_latent=None,
+        height=LATENT_SHAPE[3] * 8,
+        width=LATENT_SHAPE[4] * 8,
+    )
+
+
+def _args():
+    return SimpleNamespace(
+        pipeline_config=SimpleNamespace(vae_precision="fp32"),
+        disable_autocast=True,
+        image_encoder_cpu_offload=False,
+        vae_cpu_offload=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _cpu_device(monkeypatch):
+    """Pin the stage to CPU so the fakes and the real code agree on device.
+
+    ``get_local_torch_device`` resolves to MPS on macOS and CUDA elsewhere, and
+    nothing here needs an accelerator.
+    """
+    monkeypatch.setattr(
+        "fastvideo.pipelines.stages.image_encoding.get_local_torch_device",
+        lambda: torch.device("cpu"),
+    )
+
+
+def _i2v_stage():
+    return Hy15ImageEncodingStage(
+        image_encoder=_FakeSiglip(),
+        image_processor=_FakeProcessor(),
+        vae=_FakeVAE(),
+    )
+
+
+class TestTextToVideoPath:
+    """No reference image: the transformer must still see the T2V layout."""
+
+    def test_image_embeds_are_zero(self) -> None:
+        batch = Hy15ImageEncodingStage().forward(_batch(None), _args())
+
+        assert len(batch.image_embeds) == 1
+        assert batch.image_embeds[0].shape == (1, VISION_TOKENS, VISION_DIM)
+        # The transformer keys its T2V branch off this being all zero.
+        assert torch.all(batch.image_embeds[0] == 0)
+
+    def test_conditioning_stays_on_the_video_latent_slot(self) -> None:
+        batch = Hy15ImageEncodingStage().forward(_batch(None), _args())
+
+        # The super-resolution stages read video_latent directly, so T2V keeps
+        # populating it rather than switching to image_latent.
+        assert batch.video_latent is not None
+        assert batch.video_latent.shape == (1, 1) + LATENT_SHAPE[2:]
+        assert torch.all(batch.video_latent == 0)
+        assert batch.image_latent is None
+
+
+class TestImageToVideoPath:
+
+    def test_image_embeds_come_from_siglip(self) -> None:
+        batch = _i2v_stage().forward(_batch(REFERENCE_IMAGE), _args())
+
+        assert batch.image_embeds[0].shape == (1, VISION_TOKENS, VISION_DIM)
+        # Non-zero is the whole point: all-zero would re-select the T2V branch.
+        assert not torch.all(batch.image_embeds[0] == 0)
+
+    def test_channel_layout_is_conditioning_then_mask(self) -> None:
+        batch = _i2v_stage().forward(_batch(REFERENCE_IMAGE), _args())
+
+        assert batch.image_latent.shape == (1, LATENT_SHAPE[1] + 1) + LATENT_SHAPE[2:]
+
+        conditioning = batch.image_latent[:, :LATENT_SHAPE[1]]
+        mask = batch.image_latent[:, LATENT_SHAPE[1]:]
+
+        # A swapped layout would put a 1-wide block first, so check that the
+        # trailing channel is the mask and not part of the conditioning.
+        assert torch.all(mask[:, :, 0] == 1.0)
+        assert torch.all(mask[:, :, 1:] == 0.0)
+        assert torch.all(conditioning[:, :, 0] != 0)
+        assert torch.all(conditioning[:, :, 1:] == 0)
+
+    def test_scaling_factor_is_applied(self) -> None:
+        batch = _i2v_stage().forward(_batch(REFERENCE_IMAGE), _args())
+
+        # Fake VAE emits 3.0 and declares scaling_factor 2.0.
+        assert torch.allclose(batch.image_latent[:, :LATENT_SHAPE[1], 0],
+                              torch.full((1, LATENT_SHAPE[1]) + LATENT_SHAPE[3:], 6.0))
+
+    def test_video_latent_left_unset(self) -> None:
+        batch = _i2v_stage().forward(_batch(REFERENCE_IMAGE), _args())
+
+        # DenoisingStage checks video_latent first and would append the mask
+        # ahead of the conditioning, so this slot has to stay empty.
+        assert batch.video_latent is None
+
+    def test_missing_encoder_is_an_explicit_error(self) -> None:
+        with pytest.raises(ValueError, match="image encoder"):
+            Hy15ImageEncodingStage().forward(_batch(REFERENCE_IMAGE), _args())

--- a/fastvideo/tests/stages/test_hy15_image_encoding_stage.py
+++ b/fastvideo/tests/stages/test_hy15_image_encoding_stage.py
@@ -19,10 +19,20 @@ import PIL.Image
 import pytest
 import torch
 
+import fastvideo.models.vaes.hunyuan15vae as hunyuan15vae
+from fastvideo.configs.pipelines.hunyuan15 import (Hunyuan15I2V480PStepDistilledConfig, Hunyuan15I2V720PConfig,
+                                                   Hunyuan15SR1080PConfig, Hunyuan15T2V480PConfig,
+                                                   Hunyuan15T2V720PConfig)
+from fastvideo.models.vaes.hunyuan15vae import AutoencoderKLHunyuanVideo15
 from fastvideo.pipelines.stages.image_encoding import Hy15ImageEncodingStage
 
-LATENT_SHAPE = (1, 32, 5, 8, 12)  # B, C, T, H, W
-REFERENCE_IMAGE = PIL.Image.new("RGB", (LATENT_SHAPE[4] * 8, LATENT_SHAPE[3] * 8), (120, 60, 30))
+VAE_SPATIAL_COMPRESSION_RATIO = 16
+LATENT_SHAPE = (1, 32, 5, 4, 6)  # B, C, T, H, W
+REFERENCE_IMAGE = PIL.Image.new(
+    "RGB",
+    (LATENT_SHAPE[4] * VAE_SPATIAL_COMPRESSION_RATIO, LATENT_SHAPE[3] * VAE_SPATIAL_COMPRESSION_RATIO),
+    (120, 60, 30),
+)
 VISION_TOKENS = 729
 VISION_DIM = 1152
 
@@ -33,8 +43,10 @@ class _FakeSiglip(torch.nn.Module):
     def __init__(self) -> None:
         super().__init__()
         self.marker = torch.nn.Parameter(torch.ones(1))
+        self.forward_calls = 0
 
     def forward(self, pixel_values: torch.Tensor):
+        self.forward_calls += 1
         batch = pixel_values.shape[0]
         return SimpleNamespace(last_hidden_state=torch.full((batch, VISION_TOKENS, VISION_DIM), 0.5))
 
@@ -45,37 +57,62 @@ class _FakeProcessor:
         return SimpleNamespace(to=lambda **_: {"pixel_values": torch.zeros(1, 3, 384, 384)})
 
 
-class _FakeVAE(torch.nn.Module):
-    """Encodes to a constant so the first frame is distinguishable from zero."""
+class _ConstantEncoder(torch.nn.Module):
+    """Small encoder used inside the real HunyuanVideo 1.5 VAE wrapper."""
 
-    def __init__(self) -> None:
+    def __init__(self, out_channels: int, spatial_compression_ratio: int, **kwargs) -> None:
         super().__init__()
-        self.config = SimpleNamespace(scaling_factor=2.0)
+        self.out_channels = out_channels
+        self.spatial_compression_ratio = spatial_compression_ratio
+        self.forward_calls = 0
 
-    def encode(self, pixels: torch.Tensor):
-        _, _, _, height, width = pixels.shape
-        latent = torch.full((1, LATENT_SHAPE[1], 1, height // 8, width // 8), 3.0)
-        return SimpleNamespace(mode=lambda: latent)
+    def forward(self, pixels: torch.Tensor) -> torch.Tensor:
+        self.forward_calls += 1
+        batch_size, _, _, height, width = pixels.shape
+        return torch.full(
+            (
+                batch_size,
+                self.out_channels,
+                1,
+                height // self.spatial_compression_ratio,
+                width // self.spatial_compression_ratio,
+            ),
+            3.0,
+            device=pixels.device,
+            dtype=pixels.dtype,
+        )
 
-    def to(self, *args, **kwargs):
-        return self
+
+class _UnusedDecoder(torch.nn.Module):
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+
+    def forward(self, latents: torch.Tensor) -> torch.Tensor:
+        return latents
 
 
-def _batch(pil_image):
+def _batch(pil_image, batch_size: int = 1):
+    raw_latent_shape = (batch_size, ) + LATENT_SHAPE[1:]
     return SimpleNamespace(
         pil_image=pil_image,
-        raw_latent_shape=LATENT_SHAPE,
+        raw_latent_shape=raw_latent_shape,
         image_embeds=[],
         image_latent=None,
         video_latent=None,
-        height=LATENT_SHAPE[3] * 8,
-        width=LATENT_SHAPE[4] * 8,
+        height=LATENT_SHAPE[3] * VAE_SPATIAL_COMPRESSION_RATIO,
+        width=LATENT_SHAPE[4] * VAE_SPATIAL_COMPRESSION_RATIO,
     )
 
 
 def _args():
     return SimpleNamespace(
-        pipeline_config=SimpleNamespace(vae_precision="fp32"),
+        pipeline_config=SimpleNamespace(
+            vae_precision="fp32",
+            vae_tiling=True,
+            vae_config=SimpleNamespace(
+                arch_config=SimpleNamespace(spatial_compression_ratio=VAE_SPATIAL_COMPRESSION_RATIO)),
+        ),
         disable_autocast=True,
         image_encoder_cpu_offload=False,
         vae_cpu_offload=False,
@@ -95,12 +132,61 @@ def _cpu_device(monkeypatch):
     )
 
 
-def _i2v_stage():
+@pytest.fixture
+def lightweight_vae_factory(monkeypatch):
+    monkeypatch.setattr(hunyuan15vae, "HunyuanVideo15Encoder3D", _ConstantEncoder)
+    monkeypatch.setattr(hunyuan15vae, "HunyuanVideo15Decoder3D", _UnusedDecoder)
+
+    def build(pipeline_config=None):
+        if pipeline_config is None:
+            pipeline_config = Hunyuan15I2V480PStepDistilledConfig()
+        return AutoencoderKLHunyuanVideo15(pipeline_config.vae_config)
+
+    return build
+
+
+@pytest.fixture
+def i2v_stage(lightweight_vae_factory):
     return Hy15ImageEncodingStage(
         image_encoder=_FakeSiglip(),
         image_processor=_FakeProcessor(),
-        vae=_FakeVAE(),
+        vae=lightweight_vae_factory(),
     )
+
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [Hunyuan15I2V480PStepDistilledConfig, Hunyuan15I2V720PConfig],
+)
+def test_i2v_configs_build_the_vae_encoder_and_decoder(config_cls, lightweight_vae_factory) -> None:
+    pipeline_config = config_cls()
+    vae = lightweight_vae_factory(pipeline_config)
+
+    assert pipeline_config.vae_config.load_encoder is True
+    assert pipeline_config.vae_config.load_decoder is True
+    assert pipeline_config.text_encoder_configs[0].arch_config.output_hidden_states is True
+    assert isinstance(vae.encoder, _ConstantEncoder)
+    assert isinstance(vae.decoder, _UnusedDecoder)
+
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [Hunyuan15I2V480PStepDistilledConfig, Hunyuan15I2V720PConfig],
+)
+def test_i2v_configs_reject_disabling_the_vae_encoder(config_cls) -> None:
+    pipeline_config = config_cls()
+    pipeline_config.update_config_from_dict({"vae_config.load_encoder": False})
+
+    with pytest.raises(ValueError, match="requires the VAE encoder"):
+        pipeline_config.check_pipeline_config()
+
+
+@pytest.mark.parametrize(
+    "config_cls",
+    [Hunyuan15T2V480PConfig, Hunyuan15T2V720PConfig, Hunyuan15SR1080PConfig],
+)
+def test_non_i2v_configs_keep_the_vae_encoder_disabled(config_cls) -> None:
+    assert config_cls().vae_config.load_encoder is False
 
 
 class TestTextToVideoPath:
@@ -124,18 +210,25 @@ class TestTextToVideoPath:
         assert torch.all(batch.video_latent == 0)
         assert batch.image_latent is None
 
+    def test_placeholders_follow_the_latent_batch(self) -> None:
+        batch_size = 2
+        batch = Hy15ImageEncodingStage().forward(_batch(None, batch_size=batch_size), _args())
+
+        assert batch.image_embeds[0].shape == (batch_size, VISION_TOKENS, VISION_DIM)
+        assert batch.video_latent.shape == (batch_size, 1) + LATENT_SHAPE[2:]
+
 
 class TestImageToVideoPath:
 
-    def test_image_embeds_come_from_siglip(self) -> None:
-        batch = _i2v_stage().forward(_batch(REFERENCE_IMAGE), _args())
+    def test_image_embeds_come_from_siglip(self, i2v_stage) -> None:
+        batch = i2v_stage.forward(_batch(REFERENCE_IMAGE), _args())
 
         assert batch.image_embeds[0].shape == (1, VISION_TOKENS, VISION_DIM)
         # Non-zero is the whole point: all-zero would re-select the T2V branch.
         assert not torch.all(batch.image_embeds[0] == 0)
 
-    def test_channel_layout_is_conditioning_then_mask(self) -> None:
-        batch = _i2v_stage().forward(_batch(REFERENCE_IMAGE), _args())
+    def test_channel_layout_is_conditioning_then_mask(self, i2v_stage) -> None:
+        batch = i2v_stage.forward(_batch(REFERENCE_IMAGE), _args())
 
         assert batch.image_latent.shape == (1, LATENT_SHAPE[1] + 1) + LATENT_SHAPE[2:]
 
@@ -149,19 +242,45 @@ class TestImageToVideoPath:
         assert torch.all(conditioning[:, :, 0] != 0)
         assert torch.all(conditioning[:, :, 1:] == 0)
 
-    def test_scaling_factor_is_applied(self) -> None:
-        batch = _i2v_stage().forward(_batch(REFERENCE_IMAGE), _args())
+    def test_scaling_factor_is_applied(self, i2v_stage) -> None:
+        batch = i2v_stage.forward(_batch(REFERENCE_IMAGE), _args())
 
-        # Fake VAE emits 3.0 and declares scaling_factor 2.0.
+        expected = 3.0 * i2v_stage.vae.config.scaling_factor
         assert torch.allclose(batch.image_latent[:, :LATENT_SHAPE[1], 0],
-                              torch.full((1, LATENT_SHAPE[1]) + LATENT_SHAPE[3:], 6.0))
+                              torch.full((1, LATENT_SHAPE[1]) + LATENT_SHAPE[3:], expected))
 
-    def test_video_latent_left_unset(self) -> None:
-        batch = _i2v_stage().forward(_batch(REFERENCE_IMAGE), _args())
+    def test_video_latent_left_unset(self, i2v_stage) -> None:
+        batch = i2v_stage.forward(_batch(REFERENCE_IMAGE), _args())
 
         # DenoisingStage checks video_latent first and would append the mask
         # ahead of the conditioning, so this slot has to stay empty.
         assert batch.video_latent is None
+
+    def test_single_reference_conditioning_repeats_to_the_latent_batch(self, i2v_stage) -> None:
+        batch_size = 2
+        batch = i2v_stage.forward(_batch(REFERENCE_IMAGE, batch_size=batch_size), _args())
+
+        expected_shape = (batch_size, LATENT_SHAPE[1] + 1) + LATENT_SHAPE[2:]
+        assert batch.image_latent.shape == expected_shape
+        assert batch.image_embeds[0].shape == (batch_size, VISION_TOKENS, VISION_DIM)
+        assert torch.equal(batch.image_latent[0], batch.image_latent[1])
+        assert torch.equal(batch.image_embeds[0][0], batch.image_embeds[0][1])
+
+        conditioning = batch.image_latent[:, :LATENT_SHAPE[1]]
+        mask = batch.image_latent[:, LATENT_SHAPE[1]:]
+        assert torch.all(conditioning[:, :, 0] != 0)
+        assert torch.all(conditioning[:, :, 1:] == 0)
+        assert torch.all(mask[:, :, 0] == 1)
+        assert torch.all(mask[:, :, 1:] == 0)
+
+        assert i2v_stage.vae.encoder.forward_calls == 1
+        assert i2v_stage.image_encoder.forward_calls == 1
+
+        noise_latents = torch.zeros((batch_size, ) + LATENT_SHAPE[1:])
+        assert torch.cat([noise_latents, batch.image_latent], dim=1).shape == (
+            batch_size,
+            LATENT_SHAPE[1] * 2 + 1,
+        ) + LATENT_SHAPE[2:]
 
     def test_missing_encoder_is_an_explicit_error(self) -> None:
         with pytest.raises(ValueError, match="image encoder"):


### PR DESCRIPTION
## Purpose

`HunyuanVideo15ImageToVideoPipeline` cannot generate from a reference image.
Passing `image_path` raises `StageVerificationError` before denoising, and even
past that point the image has no route into the transformer.

Fixes #1692

## Changes

The i2v checkpoints ship a SigLIP pair that FastVideo never asked for. Their
`model_index.json` declares:

```
'feature_extractor': ['transformers', 'SiglipImageProcessor'],
'image_encoder':     ['transformers', 'SiglipVisionModel'],
```

Neither was in `_required_config_modules`, so `Hy15ImageEncodingStage` was
constructed with `image_encoder=None`. The stage only wrote `image_embeds` on
the `pil_image is None` branch, so supplying an image left it at its
`ForwardBatch` default of `[]` and the inherited output check rejected it.

Three changes:

1. `Hunyuan15I2V480PStepDistilledConfig` and `Hunyuan15I2V720PConfig` declare
   `image_encoder_config = SiglipVisionConfig`, which is what makes the loader
   build one. FastVideo already has the SigLIP implementation
   (`fastvideo/models/encoders/siglip.py`, registered at
   `fastvideo/models/registry.py:106`), so no new model code.
2. The i2v pipeline adds `image_encoder` and `feature_extractor` to its required
   modules and passes them, plus the VAE, into the stage.
3. `Hy15ImageEncodingStage` gains the i2v path: SigLIP hidden states into
   `image_embeds`, VAE latents of the reference image into the first frame of
   the conditioning stream, and a mask channel set to 1 on that frame.

### Channel order

This is the part that is invisible until an image is actually supplied.
`DenoisingStage` appends `video_latent` and a zero pad separately
(`denoising.py:405-414`), producing

```
[latents 32][mask 1][conditioning 32]
```

but the model expects

```
[latents 32][conditioning 32][mask 1]
```

For t2v both trailing blocks are zero, so the two orders yield an identical
tensor and the discrepancy never surfaces. The i2v path therefore populates
`image_latent` as one 33 channel block and leaves `video_latent` unset, so
denoising takes the `elif batch.image_latent is not None` branch that appends it
whole.

The expected layout is not a guess. The diffusers reference implementation,
`diffusers/pipelines/hunyuan_video1_5/pipeline_hunyuan_video1_5_image2video.py`,
builds `cat([latents, cond_latents_concat, mask_concat], dim=1)`, applies
`scaling_factor` to the image latents, repeats them over the temporal dimension
and zeroes every frame after the first, and sets the mask to 1 on frame 0.
`HYWorldImageEncodingStage` in this repo already assembles `image_latent` the
same way.

### Blast radius

t2v and the two super-resolution pipelines share this stage but never carry a
`pil_image`, so they keep the existing branch untouched, including
`video_latent`, which `SRDenoisingStage` reads directly
(`sr_denoising.py:168`). A pipeline built without the encoder that is handed an
image now raises a message naming the missing pieces rather than failing an
opaque field check.

## Test Plan

```bash
pytest fastvideo/tests/stages/test_hy15_image_encoding_stage.py -q
pre-commit run --files fastvideo/pipelines/stages/image_encoding.py \
                       fastvideo/pipelines/basic/hunyuan15/hunyuan15_i2v_pipeline.py \
                       fastvideo/configs/pipelines/hunyuan15.py \
                       fastvideo/tests/stages/test_hy15_image_encoding_stage.py
```

CPU only, no checkpoint needed. The tests fake SigLIP and the VAE, since what
needs guarding is the layout rather than the numerics.

Covered:

- t2v still emits all zero `image_embeds`, which is what keeps the transformer's
  `is_t2v` check true, and still populates `video_latent` for the SR stages
- i2v `image_embeds` are non-zero, which is what turns that check off
- conditioning occupies channels 0 to 31 and the mask channel 32, with the mask
  on frame 0 only and the conditioning zero after frame 0
- `scaling_factor` is applied
- `video_latent` stays unset on the i2v path, so denoising cannot take the
  branch that would swap the blocks
- a pipeline without the encoder raises a clear error

## Test Results

<details>
<summary>Test output</summary>

```
$ pytest fastvideo/tests/stages/test_hy15_image_encoding_stage.py -q
.......
7 passed, 14 warnings in 0.05s

$ pre-commit run --files ...
yapf.....................................................................Passed
ruff (legacy alias)......................................................Passed
codespell................................................................Passed
```

</details>

Before, from #1692:

```
fastvideo.pipelines.stages.base.StageVerificationError: Output verification failed
for image_encoding_stage|Hy15ImageEncodingStage: Failed fields: image_embeds
Details: Validation failures:
  Field 'image_embeds':
    1. Validator 'validator' failed. Actual: []
```

## Checklist

- [x] I ran pre-commit on the changed files and fixed all issues
- [x] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

Memory: the i2v pipelines now load a SigLIP vision tower they previously did
not. It honours `image_encoder_cpu_offload` and is moved back to CPU after the
encode, same as the other image encoding stages.

**Not verified here: an end to end i2v run on a GPU.** I am doing that next and
will post before and after in #1692. Marking this ready rather than draft since
the change is self contained and the layout question is settled against the
diffusers reference, but happy to hold it until that lands if you would rather
see the run first.

There is also no i2v example script for HY1.5 and no HY1.5 entry under
`fastvideo/tests/ssim/`, which is why this went unnoticed. Worth noting that an
SSIM reference alone would not catch a regression here once the crash is gone,
since a t2v fallback still produces a plausible video. Happy to add an example
script in a follow up.
