### PR TITLE
[feat] VSA for MiniMax H3: packed mixed-modality sparse attention

### DIFF
--- a/fastvideo/attention/backends/abstract.py
+++ b/fastvideo/attention/backends/abstract.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Adapted from vllm: https://github.com/vllm-project/vllm/blob/v0.7.3/vllm/attention/backends/abstract.py
 
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
@@ -9,6 +10,22 @@ if TYPE_CHECKING:
     pass
 
 import torch
+
+_LAYER_IDX_RE = re.compile(r"blocks\.(\d+)")
+
+
+def layer_idx_from_prefix(prefix: str, default: int | None = None) -> int:
+    """Parse the transformer-block index out of a layer prefix.
+
+    Shared by backends that key per-layer behavior off the block number
+    (vmoba, VSA-H3). Raises when unparsable unless ``default`` is given.
+    """
+    match = _LAYER_IDX_RE.search(prefix)
+    if match:
+        return int(match.group(1))
+    if default is None:
+        raise ValueError(f"cannot parse a layer index from attention prefix {prefix!r}")
+    return default
 
 
 class AttentionBackend(ABC):

--- a/fastvideo/attention/backends/video_sparse_attn.py
+++ b/fastvideo/attention/backends/video_sparse_attn.py
@@ -61,6 +61,7 @@ def construct_variable_block_sizes(
     dit_seq_shape: tuple[int, int, int],
     num_tiles: tuple[int, int, int],
     device: torch.device,
+    tile_size: tuple[int, int, int] = VSA_TILE_SIZE,
 ) -> torch.LongTensor:
     """
     Compute the number of valid (non‑padded) tokens inside every
@@ -73,7 +74,7 @@ def construct_variable_block_sizes(
     """
     # unpack
     t, h, w = dit_seq_shape
-    ts_t, ts_h, ts_w = VSA_TILE_SIZE
+    ts_t, ts_h, ts_w = tile_size
     n_t, n_h, n_w = num_tiles
 
     def _sizes(dim_len: int, tile: int, n_tiles: int) -> torch.LongTensor:

--- a/fastvideo/attention/backends/video_sparse_attn.py
+++ b/fastvideo/attention/backends/video_sparse_attn.py
@@ -158,10 +158,35 @@ class VideoSparseAttentionMetadata(AttentionMetadata):
     cache_tile_buf: bool = True
 
 
+def compute_topk(sparsity: float, num_blocks: int) -> int:
+    """Blocks to keep for a sparsity level, clamped to [1, num_blocks]."""
+    return max(1, min(math.ceil((1 - sparsity) * num_blocks), num_blocks))
+
+
 def _compute_cur_topk(attn_metadata: VideoSparseAttentionMetadata) -> int:
-    num_kv_blocks = attn_metadata.variable_block_sizes.numel()
-    cur_topk = math.ceil((1 - attn_metadata.VSA_sparsity) * num_kv_blocks)
-    return max(1, min(cur_topk, num_kv_blocks))
+    return compute_topk(attn_metadata.VSA_sparsity, attn_metadata.variable_block_sizes.numel())
+
+
+def scatter_into_tile_buf(
+    x: torch.Tensor,
+    target_shape: tuple[int, ...],
+    dst_index: torch.Tensor,
+    buf: torch.Tensor | None,
+    src_index: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Zero-padded tile scatter shared by the VSA backends.
+
+    Allocates (zeros) when ``buf`` is missing or mismatched; otherwise reuses
+    it — pad slots are never written and every non-pad slot is fully
+    overwritten per call, so a reused buffer stays valid. Callers own the
+    buffer's lifetime (per-metadata for Wan VSA, per-builder for VSA-H3) and
+    its aliasing contract: the result is only valid until the next call with
+    the same buffer.
+    """
+    if (buf is None or buf.shape != target_shape or buf.dtype != x.dtype or buf.device != x.device):
+        buf = torch.zeros(target_shape, device=x.device, dtype=x.dtype)
+    buf[:, dst_index] = x if src_index is None else x[:, src_index]
+    return buf
 
 
 class VideoSparseAttentionMetadataBuilder(AttentionMetadataBuilder):
@@ -244,23 +269,15 @@ class VideoSparseAttentionImpl(AttentionImpl):
         target_shape = (x.shape[0], t_padded_size * h_padded_size * w_padded_size, x.shape[-2], x.shape[-1])
 
         if not attn_metadata.cache_tile_buf:
-            buf = torch.zeros(target_shape, device=x.device, dtype=x.dtype)
-            buf[:, attn_metadata.non_pad_index] = x[:, attn_metadata.tile_partition_indices]
-            return buf
+            return scatter_into_tile_buf(x, target_shape, attn_metadata.non_pad_index, None,
+                                         attn_metadata.tile_partition_indices)
 
-        # Reuse the per-step buffer stashed on metadata (lazily allocated
-        # on the first VSA layer's call within a denoising step).  Pad
-        # positions are zero from the initial torch.zeros and never
-        # written to.  Scoping to metadata makes reuse safe across
-        # concurrent requests and keeps the "pad positions are zero"
-        # invariant trivially true: ``non_pad_index`` is fixed within
-        # a single metadata instance.
-        buf = attn_metadata.tile_buf
-        if (buf is None or buf.shape != target_shape or buf.dtype != x.dtype or buf.device != x.device):
-            buf = torch.zeros(target_shape, device=x.device, dtype=x.dtype)
-            attn_metadata.tile_buf = buf
-
-        buf[:, attn_metadata.non_pad_index] = x[:, attn_metadata.tile_partition_indices]
+        # Buffer scoped to the per-step metadata (lazily allocated on the
+        # first VSA layer's call within a denoising step), which keeps reuse
+        # safe across concurrent requests.
+        buf = scatter_into_tile_buf(x, target_shape, attn_metadata.non_pad_index, attn_metadata.tile_buf,
+                                    attn_metadata.tile_partition_indices)
+        attn_metadata.tile_buf = buf
         return buf
 
     def untile(self, x: torch.Tensor, untile_combined_index: torch.LongTensor) -> torch.Tensor:

--- a/fastvideo/attention/backends/video_sparse_attn_h3.py
+++ b/fastvideo/attention/backends/video_sparse_attn_h3.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+"""VSA for MiniMax H3's packed mixed-modality self-attention.
+
+H3 runs one joint bidirectional attention over
+``[text | condition keyframes | audio | generated video]``, so this
+backend differs from the Wan-tuned ``video_sparse_attn``:
+
+- Tiles are ``[segment-pure prefix chunks] + [3D (4,8,8) video tiles]``;
+  prefix tiles never straddle segment boundaries.
+- Selection is pure Python on pooled tile scores; the block-sparse kernel
+  consumes an explicit bool mask, so no kernel changes are needed.
+- The compression branch is gated by ``to_gate_compress``, which the H3
+  checkpoint does not carry: the loader zero-initializes it, so untrained
+  inference is exactly pure sparse and finetuning can learn the gate.
+- Non-video *queries* are always dense. Non-video *keys* are either
+  always-selected for every query ("exempt", default) or compete in
+  top-k under a FLOP-matched budget ("compete") — the ablation axis,
+  switched via ``FASTVIDEO_H3_VSA_MODE`` or per request via
+  ``generate_video(..., vsa_mode=...)``. Per-request scheduling knobs
+  (``vsa_dense_first_n_steps``, ``vsa_dense_layers``) let mixed schedules
+  run the diffuse steps/layers dense while pushing the rest harder.
+
+Targets sm10.x through the FA4 CuTe 256-tile path
+(``FASTVIDEO_VSA_CUTEDSL=1``); the Triton 256→64 expansion is the
+fallback and keeps identical mask semantics.
+"""
+
+import functools
+import math
+import os
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+try:
+    from fastvideo_kernel.block_sparse_attn_256 import block_sparse_attn_256_bshd
+except ImportError:
+    block_sparse_attn_256_bshd = None
+
+from fastvideo.attention.backends.abstract import (AttentionBackend, AttentionImpl, AttentionMetadata,
+                                                   AttentionMetadataBuilder)
+from fastvideo.attention.backends.video_sparse_attn import (construct_variable_block_sizes, get_non_pad_index,
+                                                            get_tile_partition_indices)
+from fastvideo.attention.backends.video_sparse_attn_h3_probe import probe_enabled, record_probe
+
+VSA_H3_TILE_SIZE = (4, 8, 8)  # 256 elements -> FA4 CuTe fastpath on sm10.x
+_TILE_ELEMS = math.prod(VSA_H3_TILE_SIZE)
+
+
+def _h3_vsa_mode() -> str:
+    mode = os.environ.get("FASTVIDEO_H3_VSA_MODE", "exempt")
+    if mode not in ("exempt", "compete"):
+        raise ValueError(f"FASTVIDEO_H3_VSA_MODE must be 'exempt' or 'compete', got {mode!r}.")
+    return mode
+
+
+@functools.lru_cache(maxsize=10)
+def _h3_tile_geometry(
+    prefix_segments: tuple[int, ...],
+    dit_seq_shape: tuple[int, int, int],
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, int]:
+    """Tile the packed sequence: segment-pure prefix chunks, then video tiles.
+
+    Returns (tile_partition_indices, variable_block_sizes, non_pad_index,
+    untile_combined_index, num_prefix_tiles, num_video_tiles).
+    """
+    prefix_len = sum(prefix_segments)
+
+    prefix_sizes: list[int] = []
+    for segment in prefix_segments:
+        full, rem = divmod(segment, _TILE_ELEMS)
+        prefix_sizes.extend([_TILE_ELEMS] * full)
+        if rem:
+            prefix_sizes.append(rem)
+    num_prefix_tiles = len(prefix_sizes)
+
+    ts_t, ts_h, ts_w = VSA_H3_TILE_SIZE
+    t, h, w = dit_seq_shape
+    num_tiles = (math.ceil(t / ts_t), math.ceil(h / ts_h), math.ceil(w / ts_w))
+    video_sizes = construct_variable_block_sizes(dit_seq_shape, num_tiles, device, VSA_H3_TILE_SIZE)
+    num_video_tiles = int(video_sizes.numel())
+
+    video_indices = get_tile_partition_indices(dit_seq_shape, VSA_H3_TILE_SIZE, device) + prefix_len
+    tile_partition_indices = torch.cat([
+        torch.arange(prefix_len, device=device, dtype=torch.long),
+        video_indices,
+    ])
+    # cat promotes the int32 helper output to int64 alongside the prefix sizes
+    variable_block_sizes = torch.cat([
+        torch.tensor(prefix_sizes, dtype=torch.long, device=device),
+        video_sizes,
+    ])
+
+    # get_non_pad_index is lru-cached on tensor identity; variable_block_sizes
+    # is itself cached by this function, so the identity stays stable.
+    non_pad_index = get_non_pad_index(variable_block_sizes, _TILE_ELEMS)
+
+    untile_combined_index = non_pad_index[torch.argsort(tile_partition_indices)]
+    return (tile_partition_indices, variable_block_sizes, non_pad_index, untile_combined_index, num_prefix_tiles,
+            num_video_tiles)
+
+
+class MiniMaxH3VSABackend(AttentionBackend):
+
+    accept_output_buffer: bool = True
+
+    @staticmethod
+    def get_supported_head_sizes() -> list[int]:
+        return [64, 128]
+
+    @staticmethod
+    def get_name() -> str:
+        return "VIDEO_SPARSE_ATTN_H3"
+
+    @staticmethod
+    def get_impl_cls() -> type["MiniMaxH3VSAImpl"]:
+        return MiniMaxH3VSAImpl
+
+    @staticmethod
+    def get_metadata_cls() -> type["MiniMaxH3VSAMetadata"]:
+        return MiniMaxH3VSAMetadata
+
+    @staticmethod
+    def get_builder_cls() -> type["MiniMaxH3VSAMetadataBuilder"]:
+        return MiniMaxH3VSAMetadataBuilder
+
+
+@dataclass
+class MiniMaxH3VSAMetadata(AttentionMetadata):
+    total_seq_length: int
+    num_prefix_tiles: int
+    num_video_tiles: int
+    exempt: bool
+    tile_partition_indices: torch.Tensor
+    variable_block_sizes: torch.Tensor
+    non_pad_index: torch.Tensor
+    untile_combined_index: torch.Tensor
+    # layers forced dense regardless of sparsity (probe-guided opt-outs)
+    dense_layers: tuple[int, ...] = ()
+    # Per-step shared padded buffer reused across the 50 VSA layers.
+    tile_buf: torch.Tensor | None = None
+
+
+class MiniMaxH3VSAMetadataBuilder(AttentionMetadataBuilder):
+
+    def __init__(self) -> None:
+        pass
+
+    def prepare(self) -> None:
+        pass
+
+    def build(  # type: ignore
+            self,
+            current_timestep: int,
+            raw_latent_shape: tuple[int, int, int],
+            patch_size: tuple[int, int, int],
+            VSA_sparsity: float,
+            prefix_segments: tuple[int, ...],
+            device: torch.device,
+            exempt: bool | None = None,
+            dense_layers: tuple[int, ...] = (),
+            **kwargs: dict[str, Any],
+    ) -> MiniMaxH3VSAMetadata:
+        dit_seq_shape = (raw_latent_shape[0] // patch_size[0], raw_latent_shape[1] // patch_size[1],
+                         raw_latent_shape[2] // patch_size[2])
+        prefix_segments = tuple(int(s) for s in prefix_segments if s > 0)
+        total_seq_length = sum(prefix_segments) + math.prod(dit_seq_shape)
+
+        (tile_partition_indices, variable_block_sizes, non_pad_index, untile_combined_index, num_prefix_tiles,
+         num_video_tiles) = _h3_tile_geometry(prefix_segments, dit_seq_shape, device)
+
+        return MiniMaxH3VSAMetadata(
+            current_timestep=current_timestep,
+            VSA_sparsity=VSA_sparsity,
+            total_seq_length=total_seq_length,
+            num_prefix_tiles=num_prefix_tiles,
+            num_video_tiles=num_video_tiles,
+            exempt=exempt if exempt is not None else _h3_vsa_mode() == "exempt",
+            tile_partition_indices=tile_partition_indices,
+            variable_block_sizes=variable_block_sizes,
+            non_pad_index=non_pad_index,
+            untile_combined_index=untile_combined_index,
+            dense_layers=tuple(dense_layers),
+        )
+
+
+def _pool_tiles(x: torch.Tensor, variable_block_sizes: torch.Tensor) -> torch.Tensor:
+    """fp32 mean over each 256-token tile. x: [B, S_pad, H, D] -> [B, H, n_tiles, D].
+
+    Pad positions in the tile buffer are guaranteed zero (zeros-init, never
+    written), so a plain sum with fp32 accumulation needs no validity mask
+    and no materialized fp32 temp; dividing by the true tile size makes it
+    the masked mean exactly.
+    """
+    batch, seq_len, heads, dim = x.shape
+    n_tiles = seq_len // _TILE_ELEMS
+    pooled = x.view(batch, n_tiles, _TILE_ELEMS, heads, dim).sum(dim=2, dtype=torch.float32)
+    pooled = pooled / variable_block_sizes.view(1, -1, 1, 1)
+    return pooled.permute(0, 2, 1, 3)
+
+
+def _build_block_mask(
+    scores: torch.Tensor,
+    num_prefix_tiles: int,
+    num_video_tiles: int,
+    VSA_sparsity: float,
+    exempt: bool,
+) -> torch.Tensor:
+    """scores: [B, H, n_tiles, n_tiles] -> bool mask, same shape."""
+    n_tiles = scores.shape[-1]
+    k_vid = max(1, min(math.ceil((1 - VSA_sparsity) * num_video_tiles), num_video_tiles))
+    if k_vid == num_video_tiles:
+        return torch.ones_like(scores, dtype=torch.bool)
+    mask = torch.zeros_like(scores, dtype=torch.bool)
+    if exempt or num_prefix_tiles == 0:
+        video_cols = scores[..., num_prefix_tiles:]
+        idx = video_cols.topk(k_vid, dim=-1).indices + num_prefix_tiles
+        mask.scatter_(-1, idx, True)
+        mask[..., :num_prefix_tiles] = True
+    else:
+        k_total = min(k_vid + num_prefix_tiles, n_tiles)
+        idx = scores.topk(k_total, dim=-1).indices
+        mask.scatter_(-1, idx, True)
+    mask[:, :, :num_prefix_tiles, :] = True
+    return mask
+
+
+class MiniMaxH3VSAImpl(AttentionImpl):
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        causal: bool,
+        softmax_scale: float,
+        num_kv_heads: int | None = None,
+        prefix: str = "",
+        **extra_impl_args,
+    ) -> None:
+        self.prefix = prefix
+        match = re.search(r"transformer_blocks\.(\d+)\.", prefix)
+        self.layer_idx = int(match.group(1)) if match else -1
+
+    def tile(self, x: torch.Tensor, attn_metadata: MiniMaxH3VSAMetadata) -> torch.Tensor:
+        """Scatter rows into the padded tile buffer (pad positions stay zero).
+
+        The returned tensor aliases the per-metadata buffer; callers must
+        consume it before the next ``tile()`` on the same metadata (both
+        call sites in ``forward()`` read it immediately).
+        """
+        if x.shape[1] != attn_metadata.total_seq_length:
+            raise ValueError(f"VSA-H3 metadata was built for sequence length {attn_metadata.total_seq_length}, "
+                             f"got {x.shape[1]}. A non-packed sequence (e.g. the token refiner) is "
+                             "routed to the VSA-H3 backend; exclude it from the supported backends.")
+        n_tiles = attn_metadata.variable_block_sizes.numel()
+        target_shape = (x.shape[0], n_tiles * _TILE_ELEMS, x.shape[-2], x.shape[-1])
+
+        buf = attn_metadata.tile_buf
+        if (buf is None or buf.shape != target_shape or buf.dtype != x.dtype or buf.device != x.device):
+            buf = torch.zeros(target_shape, device=x.device, dtype=x.dtype)
+            attn_metadata.tile_buf = buf
+
+        # single scatter: untile_combined_index maps original row i to its
+        # padded slot, so this is exactly the inverse of postprocess_output
+        # (no gathered temp of x, unlike buf[:, non_pad] = x[:, partition])
+        buf[:, attn_metadata.untile_combined_index] = x
+        return buf
+
+    def preprocess_qkv(self, qkv: torch.Tensor, attn_metadata: MiniMaxH3VSAMetadata) -> torch.Tensor:
+        return self.tile(qkv, attn_metadata)
+
+    def postprocess_output(self, output: torch.Tensor, attn_metadata: MiniMaxH3VSAMetadata) -> torch.Tensor:
+        return output[:, attn_metadata.untile_combined_index]
+
+    def forward(  # type: ignore[override]
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        gate_compress: torch.Tensor | None,
+        attn_metadata: MiniMaxH3VSAMetadata,
+    ) -> torch.Tensor:
+        if block_sparse_attn_256_bshd is None:
+            raise NotImplementedError("fastvideo_kernel.block_sparse_attn_256 is not installed")
+
+        # probe-guided per-layer opt-out: diffuse layers run dense (all-True
+        # mask) while the rest keep the configured sparsity
+        layer_sparsity = 0.0 if self.layer_idx in attn_metadata.dense_layers else attn_metadata.VSA_sparsity
+        probe_dir = probe_enabled()
+
+        scores = None
+        if layer_sparsity > 0.0 or gate_compress is not None or probe_dir is not None:
+            q_pooled = _pool_tiles(query, attn_metadata.variable_block_sizes)
+            k_pooled = _pool_tiles(key, attn_metadata.variable_block_sizes)
+            scores = torch.matmul(q_pooled, k_pooled.transpose(-2, -1)) / (query.shape[-1]**0.5)
+            if probe_dir is not None:
+                record_probe(probe_dir, self.layer_idx, query, key, scores, attn_metadata)
+
+        if scores is None:
+            n_tiles = attn_metadata.variable_block_sizes.numel()
+            mask = torch.ones(query.shape[0], query.shape[2], n_tiles, n_tiles, dtype=torch.bool, device=query.device)
+        else:
+            mask = _build_block_mask(
+                scores,
+                attn_metadata.num_prefix_tiles,
+                attn_metadata.num_video_tiles,
+                layer_sparsity,
+                attn_metadata.exempt,
+            )
+
+        out, _ = block_sparse_attn_256_bshd(query, key, value, mask, attn_metadata.variable_block_sizes)
+
+        if gate_compress is not None:
+            # Wan-style compression branch: dense attention over pooled tiles,
+            # broadcast to each tile's rows, scaled by the learned gate
+            # (zero-initialized for H3 => branch contributes nothing until
+            # finetuned; the model layer skips it entirely for all-zero gates).
+            v_pooled = _pool_tiles(value, attn_metadata.variable_block_sizes)
+            out_c = torch.matmul(torch.softmax(scores, dim=-1), v_pooled)  # [B, H, n_tiles, D]
+            out_c = out_c.permute(0, 2, 1, 3).to(out.dtype)  # [B, n_tiles, H, D]
+            batch, _, heads, dim = out.shape
+            n_tiles = attn_metadata.variable_block_sizes.numel()
+            out.view(batch, n_tiles, _TILE_ELEMS, heads,
+                     dim).addcmul_(out_c.unsqueeze(2), gate_compress.view(batch, n_tiles, _TILE_ELEMS, heads, dim))
+        return out

--- a/fastvideo/attention/backends/video_sparse_attn_h3.py
+++ b/fastvideo/attention/backends/video_sparse_attn_h3.py
@@ -15,8 +15,8 @@ backend differs from the Wan-tuned ``video_sparse_attn``:
 - Non-video *queries* are always dense. Non-video *keys* are either
   always-selected for every query ("exempt", default) or compete in
   top-k under a FLOP-matched budget ("compete") — the ablation axis,
-  switched via ``FASTVIDEO_H3_VSA_MODE`` or per request via
-  ``generate_video(..., vsa_mode=...)``. Per-request scheduling knobs
+  switched per request via ``generate_video(..., vsa_mode=...)``
+  (default: exempt). Per-request scheduling knobs
   (``vsa_dense_first_n_steps``, ``vsa_dense_layers``) let mixed schedules
   run the diffuse steps/layers dense while pushing the rest harder.
 
@@ -27,8 +27,6 @@ fallback and keeps identical mask semantics.
 
 import functools
 import math
-import os
-import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -40,20 +38,26 @@ except ImportError:
     block_sparse_attn_256_bshd = None
 
 from fastvideo.attention.backends.abstract import (AttentionBackend, AttentionImpl, AttentionMetadata,
-                                                   AttentionMetadataBuilder)
-from fastvideo.attention.backends.video_sparse_attn import (construct_variable_block_sizes, get_non_pad_index,
-                                                            get_tile_partition_indices)
+                                                   AttentionMetadataBuilder, layer_idx_from_prefix)
+from fastvideo.attention.backends.video_sparse_attn import (compute_topk, construct_variable_block_sizes,
+                                                            get_non_pad_index, get_tile_partition_indices,
+                                                            scatter_into_tile_buf)
 from fastvideo.attention.backends.video_sparse_attn_h3_probe import probe_enabled, record_probe
 
 VSA_H3_TILE_SIZE = (4, 8, 8)  # 256 elements -> FA4 CuTe fastpath on sm10.x
 _TILE_ELEMS = math.prod(VSA_H3_TILE_SIZE)
 
 
-def _h3_vsa_mode() -> str:
-    mode = os.environ.get("FASTVIDEO_H3_VSA_MODE", "exempt")
-    if mode not in ("exempt", "compete"):
-        raise ValueError(f"FASTVIDEO_H3_VSA_MODE must be 'exempt' or 'compete', got {mode!r}.")
-    return mode
+def token_tile_and_valid(variable_block_sizes: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Per padded-token tile id and pad-validity mask.
+
+    The single encoding of the padding contract, shared by the probe and the
+    test oracle so they cannot drift from the backend's tile geometry.
+    """
+    device = variable_block_sizes.device
+    token_tile = torch.arange(variable_block_sizes.numel(), device=device).repeat_interleave(_TILE_ELEMS)
+    token_valid = (torch.arange(_TILE_ELEMS, device=device)[None, :] < variable_block_sizes[:, None]).reshape(-1)
+    return token_tile, token_valid
 
 
 @functools.lru_cache(maxsize=10)
@@ -61,10 +65,10 @@ def _h3_tile_geometry(
     prefix_segments: tuple[int, ...],
     dit_seq_shape: tuple[int, int, int],
     device: torch.device,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, int]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int]:
     """Tile the packed sequence: segment-pure prefix chunks, then video tiles.
 
-    Returns (tile_partition_indices, variable_block_sizes, non_pad_index,
+    Returns (tile_partition_indices, variable_block_sizes,
     untile_combined_index, num_prefix_tiles, num_video_tiles).
     """
     prefix_len = sum(prefix_segments)
@@ -99,8 +103,7 @@ def _h3_tile_geometry(
     non_pad_index = get_non_pad_index(variable_block_sizes, _TILE_ELEMS)
 
     untile_combined_index = non_pad_index[torch.argsort(tile_partition_indices)]
-    return (tile_partition_indices, variable_block_sizes, non_pad_index, untile_combined_index, num_prefix_tiles,
-            num_video_tiles)
+    return (tile_partition_indices, variable_block_sizes, untile_combined_index, num_prefix_tiles, num_video_tiles)
 
 
 class MiniMaxH3VSABackend(AttentionBackend):
@@ -134,20 +137,22 @@ class MiniMaxH3VSAMetadata(AttentionMetadata):
     num_prefix_tiles: int
     num_video_tiles: int
     exempt: bool
-    tile_partition_indices: torch.Tensor
     variable_block_sizes: torch.Tensor
-    non_pad_index: torch.Tensor
     untile_combined_index: torch.Tensor
     # layers forced dense regardless of sparsity (probe-guided opt-outs)
     dense_layers: tuple[int, ...] = ()
-    # Per-step shared padded buffer reused across the 50 VSA layers.
-    tile_buf: torch.Tensor | None = None
+    # Single-slot holder for the padded tile buffer, owned by the BUILDER so
+    # one buffer serves the whole denoising loop (pad slots stay zero and
+    # every non-pad slot is fully overwritten per tile(), so cross-step reuse
+    # is valid; saves a ~1.4 GB alloc+memset per step at 720p). VSA-H3 runs
+    # eager today — revisit the reuse if it ever goes under cudagraphs.
+    tile_buf_holder: list = None  # type: ignore[assignment]
 
 
 class MiniMaxH3VSAMetadataBuilder(AttentionMetadataBuilder):
 
     def __init__(self) -> None:
-        pass
+        self._tile_buf_holder: list = [None]
 
     def prepare(self) -> None:
         pass
@@ -160,7 +165,7 @@ class MiniMaxH3VSAMetadataBuilder(AttentionMetadataBuilder):
             VSA_sparsity: float,
             prefix_segments: tuple[int, ...],
             device: torch.device,
-            exempt: bool | None = None,
+            exempt: bool = True,
             dense_layers: tuple[int, ...] = (),
             **kwargs: dict[str, Any],
     ) -> MiniMaxH3VSAMetadata:
@@ -169,7 +174,7 @@ class MiniMaxH3VSAMetadataBuilder(AttentionMetadataBuilder):
         prefix_segments = tuple(int(s) for s in prefix_segments if s > 0)
         total_seq_length = sum(prefix_segments) + math.prod(dit_seq_shape)
 
-        (tile_partition_indices, variable_block_sizes, non_pad_index, untile_combined_index, num_prefix_tiles,
+        (_tile_partition_indices, variable_block_sizes, untile_combined_index, num_prefix_tiles,
          num_video_tiles) = _h3_tile_geometry(prefix_segments, dit_seq_shape, device)
 
         return MiniMaxH3VSAMetadata(
@@ -178,12 +183,11 @@ class MiniMaxH3VSAMetadataBuilder(AttentionMetadataBuilder):
             total_seq_length=total_seq_length,
             num_prefix_tiles=num_prefix_tiles,
             num_video_tiles=num_video_tiles,
-            exempt=exempt if exempt is not None else _h3_vsa_mode() == "exempt",
-            tile_partition_indices=tile_partition_indices,
+            exempt=exempt,
             variable_block_sizes=variable_block_sizes,
-            non_pad_index=non_pad_index,
             untile_combined_index=untile_combined_index,
-            dense_layers=tuple(dense_layers),
+            dense_layers=tuple(int(layer) for layer in dense_layers),
+            tile_buf_holder=self._tile_buf_holder,
         )
 
 
@@ -211,7 +215,7 @@ def _build_block_mask(
 ) -> torch.Tensor:
     """scores: [B, H, n_tiles, n_tiles] -> bool mask, same shape."""
     n_tiles = scores.shape[-1]
-    k_vid = max(1, min(math.ceil((1 - VSA_sparsity) * num_video_tiles), num_video_tiles))
+    k_vid = compute_topk(VSA_sparsity, num_video_tiles)
     if k_vid == num_video_tiles:
         return torch.ones_like(scores, dtype=torch.bool)
     mask = torch.zeros_like(scores, dtype=torch.bool)
@@ -241,15 +245,14 @@ class MiniMaxH3VSAImpl(AttentionImpl):
         **extra_impl_args,
     ) -> None:
         self.prefix = prefix
-        match = re.search(r"transformer_blocks\.(\d+)\.", prefix)
-        self.layer_idx = int(match.group(1)) if match else -1
+        self.layer_idx = layer_idx_from_prefix(prefix, default=-1)
 
     def tile(self, x: torch.Tensor, attn_metadata: MiniMaxH3VSAMetadata) -> torch.Tensor:
         """Scatter rows into the padded tile buffer (pad positions stay zero).
 
-        The returned tensor aliases the per-metadata buffer; callers must
-        consume it before the next ``tile()`` on the same metadata (both
-        call sites in ``forward()`` read it immediately).
+        The returned tensor aliases the builder-owned buffer; callers must
+        consume it before the next ``tile()`` (both call sites in
+        ``forward()`` read it immediately).
         """
         if x.shape[1] != attn_metadata.total_seq_length:
             raise ValueError(f"VSA-H3 metadata was built for sequence length {attn_metadata.total_seq_length}, "
@@ -258,16 +261,11 @@ class MiniMaxH3VSAImpl(AttentionImpl):
         n_tiles = attn_metadata.variable_block_sizes.numel()
         target_shape = (x.shape[0], n_tiles * _TILE_ELEMS, x.shape[-2], x.shape[-1])
 
-        buf = attn_metadata.tile_buf
-        if (buf is None or buf.shape != target_shape or buf.dtype != x.dtype or buf.device != x.device):
-            buf = torch.zeros(target_shape, device=x.device, dtype=x.dtype)
-            attn_metadata.tile_buf = buf
-
         # single scatter: untile_combined_index maps original row i to its
         # padded slot, so this is exactly the inverse of postprocess_output
-        # (no gathered temp of x, unlike buf[:, non_pad] = x[:, partition])
-        buf[:, attn_metadata.untile_combined_index] = x
-        return buf
+        holder = attn_metadata.tile_buf_holder
+        holder[0] = scatter_into_tile_buf(x, target_shape, attn_metadata.untile_combined_index, holder[0])
+        return holder[0]
 
     def preprocess_qkv(self, qkv: torch.Tensor, attn_metadata: MiniMaxH3VSAMetadata) -> torch.Tensor:
         return self.tile(qkv, attn_metadata)

--- a/fastvideo/attention/backends/video_sparse_attn_h3_probe.py
+++ b/fastvideo/attention/backends/video_sparse_attn_h3_probe.py
@@ -59,9 +59,8 @@ def record_probe(
     # token-true check on sampled rows (exact row softmax, tile-aggregated)
     gen = torch.Generator(device="cpu").manual_seed(step * 1000 + layer)
     # sample among video rows in the PADDED/tiled domain that are non-pad
-    vbs = attn_metadata.variable_block_sizes
-    token_tile = torch.arange(vbs.numel(), device=query.device).repeat_interleave(query.shape[1] // vbs.numel())
-    token_valid = (torch.arange(query.shape[1] // vbs.numel(), device=query.device)[None, :] < vbs[:, None]).flatten()
+    from fastvideo.attention.backends.video_sparse_attn_h3 import token_tile_and_valid
+    token_tile, token_valid = token_tile_and_valid(attn_metadata.variable_block_sizes)
     video_rows = torch.nonzero((token_tile >= P) & token_valid, as_tuple=False).flatten()
     idx = video_rows[torch.randint(0, video_rows.numel(), (_TRUE_ROWS, ), generator=gen).to(query.device)]
 
@@ -69,7 +68,7 @@ def record_probe(
     logits = torch.einsum("brhd,bshd->bhrs", q_s, key.float()) / (query.shape[-1]**0.5)
     logits = logits.masked_fill(~token_valid.view(1, 1, 1, -1), float("-inf"))
     true_probs = torch.softmax(logits, dim=-1)
-    n_tiles = vbs.numel()
+    n_tiles = attn_metadata.variable_block_sizes.numel()
     tile_mass = torch.zeros(*true_probs.shape[:3], n_tiles, device=query.device, dtype=true_probs.dtype)
     tile_mass.index_add_(3, token_tile, true_probs)  # [B,H,R,n]
     tm_vid = tile_mass[..., P:]

--- a/fastvideo/attention/backends/video_sparse_attn_h3_probe.py
+++ b/fastvideo/attention/backends/video_sparse_attn_h3_probe.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attention-mass probe for VSA-H3 selection quality.
+
+Enabled via ``FASTVIDEO_H3_VSA_PROBE=<out_dir>`` on a sparsity-0 run (mask
+selects everything, so the model follows its exact dense trajectory while
+we measure what any top-k WOULD have captured). Per (step, layer) it
+records, from the pooled tile scores:
+
+- ``recall_mean``: pooled softmax mass of video->video attention captured
+  by the top-k video tiles, as a function of k/V, per head;
+- ``prefix_mass``: pooled mass video queries place on text/cond/audio tiles
+  (decides exempt-vs-compete);
+- ``true_recall@{frac}``: token-true validation on sampled query rows —
+  exact attention row aggregated per tile, mass captured by the tiles the
+  POOLED ranking would pick (catches pooling-proxy failure);
+- ``perfect_recall@{frac}``: the selection ceiling — mass captured when
+  ranking by the true tile masses themselves.
+
+One .pt file per (step, layer, rank); aggregate offline.
+"""
+
+import os
+
+import torch
+
+_FRACS = (0.05, 0.10, 0.125, 0.25, 0.50, 0.75)
+_TRUE_ROWS = 128  # sampled query rows per layer for the token-true check
+
+
+def probe_enabled() -> str | None:
+    return os.environ.get("FASTVIDEO_H3_VSA_PROBE") or None
+
+
+@torch.no_grad()
+def record_probe(
+    out_dir: str,
+    layer: int,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    scores: torch.Tensor,
+    attn_metadata,
+) -> None:
+    """scores: [B, H, n, n] scaled pooled scores; query/key tiled BSHD."""
+    step = int(attn_metadata.current_timestep)
+    P = attn_metadata.num_prefix_tiles
+    V = attn_metadata.num_video_tiles
+
+    probs = torch.softmax(scores.float(), dim=-1)  # pooled attention, all tiles
+    vid_q = probs[:, :, P:, :]  # video-query rows
+    prefix_mass = vid_q[..., :P].sum(-1).mean(dim=(0, 2))  # [H]
+
+    vid_vid = vid_q[..., P:]
+    vid_vid = vid_vid / vid_vid.sum(-1, keepdim=True).clamp_min(1e-12)
+    sorted_mass = vid_vid.sort(dim=-1, descending=True).values.cumsum(-1)  # [B,H,Vq,V]
+    ks = [max(1, min(int(round(f * V)), V)) for f in _FRACS]
+    recall = torch.stack([sorted_mass[..., k - 1] for k in ks])  # [F,B,H,Vq]
+    recall_mean = recall.mean(dim=(1, 3))  # [F,H]
+
+    # token-true check on sampled rows (exact row softmax, tile-aggregated)
+    gen = torch.Generator(device="cpu").manual_seed(step * 1000 + layer)
+    # sample among video rows in the PADDED/tiled domain that are non-pad
+    vbs = attn_metadata.variable_block_sizes
+    token_tile = torch.arange(vbs.numel(), device=query.device).repeat_interleave(query.shape[1] // vbs.numel())
+    token_valid = (torch.arange(query.shape[1] // vbs.numel(), device=query.device)[None, :] < vbs[:, None]).flatten()
+    video_rows = torch.nonzero((token_tile >= P) & token_valid, as_tuple=False).flatten()
+    idx = video_rows[torch.randint(0, video_rows.numel(), (_TRUE_ROWS, ), generator=gen).to(query.device)]
+
+    q_s = query[:, idx].float()  # [B, R, H, D]
+    logits = torch.einsum("brhd,bshd->bhrs", q_s, key.float()) / (query.shape[-1]**0.5)
+    logits = logits.masked_fill(~token_valid.view(1, 1, 1, -1), float("-inf"))
+    true_probs = torch.softmax(logits, dim=-1)
+    n_tiles = vbs.numel()
+    tile_mass = torch.zeros(*true_probs.shape[:3], n_tiles, device=query.device, dtype=true_probs.dtype)
+    tile_mass.index_add_(3, token_tile, true_probs)  # [B,H,R,n]
+    tm_vid = tile_mass[..., P:]
+    tm_vid = tm_vid / tm_vid.sum(-1, keepdim=True).clamp_min(1e-12)
+    # pooled ranking per sampled row's q-tile
+    pooled_rank = scores[:, :, P:, P:].argsort(dim=-1, descending=True)  # [B,H,Vq,V]
+    row_qtile = (token_tile[idx] - P).view(1, 1, -1, 1).expand(pooled_rank.shape[0], pooled_rank.shape[1], -1, 1)
+    row_rank = pooled_rank.gather(2, row_qtile.expand(-1, -1, -1, pooled_rank.shape[-1]))  # [B,H,R,V]
+    perfect_sorted = tm_vid.sort(dim=-1, descending=True).values.cumsum(-1)  # selection ceiling
+    true_recall = {}
+    perfect_recall = {}
+    for f, k in zip(_FRACS, ks, strict=True):
+        captured = tm_vid.gather(-1, row_rank[..., :k]).sum(-1)  # [B,H,R]
+        true_recall[f] = captured.mean().item()
+        perfect_recall[f] = perfect_sorted[..., k - 1].mean().item()
+
+    os.makedirs(out_dir, exist_ok=True)
+    payload = dict(step=step,
+                   layer=layer,
+                   P=P,
+                   V=V,
+                   fracs=_FRACS,
+                   prefix_mass=prefix_mass.cpu(),
+                   recall_mean=recall_mean.cpu(),
+                   true_recall=true_recall,
+                   perfect_recall=perfect_recall)
+    # under SP each rank holds a distinct head subset; keep every rank's stats
+    rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+    torch.save(payload, os.path.join(out_dir, f"probe_step{step:03d}_layer{layer:03d}_r{rank}.pt"))

--- a/fastvideo/attention/backends/vmoba.py
+++ b/fastvideo/attention/backends/vmoba.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import re
 from dataclasses import dataclass
 
 import torch
@@ -8,7 +7,7 @@ from einops import rearrange
 
 from fastvideo_kernel import (moba_attn_varlen, process_moba_input, process_moba_output)
 from fastvideo.attention.backends.abstract import (AttentionBackend, AttentionImpl, AttentionMetadata,
-                                                   AttentionMetadataBuilder)
+                                                   AttentionMetadataBuilder, layer_idx_from_prefix)
 from fastvideo.logger import init_logger
 
 logger = init_logger(__name__)
@@ -132,10 +131,7 @@ class VMOBAAttentionImpl(AttentionImpl):
         self.pad_input = pad_input
 
     def _get_layer_idx(self, prefix: str) -> int | None:
-        match = re.search(r"blocks\.(\d+)", prefix)
-        if not match:
-            raise ValueError(f"Invalid prefix: {prefix}")
-        return int(match.group(1))
+        return layer_idx_from_prefix(prefix)
 
     def forward(
         self,

--- a/fastvideo/attention/layer.py
+++ b/fastvideo/attention/layer.py
@@ -213,7 +213,7 @@ class DistributedAttention_VSA(DistributedAttention):
         qkvg = torch.cat(stack, dim=0)  # [3or4*batch, seq_len, num_heads, head_dim]
 
         # Redistribute heads across sequence dimension
-        # Before: [4*batch, shard_seq_len, num_heads, head_dim]
+        # Before: [3or4*batch, shard_seq_len, num_heads, head_dim]
         # After:  [4*batch, full_seq_len, shard_num_heads, head_dim]
         qkvg = sequence_model_parallel_all_to_all_4D(qkvg, scatter_dim=2, gather_dim=1)
 

--- a/fastvideo/attention/layer.py
+++ b/fastvideo/attention/layer.py
@@ -207,8 +207,10 @@ class DistributedAttention_VSA(DistributedAttention):
         ctx_attn_metadata = forward_context.attn_metadata
 
         batch_size, seq_len, num_heads, head_dim = q.shape
-        # Stack QKV
-        qkvg = torch.cat([q, k, v, gate_compress], dim=0)  # [4*batch, seq_len, num_heads, head_dim]
+        # Stack QKV (a caller with a structurally-zero gate passes None and
+        # skips the gate's share of the all-to-all/tile traffic)
+        stack = [q, k, v] if gate_compress is None else [q, k, v, gate_compress]
+        qkvg = torch.cat(stack, dim=0)  # [3or4*batch, seq_len, num_heads, head_dim]
 
         # Redistribute heads across sequence dimension
         # Before: [4*batch, shard_seq_len, num_heads, head_dim]
@@ -225,7 +227,10 @@ class DistributedAttention_VSA(DistributedAttention):
 
         qkvg = self.attn_impl.preprocess_qkv(qkvg, ctx_attn_metadata)
 
-        q, k, v, gate_compress = qkvg.chunk(4, dim=0)
+        if gate_compress is None:
+            q, k, v = qkvg.chunk(3, dim=0)
+        else:
+            q, k, v, gate_compress = qkvg.chunk(4, dim=0)
         output = self.attn_impl.forward(q, k, v, gate_compress, ctx_attn_metadata)  # type: ignore[call-arg]
 
         # Redistribute back if using sequence parallelism

--- a/fastvideo/configs/models/dits/minimax_h3.py
+++ b/fastvideo/configs/models/dits/minimax_h3.py
@@ -29,6 +29,7 @@ class MiniMaxH3ArchConfig(DiTArchConfig):
         # sm_12x). Enabled for speed experiments; output quality against the
         # SSIM references is not yet validated.
         AttentionBackendEnum.ATTN_QAT_INFER,
+        AttentionBackendEnum.VIDEO_SPARSE_ATTN_H3,
     )
 
     param_names_mapping: dict = field(

--- a/fastvideo/entrypoints/video_generator.py
+++ b/fastvideo/entrypoints/video_generator.py
@@ -71,6 +71,11 @@ _BATCH_EXTRA_PASSTHROUGH_KEYS: tuple[str, ...] = (
     "ltx2_audio_denoise_mask",
     "audio_num_frames",
     "video_position_offset_sec",
+    # MiniMax-H3 VSA per-request knobs (read by the H3 denoising stage;
+    # sparsity itself flows through the existing ForwardBatch.VSA_sparsity)
+    "vsa_mode",
+    "vsa_dense_first_n_steps",
+    "vsa_dense_layers",
 )
 
 _FROM_PRETRAINED_CONVENIENCE_KWARGS = frozenset({

--- a/fastvideo/models/dits/minimax_h3.py
+++ b/fastvideo/models/dits/minimax_h3.py
@@ -11,6 +11,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from fastvideo.attention import DistributedAttention
+from fastvideo.attention.layer import DistributedAttention_VSA
+from fastvideo.attention.selector import get_attn_backend
 from fastvideo.configs.models.dits.minimax_h3 import MiniMaxH3Config
 from fastvideo.distributed.communication_op import (
     sequence_model_parallel_all_gather_with_unpad,
@@ -23,6 +25,7 @@ from fastvideo.layers.quantization import QuantizationConfig
 from fastvideo.layers.visual_embedding import Timesteps
 from fastvideo.models.dits.base import BaseDiT
 from fastvideo.platforms import AttentionBackendEnum
+from fastvideo.utils import get_compute_dtype
 
 MINIMAX_H3_MODALITY_NUM = 3
 _CFG = MiniMaxH3Config()
@@ -131,13 +134,53 @@ class MiniMaxH3Attention(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.to_out",
         )
-        self.distributed_attention = DistributedAttention(
+        # VSA carries a learned gate on its pooled-compression branch. The H3
+        # checkpoint has no such weight, so the loader zero-initializes it
+        # (ALLOWED_NEW_PARAM_PATTERNS) and the branch is exactly disabled
+        # until finetuned. Built only when VSA-H3 actually resolves, keeping
+        # the FLASH/SDPA paths and their state_dict untouched.
+        resolved_backend = get_attn_backend(attention_head_dim,
+                                            get_compute_dtype(),
+                                            supported_attention_backends=supported_attention_backends)
+        use_vsa = resolved_backend.get_name() == "VIDEO_SPARSE_ATTN_H3"
+        attention_cls = DistributedAttention_VSA if use_vsa else DistributedAttention
+        self.distributed_attention = attention_cls(
             num_heads=num_attention_heads,
             head_size=attention_head_dim,
             causal=False,
             supported_attention_backends=supported_attention_backends,
             prefix=prefix,
         )
+        self.to_gate_compress: ReplicatedLinear | None = None
+        # None = unchecked; the first forward tests the loaded weight once and
+        # skips the gate branch entirely while it is structurally zero.
+        self._gate_compress_active: bool | None = None
+        if use_vsa:
+            self.to_gate_compress = ReplicatedLinear(
+                hidden_size,
+                inner_dim,
+                bias=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.to_gate_compress",
+            )
+
+    def _gate_active(self) -> bool:
+        """True when the compression gate can contribute.
+
+        The zero-initialized (not-yet-finetuned) gate makes the whole branch
+        a guaranteed zero — a full GEMM plus a third more all-to-all/tile
+        traffic per layer for nothing — so test the loaded weight once and
+        cache the answer. Under grad the branch always runs (gradients must
+        reach a zero gate for it to ever train).
+        """
+        if torch.is_grad_enabled():
+            return True
+        if self._gate_compress_active is None:
+            weight = self.to_gate_compress.weight
+            # bool() on a DTensor reduction resolves collectively, so every
+            # rank caches the same answer.
+            self._gate_compress_active = bool((weight != 0).any())
+        return self._gate_compress_active
 
     @staticmethod
     def _apply_rotary_emb(
@@ -176,12 +219,18 @@ class MiniMaxH3Attention(nn.Module):
 
         # H3 rotates only 96/128 channels, which the generic `freqs_cis`
         # branch cannot express. Apply it above, then pass no RoPE here.
+        extra_attention_kwargs = {}
+        if self.to_gate_compress is not None and self._gate_active():
+            gate_compress, _ = self.to_gate_compress(hidden_states)
+            extra_attention_kwargs["gate_compress"] = gate_compress.unflatten(
+                -1, (self.num_attention_heads, self.attention_head_dim))
         hidden_states, _ = self.distributed_attention(
             query,
             key,
             value,
             original_seq_len=original_seq_len,
             freqs_cis=None,
+            **extra_attention_kwargs,
         )
         hidden_states = hidden_states.flatten(2, 3).type_as(query)
         hidden_states, _ = self.to_out(hidden_states)
@@ -521,7 +570,10 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
             arch.norm_eps,
             arch.qk_norm_eps,
             arch.final_norm_eps,
-            self.supported_attention_backends,
+            # The refiner attends over the text stream only; the packed-sequence
+            # VSA backend must never be selected for it.
+            tuple(backend for backend in self.supported_attention_backends
+                  if backend != AttentionBackendEnum.VIDEO_SPARSE_ATTN_H3),
             config.quant_config,
             prefix=f"{config.prefix}.token_refiner",
         )

--- a/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py
+++ b/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py
@@ -140,9 +140,11 @@ class MiniMaxH3DenoisingStage(PipelineStage):
             vsa_prefix_segments = _h3_vsa_prefix_segments(layout, vsa_patch_size)
             # Per-request knobs (sweeps flip these between generate_video calls
             # without respawning workers); mode None defers to the env default.
-            vsa_mode = batch.extra.get("vsa_mode")
-            vsa_exempt = None if vsa_mode is None else vsa_mode == "exempt"
-            vsa_dense_layers = tuple(int(layer) for layer in batch.extra.get("vsa_dense_layers", ()))
+            vsa_mode = batch.extra.get("vsa_mode", "exempt")
+            if vsa_mode not in ("exempt", "compete"):
+                raise ValueError(f"vsa_mode must be 'exempt' or 'compete', got {vsa_mode!r}.")
+            vsa_exempt = vsa_mode == "exempt"
+            vsa_dense_layers = tuple(batch.extra.get("vsa_dense_layers", ()))
             vsa_dense_first_n = int(batch.extra.get("vsa_dense_first_n_steps", 0))
 
         controller = get_global_controller()

--- a/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py
+++ b/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import torch
 
+from fastvideo.attention.selector import component_attention_backend, get_attn_backend
 from fastvideo.distributed import get_local_torch_device
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.forward_context import set_forward_context
@@ -23,6 +24,40 @@ from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages.base import PipelineStage
 from fastvideo.pipelines.stages.validators import StageValidators as V
 from fastvideo.pipelines.stages.validators import VerificationResult
+from fastvideo.utils import get_compute_dtype
+
+
+def _h3_vsa_metadata_builder(transformer: Any, fastvideo_args: FastVideoArgs) -> Any:
+    """Builder instance when the transformer resolved to VSA-H3, else None.
+
+    Resolves through the same selector record the attention layers used
+    (``component_attention_backend``) instead of introspecting module
+    internals, mirroring the generic DenoisingStage.
+    """
+    dit_config = fastvideo_args.pipeline_config.dit_config
+    backend = get_attn_backend(
+        head_size=dit_config.attention_head_dim,
+        dtype=get_compute_dtype(),
+        supported_attention_backends=dit_config._supported_attention_backends,
+        requested=component_attention_backend(transformer),
+    )
+    if backend.get_name() != "VIDEO_SPARSE_ATTN_H3":
+        return None
+    return backend.get_builder_cls()()
+
+
+def _h3_vsa_prefix_segments(layout: MiniMaxH3PackedLayout, patch_size: tuple[int, int, int]) -> tuple[int, ...]:
+    """Segment sizes preceding the generated-video tail, validated against the layout."""
+    n_text = int(layout.text_indices.numel())
+    n_cond = int(layout.num_condition_video_rows)
+    n_audio = int(layout.audio_indices.numel())
+    n_video = ((layout.num_video_latent_frames // patch_size[0]) * (layout.latent_height // patch_size[1]) *
+               (layout.latent_width // patch_size[2]))
+    if n_text + n_cond + n_audio + n_video != layout.sequence_length:
+        raise ValueError("VSA-H3 supports the standard [text|cond|audio|video] packing only; "
+                         f"segments ({n_text}, {n_cond}, {n_audio}) + video {n_video} do not sum to "
+                         f"sequence length {layout.sequence_length}.")
+    return n_text, n_cond, n_audio
 
 
 class MiniMaxH3DenoisingStage(PipelineStage):
@@ -99,6 +134,17 @@ class MiniMaxH3DenoisingStage(PipelineStage):
         text_indices = layout.text_indices.to(device)
         prompt_embeds = batch.prompt_embeds[0].to(device)
 
+        vsa_metadata_builder = _h3_vsa_metadata_builder(self.transformer, fastvideo_args)
+        if vsa_metadata_builder is not None:
+            vsa_patch_size = fastvideo_args.pipeline_config.dit_config.patch_size
+            vsa_prefix_segments = _h3_vsa_prefix_segments(layout, vsa_patch_size)
+            # Per-request knobs (sweeps flip these between generate_video calls
+            # without respawning workers); mode None defers to the env default.
+            vsa_mode = batch.extra.get("vsa_mode")
+            vsa_exempt = None if vsa_mode is None else vsa_mode == "exempt"
+            vsa_dense_layers = tuple(int(layer) for layer in batch.extra.get("vsa_dense_layers", ()))
+            vsa_dense_first_n = int(batch.extra.get("vsa_dense_first_n_steps", 0))
+
         controller = get_global_controller()
         denoise_region = (controller.region("profiler_region_inference_denoising")
                           if controller is not None else contextlib.nullcontext())
@@ -107,6 +153,23 @@ class MiniMaxH3DenoisingStage(PipelineStage):
                 for index, (video_timestep,
                             audio_timestep) in enumerate(zip(video_timesteps, audio_timesteps, strict=True)):
                     unique_timesteps, timestep_indices = row_timestep_plan[index]
+                    attn_metadata = None
+                    if vsa_metadata_builder is not None:
+                        # Optional schedule: run the first N steps dense (sparsity 0
+                        # selects every tile — parity-proven ≡ dense ≤2e-4); early
+                        # steps set global structure and are the most damage-prone.
+                        vsa_sparsity = 0.0 if index < vsa_dense_first_n else float(batch.VSA_sparsity)
+                        attn_metadata = vsa_metadata_builder.build(
+                            current_timestep=index,
+                            raw_latent_shape=(layout.num_video_latent_frames, layout.latent_height,
+                                              layout.latent_width),
+                            patch_size=vsa_patch_size,
+                            VSA_sparsity=vsa_sparsity,
+                            prefix_segments=vsa_prefix_segments,
+                            device=device,
+                            exempt=vsa_exempt,
+                            dense_layers=vsa_dense_layers,
+                        )
                     # Under torch.compile(mode="reduce-overhead") each denoising
                     # step must be marked, or cudagraph trees flag cross-step
                     # reuse of pooled outputs as "accessing tensor output of
@@ -115,7 +178,7 @@ class MiniMaxH3DenoisingStage(PipelineStage):
                     torch.compiler.cudagraph_mark_step_begin()
                     with trace_step(index), set_forward_context(
                             current_timestep=index,
-                            attn_metadata=None,
+                            attn_metadata=attn_metadata,
                             forward_batch=batch,
                     ):
                         video_velocity, audio_velocity = self.transformer(

--- a/fastvideo/platforms/cuda.py
+++ b/fastvideo/platforms/cuda.py
@@ -184,6 +184,21 @@ class CudaPlatformBase(Platform):
                 raise ImportError("The Video Sparse Attention backend is not installed. "
                                   "To install it, please follow the instructions at: "
                                   "https://hao-ai-lab.github.io/FastVideo/video_sparse_attention/installation ") from e
+        elif selected_backend == AttentionBackendEnum.VIDEO_SPARSE_ATTN_H3:
+            try:
+                from fastvideo_kernel.block_sparse_attn_256 import (  # noqa: F401
+                    block_sparse_attn_256_bshd)
+
+                from fastvideo.attention.backends.video_sparse_attn_h3 import (  # noqa: F401
+                    MiniMaxH3VSABackend)
+                logger.info("Using MiniMax-H3 Video Sparse Attention backend.")
+
+                return "fastvideo.attention.backends.video_sparse_attn_h3.MiniMaxH3VSABackend"
+            except ImportError as e:
+                logger.error("Failed to import H3 Video Sparse Attention backend: %s", str(e))
+                raise ImportError("VIDEO_SPARSE_ATTN_H3 selected but fastvideo_kernel's block-sparse "
+                                  "kernels are unavailable. Install fastvideo-kernel or pick a different "
+                                  "FASTVIDEO_ATTENTION_BACKEND.") from e
         elif selected_backend == AttentionBackendEnum.BSA_ATTN:
             try:
                 from fastvideo.attention.backends.bsa_attn import (  # noqa: F401

--- a/fastvideo/platforms/cuda.py
+++ b/fastvideo/platforms/cuda.py
@@ -189,8 +189,6 @@ class CudaPlatformBase(Platform):
                 from fastvideo_kernel.block_sparse_attn_256 import (  # noqa: F401
                     block_sparse_attn_256_bshd)
 
-                from fastvideo.attention.backends.video_sparse_attn_h3 import (  # noqa: F401
-                    MiniMaxH3VSABackend)
                 logger.info("Using MiniMax-H3 Video Sparse Attention backend.")
 
                 return "fastvideo.attention.backends.video_sparse_attn_h3.MiniMaxH3VSABackend"

--- a/fastvideo/platforms/interface.py
+++ b/fastvideo/platforms/interface.py
@@ -18,6 +18,7 @@ class AttentionBackendEnum(enum.Enum):
     ATTN_QAT_INFER = enum.auto()
     ATTN_QAT_TRAIN = enum.auto()
     VIDEO_SPARSE_ATTN = enum.auto()
+    VIDEO_SPARSE_ATTN_H3 = enum.auto()
     BSA_ATTN = enum.auto()
     VMOBA_ATTN = enum.auto()
     SLA_ATTN = enum.auto()

--- a/fastvideo/tests/api/test_extra_overrides_routing.py
+++ b/fastvideo/tests/api/test_extra_overrides_routing.py
@@ -36,6 +36,10 @@ def test_passthrough_keys_cover_ltx2_audio_conditioning() -> None:
         "ltx2_audio_denoise_mask",
         "audio_num_frames",
         "video_position_offset_sec",
+        # MiniMax-H3 VSA per-request knobs (consumed by MiniMaxH3DenoisingStage)
+        "vsa_mode",
+        "vsa_dense_first_n_steps",
+        "vsa_dense_layers",
     }
     assert set(_BATCH_EXTRA_PASSTHROUGH_KEYS) == expected
 

--- a/fastvideo/tests/attention/test_vsa_h3_metadata.py
+++ b/fastvideo/tests/attention/test_vsa_h3_metadata.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 
 from fastvideo.attention.backends.video_sparse_attn_h3 import (_TILE_ELEMS, MiniMaxH3VSAImpl,
                                                                MiniMaxH3VSAMetadataBuilder, _build_block_mask,
-                                                               _pool_tiles)
+                                                               _pool_tiles, token_tile_and_valid)
 
 _720P = dict(raw_latent_shape=(30, 44, 80), patch_size=(1, 2, 2), prefix_segments=(512, 1760, 400))
 _TINY = dict(raw_latent_shape=(8, 8, 12), patch_size=(1, 2, 2), prefix_segments=(7, 5, 3))
@@ -36,10 +36,7 @@ def _impl():
 def reference_sparse_attention(query, key, value, mask, meta):
     """Token-level oracle: SDPA over the padded tile buffer with the block
     mask expanded to tokens. query/key/value: tiled [B, S_pad, H, D]."""
-    n_tiles = meta.variable_block_sizes.numel()
-    token_tile = torch.arange(n_tiles, device=query.device).repeat_interleave(_TILE_ELEMS)
-    token_valid = (torch.arange(_TILE_ELEMS, device=query.device)[None, :] < meta.variable_block_sizes[:,
-                                                                                                       None]).flatten()
+    token_tile, token_valid = token_tile_and_valid(meta.variable_block_sizes)
     out = torch.empty_like(query)
     for b in range(query.shape[0]):
         for h in range(query.shape[2]):
@@ -62,8 +59,8 @@ def test_geometry_720p():
     assert meta.num_prefix_tiles == 2 + 7 + 2
     assert meta.num_video_tiles == 8 * 3 * 5
     assert int(meta.variable_block_sizes.sum()) == seq
-    perm = meta.tile_partition_indices
-    assert torch.equal(torch.sort(perm).values, torch.arange(seq))
+    # (permutation coverage of [0, seq) is implied by the roundtrip below:
+    # untile_combined_index scatters seq distinct rows and recovers all of x)
     # segment purity: no prefix tile straddles a segment boundary
     boundaries = [512, 512 + 1760, 512 + 1760 + 400]
     start = 0

--- a/fastvideo/tests/attention/test_vsa_h3_metadata.py
+++ b/fastvideo/tests/attention/test_vsa_h3_metadata.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU checks for the VSA-H3 backend: tiling geometry, mask policy, and
+end-to-end equivalence against dense SDPA through a token-level mask
+reference. The same reference doubles as the GPU kernel parity oracle."""
+
+import math
+
+import torch
+import torch.nn.functional as F
+
+from fastvideo.attention.backends.video_sparse_attn_h3 import (_TILE_ELEMS, MiniMaxH3VSAImpl,
+                                                               MiniMaxH3VSAMetadataBuilder, _build_block_mask,
+                                                               _pool_tiles)
+
+_720P = dict(raw_latent_shape=(30, 44, 80), patch_size=(1, 2, 2), prefix_segments=(512, 1760, 400))
+_TINY = dict(raw_latent_shape=(8, 8, 12), patch_size=(1, 2, 2), prefix_segments=(7, 5, 3))
+
+_CPU = torch.device("cpu")
+
+
+def _build(spec, sparsity=0.0, device=_CPU):
+    return MiniMaxH3VSAMetadataBuilder().build(
+        current_timestep=0,
+        raw_latent_shape=spec["raw_latent_shape"],
+        patch_size=spec["patch_size"],
+        VSA_sparsity=sparsity,
+        prefix_segments=spec["prefix_segments"],
+        device=device,
+    )
+
+
+def _impl():
+    return MiniMaxH3VSAImpl(num_heads=2, head_size=8, causal=False, softmax_scale=8**-0.5)
+
+
+def reference_sparse_attention(query, key, value, mask, meta):
+    """Token-level oracle: SDPA over the padded tile buffer with the block
+    mask expanded to tokens. query/key/value: tiled [B, S_pad, H, D]."""
+    n_tiles = meta.variable_block_sizes.numel()
+    token_tile = torch.arange(n_tiles, device=query.device).repeat_interleave(_TILE_ELEMS)
+    token_valid = (torch.arange(_TILE_ELEMS, device=query.device)[None, :] < meta.variable_block_sizes[:,
+                                                                                                       None]).flatten()
+    out = torch.empty_like(query)
+    for b in range(query.shape[0]):
+        for h in range(query.shape[2]):
+            allow = mask[b, h][token_tile][:, token_tile] & token_valid[None, :]
+            bias = torch.zeros(allow.shape, dtype=query.dtype, device=query.device)
+            bias.masked_fill_(~allow, float("-inf"))
+            out[b, :, h] = F.scaled_dot_product_attention(
+                query[b, :, h][None],
+                key[b, :, h][None],
+                value[b, :, h][None],
+                attn_mask=bias[None],
+            )[0]
+    return out
+
+
+def test_geometry_720p():
+    meta = _build(_720P)
+    seq = meta.total_seq_length
+    assert seq == 512 + 1760 + 400 + 26400
+    assert meta.num_prefix_tiles == 2 + 7 + 2
+    assert meta.num_video_tiles == 8 * 3 * 5
+    assert int(meta.variable_block_sizes.sum()) == seq
+    perm = meta.tile_partition_indices
+    assert torch.equal(torch.sort(perm).values, torch.arange(seq))
+    # segment purity: no prefix tile straddles a segment boundary
+    boundaries = [512, 512 + 1760, 512 + 1760 + 400]
+    start = 0
+    for size in meta.variable_block_sizes[:meta.num_prefix_tiles].tolist():
+        end = start + size
+        assert all(not (start < b < end) for b in boundaries), (start, end)
+        start = end
+    # untile(tile(x)) == x
+    x = torch.randn(1, seq, 2, 4)
+    buf = _impl().tile(x, meta)
+    assert buf.shape[1] == meta.variable_block_sizes.numel() * _TILE_ELEMS
+    assert torch.equal(buf[:, meta.untile_combined_index], x)
+
+
+def test_mask_policy():
+    meta = _build(_720P, sparsity=0.9)
+    n = meta.num_prefix_tiles + meta.num_video_tiles
+    P, V = meta.num_prefix_tiles, meta.num_video_tiles
+    k_vid = math.ceil(0.1 * V)
+    scores = torch.randn(1, 2, n, n)
+
+    exempt = _build_block_mask(scores, P, V, 0.9, exempt=True)
+    assert exempt[:, :, :P].all(), "prefix queries must be dense"
+    assert exempt[..., :P].all(), "prefix keys must be visible to every query"
+    assert (exempt[:, :, P:, P:].sum(-1) == k_vid).all(), "video rows select exactly k_vid video tiles"
+
+    compete = _build_block_mask(scores, P, V, 0.9, exempt=False)
+    assert compete[:, :, :P].all()
+    assert (compete[:, :, P:].sum(-1) == min(k_vid + P, n)).all(), "budget-matched top-k"
+
+    dense = _build_block_mask(scores, P, V, 0.0, exempt=True)
+    assert dense.all(), "sparsity 0 must select everything"
+
+
+def test_sparsity_zero_matches_dense_sdpa():
+    torch.manual_seed(0)
+    meta = _build(_TINY)
+    seq = meta.total_seq_length
+    q, k, v = (torch.randn(1, seq, 2, 8) for _ in range(3))
+    impl = _impl()
+    tq, tk, tv = (impl.tile(t, meta).clone() for t in (q, k, v))
+
+    scores = torch.matmul(_pool_tiles(tq, meta.variable_block_sizes),
+                          _pool_tiles(tk, meta.variable_block_sizes).transpose(-2, -1))
+    mask = _build_block_mask(scores, meta.num_prefix_tiles, meta.num_video_tiles, 0.0, exempt=True)
+    sparse_out = impl.postprocess_output(reference_sparse_attention(tq, tk, tv, mask, meta), meta)
+
+    dense_out = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)).transpose(1, 2)
+    assert torch.allclose(sparse_out, dense_out, atol=1e-5), (sparse_out - dense_out).abs().max()
+
+
+def test_prefix_queries_stay_dense_at_high_sparsity():
+    torch.manual_seed(1)
+    meta = _build(_TINY, sparsity=0.75)
+    seq = meta.total_seq_length
+    prefix_len = sum(_TINY["prefix_segments"])
+    q, k, v = (torch.randn(1, seq, 2, 8) for _ in range(3))
+    impl = _impl()
+    tq, tk, tv = (impl.tile(t, meta).clone() for t in (q, k, v))
+
+    scores = torch.matmul(_pool_tiles(tq, meta.variable_block_sizes),
+                          _pool_tiles(tk, meta.variable_block_sizes).transpose(-2, -1))
+    for exempt in (True, False):
+        mask = _build_block_mask(scores, meta.num_prefix_tiles, meta.num_video_tiles, 0.75, exempt=exempt)
+        sparse_out = impl.postprocess_output(reference_sparse_attention(tq, tk, tv, mask, meta), meta)
+        dense_out = F.scaled_dot_product_attention(q.transpose(1, 2), k.transpose(1, 2),
+                                                   v.transpose(1, 2)).transpose(1, 2)
+        assert torch.allclose(sparse_out[:, :prefix_len], dense_out[:, :prefix_len], atol=1e-5)
+        assert not torch.allclose(sparse_out[:, prefix_len:], dense_out[:, prefix_len:], atol=1e-5), \
+            "video rows should actually be sparse at 75%"
+
+
+if __name__ == "__main__":
+    test_geometry_720p()
+    test_mask_policy()
+    test_sparsity_zero_matches_dense_sdpa()
+    test_prefix_queries_stay_dense_at_high_sparsity()
+    print("all VSA-H3 CPU checks passed")


### PR DESCRIPTION
Stacked on #1688 (H3 SFT) — retarget to main once that merges. (Rebased on its current head.)

Adds a `VIDEO_SPARSE_ATTN_H3` backend that runs VSA over H3's packed `[text | cond keyframes | audio | video]` sequence. No kernel changes: tiles are segment-pure prefix chunks + (4,8,8) video tiles (reusing the existing tiling helpers), selection is a Python mask policy over pooled tile scores, execution is the existing FA4 CuTe 256-block path on sm10.x (Triton fallback).

Design:
- Prefix (text/cond/audio) keys are always-selected for every query (`exempt`, default) or compete under a FLOP-matched top-k budget (`compete`); prefix queries are always dense. Probe data: video queries put 16–26% of attention mass on prefix tiles, so exempt is the right default.
- `to_gate_compress` (zero-init via the loader's `gate_compress` bootstrap) gates the pooled compression branch — untrained inference is exactly pure-sparse, and sparse finetuning on top of #1688 can learn it. Built only when the backend resolves; FLASH/SDPA paths and state_dict are untouched (token refiner explicitly excluded). While the loaded gate is structurally zero the branch is skipped entirely (checked once at first forward; always runs under grad so it can train).
- Per-request knobs for sweeps and mixed schedules: `vsa_mode`, `vsa_dense_first_n_steps`, `vsa_dense_layers` (via the batch-extra passthrough; sparsity itself flows through the existing `ForwardBatch.VSA_sparsity`). Dense-step/layer opt-outs exist so training can push the remaining layers/steps to higher sparsity.
- Env-gated attention-mass probe (`FASTVIDEO_H3_VSA_PROBE`) records per layer/step top-k recall (pooled, token-true, and perfect-selection ceiling) and prefix mass.

Measured on GB200 (tray, 4×): parity vs fp32 token-mask oracle ≤1e-3 and bitwise deterministic across CuTe/Triton × modes × sparsities; attention pipeline speedup vs dense SDPA 3.12× at 90% (720p, 29k tokens) and 4.25× (1080p, 66k), selection overhead included.

Training-free quality is not lossless (expected — VSA is a trained technique): MS-SSIM vs dense at 90% is 0.81 (4-step) and 0.53–0.64 (50-step, even with dense-first-5/12). This PR ships the inference path + training scaffolding; the sparse-finetune/distillation work follows on top of the SFT pipeline.

CPU tests included (tiling geometry, mask policy, sparsity-0 ≡ dense SDPA, prefix-dense invariants); the passthrough-key contract test is updated. Backend is opt-in via `FASTVIDEO_ATTENTION_BACKEND=VIDEO_SPARSE_ATTN_H3`.