### PR TITLE
[refactor] H3 pipeline cleanup: shared helpers, dead machinery, loop-invariant hoists

### DIFF
--- a/fastvideo/configs/models/encoders/minimax_h3_qwen3_vl.py
+++ b/fastvideo/configs/models/encoders/minimax_h3_qwen3_vl.py
@@ -128,10 +128,6 @@ class MiniMaxH3Qwen3VLArchConfig(TextEncoderArchConfig):
         self.mrope_section = (int(section[0]), int(section[1]), int(section[2]))
         if sum(self.mrope_section) * 2 != self.head_dim:
             raise ValueError("MiniMax H3 Qwen3-VL mRoPE sections must cover exactly half of each attention head.")
-        rope_scaling["mrope_interleaved"] = self.mrope_interleaved
-        rope_scaling["mrope_section"] = list(self.mrope_section)
-        rope_scaling.setdefault("rope_type", "default")
-        self.rope_scaling = rope_scaling
 
         if self.vision_out_hidden_size != self.hidden_size:
             raise ValueError("MiniMax H3 Qwen3-VL vision_out_hidden_size must match the language hidden_size "

--- a/fastvideo/models/dits/minimax_h3.py
+++ b/fastvideo/models/dits/minimax_h3.py
@@ -18,6 +18,7 @@ from fastvideo.distributed.communication_op import (
 )
 from fastvideo.distributed.parallel_state import get_sp_world_size, model_parallel_is_initialized
 from fastvideo.layers.linear import ReplicatedLinear
+from fastvideo.layers.mlp import MLP
 from fastvideo.layers.quantization import QuantizationConfig
 from fastvideo.layers.visual_embedding import Timesteps
 from fastvideo.models.dits.base import BaseDiT
@@ -47,39 +48,6 @@ class MiniMaxH3RotaryPosEmbed(nn.Module):
         freqs = torch.cat((freqs_t, freqs_h, freqs_w), dim=-1)
         freqs = torch.cat((freqs, freqs), dim=-1)
         return freqs.cos(), freqs.sin()
-
-
-class MiniMaxH3TimestepEmbedding(nn.Module):
-    """Linear-SiLU-linear timestep MLP."""
-
-    def __init__(
-        self,
-        input_dim: int,
-        hidden_dim: int,
-        output_dim: int,
-        quant_config: QuantizationConfig | None = None,
-        prefix: str = "",
-    ) -> None:
-        super().__init__()
-        self.fc_in = ReplicatedLinear(
-            input_dim,
-            hidden_dim,
-            bias=True,
-            quant_config=quant_config,
-            prefix=f"{prefix}.fc_in",
-        )
-        self.fc_out = ReplicatedLinear(
-            hidden_dim,
-            output_dim,
-            bias=True,
-            quant_config=quant_config,
-            prefix=f"{prefix}.fc_out",
-        )
-
-    def forward(self, sample: torch.Tensor) -> torch.Tensor:
-        hidden_states, _ = self.fc_in(sample)
-        hidden_states, _ = self.fc_out(F.silu(hidden_states))
-        return hidden_states
 
 
 class MiniMaxH3FeedForward(nn.Module):
@@ -496,14 +464,19 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
             flip_sin_to_cos=True,
             downscale_freq_shift=0,
         )
-        self.time_embedder = MiniMaxH3TimestepEmbedding(
+        self.time_embedder = MLP(
             arch.freq_dim,
             arch.time_embed_hidden_dim,
             arch.time_embed_dim,
+            act_type="silu",
             quant_config=config.quant_config,
             prefix=f"{config.prefix}.time_embedder",
         )
         self.rope = MiniMaxH3RotaryPosEmbed(arch.rope_freq_dim, arch.rope_theta)
+        # per-generation caches for loop-invariant work (see _rotary_for /
+        # _refined_text); plain attrs, never in state_dict
+        self._rope_cache: tuple | None = None
+        self._text_cache: tuple | None = None
         self.token_refiner = MiniMaxH3TokenRefiner(
             arch.hidden_size,
             arch.num_attention_heads,
@@ -573,6 +546,49 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
                                  (2 * arch.rope_freq_dim)))
             self.rope._buffers["inv_freq"] = inv_freq
 
+    def _rotary_for(self, position_ids: torch.Tensor, dtype: torch.dtype) -> tuple[torch.Tensor, torch.Tensor]:
+        """cos/sin depend only on positions; the denoising stage holds one
+        position_ids tensor for the whole loop, so cache per layout and
+        pre-cast once instead of rebuilding every step and re-casting in
+        every block. Holding the source tensor keeps the identity check safe
+        against id reuse."""
+        if torch.compiler.is_compiling():
+            cos, sin = self.rope(position_ids)
+            return cos.to(dtype), sin.to(dtype)
+        cached = self._rope_cache
+        if (cached is not None and cached[0] is position_ids and cached[1] == dtype
+                and cached[2][0].device == position_ids.device):
+            return cached[2]
+        cos, sin = self.rope(position_ids)
+        value = (cos.to(dtype), sin.to(dtype))
+        self._rope_cache = (position_ids, dtype, value)
+        return value
+
+    def _refined_text(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
+        """The prompt embedding is constant across the denoising loop and the
+        refiner blocks are timestep-free, so refine once per generation
+        (saves two transformer blocks and four collectives per step). Skipped
+        under grad (training needs the graph) and under compile."""
+        cacheable = not torch.is_grad_enabled() and not torch.compiler.is_compiling()
+        if (cacheable and self._text_cache is not None and self._text_cache[0] is encoder_hidden_states
+                and self._text_cache[1].device == encoder_hidden_states.device):
+            return self._text_cache[1]
+        text_embeds, _ = self.context_embedder(encoder_hidden_states.to(self.context_embedder.weight.dtype))
+        text_original_seq_len = text_embeds.shape[1]
+        sp_world_size = get_sp_world_size() if model_parallel_is_initialized() else 1
+        if sp_world_size > 1:
+            text_embeds, _ = sequence_model_parallel_shard(text_embeds, dim=1)
+        text_embeds = self.token_refiner(text_embeds, text_original_seq_len)
+        if sp_world_size > 1:
+            text_embeds = sequence_model_parallel_all_gather_with_unpad(
+                text_embeds,
+                text_original_seq_len,
+                dim=1,
+            )
+        if cacheable:
+            self._text_cache = (encoder_hidden_states, text_embeds)
+        return text_embeds
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -599,27 +615,19 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
         if encoder_hidden_states.shape[1] != text_indices.numel():
             raise ValueError("encoder_hidden_states row count must match text_indices.")
 
-        rotary_emb = self.rope(position_ids)
         video_embeds, _ = self.proj_in(hidden_states.to(self.proj_in.weight.dtype))
         audio_embeds, _ = self.audio_proj_in(audio_hidden_states.to(self.audio_proj_in.weight.dtype))
-        text_embeds, _ = self.context_embedder(encoder_hidden_states.to(self.context_embedder.weight.dtype))
-
-        text_original_seq_len = text_embeds.shape[1]
+        text_embeds = self._refined_text(encoder_hidden_states)
+        rotary_emb = self._rotary_for(position_ids, text_embeds.dtype)
         sp_world_size = get_sp_world_size() if model_parallel_is_initialized() else 1
-        if sp_world_size > 1:
-            text_embeds, _ = sequence_model_parallel_shard(text_embeds, dim=1)
-        text_embeds = self.token_refiner(text_embeds, text_original_seq_len)
-        if sp_world_size > 1:
-            text_embeds = sequence_model_parallel_all_gather_with_unpad(
-                text_embeds,
-                text_original_seq_len,
-                dim=1,
-            )
 
-        packed_hidden_states = text_embeds.new_zeros((text_embeds.shape[0], sequence_length, text_embeds.shape[-1]))
-        packed_hidden_states = packed_hidden_states.index_copy(1, text_indices, text_embeds)
-        packed_hidden_states = packed_hidden_states.index_copy(1, video_indices, video_embeds.to(text_embeds.dtype))
-        packed_hidden_states = packed_hidden_states.index_copy(1, audio_indices, audio_embeds.to(text_embeds.dtype))
+        # text/video/audio indices partition [0, sequence_length), so the
+        # uninitialized buffer is fully overwritten; in-place index_copy_ avoids
+        # the three full-buffer clones out-of-place index_copy would make.
+        packed_hidden_states = text_embeds.new_empty((text_embeds.shape[0], sequence_length, text_embeds.shape[-1]))
+        packed_hidden_states.index_copy_(1, text_indices, text_embeds)
+        packed_hidden_states.index_copy_(1, video_indices, video_embeds.to(text_embeds.dtype))
+        packed_hidden_states.index_copy_(1, audio_indices, audio_embeds.to(text_embeds.dtype))
 
         temb = self.time_proj(timestep)
         temb = self.time_embedder(temb.to(self.time_embedder.fc_in.weight.dtype))

--- a/fastvideo/pipelines/basic/minimax_h3/packing.py
+++ b/fastvideo/pipelines/basic/minimax_h3/packing.py
@@ -216,10 +216,7 @@ def build_packed_sequence(
     position_ids = torch.zeros(sequence_length, 3, dtype=torch.float64)
     position_ids[:num_text_tokens, 0] = torch.arange(num_text_tokens, dtype=torch.float64)
 
-    sqrt_area = np.sqrt(latent_height * latent_width)
-    height_grid = spatial_position_grid(latent_height, patch_h, sqrt_area)
-    width_grid = spatial_position_grid(latent_width, patch_w, sqrt_area)
-    frame_grid = torch.stack([axis.reshape(-1) for axis in torch.meshgrid(height_grid, width_grid, indexing="ij")], -1)
+    frame_grid, width_grid = _frame_position_grid(latent_height, latent_width, patch_h, patch_w)
 
     for index, anchor in enumerate(keyframe_anchors):
         if anchor == "first":
@@ -233,12 +230,8 @@ def build_packed_sequence(
         position_ids[rows, 0] = anchor_time
         position_ids[rows, 1:] = frame_grid
 
-    audio_time = float(num_text_tokens) + torch.arange(num_audio_latents, dtype=torch.float64)
-    position_ids[audio_start:video_start, 0] = audio_time.repeat(MINIMAX_H3_AUDIO_CHANNELS)
-    position_ids[audio_start:video_start, 2] = torch.cat([
-        torch.full((num_audio_latents, ), float(width_grid[0]), dtype=torch.float64),
-        torch.full((num_audio_rows - num_audio_latents, ), float(width_grid[-1]), dtype=torch.float64),
-    ])
+    _fill_audio_positions(position_ids, slice(audio_start, video_start), num_audio_latents, float(num_text_tokens),
+                          width_grid)
 
     video_positions = torch.empty(num_latent_frames, rows_per_frame, 3, dtype=torch.float64)
     video_positions[:, :, 0] = temporal_position_grid(num_latent_frames, float(num_text_tokens))[:, None]
@@ -487,6 +480,4 @@ def keyframe_condition_noise(
             dtype=dtype,
         )
         rows.append(patchify_video_latents(noise, patch_size))
-    if not rows:
-        return torch.empty((0, latent_channels * int(np.prod(patch_size))), device=device, dtype=dtype)
     return torch.cat(rows)

--- a/fastvideo/pipelines/basic/minimax_h3/reference.py
+++ b/fastvideo/pipelines/basic/minimax_h3/reference.py
@@ -20,6 +20,7 @@ from fastvideo.pipelines.basic.minimax_h3.packing import (
     MINIMAX_H3_FPS,
     MINIMAX_H3_FRAMES_PER_CHUNK,
     MINIMAX_H3_LATENTS_PER_CHUNK,
+    MINIMAX_H3_MAX_DURATION,
     resolve_canvas_size,
 )
 
@@ -136,16 +137,21 @@ def decode_reference_video(source: str | os.PathLike[str]) -> tuple[np.ndarray, 
         if not container.streams.video:
             raise ValueError(f"Reference media {source!s} contains no video stream.")
         stream = container.streams.video[0]
+        rate = stream.average_rate or getattr(stream, "guessed_rate", None)
+        if rate is None:
+            raise ValueError(f"Reference media {source!s} does not expose a frame rate.")
+        # everything past the trimmed maximum is discarded downstream; stop
+        # decoding (and buffering) once that many source frames are in hand
+        max_frames = math.ceil(MINIMAX_H3_MAX_DURATION * float(rate)) + 1
         frames = []
         rotation = 0.0
         for frame in container.decode(stream):
             rotation = float(getattr(frame, "rotation", 0.0) or 0.0)
             frames.append(frame.to_ndarray(format="rgb24"))
+            if len(frames) >= max_frames:
+                break
         if not frames:
             raise ValueError(f"Reference media {source!s} contains no video frames.")
-        rate = stream.average_rate or getattr(stream, "guessed_rate", None)
-        if rate is None:
-            raise ValueError(f"Reference media {source!s} does not expose a frame rate.")
 
         soundtrack = None
         if container.streams.audio:

--- a/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_conditioning.py
+++ b/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_conditioning.py
@@ -42,14 +42,6 @@ def _token_ids(tokenized: Any) -> list[int]:
     return [int(token_id) for token_id in input_ids]
 
 
-def _module_dtype(module: Any) -> torch.dtype:
-    dtype = getattr(module, "dtype", None)
-    if isinstance(dtype, torch.dtype):
-        return dtype
-    parameter = next(module.parameters(), None)
-    return torch.float32 if parameter is None else parameter.dtype
-
-
 def _create_mm_token_type_ids(processor: Any, token_ids: list[int]) -> list[list[int]]:
     """Build Qwen3-VL modality IDs across old and new Transformers releases."""
     create_ids = getattr(processor, "create_mm_token_type_ids", None)
@@ -164,22 +156,13 @@ class MiniMaxH3ConditioningStage(PipelineStage):
         **vision_inputs: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         hidden_state_index = MINIMAX_H3_TEXT_ENCODER_LAYER
-        num_hidden_layers = getattr(self.conditioner, "num_hidden_layers", None)
-        if num_hidden_layers is None:
-            config = getattr(self.conditioner, "config", None)
-            arch = getattr(config, "arch_config", config)
-            num_hidden_layers = getattr(arch, "num_hidden_layers", None)
-        if num_hidden_layers is None or num_hidden_layers <= hidden_state_index:
-            raise ValueError(f"MiniMax H3 requires more than {hidden_state_index} Qwen3-VL decoder layers to read "
-                             f"`hidden_states[{hidden_state_index}]`, got {num_hidden_layers}.")
-
         input_ids = torch.tensor([token_ids], dtype=torch.long, device=device)
         mm_token_type_ids = torch.as_tensor(
             _create_mm_token_type_ids(self.processor, token_ids),
             dtype=torch.long,
             device=device,
         )
-        dtype = _module_dtype(self.conditioner)
+        dtype = self.conditioner.dtype
         outputs = self.conditioner(
             input_ids=input_ids,
             attention_mask=torch.ones_like(input_ids),

--- a/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py
+++ b/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py
@@ -61,9 +61,8 @@ class MiniMaxH3DenoisingStage(PipelineStage):
         if not batch.prompt_embeds or batch.latents is None or batch.audio_latents is None:
             raise ValueError("MiniMax-H3 conditioning and packed latents must precede denoising.")
 
-        full_cpu_offload = (bool(getattr(fastvideo_args, "dit_cpu_offload", False))
-                            and not bool(getattr(fastvideo_args, "dit_layerwise_offload", False))
-                            and not bool(getattr(fastvideo_args, "use_fsdp_inference", False)))
+        full_cpu_offload = (fastvideo_args.dit_cpu_offload and not fastvideo_args.dit_layerwise_offload
+                            and not fastvideo_args.use_fsdp_inference)
         device = get_local_torch_device()
         if full_cpu_offload:
             self.transformer.to(device)

--- a/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_input_preparation.py
+++ b/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_input_preparation.py
@@ -34,18 +34,6 @@ MINIMAX_H3_KEYFRAMES_KEY = "minimax_h3_keyframes"
 MINIMAX_H3_KEYFRAME_ANCHORS_KEY = "minimax_h3_keyframe_anchors"
 
 
-def _component_value(module: Any, name: str) -> Any:
-    value = getattr(module, name, None)
-    if value is not None:
-        return value
-    config = getattr(module, "config", None)
-    for owner in (getattr(config, "arch_config", None), config):
-        value = getattr(owner, name, None)
-        if value is not None:
-            return value
-    raise ValueError(f"MiniMax-H3 component {type(module).__name__} does not expose `{name}`.")
-
-
 def _has_negative_prompt(value: str | list[str] | None) -> bool:
     if value is None:
         return False
@@ -81,7 +69,7 @@ def prepare_common_request(batch: ForwardBatch) -> None:
     batch.fps = MINIMAX_H3_FPS
 
 
-def resolve_target_canvas(batch: ForwardBatch, vae: object, default_aspect: tuple[int, int]) -> tuple[int, int, int]:
+def resolve_target_canvas(batch: ForwardBatch, vae: Any, default_aspect: tuple[int, int]) -> tuple[int, int, int]:
     """Resolve target geometry independently of the selected condition mode."""
     if (batch.height is None) != (batch.width is None):
         raise ValueError("MiniMax-H3 `height` and `width` must be passed together, or neither.")
@@ -95,7 +83,7 @@ def resolve_target_canvas(batch: ForwardBatch, vae: object, default_aspect: tupl
             raise ValueError(f"MiniMax-H3 `height` and `width` must be positive multiples of "
                              f"{MINIMAX_H3_CANVAS_MULTIPLE}, got {height}x{width}.")
 
-    ratio = int(_component_value(vae, "spatial_compression_ratio"))
+    ratio = int(vae.spatial_compression_ratio)
     if height % ratio or width % ratio:
         raise ValueError(f"MiniMax-H3 canvas {height}x{width} is not divisible by VAE ratio {ratio}.")
     return height, width, ratio
@@ -116,7 +104,7 @@ def resolve_target_num_frames(num_frames: object) -> int:
 class MiniMaxH3InputPreparationStage(PipelineStage):
     """Prepare FL2VA/T2VA or Ref2VA inputs without a parallel family state object."""
 
-    def __init__(self, vae: object, audio_vae: object | None = None, *, ref2va: bool = False) -> None:
+    def __init__(self, vae: Any, audio_vae: Any | None = None, *, ref2va: bool = False) -> None:
         super().__init__()
         if ref2va and audio_vae is None:
             raise ValueError("MiniMax-H3 Ref2VA input preparation requires an audio VAE.")
@@ -169,7 +157,7 @@ class MiniMaxH3InputPreparationStage(PipelineStage):
         latent_height = height // ratio
         latent_width = width // ratio
         num_latent_frames = video_latent_num_frames(num_frames)
-        latent_channels = int(_component_value(self.vae, "latent_channels"))
+        latent_channels = int(self.vae.latent_channels)
 
         batch.height = height
         batch.width = width
@@ -211,7 +199,7 @@ class MiniMaxH3InputPreparationStage(PipelineStage):
 
         height, width, ratio = resolve_target_canvas(batch, self.vae, (16, 9))
         num_frames = resolve_target_num_frames(batch.num_frames)
-        target_sample_rate = int(_component_value(self.audio_vae, "sampling_rate"))
+        target_sample_rate = int(self.audio_vae.sampling_rate)
         batch.references = [prepare_reference(reference, num_frames, target_sample_rate) for reference in references]
         self._write_target_geometry(batch, height, width, ratio, num_frames)
         batch.extra[MINIMAX_H3_KEYFRAMES_KEY] = []

--- a/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_latent_preparation.py
+++ b/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_latent_preparation.py
@@ -93,14 +93,20 @@ class MiniMaxH3LatentPreparationStage(PipelineStage):
         result.add_check("audio_latents", batch.audio_latents, V.with_dims(2))
         return result
 
+    def _encode_keyframe_latents(self, image, device: torch.device) -> torch.Tensor:
+        """Encode one keyframe image to normalized latents (fp16 round-trip
+        preserved for parity with the seeded references)."""
+        pixels = torch.from_numpy(np.asarray(image).copy()).permute(2, 0, 1)[None, :, None]
+        pixels = pixels.to(device=device, dtype=torch.float32).div_(255.0)
+        posterior = self.vae.encode_keyframe(self.vae.normalize_pixels(pixels)).latent_dist
+        return self.vae.normalize_latents(_sample_visual_posterior(posterior).to(torch.float16).float()).cpu()
+
     def _encode_visual_rows(
         self,
         references: list[MiniMaxH3PreparedReference],
         device: torch.device,
     ) -> list[torch.Tensor]:
         patch_size = self.transformer.patch_size
-        mean = self.vae.latents_mean.detach().float().cpu()
-        std = self.vae.latents_std.detach().float().cpu()
         rows: list[torch.Tensor] = []
         for reference in references:
             if reference.media_type == "audio":
@@ -108,22 +114,20 @@ class MiniMaxH3LatentPreparationStage(PipelineStage):
             if reference.media_type == "image":
                 if reference.image is None:
                     raise ValueError("MiniMax-H3 reference image pixels are missing.")
-                pixels = torch.from_numpy(np.asarray(reference.image).copy()).permute(2, 0, 1)[None, :, None]
-                encode = self.vae.encode_keyframe
+                latents = self._encode_keyframe_latents(reference.image, device)
             else:
                 if reference.frames is None:
                     raise ValueError("MiniMax-H3 reference video frames are missing.")
                 frames = reference.frames[:trim_reference_num_frames(reference.frames.shape[0])]
                 pixels = torch.from_numpy(frames.copy()).permute(3, 0, 1, 2)[None]
-                encode = self.vae.encode
-
-            pixels = pixels.to(device=device, dtype=torch.float32).div_(255.0)
-            posterior = encode(self.vae.normalize_pixels(pixels)).latent_dist
-            latents = _sample_visual_posterior(posterior).to(torch.float16).float().cpu()
+                pixels = pixels.to(device=device, dtype=torch.float32).div_(255.0)
+                posterior = self.vae.encode(self.vae.normalize_pixels(pixels)).latent_dist
+                latents = self.vae.normalize_latents(_sample_visual_posterior(posterior).to(
+                    torch.float16).float()).cpu()
             reference.num_latent_frames = int(latents.shape[2])
             reference.latent_height = int(latents.shape[3])
             reference.latent_width = int(latents.shape[4])
-            rows.append(patchify_video_latents((latents - mean) / std, patch_size))
+            rows.append(patchify_video_latents(latents, patch_size))
         return rows
 
     def _encode_audio_rows(
@@ -131,8 +135,6 @@ class MiniMaxH3LatentPreparationStage(PipelineStage):
         references: list[MiniMaxH3PreparedReference],
         device: torch.device,
     ) -> list[torch.Tensor]:
-        mean = self.audio_vae.latents_mean.detach().float().cpu().transpose(1, 2)
-        std = self.audio_vae.latents_std.detach().float().cpu().transpose(1, 2)
         rows: list[torch.Tensor] = []
         for reference in references:
             if not reference.has_audio:
@@ -140,9 +142,9 @@ class MiniMaxH3LatentPreparationStage(PipelineStage):
             if reference.waveform is None:
                 raise ValueError("MiniMax-H3 reference waveform is missing.")
             posterior = self.audio_vae.encode(reference.waveform.to(device)[:, None]).latent_dist
-            latents = posterior.mode().float().cpu().transpose(1, 2)
+            latents = self.audio_vae.normalize_latents(posterior.mode().float()).cpu().transpose(1, 2)
             reference.num_audio_latents = int(latents.shape[1])
-            rows.append(((latents - mean) / std).reshape(-1, self.audio_vae.latent_channels))
+            rows.append(latents.reshape(-1, self.audio_vae.latent_channels))
         return rows
 
     def _encode_fl2va_conditions(
@@ -160,15 +162,11 @@ class MiniMaxH3LatentPreparationStage(PipelineStage):
         vae_device = get_local_torch_device()
         self.vae.to(vae_device)
         try:
-            mean = self.vae.latents_mean.detach().float().cpu()
-            std = self.vae.latents_std.detach().float().cpu()
             clean_rows: list[torch.Tensor] = []
             for image in keyframes:
-                pixels = torch.from_numpy(np.asarray(image).copy()).permute(2, 0, 1)[None, :, None]
-                pixels = pixels.to(device=vae_device, dtype=torch.float32).div_(255.0)
-                posterior = self.vae.encode_keyframe(self.vae.normalize_pixels(pixels)).latent_dist
-                latents = _sample_visual_posterior(posterior).to(torch.float16).float().cpu()
-                clean_rows.append(patchify_video_latents((latents - mean) / std, self.transformer.patch_size))
+                clean_rows.append(
+                    patchify_video_latents(self._encode_keyframe_latents(image, vae_device),
+                                           self.transformer.patch_size))
         finally:
             if fastvideo_args.vae_cpu_offload:
                 self.vae.to("cpu")

--- a/fastvideo/train/utils/moduleloader.py
+++ b/fastvideo/train/utils/moduleloader.py
@@ -122,13 +122,9 @@ def load_module_from_path(
     transformers_or_diffusers, _architecture = module_info[:2]
     component_path = os.path.join(local_model_path, module_type)
 
-    old_override: str | None = None
+    # fastvideo_args is freshly built above and never escapes this function,
+    # so overrides are plain assignments — nothing to save or restore.
     if override_transformer_cls_name is not None:
-        old_override = getattr(
-            fastvideo_args,
-            "override_transformer_cls_name",
-            None,
-        )
         fastvideo_args.override_transformer_cls_name = str(override_transformer_cls_name)
 
     if transformer_override_safetensor:
@@ -146,29 +142,16 @@ def load_module_from_path(
 
     if disable_custom_init_weights:
         fastvideo_args._loading_teacher_critic_model = True
-    try:
-        # Attention implementations are bound while transformer layers are
-        # constructed. Scope the override to this one role so student,
-        # teacher, and critic can use independent backends in one process.
-        with attention_context:
-            module = PipelineComponentLoader.load_module(
-                module_name=module_type,
-                component_model_path=component_path,
-                transformers_or_diffusers=(transformers_or_diffusers),
-                fastvideo_args=fastvideo_args,
-            )
-    finally:
-        if disable_custom_init_weights and hasattr(fastvideo_args, "_loading_teacher_critic_model"):
-            del fastvideo_args._loading_teacher_critic_model
-        if override_transformer_cls_name is not None:
-            if old_override is None:
-                if hasattr(
-                        fastvideo_args,
-                        "override_transformer_cls_name",
-                ):
-                    fastvideo_args.override_transformer_cls_name = (None)
-            else:
-                fastvideo_args.override_transformer_cls_name = (old_override)
+    # Attention implementations are bound while transformer layers are
+    # constructed. Scope the override to this one role so student,
+    # teacher, and critic can use independent backends in one process.
+    with attention_context:
+        module = PipelineComponentLoader.load_module(
+            module_name=module_type,
+            component_model_path=component_path,
+            transformers_or_diffusers=(transformers_or_diffusers),
+            fastvideo_args=fastvideo_args,
+        )
 
     if not isinstance(module, torch.nn.Module):
         raise TypeError(f"Loaded {module_type!r} is not a "


### PR DESCRIPTION
Output of a 4-angle review pass (reuse / simplification / efficiency / altitude) over the H3 inference pipeline. 9 files, +121/−185.

Perf (eager denoising step, all bitwise-neutral):
- packing used out-of-place `index_copy` — three full-buffer clones of the packed `[1, S, 5376]` states per step; now `new_empty` + `index_copy_` (the three index sets partition the sequence, verified).
- RoPE cos/sin rebuilt every step and re-cast fp32→bf16 in every block (200 casts/step); text branch (context_embedder + 2 refiner blocks + 4 collectives) rerun every step on the constant prompt. Both are position/prompt-only, so they're cached per generation — identity-keyed on the source tensor (held, so the check is safe), bypassed under grad and compile.
- Together ~3–7 ms/step eager; reference decode also stops at the trimmed maximum instead of materializing arbitrarily long sources.

Dedup/dead code:
- `MiniMaxH3TimestepEmbedding` was byte-identical to `layers.mlp.MLP(act_type="silu")` (same submodule names → param mapping/fp32 rules unaffected); deleted.
- `build_packed_sequence` now calls the `_frame_position_grid`/`_fill_audio_positions` helpers the Ref2VA packer already extracted (byte-equivalent, incl. the `num_audio_rows - num_audio_latents == num_audio_latents` identity).
- Latent prep's three hand-rolled `(latents - mean) / std` sites use the VAEs' `normalize_latents` (fp16 round-trip preserved); one shared keyframe encoder for fl2va + reference paths.
- Dead getattr waterfalls (conditioning/input prep) for attributes the components expose as typed properties; unreachable empty-rows branch in packing; save/restore scaffolding in moduleloader around a function-local args object; never-read `rope_scaling` write-back in the encoder config.

Every change is bitwise-neutral by construction (correctly-rounded elementwise ops, identical-value caching, fully-overwritten buffers) — the golden-gate lane is the proof; SSIM lanes as usual.

Not included (sized follow-up): the Qwen3-VL conditioner builds/loads all 64 LM layers but H3 reads only `hidden_states[50]` — truncating would drop ~14 GB of weights and ~22% of encode time, but needs the hidden-state indexing convention pinned and a checkpoint-key filter in `load_weights`.