### PR TITLE
[perf] MiniMax-H3: rank-reduced AdaLN pruned model option (-39% params, -23 GiB VRAM)

### DIFF
--- a/examples/inference/basic/basic_minimax_h3_fl2va.py
+++ b/examples/inference/basic/basic_minimax_h3_fl2va.py
@@ -25,6 +25,7 @@ from fastvideo.pipelines.basic.minimax_h3.packing import resolve_canvas_size
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3")
+    # parser.add_argument("--model-path", default="noctuashap/MiniMax-H3-pruned-r16")  # rank-16 AdaLN: -39% params, -23 GiB VRAM
     parser.add_argument("--image", required=True, help="First-frame image path.")
     parser.add_argument("--last-image", help="Optional last-frame image path.")
     parser.add_argument("--output", default="outputs/minimax_h3_fl2va")

--- a/examples/inference/basic/basic_minimax_h3_fl2va.py
+++ b/examples/inference/basic/basic_minimax_h3_fl2va.py
@@ -25,7 +25,12 @@ from fastvideo.pipelines.basic.minimax_h3.packing import resolve_canvas_size
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3")
-    # parser.add_argument("--model-path", default="noctuashap/MiniMax-H3-pruned-r16")  # rank-16 AdaLN: -39% params, -23 GiB VRAM
+    # Rank-reduced AdaLN checkpoint (-39% params, -23 GiB VRAM): pass
+    #   --model-path noctuashap/MiniMax-H3-pruned-r16
+    # (or a local dir converted with tools/minimax_h3/fit_adaln_basis.py).
+    # adaln_rank is read from the checkpoint config; no other flags needed.
+    # Rank-reduced checkpoints are inference-only: training needs the
+    # full-rank release.
     parser.add_argument("--image", required=True, help="First-frame image path.")
     parser.add_argument("--last-image", help="Optional last-frame image path.")
     parser.add_argument("--output", default="outputs/minimax_h3_fl2va")

--- a/examples/inference/basic/basic_minimax_h3_ref2va.py
+++ b/examples/inference/basic/basic_minimax_h3_ref2va.py
@@ -25,6 +25,7 @@ from fastvideo.pipelines.basic.minimax_h3 import MiniMaxH3Reference
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3")
+    # parser.add_argument("--model-path", default="noctuashap/MiniMax-H3-pruned-r16")  # rank-16 AdaLN: -39% params, -23 GiB VRAM
     parser.add_argument("--reference-video", required=True)
     parser.add_argument("--reference-audio", help="Optional additional audio reference.")
     parser.add_argument("--output", default="outputs/minimax_h3_ref2va")

--- a/examples/inference/basic/basic_minimax_h3_ref2va.py
+++ b/examples/inference/basic/basic_minimax_h3_ref2va.py
@@ -25,7 +25,12 @@ from fastvideo.pipelines.basic.minimax_h3 import MiniMaxH3Reference
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3")
-    # parser.add_argument("--model-path", default="noctuashap/MiniMax-H3-pruned-r16")  # rank-16 AdaLN: -39% params, -23 GiB VRAM
+    # Rank-reduced AdaLN checkpoint (-39% params, -23 GiB VRAM): pass
+    #   --model-path noctuashap/MiniMax-H3-pruned-r16
+    # (or a local dir converted with tools/minimax_h3/fit_adaln_basis.py).
+    # adaln_rank is read from the checkpoint config; no other flags needed.
+    # Rank-reduced checkpoints are inference-only: training needs the
+    # full-rank release.
     parser.add_argument("--reference-video", required=True)
     parser.add_argument("--reference-audio", help="Optional additional audio reference.")
     parser.add_argument("--output", default="outputs/minimax_h3_ref2va")

--- a/examples/inference/basic/basic_minimax_h3_t2v.py
+++ b/examples/inference/basic/basic_minimax_h3_t2v.py
@@ -22,7 +22,12 @@ from fastvideo.api import (
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3")
-    # parser.add_argument("--model-path", default="noctuashap/MiniMax-H3-pruned-r16")  # rank-16 AdaLN: -39% params, -23 GiB VRAM
+    # Rank-reduced AdaLN checkpoint (-39% params, -23 GiB VRAM): pass
+    #   --model-path noctuashap/MiniMax-H3-pruned-r16
+    # (or a local dir converted with tools/minimax_h3/fit_adaln_basis.py).
+    # adaln_rank is read from the checkpoint config; no other flags needed.
+    # Rank-reduced checkpoints are inference-only: training needs the
+    # full-rank release.
     parser.add_argument("--prompt", required=True)
     parser.add_argument("--output", default="outputs/minimax_h3_t2v")
     parser.add_argument("--height", type=int, default=768)

--- a/examples/inference/basic/basic_minimax_h3_t2v.py
+++ b/examples/inference/basic/basic_minimax_h3_t2v.py
@@ -22,6 +22,7 @@ from fastvideo.api import (
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3")
+    # parser.add_argument("--model-path", default="noctuashap/MiniMax-H3-pruned-r16")  # rank-16 AdaLN: -39% params, -23 GiB VRAM
     parser.add_argument("--prompt", required=True)
     parser.add_argument("--output", default="outputs/minimax_h3_t2v")
     parser.add_argument("--height", type=int, default=768)

--- a/fastvideo/configs/models/dits/minimax_h3.py
+++ b/fastvideo/configs/models/dits/minimax_h3.py
@@ -52,6 +52,7 @@ class MiniMaxH3ArchConfig(DiTArchConfig):
     freq_dim: int = 256
     time_embed_hidden_dim: int = 5376
     time_embed_dim: int = 2688
+    adaln_rank: int | None = None
     rope_freq_dim: int = 16
     rope_theta: float = 10000.0
     norm_eps: float = 1e-5
@@ -65,6 +66,9 @@ class MiniMaxH3ArchConfig(DiTArchConfig):
         self.patch_size = (self.patch_size[0], self.patch_size[1], self.patch_size[2])
         self.num_channels_latents = self.in_channels
         self.out_channels = self.in_channels
+        if self.adaln_rank is not None and not 0 < self.adaln_rank <= self.time_embed_dim:
+            raise ValueError(f"MiniMax H3 adaln_rank must be in (0, time_embed_dim={self.time_embed_dim}], "
+                             f"got {self.adaln_rank}.")
         rotary_dim = 2 * 3 * self.rope_freq_dim
         if rotary_dim > self.attention_head_dim or rotary_dim % 2:
             raise ValueError(f"MiniMax H3 rotary width must be even and no larger than the head width; got "

--- a/fastvideo/models/dits/minimax_h3.py
+++ b/fastvideo/models/dits/minimax_h3.py
@@ -275,9 +275,11 @@ class MiniMaxH3AdaLayerNormModulation(nn.Module):
         hidden_size: int,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        apply_silu: bool = True,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
+        self.apply_silu = apply_silu
         self.linear = ReplicatedLinear(
             time_embed_dim,
             6 * hidden_size * MINIMAX_H3_MODALITY_NUM,
@@ -287,7 +289,9 @@ class MiniMaxH3AdaLayerNormModulation(nn.Module):
         )
 
     def forward(self, temb: torch.Tensor) -> tuple[torch.Tensor, ...]:
-        temb, _ = self.linear(F.silu(temb).to(self.linear.weight.dtype))
+        if self.apply_silu:
+            temb = F.silu(temb)
+        temb, _ = self.linear(temb.to(self.linear.weight.dtype))
         return temb.view(-1, 6 * self.hidden_size).chunk(6, dim=-1)
 
 
@@ -301,9 +305,11 @@ class MiniMaxH3AdaLayerNormOut(nn.Module):
         eps: float,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        apply_silu: bool = True,
     ) -> None:
         super().__init__()
         self.norm = nn.RMSNorm(hidden_size, eps=eps)
+        self.apply_silu = apply_silu
         self.linear = ReplicatedLinear(
             time_embed_dim,
             2 * hidden_size,
@@ -318,7 +324,9 @@ class MiniMaxH3AdaLayerNormOut(nn.Module):
         temb: torch.Tensor,
         timestep_indices: torch.Tensor,
     ) -> torch.Tensor:
-        shift_scale, _ = self.linear(F.silu(temb).to(self.linear.weight.dtype))
+        if self.apply_silu:
+            temb = F.silu(temb)
+        shift_scale, _ = self.linear(temb.to(self.linear.weight.dtype))
         shift, scale = shift_scale.chunk(2, dim=-1)
         hidden_states = self.norm(hidden_states)
         return hidden_states * (1.0 + scale.index_select(0, timestep_indices)) + shift.index_select(0, timestep_indices)
@@ -339,6 +347,7 @@ class MiniMaxH3TransformerBlock(nn.Module):
         supported_attention_backends: tuple[AttentionBackendEnum, ...],
         quant_config: QuantizationConfig | None,
         prefix: str,
+        adaln_apply_silu: bool = True,
     ) -> None:
         super().__init__()
         self.norm1 = nn.RMSNorm(hidden_size, eps=norm_eps)
@@ -363,6 +372,7 @@ class MiniMaxH3TransformerBlock(nn.Module):
             hidden_size,
             quant_config=quant_config,
             prefix=f"{prefix}.adaln_proj",
+            apply_silu=adaln_apply_silu,
         )
 
     def forward(
@@ -373,7 +383,8 @@ class MiniMaxH3TransformerBlock(nn.Module):
         rotary_emb: tuple[torch.Tensor, torch.Tensor],
         original_seq_len: int,
     ) -> torch.Tensor:
-        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.adaln_proj(temb)
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            t.to(hidden_states.dtype) for t in self.adaln_proj(temb))
 
         residual = hidden_states
         norm_hidden_states = self.norm1(hidden_states)
@@ -414,12 +425,28 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
     })
 
     def _get_parameter_dtype(self, name: str, default_dtype: torch.dtype) -> torch.dtype:
-        """Select a uniform Fully Sharded Data Parallel dtype or H3's inference dtype.
+        """Per-parameter dtype overrides.
 
-        FastVideo's Fully Sharded Data Parallel loading path requires one dtype
-        for every trainable parameter. H3 inference preserves FP32 input, timestep,
-        and output projections because those boundaries are part of its numerical policy.
+        The released input, timestep, and output projections stay FP32.
+        Factorized AdaLN is FP16 -- not FP32 -- because FP16 tracks the released
+        BF16 full-rank error, while BF16 is ~1.7x worse there (the
+        factorization sums few large cancelling terms instead of many small
+        ones) and FP32 is more accurate than the model being reproduced.
+        ``uniform_parameter_dtype`` (the Fully Sharded Data Parallel training
+        path, which needs one dtype for every trainable parameter) applies to
+        everything else.
         """
+        # Precedence: the factorized-AdaLN FP16 pin wins over
+        # uniform_parameter_dtype on purpose. Under FSDP's one-dtype rule the
+        # resulting mix hard-fails at load time, which beats silently training
+        # AdaLN in BF16 (~1.7x worse than the FP16 the factorization was fit
+        # for). Rank-reduced checkpoints are inference artifacts -- train from
+        # the full-rank release.
+        if getattr(self, "adaln_rank", None) is not None and (name.endswith("adaln_proj.linear.weight")
+                                                              or name.endswith("adaln_proj.linear.bias")
+                                                              or name.startswith("norm_out.linear.")
+                                                              or name.startswith("adaln_basis.")):
+            return torch.float16
         if self.config.uniform_parameter_dtype:
             return default_dtype
         return torch.float32 if name.split(".", 1)[0] in self._keep_in_fp32_modules else default_dtype
@@ -472,6 +499,16 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
             quant_config=config.quant_config,
             prefix=f"{config.prefix}.time_embedder",
         )
+        self.adaln_rank: int | None = arch.adaln_rank
+        adaln_dim = self.adaln_rank or arch.time_embed_dim
+        self.adaln_basis = ReplicatedLinear(
+            arch.time_embed_dim,
+            self.adaln_rank,
+            bias=False,
+            quant_config=None,
+            prefix=f"{config.prefix}.adaln_basis",
+        ) if self.adaln_rank else None
+
         self.rope = MiniMaxH3RotaryPosEmbed(arch.rope_freq_dim, arch.rope_theta)
         # per-generation caches for loop-invariant work (see _rotary_for /
         # _refined_text); plain attrs, never in state_dict
@@ -496,20 +533,22 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
                 arch.num_attention_heads,
                 arch.attention_head_dim,
                 arch.ffn_dim,
-                arch.time_embed_dim,
+                adaln_dim,
                 arch.norm_eps,
                 arch.qk_norm_eps,
                 self.supported_attention_backends,
                 config.quant_config,
                 prefix=f"{config.prefix}.transformer_blocks.{index}",
+                adaln_apply_silu=self.adaln_rank is None,
             ) for index in range(arch.num_layers)
         ])
         self.norm_out = MiniMaxH3AdaLayerNormOut(
             arch.hidden_size,
-            arch.time_embed_dim,
+            adaln_dim,
             arch.final_norm_eps,
             quant_config=config.quant_config,
             prefix=f"{config.prefix}.norm_out",
+            apply_silu=self.adaln_rank is None,
         )
         self.proj_out = ReplicatedLinear(
             arch.hidden_size,
@@ -631,6 +670,8 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
 
         temb = self.time_proj(timestep)
         temb = self.time_embedder(temb.to(self.time_embedder.fc_in.weight.dtype))
+        if self.adaln_basis is not None:
+            temb, _ = self.adaln_basis(F.silu(temb).to(self.adaln_basis.weight.dtype))
         adaln_indices = timestep_indices * MINIMAX_H3_MODALITY_NUM + token_tags
         local_timestep_indices = timestep_indices
         original_seq_len = sequence_length

--- a/fastvideo/models/dits/minimax_h3.py
+++ b/fastvideo/models/dits/minimax_h3.py
@@ -490,6 +490,14 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
             prefix=f"{config.prefix}.time_embedder",
         )
         self.adaln_rank: int | None = arch.adaln_rank
+        if self.adaln_rank is not None and config.uniform_parameter_dtype:
+            raise ValueError(
+                "Rank-reduced AdaLN checkpoints (adaln_rank set) cannot be trained: "
+                "uniform_parameter_dtype needs one dtype for every trainable "
+                "parameter, but factorized AdaLN weights are pinned to FP16 "
+                "(BF16 reconstructs them ~1.7x worse). Fine-tune the full-rank "
+                "checkpoint instead, then re-fit the basis with "
+                "tools/minimax_h3/fit_adaln_basis.py.")
         adaln_dim = self.adaln_rank or arch.time_embed_dim
         self.adaln_basis = ReplicatedLinear(
             arch.time_embed_dim,

--- a/fastvideo/models/dits/minimax_h3.py
+++ b/fastvideo/models/dits/minimax_h3.py
@@ -425,27 +425,17 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
     })
 
     def _get_parameter_dtype(self, name: str, default_dtype: torch.dtype) -> torch.dtype:
-        """Per-parameter dtype overrides.
+        """Keep the released input, timestep, and output projections in FP32.
 
-        The released input, timestep, and output projections stay FP32.
-        Factorized AdaLN is FP16 -- not FP32 -- because FP16 tracks the released
-        BF16 full-rank error, while BF16 is ~1.7x worse there (the
-        factorization sums few large cancelling terms instead of many small
-        ones) and FP32 is more accurate than the model being reproduced.
-        ``uniform_parameter_dtype`` (the Fully Sharded Data Parallel training
-        path, which needs one dtype for every trainable parameter) applies to
-        everything else.
+        Factorized AdaLN uses FP16; BF16 is ~1.7x worse there.
         """
         # Precedence: the factorized-AdaLN FP16 pin wins over
         # uniform_parameter_dtype on purpose. Under FSDP's one-dtype rule the
         # resulting mix hard-fails at load time, which beats silently training
-        # AdaLN in BF16 (~1.7x worse than the FP16 the factorization was fit
-        # for). Rank-reduced checkpoints are inference artifacts -- train from
-        # the full-rank release.
-        if getattr(self, "adaln_rank", None) is not None and (name.endswith("adaln_proj.linear.weight")
-                                                              or name.endswith("adaln_proj.linear.bias")
-                                                              or name.startswith("norm_out.linear.")
-                                                              or name.startswith("adaln_basis.")):
+        # AdaLN in BF16. Rank-reduced checkpoints are inference artifacts --
+        # train from the full-rank release.
+        if getattr(self, "adaln_rank", None) is not None and (
+                ".adaln_proj." in name or name.startswith(("norm_out.linear.", "adaln_basis."))):
             return torch.float16
         if self.config.uniform_parameter_dtype:
             return default_dtype

--- a/tools/minimax_h3/fit_adaln_basis.py
+++ b/tools/minimax_h3/fit_adaln_basis.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rank-reduce the MiniMax-H3 AdaLN modulation projections.
+
+Every AdaLN projection consumes ``silu(time_embedder(time_proj(t)))`` where ``t``
+is a scalar timestep, so its reachable input set is a smooth 1-D curve. Sampling
+that curve and truncating its SVD yields a shared basis ``V`` such that
+
+    W @ u(t)  ==  (W @ V) @ (V.T @ u(t))
+
+to within the truncation error. Pre-multiplying every block's ``[96768, 2688]``
+projection by ``V`` leaves ``[96768, r]``, removing ~39% of the model's
+parameters with no change to the forward's arithmetic structure.
+
+Unlike ComfyUI's "pruned" checkpoints this keeps ``time_embedder`` and stores the
+basis as a real projection instead of replacing the timestep MLP with a 1025-point
+lookup table. That costs 14.5M parameters (0.03 GB of the ~26 GB saved) and buys
+exactness at arbitrary ``t`` -- no grid interpolation and no clamped domain, which
+matters if the schedule is ever changed (different flow shift, distilled sigmas).
+
+Writes a diffusers-format component directory that ``TransformerLoader`` picks up
+directly: ``adaln_rank`` in ``config.json`` flows onto the arch config through
+``update_model_arch``. No flag is needed at inference -- a checkpoint carrying
+``adaln_rank`` selects the factorized path, one without it stays full rank.
+
+Usage::
+
+    python tools/minimax_h3/fit_adaln_basis.py \
+        --src  /path/to/MiniMax-H3/transformer \
+        --dst  /path/to/MiniMax-H3-r16/transformer --rank 16
+
+    # then assemble a model dir whose other components point at the original
+    ln -s /path/to/MiniMax-H3/{text_encoder,tokenizer,processor,vae,audio_vae,\
+scheduler,audio_scheduler,modular_model_index.json} /path/to/MiniMax-H3-r16/
+
+    python examples/inference/basic/basic_minimax_h3_t2v.py \
+        --model-path /path/to/MiniMax-H3-r16 --prompt "..."
+
+Use ``--report-only`` to measure the fit error at a candidate rank without
+writing a checkpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+INDEX_NAME = "diffusion_pytorch_model.safetensors.index.json"
+ADALN_SUFFIX = "adaln_proj.linear.weight"
+NORM_OUT_WEIGHT = "norm_out.linear.weight"
+TIME_EMBEDDER_KEYS = (
+    "time_embedder.linear_1.weight",
+    "time_embedder.linear_1.bias",
+    "time_embedder.linear_2.weight",
+    "time_embedder.linear_2.bias",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--src", required=True, help="Official transformer component dir.")
+    p.add_argument("--dst", required=True, help="Output component dir.")
+    p.add_argument("--rank", type=int, default=16)
+    p.add_argument("--grid", type=int, default=4096, help="Timestep samples used to fit the basis.")
+    p.add_argument("--freq-dim", type=int, default=256)
+    p.add_argument("--report-only", action="store_true", help="Fit and report error without writing.")
+    return p.parse_args()
+
+
+def timestep_embedding(t: torch.Tensor, dim: int) -> torch.Tensor:
+    """diffusers get_timestep_embedding, flip_sin_to_cos=True, downscale_freq_shift=0."""
+    half = dim // 2
+    exponent = -math.log(10000.0) * torch.arange(half, dtype=torch.float64) / half
+    emb = t[:, None].double() * torch.exp(exponent)[None, :]
+    return torch.cat([torch.cos(emb), torch.sin(emb)], dim=-1)
+
+
+def load_keys(src: Path, index: dict[str, str], keys: list[str]) -> dict[str, torch.Tensor]:
+    by_shard: dict[str, list[str]] = {}
+    for key in keys:
+        by_shard.setdefault(index[key], []).append(key)
+    out: dict[str, torch.Tensor] = {}
+    for shard, shard_keys in by_shard.items():
+        with safe_open(str(src / shard), framework="pt") as f:
+            for key in shard_keys:
+                out[key] = f.get_tensor(key)
+    return out
+
+
+def fit_basis(src: Path, index: dict[str, str], rank: int, grid: int,
+              freq_dim: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return (V [time_embed_dim, rank], U [grid, time_embed_dim]) in float64."""
+    embedder = load_keys(src, index, list(TIME_EMBEDDER_KEYS))
+    # t is the DiT's timestep input: scheduler.timesteps = 1 - sigmas, so t in [0, 1].
+    # Condition rows pin t to 0.999 / 1.0, so the endpoint must be included.
+    t = torch.linspace(0.0, 1.0, grid, dtype=torch.float64)
+    h = timestep_embedding(t, freq_dim)
+    h = h @ embedder["time_embedder.linear_1.weight"].double().T + embedder["time_embedder.linear_1.bias"].double()
+    h = torch.nn.functional.silu(h)
+    temb = h @ embedder["time_embedder.linear_2.weight"].double().T + embedder["time_embedder.linear_2.bias"].double()
+    u = torch.nn.functional.silu(temb)
+    _, s, vh = torch.linalg.svd(u, full_matrices=False)
+    residual = ((s[rank:]**2).sum() / (s**2).sum()).sqrt()
+    print(f"basis: U={tuple(u.shape)} rank={rank} relative residual ||U-U_r||/||U|| = {residual:.3e}")
+    return vh[:rank].T.contiguous(), u
+
+
+def main() -> None:
+    args = parse_args()
+    src, dst = Path(args.src), Path(args.dst)
+    index_map = json.loads((src / INDEX_NAME).read_text())["weight_map"]
+
+    basis, u = fit_basis(src, index_map, args.rank, args.grid, args.freq_dim)
+
+    # Worst-case induced error on the actual modulation outputs.
+    worst = 0.0
+    scale = 0.0
+    for key in sorted(k for k in index_map if k.endswith(ADALN_SUFFIX) or k == NORM_OUT_WEIGHT):
+        w = load_keys(src, index_map, [key])[key].double()
+        ref = u @ w.T
+        approx = (u @ basis) @ (w @ basis).T
+        worst = max(worst, (ref - approx).abs().max().item())
+        scale = max(scale, ref.abs().max().item())
+    print(f"modulation error over all projections: max|err|={worst:.3e} "
+          f"(|Wu|max={scale:.3f}, relative={worst / scale:.3e})")
+    if args.report_only:
+        return
+
+    dst.mkdir(parents=True, exist_ok=True)
+    new_index: dict[str, str] = {}
+    total_before = total_after = 0
+    for shard in sorted(set(index_map.values())):
+        tensors: dict[str, torch.Tensor] = {}
+        with safe_open(str(src / shard), framework="pt") as f:
+            shard_keys = list(f.keys())
+            for key in shard_keys:
+                tensor = f.get_tensor(key)
+                total_before += tensor.numel()
+                if key.endswith(ADALN_SUFFIX) or key == NORM_OUT_WEIGHT:
+                    # [out, time_embed_dim] @ [time_embed_dim, rank] -> [out, rank]
+                    tensor = (tensor.double() @ basis).to(torch.float16)
+                tensors[key] = tensor
+                total_after += tensor.numel()
+                new_index[key] = shard
+        save_file(tensors, str(dst / shard), metadata={"format": "pt"})
+        print(f"wrote {shard} ({len(tensors)} tensors)")
+
+    # ReplicatedLinear stores [out_features, in_features], so the basis is V.T.
+    basis_shard = "diffusion_pytorch_model-adaln-basis.safetensors"
+    save_file({"adaln_basis.weight": basis.T.to(torch.float16).contiguous()},
+              str(dst / basis_shard),
+              metadata={"format": "pt"})
+    new_index["adaln_basis.weight"] = basis_shard
+    total_after += basis.numel()
+
+    (dst / INDEX_NAME).write_text(json.dumps({"metadata": {}, "weight_map": new_index}, indent=1))
+
+    config = json.loads((src / "config.json").read_text())
+    config["adaln_rank"] = args.rank
+    (dst / "config.json").write_text(json.dumps(config, indent=2))
+    for extra in src.glob("*.json"):
+        if extra.name not in {INDEX_NAME, "config.json"}:
+            shutil.copy2(extra, dst / extra.name)
+
+    print(f"\nparameters: {total_before / 1e9:.3f}B -> {total_after / 1e9:.3f}B "
+          f"({100 * (1 - total_after / total_before):.1f}% removed)")
+    print(f"bf16 footprint: {total_before * 2 / 1e9:.1f} GB -> ~{total_after * 2 / 1e9:.1f} GB")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# [perf] MiniMax-H3: optional rank-reduced AdaLN (-39% params, -23 GiB VRAM)

## Purpose

MiniMax-H3's AdaLN modulation projections account for 13.01B of the DiT's 33.12B
parameters — 39% of the model — while contributing roughly 0.003% of its FLOPs. Each
projection consumes `silu(time_embedder(time_proj(t)))` where `t` is a scalar timestep, so
the set of inputs it can ever see is a smooth 1-D curve spanning a very small subspace,
even though the weight is stored as `[96768, 2688]`.

This PR adds an opt-in path that stores those projections against a shared low-rank basis
instead. At rank 16 the DiT drops to 20.17B parameters and peak VRAM falls by 22.8 GiB per
GPU, with no change in latency. Nothing changes for anyone who does not opt in.

Fixes # N/A

## Changes

- `MiniMaxH3ArchConfig.adaln_rank: int | None` (default `None`), with a range check in
  `__post_init__`. When it is set, `adaln_proj.linear` and `norm_out.linear` are built at
  `[out, adaln_rank]` and a shared `adaln_basis` projects `silu(temb)` into that subspace.
- `MiniMaxH3AdaLayerNormModulation` and `MiniMaxH3AdaLayerNormOut` gain an `apply_silu`
  flag, since SiLU is applied once before the basis rather than inside each consumer.
- `MiniMaxH3TransformerBlock.forward` narrows the six modulation tensors to the activation
  dtype so the block stays BF16 end to end.
- `_get_parameter_dtype` pins the factorized projections to FP16. This is deliberate and
  is explained under *Test Results*: BF16 is materially worse there, and FP32 is more
  accurate than the model being reproduced.
- `tools/minimax_h3/fit_adaln_basis.py` fits the basis by truncated SVD of the sampled
  timestep curve and writes a converted diffusers component directory. `adaln_rank` in the
  checkpoint's `config.json` reaches the arch config through the existing
  `update_model_arch`, so **no loader changes are required** and no runtime flag is needed.
- The three H3 examples carry a commented-out `--model-path` pointing at a converted
  checkpoint.

A converted rank-16 checkpoint for both partitions is published at
[noctuashap/MiniMax-H3-pruned-r16](https://huggingface.co/noctuashap/MiniMax-H3-pruned-r16).

## Test Plan

```bash
pre-commit run --files \
    fastvideo/configs/models/dits/minimax_h3.py \
    fastvideo/models/dits/minimax_h3.py \
    tools/minimax_h3/fit_adaln_basis.py

# fit error at candidate ranks, no checkpoint written
python tools/minimax_h3/fit_adaln_basis.py --src $H3/transformer --dst /dev/null \
    --rank 16 --report-only

# convert both partitions
python tools/minimax_h3/fit_adaln_basis.py --src $H3/transformer      --dst $OUT/transformer      --rank 16
python tools/minimax_h3/fit_adaln_basis.py --src $H3/transformer_ref  --dst $OUT/transformer_ref  --rank 16

# A/B through the stock example, 4x GB200, 50 steps, 1344x768, 124 frames, seed 0
python examples/inference/basic/basic_minimax_h3_t2v.py --model-path $H3  --steps 50 --num-gpus 4 --seed 0 --prompt "$P"
python examples/inference/basic/basic_minimax_h3_t2v.py --model-path $OUT --steps 50 --num-gpus 4 --seed 0 --prompt "$P"

# Ref2VA, same reference video and seed
python examples/inference/basic/basic_minimax_h3_ref2va.py --model-path $H3  --reference-video ref.mp4 --steps 50 --num-gpus 4 --seed 0 --prompt "$P2"
python examples/inference/basic/basic_minimax_h3_ref2va.py --model-path $OUT --reference-video ref.mp4 --steps 50 --num-gpus 4 --seed 0 --prompt "$P2"
```

## Test Results

**The released path is untouched.** With `adaln_rank` unset, a full-rank generation on this
branch is byte-for-byte identical to one on `main` — MS-SSIM 1.000000, 100% identical
pixels, zero audio difference. Repeated runs and SP=1 vs SP=4 are also bit-identical, so
the pipeline has no run-to-run noise and that comparison is meaningful.

| | official | rank-16 |
|---|---:|---:|
| parameters | 33.12B | 20.17B |
| peak VRAM / GPU | 88.3 GiB | 65.5 GiB |
| T2VA latency (warm) | 95.05 s | 95.44 s |
| Ref2VA latency | 355.93 s | 354.60 s |

Side-by-side, official weights on the left and the rank-16 checkpoint on the right. Same
prompt, same seed, both generated with the stock `basic_minimax_h3_t2v.py`:

https://github.com/user-attachments/assets/47f4b66b-41df-4fbb-b63d-dea39b46544c


<details>
<summary>Fit error and the FP16 choice</summary>

```
Fit error over all 51 projections, vs an FP64 reference:
  rank  8 : max|err| 6.678e-03   relative 5.4e-04
  rank 16 : max|err| 6.306e-08   relative 5.1e-09
  rank 32 : max|err| 1.013e-13   relative 8.2e-15

Runtime error through the whole chain, including the narrowing cast at the
apply site, per block at rank 16:
  released full-rank BF16   3.4e-03 .. 4.4e-03
  factorized BF16           6.4e-03 .. 7.6e-03    (~1.7x worse)
  factorized FP16           3.1e-03 .. 4.6e-03    (matches released)
  factorized FP32           2.4e-03 .. 3.8e-03    (better than released)
```

The BF16 error is flat from rank 8 through rank 128, so it is cancellation rather than
truncation: `u(t)` is 2688 values (max 0.806, mean 1.4e-03) summed as many small terms,
and the factorization rebuilds the same value from `r` large terms that cancel. FP16 has
two more mantissa bits than BF16, which is enough to absorb that. FP32 was rejected because
the aim is to reproduce the released model, not to improve on it. ComfyUI's independent
rank-8 variant stores these tensors as F16 for the same reason, and raises precision only
for its factorized checkpoints.

</details>

<details>
<summary>Conversion output</summary>

```
$ python tools/minimax_h3/fit_adaln_basis.py --src .../transformer --dst .../transformer --rank 16
basis: U=(4096, 2688) rank=16 relative residual ||U-U_r||/||U|| = 1.495e-09
modulation error over all projections: max|err|=6.306e-08 (|Wu|max=12.376, relative=5.095e-09)
parameters: 33.123B -> 20.166B (39.1% removed)
bf16 footprint: 66.2 GB -> ~40.3 GB

$ ... --src .../transformer_ref --dst .../transformer_ref --rank 16
basis: U=(4096, 2688) rank=16 relative residual ||U-U_r||/||U|| = 1.660e-09
modulation error over all projections: max|err|=6.435e-08 (|Wu|max=12.624, relative=5.097e-09)
```

`transformer` and `transformer_ref` need separate fits: their `time_embedder` weights
differ by 1–6% relative, so one basis cannot serve both.

</details>

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues — *ran on the changed files;
      yapf, ruff and codespell pass. mypy fails, but identically on untouched files, because
      it reads the worktree directory name as a package; it should be re-checked on a
      normally-named checkout.*
- [ ] I added or updated tests for my changes — **not done.** Verification used out-of-tree
      scripts (parity harness, dtype diagnostics). Happy to upstream a rank-fit unit test
      and a dtype-resolution test if wanted.
- [x] I updated documentation if needed — examples carry the alternative `--model-path`; the
      converter documents its own usage. No support-matrix change, since this adds no model.
- [x] I considered GPU memory impact of my changes — that is the point of the PR; measured
      88.3 → 65.5 GiB peak per GPU.

**For model/pipeline changes, also check:**

- [ ] I verified SSIM regression tests pass — **they will not pass with a pruned
      checkpoint, by construction.** See *Test Results*. With `adaln_rank` unset the
      released path is bit-identical, so existing references remain valid for the default
      configuration.
- [ ] I updated the support matrix if adding a new model — not applicable, no new model.

## Known limitations

- Quality was checked on one prompt per task (T2VA and Ref2VA), compared against the
  full-rank output and inspected by eye. There is no multi-prompt sweep behind these
  numbers.
- Rank 16 is a safety margin rather than a requirement. It was chosen from FP64 fit error,
  and the later dtype work showed that FP16 rounding (3.1–4.6e-03) is 6–8× larger than
  rank-8 truncation (5.4e-04), so rank 8 would likely be indistinguishable.
- Should merge other commits touching H3 dit first, will rebase after that


