### PR TITLE
[misc]: re-run yapf on main so pre-commit passes again

### DIFF
--- a/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py
+++ b/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import contextlib
 from typing import Any
 
-
 import torch
 
 from fastvideo.distributed import get_local_torch_device
@@ -106,8 +105,8 @@ class MiniMaxH3DenoisingStage(PipelineStage):
                           if controller is not None else contextlib.nullcontext())
         try:
             with denoise_region:
-                for index, (video_timestep, audio_timestep) in enumerate(zip(video_timesteps, audio_timesteps,
-                                                                             strict=True)):
+                for index, (video_timestep,
+                            audio_timestep) in enumerate(zip(video_timesteps, audio_timesteps, strict=True)):
                     unique_timesteps, timestep_indices = row_timestep_plan[index]
                     # Under torch.compile(mode="reduce-overhead") each denoising
                     # step must be marked, or cudagraph trees flag cross-step

--- a/fastvideo/utils.py
+++ b/fastvideo/utils.py
@@ -720,15 +720,11 @@ def maybe_download_model_index(model_name_or_path: str, revision: str | None = N
         config_filename = "model_index.json"
         try:
             filename = f"{subfolder}/{config_filename}" if subfolder else config_filename
-            model_index_path = hf_hub_download(repo_id=repo_id,
-                                               filename=filename,
-                                               revision=revision)
+            model_index_path = hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
         except EntryNotFoundError:
             config_filename = "modular_model_index.json"
             filename = f"{subfolder}/{config_filename}" if subfolder else config_filename
-            model_index_path = hf_hub_download(repo_id=repo_id,
-                                               filename=filename,
-                                               revision=revision)
+            model_index_path = hf_hub_download(repo_id=repo_id, filename=filename, revision=revision)
 
         # Load the selected manifest.
         with open(model_index_path) as f:
@@ -739,14 +735,12 @@ def maybe_download_model_index(model_name_or_path: str, revision: str | None = N
             raise ValueError(f"{config_filename} for {model_name_or_path} does not contain _class_name field")
 
         if "_diffusers_version" not in config:
-            raise ValueError(
-                f"{config_filename} for {model_name_or_path} does not contain _diffusers_version field")
+            raise ValueError(f"{config_filename} for {model_name_or_path} does not contain _diffusers_version field")
 
         # Add the pipeline name for downstream use
         config["pipeline_name"] = config["_class_name"]
 
-        logger.info("Downloaded %s for %s, pipeline: %s", config_filename, model_name_or_path,
-                    config["_class_name"])
+        logger.info("Downloaded %s for %s, pipeline: %s", config_filename, model_name_or_path, config["_class_name"])
         return config
 
     except Exception as e:


### PR DESCRIPTION
## Purpose

`pre-commit run yapf --all-files` currently reformats two files on main, so the
CI pre-commit job fails on every PR opened against it regardless of what that PR
touches. I hit it on #1693, which touches neither file.

## Changes

Whitespace only, produced by running the repo's own hook. Both files sit inside
the 120 column limit the config sets, so yapf joins the wrapped calls back onto
one line.

- `fastvideo/utils.py`, last touched by #1684
- `fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py`, last
  touched by #1689

No behavior change.

## Test Plan

```bash
pre-commit run --all-files
```

## Test Results

```
yapf.....................................................................Passed
ruff (legacy alias)......................................................Passed
codespell................................................................Passed
PyMarkdown...............................................................Passed
```

mypy could not run in my checkout, which is named with a hyphen and so is not a
valid package name. It passes in CI.

Reproducing the failure before this change, on a branch that touches neither
file:

```
$ git status --short
 M fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py
 M fastvideo/utils.py
```

## Note on how this landed

Both #1684 and #1689 show a failing pre-commit check on their final commit, and
both merged. The merge protections list `check-success~=pre-commit` as required,
so something let them through, and the same gap will let the next one through.
Flagging rather than proposing a change, since I cannot see the merge queue runs
from outside.

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

No tests: the change is whitespace, and the hook that produces it is the test.
