### PR TITLE
[bugfix]: retain NVFP4 weights for LTX2 refinement LoRA

### DIFF
--- a/apps/dreamverse/dreamverse/video_generation.py
+++ b/apps/dreamverse/dreamverse/video_generation.py
@@ -308,7 +308,13 @@ class VideoGenerationWorker:
                     dynamic=False,
                 ),
                 use_fsdp_inference=False,
-                quantization=QuantizationConfig(transformer_quant="NVFP4"),
+                # The bundled LTX2 model enables a refinement LoRA during the
+                # first request. NVFP4 otherwise purges the dense weights that
+                # FastVideo's LoRA merge path requires.
+                quantization=QuantizationConfig(
+                    transformer_quant="NVFP4",
+                    transformer_retain_original_weights=True,
+                ),
             ),
             pipeline=PipelineSelection(
                 components=components,

--- a/fastvideo/api/compat.py
+++ b/fastvideo/api/compat.py
@@ -276,7 +276,11 @@ def generator_config_to_fastvideo_args(config: GeneratorConfig | Mapping[str, An
         # downstream code can rely on a single source of truth.
         from fastvideo.layers.quantization import get_quantization_config
         _resolved_quant_cls = get_quantization_config(quantization.transformer_quant)
-        kwargs["transformer_quant"] = _resolved_quant_cls()
+        retain_original_weights = quantization.transformer_retain_original_weights
+        if retain_original_weights is not None and quantization.transformer_quant.lower() != "nvfp4":
+            raise ValueError("transformer_retain_original_weights is only supported with transformer_quant='NVFP4'")
+        quant_kwargs = ({} if retain_original_weights is None else {"retain_original_weights": retain_original_weights})
+        kwargs["transformer_quant"] = _resolved_quant_cls(**quant_kwargs)
 
     components = normalized.pipeline.components
     if components.pipeline_config_path is not None:

--- a/fastvideo/api/schema.py
+++ b/fastvideo/api/schema.py
@@ -69,6 +69,9 @@ class CompileConfig:
 class QuantizationConfig:
     text_encoder_quant: str | None = None
     transformer_quant: str | None = None
+    # NVFP4 can purge the original dense weights after conversion. Keep them
+    # when inference will later merge a transformer LoRA adapter.
+    transformer_retain_original_weights: bool | None = None
 
 
 @dataclass

--- a/fastvideo/tests/api/test_typed_quant_flow.py
+++ b/fastvideo/tests/api/test_typed_quant_flow.py
@@ -58,6 +58,34 @@ def test_typed_transformer_quant_resolves_to_nvfp4_instance(captured_kwargs) -> 
                                      f"{type(captured_kwargs['transformer_quant']).__name__}")
 
 
+def test_typed_nvfp4_quant_can_retain_original_weights(captured_kwargs) -> None:
+    cfg = GeneratorConfig(
+        model_path="FastVideo/LTX2-Distilled-Diffusers",
+        engine=EngineConfig(
+            quantization=QuantizationConfig(
+                transformer_quant="NVFP4",
+                transformer_retain_original_weights=True,
+            ), ),
+    )
+    generator_config_to_fastvideo_args(cfg)
+    quant_config = captured_kwargs["transformer_quant"]
+    assert isinstance(quant_config, NVFP4Config)
+    assert quant_config.retain_original_weights is True
+
+
+def test_retain_original_weights_rejects_non_nvfp4_quant(captured_kwargs) -> None:
+    cfg = GeneratorConfig(
+        model_path="model",
+        engine=EngineConfig(
+            quantization=QuantizationConfig(
+                transformer_quant="FP8",
+                transformer_retain_original_weights=True,
+            ), ),
+    )
+    with pytest.raises(ValueError, match="only supported with transformer_quant='NVFP4'"):
+        generator_config_to_fastvideo_args(cfg)
+
+
 def test_no_typed_quant_omits_transformer_quant_kwarg(captured_kwargs) -> None:
     """Default GeneratorConfig has ``quantization=None`` — the carrier
     must not be set, so the existing legacy path

--- a/fastvideo/tests/ops/quantization/test_nvfp4_purge.py
+++ b/fastvideo/tests/ops/quantization/test_nvfp4_purge.py
@@ -18,6 +18,7 @@ import torch
 import torch.nn as nn
 
 import fastvideo.layers.quantization.nvfp4_config as nv
+from fastvideo.layers.lora.linear import BaseLayerWithLoRA
 
 _ALWAYS_FP4_PREFIX = "ltx2.blocks.0.attn1.to_q"
 _REFINE_ONLY_PREFIX = "ltx2.blocks.0.audio_to_video_attn.to_q"
@@ -84,6 +85,14 @@ def test_retain_true_keeps_everything() -> None:
     nv.convert_model_to_nvfp4(model)
     assert model.always_fp4.weight is not None
     assert model.refine_only.weight is not None
+
+
+def test_retained_weight_can_be_wrapped_by_lora() -> None:
+    model = _model(retain=True)
+    nv.convert_model_to_nvfp4(model)
+    wrapped = BaseLayerWithLoRA(model.always_fp4)
+    assert wrapped.cpu_weight is not None
+    assert wrapped.cpu_weight.shape == model.always_fp4.weight.shape
 
 
 def test_retain_false_still_retains_dense_capable_layers() -> None:


### PR DESCRIPTION
## Summary

Fixes the DreamVerse warmup crash reported in #1685 when the bundled LTX2 pipeline applies its refinement LoRA after NVFP4 conversion.

NVFP4 purges original dense transformer weights by default. The LoRA wrapper then receives `weight=None` and fails while capturing the CPU base weight. This change adds an opt-in typed API flag for retaining those weights and enables it for DreamVerse's LTX2 configuration.

## Validation

- `uv run pytest fastvideo/tests/api/test_typed_quant_flow.py fastvideo/tests/ops/quantization/test_nvfp4_purge.py fastvideo/tests/inference/lora/test_merge_lora_math.py -q` — 19 passed.
- `uv run pytest apps/dreamverse/dreamverse/tests/test_config.py apps/dreamverse/dreamverse/tests/test_entrypoints.py apps/dreamverse/dreamverse/tests/test_gpu_pool.py -q` — 25 passed.
- `uvx pre-commit run --files fastvideo/api/schema.py fastvideo/api/compat.py apps/dreamverse/dreamverse/video_generation.py` — all configured hooks passed.
- Single-B200 Modal validation using the current source mounted into the CUDA DreamVerse image — `ISSUE_1685_VALIDATION=PASS`; NVFP4 retained 576 dense weights, the refinement LoRA applied to 1,344 layers, and all three startup warmup segments completed.

## Review notes

- The fix is scoped to the LTX2 DreamVerse deployment profile. Generic LoRA and quantization behavior is unchanged unless callers opt into the new NVFP4 retention flag.
- The B200 run used the current source mounted into the existing `ghcr.io/hao-ai-lab/fastvideo/dreamverse:dreamverse-cuda12.9.1-latest` image. A rebuilt release image should be validated after merge.
- The broader `fastvideo/tests/api` suite also reports 251 passed and 5 unrelated failures in existing attention-QAT capability and schema-inventory tests.
