### PR TITLE
[perf] VSA Triton: widen the autotune num_stages range (the optimum was outside it)

### DIFF
--- a/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/block_sparse_attn_triton.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/block_sparse_attn_triton.py
@@ -16,14 +16,21 @@ import triton.language as tl
 import math  # small utility needed by the sparse wrapper
 # ──────────────────────────── SPARSE ADDITION END ─────────────────────────────
 
-# We don't run auto-tuning every time to keep the tutorial fast. Keeping
-# the code below and commenting out the equivalent parameters is convenient for
-# re-tuning.
+# BLOCK_M / BLOCK_N are fixed at 64 because they are structural, not tunable:
+# the kernel indexes the top-k list per BLOCK_M q-tile and addresses keys as
+# kv_idx * BLOCK_N, so both must match the granularity q2k_index and
+# variable_block_sizes were built at.
+#
+# num_stages / num_warps ARE free, and the previous {3, 4, 7} was inherited from
+# the upstream tutorial rather than tuned here. It skips 5 and 6; on Blackwell
+# (sm_121) the optimum is num_stages=5, so the search could not reach it. Both
+# block paths independently select 5 once it is available. Autotune still picks
+# per architecture, so other GPUs re-tune rather than inheriting this choice.
 configs = [
     triton.Config({'BLOCK_M': BM, 'BLOCK_N': BN}, num_stages=s, num_warps=w) \
     for BM in [64]\
     for BN in [64]\
-    for s in [3, 4, 7]\
+    for s in [2, 3, 4, 5, 6, 7]\
     for w in [4, 8]\
 ]
 


### PR DESCRIPTION
## Purpose

`_attn_fwd_sparse` (the VSA block-sparse attention kernel) inherited its autotune
configuration from the upstream Triton flash-attention tutorial it was adapted
from, including the comment explaining why it was never tuned:

```python
# We don't run auto-tuning every time to keep the tutorial fast.
configs = [
    triton.Config({'BLOCK_M': BM, 'BLOCK_N': BN}, num_stages=s, num_warps=w)
    for BM in [64] for BN in [64] for s in [3, 4, 7] for w in [4, 8]
]
```

`num_stages ∈ {3, 4, 7}` skips 5 and 6. On Blackwell (GB10 / sm_121) the optimum
is **`num_stages=5`**, so the search could never reach it — the 64-block path
settled for 3 and the 256-block path for 4.

## Changes

One line: `for s in [3, 4, 7]` → `for s in [2, 3, 4, 5, 6, 7]`. Both block paths
then independently select `num_stages=5`.

`BLOCK_M` / `BLOCK_N` are left pinned at 64 deliberately — they are structural,
not tunable (the kernel indexes the top-k list per `BLOCK_M` q-tile and addresses
keys as `kv_idx * BLOCK_N`, so both must match the granularity `q2k_index` and
`variable_block_sizes` were built at). The comment now says so, since their
presence in the `Config` dict makes them look tunable.

This does not change numerics or behaviour — it only lets autotune consider more
schedules. Autotune still selects **per architecture**, so other GPUs re-tune
rather than inheriting this result.

## Test Results

### Kernel level

Isolated phase timing inside `video_sparse_attn`, GB10, bf16, 12 heads,
head_dim 128, 90% sparsity, CUDA-event timed, median of 50 after 10 warmup.
Single session per pair, config list reverted in place between arms.

**64-block path:**

| tokens | `{3,4,7}` (picks 3) | `{2..7}` (picks 5) | delta |
|---|---|---|---|
| 33,280 | 14.516 ms | 11.913 ms | **−17.9%** |
| 76,800 | 80.162 ms | 64.652 ms | **−19.3%** |
| 163,200 | 365.244 ms | 296.640 ms | **−18.8%** |

**256-block path** (172,800 tokens): 414.481 ms (picks 4) → 325.024 ms (picks 5),
**−21.6%**.

Noise floor for those runs, taken from dense SDPA in the same process (untouched
by this change): ±0.7–1.3%. Cross-session reproducibility ±0.5%.

### End to end — this is the number that matters, and it is much smaller

`FastWan2.1-T2V-1.3B-Diffusers`, `VSA_sparsity=0.8`, 448×832×81, 3 steps, one
process, fixed seed, 4 generations with the first discarded (it pays autotune),
medians:

| | `{3,4,7}` | `{2..7}` | delta |
|---|---|---|---|
| denoise | 17,007.5 ms | 16,481.2 ms | **−3.1%** |
| timed stages total | 38,183.5 ms | 37,663.9 ms | **−1.4%** |

Run-to-run denoise spread was 0.6–1.0%, so −3.1% is above noise but modest.

**Why the gap.** At 448×832×81 the DiT sequence is 30,576 tokens after
patchification, and at 80% sparsity the sparse attention is only **~11% of
denoise time** (~603 ms of a ~5,494 ms step). An 18% win on 11% of the work is
~2%, which is what shows up. VSA has already done the heavy lifting on
attention; the remainder of denoise is dense linear work.

Extrapolating the same way, the denoise gain grows with sequence length —
roughly 3% at 480p, 5% at 720p, 9% at 1080p — but never approaches the kernel
number, because the non-attention work grows too.

### Cost

Autotune searches 12 configs instead of 6: about **7 s extra per shape, once per
process**. At 163k tokens the saving is ~2.1 s per denoise step, so it pays for
itself within roughly three steps of a 50-step run.

## Test Plan

```bash
export PYTHONPATH="$PWD/fastvideo-kernel/python${PYTHONPATH:+:$PYTHONPATH}"

python -m pytest -q \
  fastvideo-kernel/tests/test_vsa.py \
  fastvideo-kernel/tests/test_vsa_forward.py \
  fastvideo-kernel/tests/test_vsa_varlen.py \
  fastvideo-kernel/tests/test_vsa256_forward.py \
  fastvideo-kernel/tests/test_vsa256_forward_vbs.py \
  fastvideo-kernel/tests/test_vsa256_forward_cross.py \
  fastvideo-kernel/tests/test_vsa256_triton.py
```

Green on GB10 (4 skips are the sm90 / FA4-CuTe gated cases).

## Scope and caveats

- **All numbers are GB10 / sm_121.** I do not have H100/B200/B300 access. Other
  architectures cannot regress — autotune re-runs per arch and can still pick
  their previous config — but whether they *gain* is for someone with that
  hardware to report.
- The e2e measurement is one model at one resolution. The claim is −3.1% denoise
  there, not a general speedup.
- Not related to #1639 (FA4 CuTe **backward**, sm_100+); this is the Triton
  **forward** path, which is what non-datacenter Blackwell falls back to. That
  PR's own benchmark shows the Triton forward 1.89–2.41× behind CuTe on B300,
  which is consistent with this kernel being undertuned.
