### PR TITLE
[bugfix] wrap the generic DenoisingStage in the inference_denoising p…

### DIFF
--- a/fastvideo/pipelines/stages/denoising.py
+++ b/fastvideo/pipelines/stages/denoising.py
@@ -27,6 +27,7 @@ from fastvideo.pipelines.stages.base import PipelineStage
 from fastvideo.pipelines.stages.validators import StageValidators as V
 from fastvideo.pipelines.stages.validators import VerificationResult
 from fastvideo.platforms import AttentionBackendEnum
+from fastvideo.profiler import profiler_region
 from fastvideo.utils import dict_to_3d_list, masks_like
 
 try:
@@ -368,7 +369,7 @@ class DenoisingStage(PipelineStage):
         _cfg_gate_invalidations = 0
 
         # Run denoising loop
-        with self.progress_bar(total=num_inference_steps) as progress_bar:
+        with profiler_region("inference_denoising"), self.progress_bar(total=num_inference_steps) as progress_bar:
             for i, t in enumerate(timesteps):
                 # Skip if interrupted
                 if hasattr(self, 'interrupt') and self.interrupt:
@@ -1320,7 +1321,7 @@ class DmdDenoisingStage(DenoisingStage):
                                  device=get_local_torch_device())
 
         # Run denoising loop
-        with self.progress_bar(total=len(timesteps)) as progress_bar:
+        with profiler_region("inference_denoising"), self.progress_bar(total=len(timesteps)) as progress_bar:
             for i, t in enumerate(timesteps):
                 # Skip if interrupted
                 if hasattr(self, 'interrupt') and self.interrupt:


### PR DESCRIPTION
## Purpose

`profiler_region_inference_denoising` was wrapped in exactly one place in the tree —
`fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py:150`. Every model that
runs through the generic `DenoisingStage` (Wan among them) recorded no denoising work at all.

Setting

```bash
FASTVIDEO_TORCH_PROFILER_DIR=/path/to/traces \
FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_denoising
```

starts the profiler, leaves collection gated off for the entire run, and exports a trace with
no denoising in it. The failure is silent: the profiler logs that it started, the trace file is
produced, and it just has nothing in it. Nothing warns that the requested region was never
entered.

Pre-fix, every region call site in non-test code:

```
$ grep -rn "profiler_region(\|\.region(" --include=*.py fastvideo/ | grep -v tests/
fastvideo/training/training_pipeline.py:622:  ... region("profiler_region_training_save_checkpoint")
fastvideo/training/training_pipeline.py:633:  ... region("profiler_region_training_validation")
fastvideo/pipelines/composed_pipeline_base.py:102: ... region("profiler_region_model_loading")
fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_denoising.py:150: ... profiler_region("inference_denoising")
```

One `inference_denoising` wrap, in a model-specific stage. There is no `@profile_region`
decorator on the generic stage either.

## Changes

- Wrap the denoising loop in `DenoisingStage` and in `DmdDenoisingStage` with
  `profiler_region("inference_denoising")`.
- These are the two classes the performance harness maps to `dit_time_s` through
  `STAGE_METRIC_MAP` in `fastvideo/tests/performance/test_inference_performance.py`, so the
  profiler region and the reported DiT metric now cover the same code.
- Both are one-line additions to the existing `with self.progress_bar(...)` statement. The loop
  bodies are not re-indented, so the diff is 3 lines including the import.
- The Cosmos denoising subclasses override `forward` entirely and are not mapped to
  `dit_time_s`; they are left alone.

## Blast radius

52 pipeline files reference `DenoisingStage`, but 17 of its 18 subclasses (Cosmos, Causal,
LongCat, MatrixGame, GameCraft, Gen3C, GlmImage, HYWorld, DreamXWorld variants) override
`forward` entirely and are untouched. The change is live in exactly the two patched methods.
With no profiler configured, `profiler_region` reduces to a `None`-check and a bare `yield`,
entered once per generation (not per step).

## Test Plan

```bash
# lint
pre-commit run --all-files

# CPU sweep across suites
pytest fastvideo/tests/api/ fastvideo/tests/stages/ fastvideo/tests/contract/ \
       fastvideo/tests/entrypoints/ fastvideo/tests/hooks/ -q

# profiler contract tests
pytest fastvideo/tests/contract/test_profiler_regions.py -q

# the repo's own inference benchmark, A/B against pristine main
CUDA_VISIBLE_DEVICES=0,1 pytest fastvideo/tests/performance/test_inference_performance.py -vs

# the region actually fires now (Wan2.1-T2V-1.3B, 2x H100, sp_size=2)
FASTVIDEO_TORCH_PROFILER_DIR=/tmp/traces/wan \
FASTVIDEO_TORCH_PROFILE_REGIONS=profiler_region_inference_denoising \
CUDA_VISIBLE_DEVICES=0,1 \
pytest fastvideo/tests/performance/test_inference_performance.py -vs

# numerics unchanged
CUDA_VISIBLE_DEVICES=0,1 pytest fastvideo/tests/ssim/test_wan_t2v_similarity.py -v
```

## Test Results

<details>
<summary>pre-commit run --all-files</summary>

```
yapf.....................................................................Passed
ruff (legacy alias)......................................................Passed
codespell................................................................Passed
PyMarkdown...............................................................Passed
Lint GitHub Actions workflow files.......................................Passed
mypy.....................................................................Passed
Check for spaces in all filenames........................................Passed
Suggestion...............................................................Passed
exit 0
```

</details>

<details>
<summary>Unit tests — no new failures</summary>

```
$ pytest fastvideo/tests/api/ fastvideo/tests/stages/ fastvideo/tests/contract/ \
         fastvideo/tests/entrypoints/ fastvideo/tests/hooks/ -q
599 passed, 7 failed, 7 skipped

$ pytest fastvideo/tests/contract/test_profiler_regions.py -q
2 passed
```

The 7 failures (`test_attn_qat_infer_capability_gate.py` ×3,
`test_schema_parity_inventory.py` ×2, `test_modal_fa4_policy.py` ×2) reproduce identically on
unmodified `main` in the same environment — pre-existing, none introduced by this change.

</details>

<details>
<summary>Inference benchmark — no performance regression (2× H100, Wan2.1-T2V-1.3B, sp2)</summary>

`fastvideo/tests/performance/test_inference_performance.py`, alternating runs on the same
box, `dit_time_s` mean of 5 measured generations per run:

```
pristine main : 1917.3 / 1911.4 / 1907.7 / 1920.0 ms   (per-run sigma 5-14 ms)
with change   : 1931.8 / 1924.3 / 1912.9 ms            (per-run sigma 10-17 ms)
```

(One additional with-change run measured 1970 ms with sigma=51 ms and a 2056 ms outlier —
3-6× the machine's established run-to-run sigma — and is reported here as discarded rather
than silently dropped. The three retained runs and the four pristine runs all have normal
sigma.)

Pooled means differ by well under 1%, the final with-change run sits in the middle of the
pristine band, and peak memory is bit-identical (8429.7 MB) on every run. Expected, since the
no-profiler path is a `None`-check entered once per generation. All benchmark invocations
passed.

</details>

<details>
<summary>Region now enters and exits once per generation (was: never)</summary>

```
(Worker pid=19060) PROFILER: Setting collection to True (depth=1) for region inference_denoising
(Worker pid=19060) PROFILER: Decreasing active region depth to 0
(Worker pid=19060) PROFILER: Setting collection to False upon exiting region inference_denoising
... (repeats once per generation)
```

The denoising span is present in the exported trace as
`fastvideo.region::profiler_region_inference_denoising`, 2347 ms wide, matching the
`dit_time_s` the perf harness reports for the same run.

</details>

<details>
<summary>SSIM regression — numerics unaffected</summary>

Wan2.1-T2V-1.3B, 2x H100, `sp_size=2`, seed 1024, 4 steps. References were generated from the
unmodified tree, then the change was applied and the suite re-run:

```
$ CUDA_VISIBLE_DEVICES=0,1 pytest fastvideo/tests/ssim/test_wan_t2v_similarity.py -v
2 passed in 492.08s

FLASH_ATTN  mean_ssim=1.0  min_ssim=1.0  max_ssim=1.0
TORCH_SDPA  mean_ssim=1.0  min_ssim=1.0  max_ssim=1.0
```

Exactly 1.0, i.e. byte-identical output. `profiler_region` is a no-op context manager when no
profiler is configured, so this is expected — but it is verified rather than assumed.

</details>

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

Notes on the unchecked boxes:

- **Tests**: `fastvideo/tests/contract/test_profiler_regions.py` already asserts that
  `fastvideo.region::profiler_region_inference_denoising` lands in a trace, but it does so
  against a synthetic `with profiler_region(...)` block rather than against a real pipeline
  stage — which is why it passed while the production path recorded nothing. A test that
  asserts the generic `DenoisingStage` is inside the region would need a GPU pipeline run;
  happy to add one if you'd like it in this PR or a follow-up.
- **Docs**: `docs/contributing/profiling.md` documents the region list and does not enumerate
  which stages are wrapped, so no doc change is required.

**For model/pipeline changes, also check:**
- [x] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model (n/a)

---

### Follow-up, not in this PR

While verifying this, a second and independent problem in the same subsystem showed up:
`TorchProfilerController._set_collection()` calls
`toggle_collection_dynamic(enabled, [CPU, CUDA])`, and toggling CUDA activity **off** after GPU
events have been collected discards every GPU event from the exported trace. The result is a
trace with `cpu_op` entries only and `self_device_time_total == 0` on every row.

Reproduced standalone on torch 2.12.0+cu126, no FastVideo involved — same workload, the only
difference being the trailing toggle-off that the region exit performs:

| `start -> OFF -> work -> ON -> work -> ...` | kernels | cuda_runtime |
|---|---:|---:|
| `... -> OFF -> stop` (what region exit does) | **0** | **0** |
| `... -> stop` | 7 | 15 |
| `... -> OFF(CPU activity only) -> stop` | 14 | 27 |

torch warns on this path: `Toggling CPU activity with GPU activity on may result in traces with
GPU events on arbitrary tracks`.

I've kept it out of this PR since it's a distinct defect with a different fix (candidates:
toggle only the CPU activity and filter by region annotation offline, or start/stop a fresh
profiler per region entry). Happy to file it as an issue or send a second PR — let me know
which you'd prefer.