### PR TITLE
[misc] MiniMax-H3: move the AdaLN converter into scripts/checkpoint_conversion

### DIFF
--- a/examples/inference/basic/basic_minimax_h3_fl2va.py
+++ b/examples/inference/basic/basic_minimax_h3_fl2va.py
@@ -27,7 +27,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3")
     # Rank-reduced AdaLN checkpoint (-39% params, -23 GiB VRAM): pass
     #   --model-path noctuashap/MiniMax-H3-pruned-r16
-    # (or a local dir converted with tools/minimax_h3/fit_adaln_basis.py).
+    # (or a local dir produced by
+    #   scripts/checkpoint_conversion/convert_minimax_h3_adaln_rank.py).
     # adaln_rank is read from the checkpoint config; no other flags needed.
     # Rank-reduced checkpoints are inference-only: training needs the
     # full-rank release.

--- a/examples/inference/basic/basic_minimax_h3_ref2va.py
+++ b/examples/inference/basic/basic_minimax_h3_ref2va.py
@@ -27,7 +27,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3")
     # Rank-reduced AdaLN checkpoint (-39% params, -23 GiB VRAM): pass
     #   --model-path noctuashap/MiniMax-H3-pruned-r16
-    # (or a local dir converted with tools/minimax_h3/fit_adaln_basis.py).
+    # (or a local dir produced by
+    #   scripts/checkpoint_conversion/convert_minimax_h3_adaln_rank.py).
     # adaln_rank is read from the checkpoint config; no other flags needed.
     # Rank-reduced checkpoints are inference-only: training needs the
     # full-rank release.

--- a/examples/inference/basic/basic_minimax_h3_t2v.py
+++ b/examples/inference/basic/basic_minimax_h3_t2v.py
@@ -24,7 +24,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3")
     # Rank-reduced AdaLN checkpoint (-39% params, -23 GiB VRAM): pass
     #   --model-path noctuashap/MiniMax-H3-pruned-r16
-    # (or a local dir converted with tools/minimax_h3/fit_adaln_basis.py).
+    # (or a local dir produced by
+    #   scripts/checkpoint_conversion/convert_minimax_h3_adaln_rank.py).
     # adaln_rank is read from the checkpoint config; no other flags needed.
     # Rank-reduced checkpoints are inference-only: training needs the
     # full-rank release.

--- a/fastvideo/models/dits/minimax_h3.py
+++ b/fastvideo/models/dits/minimax_h3.py
@@ -546,7 +546,7 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
                 "parameter, but factorized AdaLN weights are pinned to FP16 "
                 "(BF16 reconstructs them ~1.7x worse). Fine-tune the full-rank "
                 "checkpoint instead, then re-fit the basis with "
-                "tools/minimax_h3/fit_adaln_basis.py.")
+                "scripts/checkpoint_conversion/convert_minimax_h3_adaln_rank.py.")
         adaln_dim = self.adaln_rank or arch.time_embed_dim
         self.adaln_basis = ReplicatedLinear(
             arch.time_embed_dim,

--- a/scripts/checkpoint_conversion/AGENTS.md
+++ b/scripts/checkpoint_conversion/AGENTS.md
@@ -14,6 +14,7 @@ checkpoint_conversion/
 ├── convert_gamecraft_weights.py         # DiT only
 ├── convert_gen3c_to_fastvideo.py
 ├── convert_ltx2_weights.py
+├── convert_minimax_h3_adaln_rank.py     # Rank-reduces AdaLN in place; same family
 ├── convert_turbodiffusion_to_diffusers.py
 ├── convert_turbodiffusion_i2v_to_diffusers.py
 ├── extract_llava_text_encoder.py        # Encoder extraction from a multimodal repo

--- a/scripts/checkpoint_conversion/convert_minimax_h3_adaln_rank.py
+++ b/scripts/checkpoint_conversion/convert_minimax_h3_adaln_rank.py
@@ -24,7 +24,7 @@ directly: ``adaln_rank`` in ``config.json`` flows onto the arch config through
 
 Usage::
 
-    python tools/minimax_h3/fit_adaln_basis.py \
+    python scripts/checkpoint_conversion/convert_minimax_h3_adaln_rank.py \
         --src  /path/to/MiniMax-H3/transformer \
         --dst  /path/to/MiniMax-H3-r16/transformer --rank 16
 


### PR DESCRIPTION
## Purpose

#1699 added the AdaLN rank-reduction script under a new top-level `tools/`, but the repo
already has `scripts/checkpoint_conversion/` for exactly this. This moves it there and drops
`tools/`, which held nothing else.

## Changes

- `tools/minimax_h3/fit_adaln_basis.py` → `scripts/checkpoint_conversion/convert_minimax_h3_adaln_rank.py`,
  renamed to match the directory's `convert_<model>_*.py` convention and listed in its `AGENTS.md`.
- Updated the five references to the old path: three example-script comments, the
  `uniform_parameter_dtype` error message, and the script's own usage block.

No behaviour change.

## Test Plan

```bash
python scripts/checkpoint_conversion/convert_minimax_h3_adaln_rank.py \
    --src $H3/transformer --dst /tmp/unused --rank 16 --report-only
```

## Test Results

Same numbers as #1699:

```
basis: U=(4096, 2688) rank=16 relative residual ||U-U_r||/||U|| = 1.495e-09
modulation error over all projections: max|err|=6.306e-08 (|Wu|max=12.376, relative=5.095e-09)
```

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues — *every path here is excluded from
      pre-commit (`scripts/`, `examples/`, `fastvideo/models/`), so I ran ruff, codespell and yapf
      by hand; all clean on the moved script.*
- [ ] I added or updated tests for my changes — not applicable, this is a move.
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes — not applicable.

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass — not applicable; the only change under `fastvideo/`
      is a path string inside an error message.
- [ ] I updated the support matrix if adding a new model — no new model.