### PR TITLE
[perf]: stop holding the whole checkpoint during DiT load, unblocking MiniMax H3 on one GB10

### DIFF
--- a/fastvideo/models/loader/fsdp_load.py
+++ b/fastvideo/models/loader/fsdp_load.py
@@ -545,11 +545,12 @@ def load_model_from_full_model_state_dict(
     sharded_sd = {}
     custom_param_sd, reverse_param_names_mapping = hf_to_custom_state_dict(full_sd_iterator,
                                                                            param_names_mapping)  # type: ignore
-    # Drain rather than iterate. Every value here is a view into a mmap'd
-    # safetensors shard, so holding the dict holds the whole checkpoint: the
-    # pages faulted in by the copy below stay referenced and the kernel cannot
-    # reclaim them, and peak memory becomes checkpoint + model instead of just
-    # model. Popping each entry lets its pages go as soon as the copy is done.
+    # Drain rather than iterate. Production safetensors values may retain
+    # memory-mapped shard storage, while mapped or merged parameters can own
+    # ordinary allocations. Keeping the dict retains all of that source
+    # storage until loading finishes; popping releases each reference as soon
+    # as its conversion completes and lowers the host/unified-memory working
+    # set.
     for target_param_name in list(custom_param_sd):
         full_tensor = custom_param_sd.pop(target_param_name)
         meta_sharded_param = meta_sd.get(target_param_name)

--- a/fastvideo/models/loader/fsdp_load.py
+++ b/fastvideo/models/loader/fsdp_load.py
@@ -545,7 +545,13 @@ def load_model_from_full_model_state_dict(
     sharded_sd = {}
     custom_param_sd, reverse_param_names_mapping = hf_to_custom_state_dict(full_sd_iterator,
                                                                            param_names_mapping)  # type: ignore
-    for target_param_name, full_tensor in custom_param_sd.items():
+    # Drain rather than iterate. Every value here is a view into a mmap'd
+    # safetensors shard, so holding the dict holds the whole checkpoint: the
+    # pages faulted in by the copy below stay referenced and the kernel cannot
+    # reclaim them, and peak memory becomes checkpoint + model instead of just
+    # model. Popping each entry lets its pages go as soon as the copy is done.
+    for target_param_name in list(custom_param_sd):
+        full_tensor = custom_param_sd.pop(target_param_name)
         meta_sharded_param = meta_sd.get(target_param_name)
         if meta_sharded_param is None:
             # Some checkpoints include extra entries that are not part of the

--- a/fastvideo/tests/loader/test_fsdp_load_releases_checkpoint.py
+++ b/fastvideo/tests/loader/test_fsdp_load_releases_checkpoint.py
@@ -2,11 +2,10 @@
 """The loader must not hold the whole checkpoint alive while it copies it.
 
 ``hf_to_custom_state_dict`` drains the weight iterator into one dict before a
-single parameter is placed. Every value in that dict is a view into a mmap'd
-safetensors shard, so as long as the dict is alive the pages the copy faults in
-stay referenced and the kernel cannot reclaim them. Peak memory becomes
-checkpoint plus model rather than just model, which on a unified-memory device
-is the difference between loading and being killed partway through.
+single parameter is placed. Production safetensors values may retain
+memory-mapped shard storage, and mapped or merged parameters can own ordinary
+allocations. Keeping every source reference until loading finishes raises the
+host or unified-memory working set enough to kill a large-model load.
 
 Checking after the call proves nothing, because the dict is a local and dies
 with the frame. So these tests keep a reference to that dict from the outside

--- a/fastvideo/tests/loader/test_fsdp_load_releases_checkpoint.py
+++ b/fastvideo/tests/loader/test_fsdp_load_releases_checkpoint.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The loader must not hold the whole checkpoint alive while it copies it.
+
+``hf_to_custom_state_dict`` drains the weight iterator into one dict before a
+single parameter is placed. Every value in that dict is a view into a mmap'd
+safetensors shard, so as long as the dict is alive the pages the copy faults in
+stay referenced and the kernel cannot reclaim them. Peak memory becomes
+checkpoint plus model rather than just model, which on a unified-memory device
+is the difference between loading and being killed partway through.
+
+Checking after the call proves nothing, because the dict is a local and dies
+with the frame. So these tests keep a reference to that dict from the outside
+and assert it comes back empty: if the loader iterated instead of draining,
+every source tensor would still be reachable through the reference we hold.
+"""
+from __future__ import annotations
+
+import gc
+import weakref
+
+import pytest
+import torch
+from torch import nn
+
+from fastvideo.models.loader import fsdp_load
+from fastvideo.models.loader.fsdp_load import load_model_from_full_model_state_dict
+
+PARAM_NAMES = ("a.weight", "b.weight", "c.weight")
+
+
+class _TinyModel(nn.Module):
+    """Plain module, no device mesh, so the loader takes its unsharded path."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.a = nn.Linear(8, 8, bias=False)
+        self.b = nn.Linear(8, 8, bias=False)
+        self.c = nn.Linear(8, 8, bias=False)
+
+
+def _identity_mapping(name: str) -> tuple[str, None, None]:
+    return name, None, None
+
+
+def _source_tensors(scale: bool = False) -> dict[str, torch.Tensor]:
+    # FP32 on purpose: the loader casts to param_dtype, and a cast is what makes
+    # the copy a real copy. Handing it tensors that already match would let
+    # `.to()` return the same object, and the model would then legitimately keep
+    # the source alive for reasons that have nothing to do with this fix.
+    return {
+        name: torch.ones(8, 8, dtype=torch.float32) * (index + 1 if scale else 1)
+        for index, name in enumerate(PARAM_NAMES)
+    }
+
+
+def _capture_state_dict(monkeypatch) -> dict:
+    """Hold the loader's internal dict from outside so we can inspect it after."""
+    captured: dict = {}
+    real = fsdp_load.hf_to_custom_state_dict
+
+    def spy(*args, **kwargs):
+        custom_param_sd, reverse = real(*args, **kwargs)
+        captured["sd"] = custom_param_sd
+        return custom_param_sd, reverse
+
+    monkeypatch.setattr(fsdp_load, "hf_to_custom_state_dict", spy)
+    return captured
+
+
+def test_the_state_dict_is_drained_not_iterated(monkeypatch) -> None:
+    captured = _capture_state_dict(monkeypatch)
+
+    load_model_from_full_model_state_dict(
+        _TinyModel(),
+        iter(list(_source_tensors().items())),
+        torch.device("cpu"),
+        torch.bfloat16,
+        strict=False,
+        param_names_mapping=_identity_mapping,
+        training_mode=False,
+    )
+
+    assert captured["sd"] == {}, ("the loader finished with the checkpoint still in hand; on a real model that is the "
+                                  "whole file held resident for the length of the copy")
+
+
+@pytest.mark.parametrize(
+    ("skipped_name", "strict"),
+    (("metadata._extra_state", True), ("unexpected.weight", False)),
+)
+def test_skipped_source_entry_is_popped_before_continue(monkeypatch, skipped_name: str, strict: bool) -> None:
+    """Both skip branches must drop their source before advancing the loop."""
+    captured = _capture_state_dict(monkeypatch)
+    warning_names = []
+
+    def assert_popped_before_warning(_message, warned_name) -> None:
+        assert warned_name not in captured["sd"]
+        warning_names.append(warned_name)
+
+    monkeypatch.setattr(fsdp_load.logger, "warning", assert_popped_before_warning)
+    sources = {**_source_tensors(), skipped_name: torch.ones(8, 8)}
+
+    load_model_from_full_model_state_dict(
+        _TinyModel(),
+        iter(sources.items()),
+        torch.device("cpu"),
+        torch.bfloat16,
+        strict=strict,
+        param_names_mapping=_identity_mapping,
+        training_mode=False,
+    )
+
+    assert warning_names == [skipped_name]
+    assert captured["sd"] == {}
+
+
+def test_source_tensors_become_collectable(monkeypatch) -> None:
+    """The reason the drain matters: the tensors have to actually go."""
+    captured = _capture_state_dict(monkeypatch)
+    sources = _source_tensors()
+    refs = {name: weakref.ref(tensor) for name, tensor in sources.items()}
+
+    # Mirror safetensors_weights_iterator, which drops each tensor as it yields.
+    def iterator():
+        while sources:
+            yield sources.popitem()
+
+    load_model_from_full_model_state_dict(
+        _TinyModel(),
+        iterator(),
+        torch.device("cpu"),
+        torch.bfloat16,
+        strict=False,
+        param_names_mapping=_identity_mapping,
+        training_mode=False,
+    )
+
+    # captured["sd"] is still in scope here on purpose: it is the reference that
+    # would keep them alive if the loader had not popped.
+    gc.collect()
+    alive = sorted(name for name, ref in refs.items() if ref() is not None)
+    assert not alive, f"still reachable through the loader's state dict: {alive}"
+
+
+def test_weights_still_land_in_the_model() -> None:
+    """Releasing early must not cost correctness."""
+    sources = _source_tensors(scale=True)
+    expected = {name: tensor[0, 0].item() for name, tensor in sources.items()}
+
+    model = _TinyModel()
+    load_model_from_full_model_state_dict(
+        model,
+        iter(list(sources.items())),
+        torch.device("cpu"),
+        torch.bfloat16,
+        strict=False,
+        param_names_mapping=_identity_mapping,
+        training_mode=False,
+    )
+
+    loaded = dict(model.named_parameters())
+    for name, value in expected.items():
+        assert loaded[name].dtype == torch.bfloat16
+        assert loaded[name][0, 0].item() == value


### PR DESCRIPTION
## Purpose

`load_model_from_full_model_state_dict` retained every source tensor until the
entire model copy completed. For MiniMax-H3 this kept the checkpoint storage and
the progressively materialized DiT resident together, exceeding the practical
working set of a single 121 GiB GB10.

This change drains the converted state dictionary as parameters are consumed.
It is generic loader behavior: discrete-GPU systems reduce host-memory pressure,
while unified-memory systems reduce pressure on the shared physical pool.

## Changes

- Iterate over a snapshot of parameter names and `pop` each source tensor before
  copying it into the model.
- Preserve mapping order, dtype selection, custom loader behavior, DTensor
  distribution, strict/non-strict handling, and unused-key accounting.
- Add regression tests that retain an external reference to the internal state
  dictionary and prove that entries are released during the load, including
  continue paths and mixed-dtype placement.
- Describe the lifetime reduction in storage-neutral terms. Inputs may be views
  backed by safetensors mappings or ordinary allocated tensors; the optimization
  is valid for both.

## Dependency

This PR introduces `fastvideo/tests/loader/`. Merged PR #1710 owns the shared
unit-lane collection entry for that directory, so this branch is rebased onto
its merge commit rather than duplicating the CI wiring. Final head:
`54c7652b3245bb5add9ee950949f8dd9a57457b8`.

## Verification

```text
fastvideo/tests/loader/test_fsdp_load_releases_checkpoint.py: 5 passed
tests/local_tests/models/test_fsdp_load_mixed_dtype.py: 3 passed, 1 skipped
explicit GB10 nested-FSDP mixed-dtype case: 1 passed
focused stack on merged #1710: 21 passed, 1 skipped
equivalent exact unit lane with #1710: 962 passed, 7 skipped
pre-commit: passed for every applicable changed path
```

The original GB10 measurement remains representative of the motivating working
set: draining the dictionary allowed all 20.17B transformer parameters to load,
where retaining the source set repeatedly exhausted memory partway through the
copy. This PR treats that as memory-lifecycle evidence, not as a performance or
quality baseline.

## Checklist

- [x] Tests cover source release and parameter placement
- [x] Applicable pre-commit hooks pass
- [x] Memory impact was reviewed on GB10
- [x] No model weights, inference numerics, or output-quality policy changes
