### PR TITLE
[perf]: QAT/QAD add safe regional compile for modular training

### DIFF
--- a/docs/training/train_infra.md
+++ b/docs/training/train_infra.md
@@ -155,6 +155,8 @@ training:
     weighting_scheme: uniform   # uniform, logit_normal, mode
     precondition_outputs: false
     enable_gradient_checkpointing_type: full
+    enable_torch_compile: false
+    torch_compile_kwargs: {}
 
   vsa:
     sparsity: 0.0         # 0.0 = disabled
@@ -176,6 +178,47 @@ The repeat count duplicates that dataset's parquet file list before shuffling/sa
 
 See [Training Trackers](trackers.md) to configure Weights & Biases or SwanLab,
 including SwanLab installation and authentication.
+
+### `torch.compile` for modular training
+
+Set `training.model.enable_torch_compile: true` to compile the repeated DiT
+blocks selected by the model's `_compile_conditions`. Training compilation is
+regional and always uses `fullgraph=True`: activation checkpointing is applied
+first, FSDP establishes the runtime parameter representation, and each selected
+block is then compiled inside its eager checkpoint wrapper. The checkpoint
+control logic, FSDP hooks, and the model-level block loop all remain outside
+the compiled region; checkpoint state-dict names are preserved.
+
+Only no-grad block calls use the compiled path. Gradient-bearing student and
+critic calls remain eager because the current Inductor backward is not
+numerically reliable for the FA4 + FSDP + activation-checkpointed Wan stack.
+This still accelerates DMD2 simulated rollouts and teacher evaluation without
+invoking the affected compiled backward path.
+
+Additional supported `torch.compile` options can be provided under
+`training.model.torch_compile_kwargs`; `fullgraph: false` is rejected because
+it would silently reintroduce partial graphs. For example:
+
+```yaml
+training:
+  model:
+    enable_gradient_checkpointing_type: full
+    enable_torch_compile: true
+    torch_compile_kwargs:
+      dynamic: false
+```
+
+The first step includes Dynamo, AOTAutograd, Inductor, and attention-kernel
+compilation, so compare steady-state steps after warmup as well as total job
+time. Use `TORCH_LOGS=recompiles,graph_breaks` when diagnosing specialization.
+A single initial type specialization can occur when DMD2 first reaches a role
+whose block has a different FSDP/checkpoint wrapper type; repeated recompilation
+in steady state is not expected.
+
+`FLASH_ATTN` does not select FlashAttention-4 merely because FA4 is installed.
+Set `FASTVIDEO_FA4=1` together with a `FLASH_ATTN` role backend to opt in. Set
+`FASTVIDEO_DISABLE_ATTENTION_COMPILE=1` only as a debugging escape hatch when
+an attention implementation cannot participate in a compiled block.
 
 ### `callbacks` — Pluggable hooks
 

--- a/docs/training/train_infra.md
+++ b/docs/training/train_infra.md
@@ -189,11 +189,14 @@ block is then compiled inside its eager checkpoint wrapper. The checkpoint
 control logic, FSDP hooks, and the model-level block loop all remain outside
 the compiled region; checkpoint state-dict names are preserved.
 
-Only no-grad block calls use the compiled path. Gradient-bearing student and
-critic calls remain eager because the current Inductor backward is not
-numerically reliable for the FA4 + FSDP + activation-checkpointed Wan stack.
-This still accelerates DMD2 simulated rollouts and teacher evaluation without
-invoking the affected compiled backward path.
+Both forward and backward block calls use the compiled path. Wan modulation is
+kept behind a small opaque operator boundary: this ensures all six modulation
+gradient slices are materialized before they are returned to FSDP instead of
+being fused into an incomplete Inductor output buffer. Eager execution keeps
+the original native PyTorch path. Regional training compile also enables
+Inductor's `emulate_precision_casts` option by default so fused BF16 operators
+retain eager's intermediate rounding points. It can be overridden explicitly
+under `torch_compile_kwargs.options`.
 
 Additional supported `torch.compile` options can be provided under
 `training.model.torch_compile_kwargs`; `fullgraph: false` is rejected because

--- a/examples/train/configs/distribution_matching/wan/dmd2_t2v.yaml
+++ b/examples/train/configs/distribution_matching/wan/dmd2_t2v.yaml
@@ -74,6 +74,7 @@ training:
 
   model:
     enable_gradient_checkpointing_type: full
+    enable_torch_compile: true
 
 callbacks:
   grad_clip:

--- a/examples/train/configs/distribution_matching/wan/dmd2_t2v_fa3.yaml
+++ b/examples/train/configs/distribution_matching/wan/dmd2_t2v_fa3.yaml
@@ -1,4 +1,6 @@
 # DMD2 distillation: Wan 2.1 T2V 1.3B (teacher 50-step -> student 4-step).
+# Variant for flash-attn 3 (Hopper) machines: identical to dmd2_t2v.yaml
+# except torch.compile is off (FA3 training path is not fullgraph-safe).
 #
 # - Teacher: frozen pretrained Wan 2.1 T2V 1.3B
 # - Student: trainable, initialized from the same pretrained weights
@@ -74,11 +76,11 @@ training:
 
   model:
     enable_gradient_checkpointing_type: full
-    # Regional fullgraph compile. Requires a compile-safe attention path
-    # (FA2, FA4 via FASTVIDEO_FA4=1, or TORCH_SDPA). On flash-attn 3
-    # machines the loader auto-disables this with a warning — or use
-    # dmd2_t2v_fa3.yaml, which turns it off explicitly.
-    enable_torch_compile: true
+    # flash-attn 3 hosts: FA3's grad-enabled attention path takes a dynamo
+    # graph break, which regional fullgraph compile turns into a hard error
+    # at step 1 — so compile stays off in this variant. Switch to
+    # dmd2_t2v.yaml with FA2/FA4/TORCH_SDPA to get compiled training.
+    enable_torch_compile: false
 
 callbacks:
   grad_clip:
@@ -90,10 +92,10 @@ callbacks:
     sampling_steps: [4]
     sampling_timesteps: [1000, 750, 500, 250]
     guidance_scale: 6.0
-  ema:                                                                                                                     
-    _target_: fastvideo.train.callbacks.ema.EMACallback                                                                    
-    decay: 0.98                                                                                                          
-    start_iter: 0        # delay EMA updates until this iteration 
+  ema:
+    _target_: fastvideo.train.callbacks.ema.EMACallback
+    decay: 0.98
+    start_iter: 0        # delay EMA updates until this iteration
 
 pipeline:
   flow_shift: 8

--- a/fastvideo/attention/utils/flash_attn_cute.py
+++ b/fastvideo/attention/utils/flash_attn_cute.py
@@ -108,6 +108,10 @@ def _flash_attn_cute_forward(
         softcap=0.0,
         num_splits=1,
         pack_gqa=None,
+        # AOTAutograd executes its compiled forward with detached primals, so
+        # FA4 cannot infer from ``requires_grad`` that backward will need LSE.
+        # Keep the auxiliary tensor explicit in the custom-op contract.
+        return_lse=True,
     )[:2]
     return out, lse
 
@@ -132,9 +136,58 @@ def _flash_attn_cute_setup_context(ctx: torch.autograd.function.FunctionCtx, inp
     q, k, v, softmax_scale, causal, deterministic = inputs
     out, lse = output
     ctx.save_for_backward(q, k, v, out, lse)
+    ctx.mark_non_differentiable(lse)
     ctx.softmax_scale = softmax_scale
     ctx.causal = causal
     ctx.deterministic = deterministic
+
+
+@torch.library.custom_op(
+    "fastvideo::_flash_attn_cute_backward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _flash_attn_cute_backward_op(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    grad_out: torch.Tensor,
+    lse: torch.Tensor,
+    softmax_scale: float | None,
+    causal: bool,
+    deterministic: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        grad_out,
+        lse,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        softcap=0.0,
+        window_size_left=None,
+        window_size_right=None,
+        deterministic=deterministic,
+    )
+
+
+@torch.library.register_fake("fastvideo::_flash_attn_cute_backward")
+def _flash_attn_cute_backward_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    grad_out: torch.Tensor,
+    lse: torch.Tensor,
+    softmax_scale: float | None,
+    causal: bool,
+    deterministic: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    del out, grad_out, lse, softmax_scale, causal, deterministic
+    return torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
 
 
 def _flash_attn_cute_backward(
@@ -144,19 +197,16 @@ def _flash_attn_cute_backward(
 ):
     del grad_lse
     q, k, v, out, lse = ctx.saved_tensors
-    dq, dk, dv = _flash_attn_bwd(
+    dq, dk, dv = torch.ops.fastvideo._flash_attn_cute_backward(
         q,
         k,
         v,
         out,
         grad_out,
         lse,
-        softmax_scale=ctx.softmax_scale,
-        causal=ctx.causal,
-        softcap=0.0,
-        window_size_left=None,
-        window_size_right=None,
-        deterministic=ctx.deterministic,
+        ctx.softmax_scale,
+        ctx.causal,
+        ctx.deterministic,
     )
     return dq, dk, dv, None, None, None
 
@@ -200,6 +250,7 @@ def _flash_attn_cute_varlen_forward(
         softcap=0.0,
         num_splits=1,
         pack_gqa=None,
+        return_lse=True,
     )[:2]
     return out, lse
 
@@ -241,11 +292,73 @@ def _flash_attn_cute_varlen_setup_context(ctx: torch.autograd.function.FunctionC
     ) = inputs
     out, lse = output
     ctx.save_for_backward(q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k)
+    ctx.mark_non_differentiable(lse)
     ctx.max_seqlen_q = max_seqlen_q
     ctx.max_seqlen_k = max_seqlen_k
     ctx.softmax_scale = softmax_scale
     ctx.causal = causal
     ctx.deterministic = deterministic
+
+
+@torch.library.custom_op(
+    "fastvideo::_flash_attn_cute_varlen_backward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _flash_attn_cute_varlen_backward_op(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    grad_out: torch.Tensor,
+    lse: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float | None,
+    causal: bool,
+    deterministic: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _flash_attn_bwd(
+        q,
+        k,
+        v,
+        out,
+        grad_out,
+        lse,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        softcap=0.0,
+        window_size_left=None,
+        window_size_right=None,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        deterministic=deterministic,
+    )
+
+
+@torch.library.register_fake("fastvideo::_flash_attn_cute_varlen_backward")
+def _flash_attn_cute_varlen_backward_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    out: torch.Tensor,
+    grad_out: torch.Tensor,
+    lse: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    softmax_scale: float | None,
+    causal: bool,
+    deterministic: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    del out, grad_out, lse, cu_seqlens_q, cu_seqlens_k
+    del max_seqlen_q, max_seqlen_k, softmax_scale, causal, deterministic
+    return torch.empty_like(q), torch.empty_like(k), torch.empty_like(v)
 
 
 def _flash_attn_cute_varlen_backward(
@@ -255,23 +368,20 @@ def _flash_attn_cute_varlen_backward(
 ):
     del grad_lse
     q, k, v, out, lse, cu_seqlens_q, cu_seqlens_k = ctx.saved_tensors
-    dq, dk, dv = _flash_attn_bwd(
+    dq, dk, dv = torch.ops.fastvideo._flash_attn_cute_varlen_backward(
         q,
         k,
         v,
         out,
         grad_out,
         lse,
-        softmax_scale=ctx.softmax_scale,
-        causal=ctx.causal,
-        softcap=0.0,
-        window_size_left=None,
-        window_size_right=None,
-        cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
-        max_seqlen_q=ctx.max_seqlen_q,
-        max_seqlen_k=ctx.max_seqlen_k,
-        deterministic=ctx.deterministic,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        ctx.max_seqlen_q,
+        ctx.max_seqlen_k,
+        ctx.softmax_scale,
+        ctx.causal,
+        ctx.deterministic,
     )
     return dq, dk, dv, None, None, None, None, None, None, None
 

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -203,6 +203,10 @@ class FastVideoArgs:
     # Per-component flags below let callers compile additional submodules
     # independently; ``False`` leaves the component eager.
     enable_torch_compile: bool = False
+    # Regional fullgraph compile of repeated blocks (modular fastvideo/train
+    # stack). False preserves the legacy whole-model torch.compile semantics
+    # for fastvideo/training recipes; the modular moduleloader sets it True.
+    regional_compile: bool = False
     enable_torch_compile_text_encoder: bool = False
     enable_torch_compile_vae: bool = False
     enable_torch_compile_audio_vae: bool = False
@@ -688,7 +692,9 @@ class FastVideoArgs:
             type=str,
             default=None,
             help=
-            "JSON string of kwargs to pass to torch.compile. Example: '{\"backend\":\"inductor\",\"mode\":\"reduce-overhead\"}'",
+            "JSON string of kwargs to pass to torch.compile. Example: '{\"backend\":\"inductor\",\"mode\":\"reduce-overhead\"}'. "
+            "Note: the modular fastvideo/train stack uses regional fullgraph compile, which rejects 'mode' "
+            "(it injects inductor options); express mode effects via 'options' there.",
         )
         parser.add_argument(
             "--inference-torch-compile",

--- a/fastvideo/models/dits/wanvideo.py
+++ b/fastvideo/models/dits/wanvideo.py
@@ -30,6 +30,129 @@ from fastvideo.distributed.parallel_state import get_sp_world_size
 logger = init_logger(__name__)
 
 
+@torch.library.custom_op(
+    "fastvideo::_wan_modulation_forward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _wan_modulation_forward(
+    scale_shift_table: torch.Tensor,
+    temb: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Keep Wan modulation gradients outside Inductor's fused reductions.
+
+    The six cloned outputs are intentional: custom operators may not return
+    aliased views, and keeping the outputs distinct prevents AOTAutograd from
+    reassembling their gradients inside the compiled block backward.
+    """
+    if temb.dim() == 4:
+        modulation = scale_shift_table.unsqueeze(0).float() + temb.float()
+        chunk_dim = 2
+    else:
+        modulation = scale_shift_table.float() + temb.float()
+        chunk_dim = 1
+    return tuple(chunk.clone() for chunk in modulation.chunk(6, dim=chunk_dim))  # type: ignore[return-value]
+
+
+@torch.library.register_fake("fastvideo::_wan_modulation_forward")
+def _wan_modulation_forward_fake(
+    scale_shift_table: torch.Tensor,
+    temb: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    if temb.dim() == 4:
+        shape = (*temb.shape[:2], 1, temb.shape[-1])
+    else:
+        shape = (temb.shape[0], 1, temb.shape[-1])
+    return tuple(temb.new_empty(shape, dtype=torch.float32) for _ in range(6))  # type: ignore[return-value]
+
+
+@torch.library.custom_op(
+    "fastvideo::_wan_modulation_backward",
+    mutates_args=(),
+    device_types="cuda",
+)
+def _wan_modulation_backward_op(
+    grad_shift_msa: torch.Tensor,
+    grad_scale_msa: torch.Tensor,
+    grad_gate_msa: torch.Tensor,
+    grad_c_shift_msa: torch.Tensor,
+    grad_c_scale_msa: torch.Tensor,
+    grad_c_gate_msa: torch.Tensor,
+    scale_shift_table: torch.Tensor,
+    temb: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    chunk_dim = 2 if temb.dim() == 4 else 1
+    chunk_shape = ((*temb.shape[:2], 1, temb.shape[-1])
+                   if temb.dim() == 4 else (temb.shape[0], 1, temb.shape[-1]))
+    grad_modulation = torch.cat(
+        tuple(grad.reshape(chunk_shape) for grad in (
+            grad_shift_msa,
+            grad_scale_msa,
+            grad_gate_msa,
+            grad_c_shift_msa,
+            grad_c_scale_msa,
+            grad_c_gate_msa,
+        )),
+        dim=chunk_dim,
+    )
+    grad_scale_shift = grad_modulation.sum_to_size(scale_shift_table.shape)
+    return (
+        grad_scale_shift.to(scale_shift_table.dtype).clone(),
+        grad_modulation.to(temb.dtype).clone(),
+    )
+
+
+@torch.library.register_fake("fastvideo::_wan_modulation_backward")
+def _wan_modulation_backward_fake(
+    grad_shift_msa: torch.Tensor,
+    grad_scale_msa: torch.Tensor,
+    grad_gate_msa: torch.Tensor,
+    grad_c_shift_msa: torch.Tensor,
+    grad_c_scale_msa: torch.Tensor,
+    grad_c_gate_msa: torch.Tensor,
+    scale_shift_table: torch.Tensor,
+    temb: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del grad_shift_msa, grad_scale_msa, grad_gate_msa
+    del grad_c_shift_msa, grad_c_scale_msa, grad_c_gate_msa
+    return torch.empty_like(scale_shift_table), torch.empty_like(temb)
+
+
+def _wan_modulation_setup_context(ctx: torch.autograd.function.FunctionCtx, inputs, output) -> None:
+    del output
+    scale_shift_table, temb = inputs
+    ctx.save_for_backward(scale_shift_table, temb)
+
+
+def _wan_modulation_backward(
+    ctx: torch.autograd.function.FunctionCtx,
+    grad_shift_msa: torch.Tensor,
+    grad_scale_msa: torch.Tensor,
+    grad_gate_msa: torch.Tensor,
+    grad_c_shift_msa: torch.Tensor,
+    grad_c_scale_msa: torch.Tensor,
+    grad_c_gate_msa: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    scale_shift_table, temb = ctx.saved_tensors
+    return torch.ops.fastvideo._wan_modulation_backward(
+        grad_shift_msa,
+        grad_scale_msa,
+        grad_gate_msa,
+        grad_c_shift_msa,
+        grad_c_scale_msa,
+        grad_c_gate_msa,
+        scale_shift_table,
+        temb,
+    )
+
+
+torch.library.register_autograd(
+    "fastvideo::_wan_modulation_forward",
+    _wan_modulation_backward,
+    setup_context=_wan_modulation_setup_context,
+)
+
+
 class WanImageEmbedding(torch.nn.Module):
 
     def __init__(self, in_features: int, out_features: int):
@@ -372,7 +495,17 @@ class WanTransformerBlock(nn.Module):
         orig_dtype = hidden_states.dtype
         # assert orig_dtype != torch.float32
 
-        if temb.dim() == 4:
+        if hidden_states.is_cuda and torch.compiler.is_compiling():
+            shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
+                torch.ops.fastvideo._wan_modulation_forward(self.scale_shift_table, temb))
+            if temb.dim() == 4:
+                shift_msa = shift_msa.squeeze(2)
+                scale_msa = scale_msa.squeeze(2)
+                gate_msa = gate_msa.squeeze(2)
+                c_shift_msa = c_shift_msa.squeeze(2)
+                c_scale_msa = c_scale_msa.squeeze(2)
+                c_gate_msa = c_gate_msa.squeeze(2)
+        elif temb.dim() == 4:
             # temb: batch_size, seq_len, 6, inner_dim (wan2.2 ti2v)
             shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
                 self.scale_shift_table.unsqueeze(0) + temb.float()).chunk(6, dim=2)
@@ -530,8 +663,12 @@ class WanTransformerBlock_VSA(nn.Module):
         bs, seq_length, _ = hidden_states.shape
         orig_dtype = hidden_states.dtype
         # assert orig_dtype != torch.float32
-        e = self.scale_shift_table + temb.float()
-        shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = e.chunk(6, dim=1)
+        if hidden_states.is_cuda and torch.compiler.is_compiling():
+            shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
+                torch.ops.fastvideo._wan_modulation_forward(self.scale_shift_table, temb))
+        else:
+            e = self.scale_shift_table + temb.float()
+            shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = e.chunk(6, dim=1)
         assert shift_msa.dtype == torch.float32
 
         # 1. Self-attention

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -1147,6 +1147,7 @@ class TransformerLoader(ComponentLoader):
                 # once the module tree exists.
                 lora_path=getattr(fastvideo_args, "lora_path", None),
                 lora_strength=getattr(fastvideo_args, "lora_strength", 1.0),
+                pre_fsdp_transform=getattr(fastvideo_args, "_pre_fsdp_transform", None),
             )
 
         total_params = sum(p.numel() for p in model.parameters())

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -1147,6 +1147,7 @@ class TransformerLoader(ComponentLoader):
                 # once the module tree exists.
                 lora_path=getattr(fastvideo_args, "lora_path", None),
                 lora_strength=getattr(fastvideo_args, "lora_strength", 1.0),
+                regional_compile=getattr(fastvideo_args, "regional_compile", False),
                 pre_fsdp_transform=getattr(fastvideo_args, "_pre_fsdp_transform", None),
             )
 

--- a/fastvideo/models/loader/fsdp_load.py
+++ b/fastvideo/models/loader/fsdp_load.py
@@ -9,7 +9,6 @@ import os
 import contextlib
 import re
 from collections.abc import Callable, Generator
-from functools import wraps
 from itertools import chain
 from typing import Any
 
@@ -382,15 +381,11 @@ def _enable_regional_attention_compile(model: nn.Module) -> int:
 
 
 def _compile_model_regions(model: nn.Module, compile_kwargs: dict[str, Any]) -> int:
-    """Compile no-grad calls to repeated regions after FSDP setup.
+    """Compile repeated mathematical regions after FSDP setup.
 
     Only the selected module ``forward`` is replaced. This keeps activation
     checkpoint wrappers structurally transparent while FSDP pre/post hooks
-    execute outside the compiled region. Gradient-bearing calls deliberately
-    stay eager: Inductor's compiled backward is not numerically reliable for
-    the current FA4 + FSDP + checkpointed Wan block stack, while DMD2's
-    simulated rollouts and teacher calls still provide substantial no-grad
-    regions to optimize.
+    execute outside the compiled region.
     """
     compile_conditions = getattr(model, "_compile_conditions", None)
     if not compile_conditions:
@@ -399,33 +394,25 @@ def _compile_model_regions(model: nn.Module, compile_kwargs: dict[str, Any]) -> 
     if compile_kwargs.get("fullgraph", True) is not True:
         raise ValueError("Regional training compile requires fullgraph=True")
     kwargs = {**compile_kwargs, "fullgraph": True}
+    options = {"emulate_precision_casts": True}
+    options.update(kwargs.get("options") or {})
+    kwargs["options"] = options
     compiled_count = 0
     for name, submodule in list(model.named_modules()):
         if not name:
             continue
         if any(condition(name, submodule) for condition in compile_conditions):
             # Activation checkpoint wrappers are control-flow boundaries, not
-            # mathematical regions. Compiling the wrapper asks AOTAutograd to
-            # trace checkpoint's saved-tensor/recompute machinery and has
-            # produced invalid training gradients. Keep that machinery eager
-            # and compile only no-grad calls to the repeated block it owns.
+            # mathematical regions. Keep their saved-tensor/recompute logic
+            # eager and compile only the repeated block they own.
             compile_target = getattr(submodule, "_checkpoint_wrapped_module", submodule)
-            eager_forward = compile_target.forward
-            compiled_forward = torch.compile(eager_forward, **kwargs)
-
-            @wraps(eager_forward)
-            def forward(*args, _eager=eager_forward, _compiled=compiled_forward, **forward_kwargs):
-                if torch.is_grad_enabled():
-                    return _eager(*args, **forward_kwargs)
-                return _compiled(*args, **forward_kwargs)
-
-            compile_target.forward = forward
+            compile_target.forward = torch.compile(compile_target.forward, **kwargs)
             compiled_count += 1
 
     if compiled_count == 0:
         raise ValueError(f"No submodules in {type(model).__name__} matched _compile_conditions")
     logger.info(
-        "Enabled regional no-grad torch.compile for %d submodules in %s after FSDP setup with kwargs=%s",
+        "Enabled regional torch.compile for %d submodules in %s after FSDP setup with kwargs=%s",
         compiled_count,
         type(model).__name__,
         kwargs,

--- a/fastvideo/models/loader/fsdp_load.py
+++ b/fastvideo/models/loader/fsdp_load.py
@@ -9,6 +9,7 @@ import os
 import contextlib
 import re
 from collections.abc import Callable, Generator
+from functools import wraps
 from itertools import chain
 from typing import Any
 
@@ -167,6 +168,7 @@ def maybe_load_fsdp_model(
     inference_vsa_tile_size: int | None = None,
     lora_path: str | None = None,
     lora_strength: float = 1.0,
+    pre_fsdp_transform: Callable[[nn.Module], nn.Module] | None = None,
 ) -> torch.nn.Module:
     """
     Load the model with FSDP if is training, else load the model without FSDP.
@@ -192,6 +194,9 @@ def maybe_load_fsdp_model(
     logger.info("Loading model with default_dtype: %s", default_dtype)
     with set_default_dtype(default_dtype), torch.device("meta"):
         model = model_cls(**init_params)
+
+    if pre_fsdp_transform is not None:
+        model = pre_fsdp_transform(model)
 
     dtype_selector = getattr(model, "_get_parameter_dtype", None)
     has_mixed_parameter_dtypes = callable(dtype_selector) and any(
@@ -289,16 +294,8 @@ def maybe_load_fsdp_model(
     # are present (lazy imports inside the helper).
     _maybe_quantize_model(model)
 
-    compile_in_loader = enable_torch_compile and training_mode
-    if compile_in_loader:
-        unsupported = _prepare_model_for_compile(model, regional=False)
-        if unsupported is not None:
-            logger.warning("Training torch.compile requested but disabled: %s. Model stays eager.", unsupported)
-        else:
-            compile_kwargs = torch_compile_kwargs or {}
-            logger.info("Enabling torch.compile for FSDP training module with kwargs=%s", compile_kwargs)
-            model = torch.compile(model, **compile_kwargs)
-            logger.info("torch.compile enabled for %s", type(model).__name__)
+    if enable_torch_compile and training_mode:
+        _compile_model_regions(model, torch_compile_kwargs or {})
     elif inference_regional_compile and not training_mode:
         # Inference-side counterpart of the #1718 training regional compile:
         # per-block fullgraph compile right after the transformer loads, no
@@ -385,48 +382,50 @@ def _enable_regional_attention_compile(model: nn.Module) -> int:
 
 
 def _compile_model_regions(model: nn.Module, compile_kwargs: dict[str, Any]) -> int:
-    """Compile repeated mathematical regions of a loaded model.
+    """Compile no-grad calls to repeated regions after FSDP setup.
 
     Only the selected module ``forward`` is replaced. This keeps activation
-    checkpoint wrappers structurally transparent while any module-level hooks
-    (FSDP pre/post, layerwise offload) execute outside the compiled region.
+    checkpoint wrappers structurally transparent while FSDP pre/post hooks
+    execute outside the compiled region. Gradient-bearing calls deliberately
+    stay eager: Inductor's compiled backward is not numerically reliable for
+    the current FA4 + FSDP + checkpointed Wan block stack, while DMD2's
+    simulated rollouts and teacher calls still provide substantial no-grad
+    regions to optimize.
     """
     compile_conditions = getattr(model, "_compile_conditions", None)
     if not compile_conditions:
         raise ValueError(f"{type(model).__name__} does not declare _compile_conditions")
 
     if compile_kwargs.get("fullgraph", True) is not True:
-        raise ValueError("Regional compile requires fullgraph=True")
-    if "mode" in compile_kwargs:
-        # torch.compile forbids passing both `mode` and `options`, and
-        # regional compile always injects options (emulate_precision_casts)
-        # to match the training-side regional-compile configuration. Fail here
-        # with an actionable message instead of letting torch raise a
-        # mode/options conflict about an `options` key the user never wrote.
-        raise ValueError("Regional compile sets inductor options "
-                         "(emulate_precision_casts) and cannot be combined "
-                         "with torch_compile_kwargs['mode']. Remove 'mode' or "
-                         "express its effect via torch_compile_kwargs['options'].")
+        raise ValueError("Regional training compile requires fullgraph=True")
     kwargs = {**compile_kwargs, "fullgraph": True}
-    options = {"emulate_precision_casts": True}
-    options.update(kwargs.get("options") or {})
-    kwargs["options"] = options
     compiled_count = 0
     for name, submodule in list(model.named_modules()):
         if not name:
             continue
         if any(condition(name, submodule) for condition in compile_conditions):
             # Activation checkpoint wrappers are control-flow boundaries, not
-            # mathematical regions. Keep their saved-tensor/recompute logic
-            # eager and compile only the repeated block they own.
+            # mathematical regions. Compiling the wrapper asks AOTAutograd to
+            # trace checkpoint's saved-tensor/recompute machinery and has
+            # produced invalid training gradients. Keep that machinery eager
+            # and compile only no-grad calls to the repeated block it owns.
             compile_target = getattr(submodule, "_checkpoint_wrapped_module", submodule)
-            compile_target.forward = torch.compile(compile_target.forward, **kwargs)
+            eager_forward = compile_target.forward
+            compiled_forward = torch.compile(eager_forward, **kwargs)
+
+            @wraps(eager_forward)
+            def forward(*args, _eager=eager_forward, _compiled=compiled_forward, **forward_kwargs):
+                if torch.is_grad_enabled():
+                    return _eager(*args, **forward_kwargs)
+                return _compiled(*args, **forward_kwargs)
+
+            compile_target.forward = forward
             compiled_count += 1
 
     if compiled_count == 0:
         raise ValueError(f"No submodules in {type(model).__name__} matched _compile_conditions")
     logger.info(
-        "Enabled regional torch.compile for %d submodules in %s with kwargs=%s",
+        "Enabled regional no-grad torch.compile for %d submodules in %s after FSDP setup with kwargs=%s",
         compiled_count,
         type(model).__name__,
         kwargs,

--- a/fastvideo/models/loader/fsdp_load.py
+++ b/fastvideo/models/loader/fsdp_load.py
@@ -312,6 +312,7 @@ def maybe_load_fsdp_model(
         else:
             unsupported = _regional_compile_unsupported_reason(
                 init_params,
+                model=model,
                 training=True,
                 vsa_tile_size=inference_vsa_tile_size,
             )
@@ -331,6 +332,7 @@ def maybe_load_fsdp_model(
         # user kwargs needed (fullgraph + emulate_precision_casts injected).
         unsupported = _regional_compile_unsupported_reason(
             init_params,
+            model=model,
             vsa_tile_size=inference_vsa_tile_size,
         )
         if unsupported is None:
@@ -361,6 +363,7 @@ def _strip_checkpoint_wrapper_prefix(name: str) -> str:
 def _regional_compile_unsupported_reason(
     init_params: dict[str, Any],
     *,
+    model: nn.Module | None = None,
     training: bool = False,
     vsa_tile_size: int | None = None,
 ) -> str | None:
@@ -390,21 +393,41 @@ def _regional_compile_unsupported_reason(
                     "forwards out of compiled graphs via torch.compiler."
                     "disable, which fullgraph regional compile cannot trace; "
                     "this model stays eager")
-    config = init_params.get("config")
-    resolved = getattr(config, "_resolved_attention_backend", None)
-    resolved_name = getattr(resolved, "name", "")
-    if training and resolved_name == "FLASH_ATTN":
+    backend_names: set[str] = set()
+    if model is not None:
+        from fastvideo.attention.layer import DistributedAttention, LocalAttention
+
+        for submodule in model.modules():
+            if not isinstance(submodule, (DistributedAttention, LocalAttention)):
+                continue
+            backend = getattr(submodule, "backend", None)
+            backend_name = getattr(backend, "name", "")
+            if backend_name:
+                backend_names.add(backend_name)
+
+    # The component config stores the requested backend. ``None`` means
+    # platform automatic selection, so once a constructed model is available
+    # its attention instances are the source of truth. Keep the config fallback
+    # for callers that validate policy before or without model construction.
+    if not backend_names:
+        config = init_params.get("config")
+        resolved = getattr(config, "_resolved_attention_backend", None)
+        resolved_name = getattr(resolved, "name", "")
+        if resolved_name:
+            backend_names.add(resolved_name)
+
+    if training and "FLASH_ATTN" in backend_names:
         try:
             from fastvideo.attention.utils.flash_attn_default import fa_version
         except Exception:  # pragma: no cover - flash-attn stack not importable
             pass
         else:
             if fa_version == "3":
-                return ("attention backend resolved to FLASH_ATTN with flash-attn 3, "
+                return ("model uses FLASH_ATTN with flash-attn 3, "
                         "whose grad-enabled path graph-breaks (incompatible with "
                         "fullgraph regional compile); use FA2, FA4 (FASTVIDEO_FA4=1), "
                         "or TORCH_SDPA for compiled training")
-    if resolved_name == "VIDEO_SPARSE_ATTN_H3":
+    if "VIDEO_SPARSE_ATTN_H3" in backend_names:
         if training:
             return ("VIDEO_SPARSE_ATTN_H3 regional compile is supported only for inference; "
                     "compiled training stays eager")
@@ -417,8 +440,8 @@ def _regional_compile_unsupported_reason(
         if vsa_tile_size != 64:
             return ("VIDEO_SPARSE_ATTN_H3 regional compile requires VSA_tile_size=64; "
                     f"got {vsa_tile_size!r}, so tile-256/CuTe VSA stays eager")
-    if resolved_name == "VIDEO_SPARSE_ATTN":
-        return (f"attention backend resolved to {resolved_name}, whose Triton "
+    if "VIDEO_SPARSE_ATTN" in backend_names:
+        return ("attention backend resolved to VIDEO_SPARSE_ATTN, whose Triton "
                 "kernels, sequence-parallel collectives, and sync metadata "
                 "guard graph-break (incompatible with fullgraph regional "
                 "compile); this model stays eager")

--- a/fastvideo/models/loader/fsdp_load.py
+++ b/fastvideo/models/loader/fsdp_load.py
@@ -168,6 +168,7 @@ def maybe_load_fsdp_model(
     lora_path: str | None = None,
     lora_strength: float = 1.0,
     pre_fsdp_transform: Callable[[nn.Module], nn.Module] | None = None,
+    regional_compile: bool = False,
 ) -> torch.nn.Module:
     """
     Load the model with FSDP if is training, else load the model without FSDP.
@@ -199,7 +200,8 @@ def maybe_load_fsdp_model(
 
     dtype_selector = getattr(model, "_get_parameter_dtype", None)
     has_mixed_parameter_dtypes = callable(dtype_selector) and any(
-        dtype_selector(name, param_dtype) != param_dtype for name, _ in model.named_parameters())
+        dtype_selector(_strip_checkpoint_wrapper_prefix(name), param_dtype) != param_dtype
+        for name, _ in model.named_parameters())
     if training_mode and has_mixed_parameter_dtypes:
         raise NotImplementedError("FSDP training with model-selected mixed parameter dtypes requires "
                                   "separate gradient synchronization for replicated parameters.")
@@ -258,7 +260,10 @@ def maybe_load_fsdp_model(
         # H3's compression gate is created only by the VSA attention backend. Loading a
         # VSA student under dense attention would otherwise warn about 50 unmatched
         # replacements and continue with a silently incomplete model.
-        model_parameter_names = {name for name, _ in model.named_parameters()}
+        model_parameter_names = {
+            _strip_checkpoint_wrapper_prefix(name)
+            for name, _ in model.named_parameters()
+        }
         missing_vsa_gates = sorted(name for name in dense_lora_patch.replacement_parameters
                                    if "gate_compress" in name and name not in model_parameter_names)
         if missing_vsa_gates:
@@ -294,7 +299,32 @@ def maybe_load_fsdp_model(
     _maybe_quantize_model(model)
 
     if enable_torch_compile and training_mode:
-        _compile_model_regions(model, torch_compile_kwargs or {})
+        if not regional_compile:
+            # Legacy training stack (--enable-torch-compile): preserve the
+            # whole-model compile behavior and pass kwargs through unchanged.
+            unsupported = _prepare_model_for_compile(model, regional=False)
+            if unsupported is not None:
+                logger.warning("Training torch.compile requested but disabled: %s. Model stays eager.", unsupported)
+            else:
+                compile_kwargs = torch_compile_kwargs or {}
+                logger.info("Enabling whole-model torch.compile with kwargs=%s", compile_kwargs)
+                model = torch.compile(model, **compile_kwargs)
+        else:
+            unsupported = _regional_compile_unsupported_reason(
+                init_params,
+                training=True,
+                vsa_tile_size=inference_vsa_tile_size,
+            )
+            if unsupported is None:
+                unsupported = _prepare_model_for_compile(model, regional=False)
+            if unsupported is not None:
+                logger.warning(
+                    "enable_torch_compile requested but disabled: %s. "
+                    "Training continues in eager mode.", unsupported)
+            else:
+                attention_count = _enable_regional_attention_compile(model)
+                logger.info("Enabled attention tracing for %d modules in %s", attention_count, type(model).__name__)
+                _compile_model_regions(model, torch_compile_kwargs or {})
     elif inference_regional_compile and not training_mode:
         # Inference-side counterpart of the #1718 training regional compile:
         # per-block fullgraph compile right after the transformer loads, no
@@ -316,16 +346,29 @@ def maybe_load_fsdp_model(
     return model
 
 
+def _strip_checkpoint_wrapper_prefix(name: str) -> str:
+    """Canonicalize an FQN produced after activation-checkpoint wrapping.
+
+    ``checkpoint_wrapper`` strips its ``_checkpoint_wrapped_module.`` prefix
+    from ``state_dict()`` keys via hooks, but plain ``named_parameters()`` /
+    ``named_buffers()`` recursion still yields prefixed names. Checkpoint
+    keys are always clean, so every name-keyed lookup against loaded weights
+    must compare clean names.
+    """
+    return name.replace("._checkpoint_wrapped_module.", ".").removeprefix("_checkpoint_wrapped_module.")
+
+
 def _regional_compile_unsupported_reason(
     init_params: dict[str, Any],
     *,
+    training: bool = False,
     vsa_tile_size: int | None = None,
 ) -> str | None:
     """Return why regional fullgraph compile cannot run, or None if it can.
 
-    Dense FA2, FA3, and FA4 inference all route through compile-visible
-    custom-op boundaries. FA3's raw autograd.Function carve-out applies only
-    to grad-enabled calls, outside this inference-only loader path.
+    Dense FA2 and FA4 route through compile-visible custom-op boundaries.
+    FA3 is safe for inference but its grad-enabled path graph-breaks, so it is
+    rejected for regional training compile.
 
     The legacy VSA backend remains outside the fullgraph support envelope.
     MiniMax H3's VSA backend is supported only through the inference-only
@@ -350,7 +393,21 @@ def _regional_compile_unsupported_reason(
     config = init_params.get("config")
     resolved = getattr(config, "_resolved_attention_backend", None)
     resolved_name = getattr(resolved, "name", "")
+    if training and resolved_name == "FLASH_ATTN":
+        try:
+            from fastvideo.attention.utils.flash_attn_default import fa_version
+        except Exception:  # pragma: no cover - flash-attn stack not importable
+            pass
+        else:
+            if fa_version == "3":
+                return ("attention backend resolved to FLASH_ATTN with flash-attn 3, "
+                        "whose grad-enabled path graph-breaks (incompatible with "
+                        "fullgraph regional compile); use FA2, FA4 (FASTVIDEO_FA4=1), "
+                        "or TORCH_SDPA for compiled training")
     if resolved_name == "VIDEO_SPARSE_ATTN_H3":
+        if training:
+            return ("VIDEO_SPARSE_ATTN_H3 regional compile is supported only for inference; "
+                    "compiled training stays eager")
         if os.environ.get("FASTVIDEO_H3_VSA_PROBE"):
             return ("FASTVIDEO_H3_VSA_PROBE records tensors and files from the VSA-H3 attention body, which "
                     "regional fullgraph compile cannot capture; this model stays eager")
@@ -392,7 +449,17 @@ def _compile_model_regions(model: nn.Module, compile_kwargs: dict[str, Any]) -> 
         raise ValueError(f"{type(model).__name__} does not declare _compile_conditions")
 
     if compile_kwargs.get("fullgraph", True) is not True:
-        raise ValueError("Regional training compile requires fullgraph=True")
+        raise ValueError("Regional compile requires fullgraph=True")
+    if "mode" in compile_kwargs:
+        # torch.compile forbids passing both `mode` and `options`, and
+        # regional compile always injects options (emulate_precision_casts)
+        # for bf16 numerics parity. Fail here with an actionable message
+        # instead of letting torch raise a mode/options conflict about an
+        # `options` key the user never wrote.
+        raise ValueError("Regional compile sets inductor options "
+                         "(emulate_precision_casts) and cannot be combined "
+                         "with torch_compile_kwargs['mode']. Remove 'mode' or "
+                         "express its effect via torch_compile_kwargs['options'].")
     kwargs = {**compile_kwargs, "fullgraph": True}
     options = {"emulate_precision_casts": True}
     options.update(kwargs.get("options") or {})
@@ -470,7 +537,7 @@ def shard_model(
         ignored_params = {
             parameter
             for name, parameter in model.named_parameters()
-            if dtype_selector(name, default_param_dtype) != default_param_dtype
+            if dtype_selector(_strip_checkpoint_wrapper_prefix(name), default_param_dtype) != default_param_dtype
         }
     named_modules = list(model.named_modules())
     ignored_params_by_module = {
@@ -571,8 +638,14 @@ def load_model_from_full_model_state_dict(
         NotImplementedError: If got FSDP with more than 1D.
     """
     meta_sd = model.state_dict()
-    named_parameters = dict(model.named_parameters())
-    named_buffers = dict(model.named_buffers())
+    # state_dict() keys are clean (checkpoint-wrapper hooks strip the AC
+    # prefix) but named_parameters()/named_buffers() are not; checkpoint keys
+    # are clean, so canonicalize before any name-keyed lookup. Without this,
+    # a loaded buffer inside an AC-wrapped block misses the named_buffers
+    # membership test below and is silently converted into a trainable
+    # nn.Parameter by load_state_dict(assign=True).
+    named_parameters = {_strip_checkpoint_wrapper_prefix(k): v for k, v in model.named_parameters()}
+    named_buffers = {_strip_checkpoint_wrapper_prefix(k): v for k, v in model.named_buffers()}
     sharded_sd = {}
     custom_param_sd, reverse_param_names_mapping = hf_to_custom_state_dict(full_sd_iterator,
                                                                            param_names_mapping)  # type: ignore

--- a/fastvideo/tests/attention/test_compile_policy.py
+++ b/fastvideo/tests/attention/test_compile_policy.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attention compile-boundary policy tests."""
+
+from fastvideo.attention.layer import _attention_compile_disabled
+
+
+def test_attention_compile_is_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("FASTVIDEO_DISABLE_ATTENTION_COMPILE", raising=False)
+
+    assert _attention_compile_disabled()
+
+
+def test_attention_compile_escape_hatch(monkeypatch) -> None:
+    monkeypatch.setenv("FASTVIDEO_DISABLE_ATTENTION_COMPILE", "1")
+
+    assert _attention_compile_disabled()
+
+    monkeypatch.setenv("FASTVIDEO_DISABLE_ATTENTION_COMPILE", "0")
+    assert not _attention_compile_disabled()

--- a/fastvideo/tests/attention/test_flash_attn_cute_custom_op.py
+++ b/fastvideo/tests/attention/test_flash_attn_cute_custom_op.py
@@ -173,6 +173,37 @@ def test_flash_attn_func_parity_forward_backward(flash_attn_impls, dtype: torch.
     _assert_close(dv_test, dv_ref, dtype=dtype, is_grad=True)
 
 
+def test_flash_attn_func_fullgraph_compile_backward(flash_attn_impls):
+    custom_flash_attn_func, _, _, _ = flash_attn_impls
+
+    def loss(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        return custom_flash_attn_func(q, k, v).square().mean()
+
+    torch.manual_seed(2)
+    base_inputs = [
+        torch.randn(
+            1,
+            64,
+            4,
+            64,
+            device="cuda",
+            dtype=torch.bfloat16,
+            requires_grad=False,
+        ) for _ in range(3)
+    ]
+    eager_inputs = [tensor.clone().requires_grad_(True) for tensor in base_inputs]
+    compiled_inputs = [tensor.clone().requires_grad_(True) for tensor in base_inputs]
+
+    eager_loss = loss(*eager_inputs)
+    eager_grads = torch.autograd.grad(eager_loss, eager_inputs)
+    compiled_loss = torch.compile(loss, fullgraph=True)(*compiled_inputs)
+    compiled_grads = torch.autograd.grad(compiled_loss, compiled_inputs)
+
+    _assert_close(compiled_loss, eager_loss, dtype=torch.bfloat16)
+    for compiled_grad, eager_grad in zip(compiled_grads, eager_grads):
+        _assert_close(compiled_grad, eager_grad, dtype=torch.bfloat16, is_grad=True)
+
+
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("causal", [False, True])
 def test_flash_attn_varlen_func_parity_forward_backward(flash_attn_impls, dtype: torch.dtype, causal: bool):

--- a/fastvideo/tests/inference/test_inference_regional_compile.py
+++ b/fastvideo/tests/inference/test_inference_regional_compile.py
@@ -38,11 +38,21 @@ from fastvideo.models.loader.fsdp_load import (
     _prepare_model_for_compile,
     _regional_compile_unsupported_reason,
 )
+from fastvideo.platforms import AttentionBackendEnum
 
 
 def _init_params_for(backend_name: str | None) -> dict:
     resolved = None if backend_name is None else SimpleNamespace(name=backend_name)
     return {"config": SimpleNamespace(_resolved_attention_backend=resolved)}
+
+
+def _model_with_actual_backend(backend: AttentionBackendEnum) -> nn.Module:
+    attention = DistributedAttention.__new__(DistributedAttention)
+    nn.Module.__init__(attention)
+    attention.backend = backend
+    model = nn.Module()
+    model.add_module("attention", attention)
+    return model
 
 
 def test_legacy_vsa_backend_degrades_to_eager(monkeypatch) -> None:
@@ -266,6 +276,37 @@ def test_dense_flash_attention_inference_allows_compile(fa_version, monkeypatch)
     monkeypatch.setitem(sys.modules, fake_module.__name__, fake_module)
 
     assert _regional_compile_unsupported_reason(_init_params_for("FLASH_ATTN")) is None
+
+
+def test_automatic_flash_attention_fa3_training_degrades_to_eager(monkeypatch) -> None:
+    monkeypatch.delenv("FASTVIDEO_DISABLE_ATTENTION_COMPILE", raising=False)
+    fake_module = ModuleType("fastvideo.attention.utils.flash_attn_default")
+    fake_module.fa_version = "3"
+    monkeypatch.setitem(sys.modules, fake_module.__name__, fake_module)
+    model = _model_with_actual_backend(AttentionBackendEnum.FLASH_ATTN)
+
+    reason = _regional_compile_unsupported_reason(
+        _init_params_for(None),
+        model=model,
+        training=True,
+    )
+
+    assert reason is not None
+    assert "flash-attn 3" in reason
+
+
+def test_actual_sdpa_backend_overrides_flash_request_for_fa3_guard(monkeypatch) -> None:
+    monkeypatch.delenv("FASTVIDEO_DISABLE_ATTENTION_COMPILE", raising=False)
+    fake_module = ModuleType("fastvideo.attention.utils.flash_attn_default")
+    fake_module.fa_version = "3"
+    monkeypatch.setitem(sys.modules, fake_module.__name__, fake_module)
+    model = _model_with_actual_backend(AttentionBackendEnum.TORCH_SDPA)
+
+    assert _regional_compile_unsupported_reason(
+        _init_params_for("FLASH_ATTN"),
+        model=model,
+        training=True,
+    ) is None
 
 
 def test_default_attention_dispatch_stays_compiler_disabled(monkeypatch) -> None:

--- a/fastvideo/tests/models/test_wan_modulation_custom_op.py
+++ b/fastvideo/tests/models/test_wan_modulation_custom_op.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Compiled Wan modulation forward/backward regression tests."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+# Import registers the model-local custom operators.
+import fastvideo.models.dits.wanvideo  # noqa: F401
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("temb_shape", [(2, 6, 32), (2, 3, 6, 32)])
+def test_wan_modulation_fullgraph_backward_matches_eager(temb_shape: tuple[int, ...]) -> None:
+    torch.manual_seed(0)
+    scale_base = torch.randn(1, 6, 32, device="cuda", dtype=torch.bfloat16)
+    temb_base = torch.randn(temb_shape, device="cuda", dtype=torch.bfloat16)
+    chunk_shape = (*temb_shape[:2], 1, temb_shape[-1]) if len(temb_shape) == 4 else (temb_shape[0], 1,
+                                                                                   temb_shape[-1])
+    weights = [torch.randn(chunk_shape, device="cuda") for _ in range(6)]
+
+    scale_eager = scale_base.clone().requires_grad_(True)
+    temb_eager = temb_base.clone().requires_grad_(True)
+    chunk_dim = 2 if len(temb_shape) == 4 else 1
+    modulation = (scale_eager.unsqueeze(0).float() if len(temb_shape) == 4 else
+                  scale_eager.float()) + temb_eager.float()
+    eager_outputs = modulation.chunk(6, dim=chunk_dim)
+    eager_loss = sum((output * weight).sum() for output, weight in zip(eager_outputs, weights))
+    eager_grads = torch.autograd.grad(eager_loss, (scale_eager, temb_eager))
+
+    scale_compiled = scale_base.clone().requires_grad_(True)
+    temb_compiled = temb_base.clone().requires_grad_(True)
+
+    def loss(scale_shift_table: torch.Tensor, temb: torch.Tensor) -> torch.Tensor:
+        outputs = torch.ops.fastvideo._wan_modulation_forward(scale_shift_table, temb)
+        return sum((output * weight).sum() for output, weight in zip(outputs, weights))
+
+    compiled_loss = torch.compile(loss, fullgraph=True)(scale_compiled, temb_compiled)
+    compiled_grads = torch.autograd.grad(compiled_loss, (scale_compiled, temb_compiled))
+
+    for compiled_grad, eager_grad in zip(compiled_grads, eager_grads):
+        torch.testing.assert_close(compiled_grad, eager_grad, rtol=0, atol=0)

--- a/fastvideo/tests/train/models/test_wan_compile_setup.py
+++ b/fastvideo/tests/train/models/test_wan_compile_setup.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Wan activation-checkpoint and regional-compile setup tests."""
+
+from __future__ import annotations
+
+import torch
+
+from fastvideo.configs.pipelines.base import PipelineConfig
+from fastvideo.train.models.wan import wan
+from fastvideo.train.models.wan.wan import WanModel
+from fastvideo.train.utils.training_config import (
+    ModelTrainingConfig,
+    TrainingConfig,
+)
+
+
+def test_wan_passes_activation_checkpointing_to_pre_fsdp_load(monkeypatch) -> None:
+    training_config = TrainingConfig(
+        model=ModelTrainingConfig(enable_gradient_checkpointing_type="full"),
+        pipeline_config=PipelineConfig(),
+    )
+    captured: dict = {}
+    transformer = torch.nn.Linear(1, 1)
+
+    def _fake_load_module_from_path(**kwargs):
+        captured.update(kwargs)
+        return transformer
+
+    monkeypatch.setattr(wan, "load_module_from_path", _fake_load_module_from_path)
+    monkeypatch.setattr(wan, "apply_trainable", lambda module, trainable: module)
+    monkeypatch.setattr(WanModel, "_enable_lora_if_configured", lambda self, module: False)
+
+    model = WanModel.__new__(WanModel)
+    result = model._load_transformer(
+        init_from="fake/model",
+        trainable=True,
+        disable_custom_init_weights=False,
+        enable_gradient_checkpointing_type=None,
+        training_config=training_config,
+    )
+
+    assert result is transformer
+    transform = captured["pre_fsdp_transform"]
+    assert transform is not None
+    assert transform.keywords == {"checkpointing_type": "full"}
+
+
+def test_wan_skips_activation_checkpointing_for_frozen_role(monkeypatch) -> None:
+    training_config = TrainingConfig(
+        model=ModelTrainingConfig(enable_gradient_checkpointing_type="full"),
+        pipeline_config=PipelineConfig(),
+    )
+    captured: dict = {}
+    transformer = torch.nn.Linear(1, 1)
+
+    def _fake_load_module_from_path(**kwargs):
+        captured.update(kwargs)
+        return transformer
+
+    monkeypatch.setattr(wan, "load_module_from_path", _fake_load_module_from_path)
+    monkeypatch.setattr(wan, "apply_trainable", lambda module, trainable: module)
+    monkeypatch.setattr(WanModel, "_enable_lora_if_configured", lambda self, module: False)
+
+    model = WanModel.__new__(WanModel)
+    model._load_transformer(
+        init_from="fake/model",
+        trainable=False,
+        disable_custom_init_weights=True,
+        enable_gradient_checkpointing_type=None,
+        training_config=training_config,
+    )
+
+    assert captured["pre_fsdp_transform"] is None

--- a/fastvideo/tests/train/utils/test_config.py
+++ b/fastvideo/tests/train/utils/test_config.py
@@ -84,6 +84,8 @@ def test_minimal_yaml_applies_all_defaults(tmp_path: Path) -> None:
     assert t.model.weighting_scheme == "uniform"
     assert t.model.precondition_outputs is False
     assert t.model.moba_config == {}
+    assert t.model.enable_torch_compile is False
+    assert t.model.torch_compile_kwargs == {}
 
     assert t.dit_precision == "fp32"
     assert t.vsa_sparsity == 0.0
@@ -142,6 +144,10 @@ def test_full_yaml_populates_all_training_fields(tmp_path: Path) -> None:
             "logit_mean": 0.5,
             "logit_std": 1.5,
             "precondition_outputs": True,
+            "enable_torch_compile": True,
+            "torch_compile_kwargs": {
+                "dynamic": False,
+            },
         },
         "dit_precision": "bf16",
     }
@@ -175,6 +181,8 @@ def test_full_yaml_populates_all_training_fields(tmp_path: Path) -> None:
     assert t.vsa_sparsity == pytest.approx(0.5)
     assert t.model.weighting_scheme == "logit_normal"
     assert t.model.precondition_outputs is True
+    assert t.model.enable_torch_compile is True
+    assert t.model.torch_compile_kwargs == {"dynamic": False}
     assert t.dit_precision == "bf16"
 
 

--- a/fastvideo/tests/train/utils/test_moduleloader_attention_backend.py
+++ b/fastvideo/tests/train/utils/test_moduleloader_attention_backend.py
@@ -12,6 +12,7 @@ from fastvideo.platforms import AttentionBackendEnum
 from fastvideo.train.utils import moduleloader
 from fastvideo.train.utils.training_config import (
     DistributedConfig,
+    ModelTrainingConfig,
     TrainingConfig,
 )
 
@@ -92,3 +93,75 @@ def test_load_transformer_restores_backend_when_loading_fails(
             attention_backend="ATTN_QAT_TRAIN",
         )
     assert _active_component_attention_backend_scope() is None
+
+
+def test_training_args_propagate_compile_settings() -> None:
+    training_config = TrainingConfig(
+        distributed=DistributedConfig(hsdp_shard_dim=1),
+        model=ModelTrainingConfig(
+            enable_torch_compile=True,
+            torch_compile_kwargs={"dynamic": False},
+        ),
+        pipeline_config=PipelineConfig(),
+    )
+
+    args = moduleloader._make_training_args(training_config, model_path="fake/model")
+
+    assert args.enable_torch_compile is True
+    assert args.torch_compile_kwargs == {"dynamic": False}
+
+
+def test_load_transformer_forwards_pre_fsdp_transform(monkeypatch, tmp_path) -> None:
+    training_config = TrainingConfig(
+        distributed=DistributedConfig(hsdp_shard_dim=1),
+        pipeline_config=PipelineConfig(),
+    )
+
+    def transform(module):
+        return module
+
+    captured = None
+
+    monkeypatch.setattr(moduleloader, "maybe_download_model", lambda path: str(tmp_path))
+    monkeypatch.setattr(
+        moduleloader,
+        "verify_model_config_and_directory",
+        lambda path: {"transformer": ("diffusers", "FakeTransformer")},
+    )
+
+    def _fake_load_module(**kwargs):
+        nonlocal captured
+        captured = getattr(kwargs["fastvideo_args"], "_pre_fsdp_transform", None)
+        return torch.nn.Linear(1, 1)
+
+    monkeypatch.setattr(moduleloader.PipelineComponentLoader, "load_module", _fake_load_module)
+
+    moduleloader.load_module_from_path(
+        model_path="fake/model",
+        module_type="transformer",
+        training_config=training_config,
+        pre_fsdp_transform=transform,
+    )
+
+    assert captured is transform
+
+
+def test_pre_fsdp_transform_rejects_non_transformer(monkeypatch, tmp_path) -> None:
+    training_config = TrainingConfig(
+        distributed=DistributedConfig(hsdp_shard_dim=1),
+        pipeline_config=PipelineConfig(),
+    )
+    monkeypatch.setattr(moduleloader, "maybe_download_model", lambda path: str(tmp_path))
+    monkeypatch.setattr(
+        moduleloader,
+        "verify_model_config_and_directory",
+        lambda path: {"vae": ("diffusers", "FakeVAE")},
+    )
+
+    with pytest.raises(ValueError, match="only be set when loading a transformer"):
+        moduleloader.load_module_from_path(
+            model_path="fake/model",
+            module_type="vae",
+            training_config=training_config,
+            pre_fsdp_transform=lambda module: module,
+        )

--- a/fastvideo/tests/train/utils/test_torch_compile.py
+++ b/fastvideo/tests/train/utils/test_torch_compile.py
@@ -117,3 +117,77 @@ def test_regional_compile_forwards_supported_kwargs(monkeypatch) -> None:
 def test_regional_compile_rejects_partial_graph_mode() -> None:
     with pytest.raises(ValueError, match="fullgraph=True"):
         _compile_model_regions(_RepeatedModel(), {"fullgraph": False})
+
+
+def test_regional_compile_rejects_mode_kwarg() -> None:
+    """`mode` conflicts with the always-injected inductor options.
+
+    torch.compile forbids mode+options together; the loader must fail with an
+    actionable message rather than letting torch blame an `options` key the
+    user never wrote (the CLI help's own example uses `mode`).
+    """
+    model = _RepeatedModel()
+    with pytest.raises(ValueError, match="mode"):
+        _compile_model_regions(model, {"mode": "reduce-overhead"})
+
+
+def test_checkpoint_wrapper_prefix_normalization() -> None:
+    """AC-wrapped blocks must not break name-keyed weight-loader lookups.
+
+    checkpoint_wrapper strips its prefix from state_dict() keys via hooks but
+    NOT from named_parameters()/named_buffers(); checkpoint keys are clean.
+    Pre-fix, a loaded buffer inside a wrapped block missed the named_buffers
+    membership test and was silently converted into a trainable nn.Parameter
+    by load_state_dict(assign=True).
+    """
+    from fastvideo.models.loader.fsdp_load import _strip_checkpoint_wrapper_prefix
+
+    class _BufferBlock(torch.nn.Module):
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.lin = torch.nn.Linear(4, 4)
+            self.register_buffer("freq", torch.arange(4.0))
+
+        def forward(self, value: torch.Tensor) -> torch.Tensor:
+            return self.lin(value) + self.freq
+
+    class _BufferModel(torch.nn.Module):
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.blocks = torch.nn.ModuleList([_BufferBlock()])
+
+    from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+        checkpoint_wrapper, )
+
+    model = _BufferModel()
+    model.blocks[0] = checkpoint_wrapper(model.blocks[0])
+
+    # state_dict is clean; raw named_buffers is prefixed.
+    assert "blocks.0.freq" in model.state_dict()
+    raw_buffer_names = {name for name, _ in model.named_buffers()}
+    assert "blocks.0.freq" not in raw_buffer_names
+    assert "blocks.0._checkpoint_wrapped_module.freq" in raw_buffer_names
+
+    # The canonicalized views match checkpoint keys exactly.
+    clean_buffers = {_strip_checkpoint_wrapper_prefix(name) for name, _ in model.named_buffers()}
+    clean_params = {_strip_checkpoint_wrapper_prefix(name) for name, _ in model.named_parameters()}
+    assert clean_buffers == {"blocks.0.freq"}
+    assert clean_params == {"blocks.0.lin.weight", "blocks.0.lin.bias"}
+
+    # End-to-end: membership keyed on canonical names keeps a loaded buffer a
+    # buffer under load_state_dict(assign=True) instead of promoting it to a
+    # trainable parameter.
+    loaded = {
+        "blocks.0.freq": torch.ones(4),
+        "blocks.0.lin.weight": torch.ones(4, 4),
+        "blocks.0.lin.bias": torch.ones(4),
+    }
+    sharded_sd = {
+        key: (value if key in clean_buffers else torch.nn.Parameter(value))
+        for key, value in loaded.items()
+    }
+    model.load_state_dict(sharded_sd, assign=True)
+    assert any("freq" in name for name, _ in model.named_buffers())
+    assert not any("freq" in name for name, _ in model.named_parameters())

--- a/fastvideo/tests/train/utils/test_torch_compile.py
+++ b/fastvideo/tests/train/utils/test_torch_compile.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regional training compile policy regression tests."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from fastvideo.models.loader.fsdp_load import _compile_model_regions
+from fastvideo.train.utils.activation_checkpoint import apply_activation_checkpointing
+
+
+class _RepeatedModel(torch.nn.Module):
+    _compile_conditions = [
+        lambda name, module: name.startswith("blocks.") and name.count(".") == 1
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.blocks = torch.nn.ModuleList([
+            torch.nn.Linear(4, 4),
+            torch.nn.Linear(4, 4),
+        ])
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        for block in self.blocks:
+            value = block(value)
+        return value
+
+
+def test_regional_compile_preserves_checkpoint_state_dict(monkeypatch) -> None:
+    model = apply_activation_checkpointing(_RepeatedModel())
+    state_dict_keys = list(model.state_dict())
+    calls: list[tuple[torch.nn.Module, dict]] = []
+
+    def _fake_compile(forward, **kwargs):
+        calls.append((forward.__self__, kwargs))
+        return forward
+
+    monkeypatch.setattr(torch, "compile", _fake_compile)
+
+    assert _compile_model_regions(model, {}) == 2
+    assert [target for target, _ in calls] == [
+        block._checkpoint_wrapped_module for block in model.blocks
+    ]
+    assert [kwargs for _, kwargs in calls] == [
+        {"fullgraph": True},
+        {"fullgraph": True},
+    ]
+    assert list(model.state_dict()) == state_dict_keys
+
+
+def test_regional_compile_dispatches_only_no_grad_calls(monkeypatch) -> None:
+    model = _RepeatedModel()
+    compiled_calls = 0
+
+    def _fake_compile(eager_forward, **kwargs):
+        del kwargs
+
+        def _compiled(*args, **forward_kwargs):
+            nonlocal compiled_calls
+            compiled_calls += 1
+            return eager_forward(*args, **forward_kwargs)
+
+        return _compiled
+
+    monkeypatch.setattr(torch, "compile", _fake_compile)
+    _compile_model_regions(model, {})
+
+    value = torch.randn(2, 4)
+    model(value)
+    assert compiled_calls == 0
+
+    with torch.no_grad():
+        model(value)
+    assert compiled_calls == 2
+
+
+def test_regional_compile_forwards_supported_kwargs(monkeypatch) -> None:
+    model = _RepeatedModel()
+    calls: list[dict] = []
+
+    def _fake_compile(forward, **kwargs):
+        calls.append(kwargs)
+        return forward
+
+    monkeypatch.setattr(torch, "compile", _fake_compile)
+
+    _compile_model_regions(model, {"dynamic": False})
+
+    assert calls == [
+        {"fullgraph": True, "dynamic": False},
+        {"fullgraph": True, "dynamic": False},
+    ]
+
+
+def test_regional_compile_rejects_partial_graph_mode() -> None:
+    with pytest.raises(ValueError, match="fullgraph=True"):
+        _compile_model_regions(_RepeatedModel(), {"fullgraph": False})

--- a/fastvideo/tests/train/utils/test_torch_compile.py
+++ b/fastvideo/tests/train/utils/test_torch_compile.py
@@ -44,13 +44,13 @@ def test_regional_compile_preserves_checkpoint_state_dict(monkeypatch) -> None:
         block._checkpoint_wrapped_module for block in model.blocks
     ]
     assert [kwargs for _, kwargs in calls] == [
-        {"fullgraph": True},
-        {"fullgraph": True},
+        {"fullgraph": True, "options": {"emulate_precision_casts": True}},
+        {"fullgraph": True, "options": {"emulate_precision_casts": True}},
     ]
     assert list(model.state_dict()) == state_dict_keys
 
 
-def test_regional_compile_dispatches_only_no_grad_calls(monkeypatch) -> None:
+def test_regional_compile_dispatches_grad_and_no_grad_calls(monkeypatch) -> None:
     model = _RepeatedModel()
     compiled_calls = 0
 
@@ -69,11 +69,11 @@ def test_regional_compile_dispatches_only_no_grad_calls(monkeypatch) -> None:
 
     value = torch.randn(2, 4)
     model(value)
-    assert compiled_calls == 0
+    assert compiled_calls == 2
 
     with torch.no_grad():
         model(value)
-    assert compiled_calls == 2
+    assert compiled_calls == 4
 
 
 def test_regional_compile_forwards_supported_kwargs(monkeypatch) -> None:
@@ -86,11 +86,31 @@ def test_regional_compile_forwards_supported_kwargs(monkeypatch) -> None:
 
     monkeypatch.setattr(torch, "compile", _fake_compile)
 
-    _compile_model_regions(model, {"dynamic": False})
+    _compile_model_regions(model, {
+        "dynamic": False,
+        "options": {
+            "emulate_precision_casts": False,
+            "max_autotune": True,
+        },
+    })
 
     assert calls == [
-        {"fullgraph": True, "dynamic": False},
-        {"fullgraph": True, "dynamic": False},
+        {
+            "fullgraph": True,
+            "dynamic": False,
+            "options": {
+                "emulate_precision_casts": False,
+                "max_autotune": True,
+            },
+        },
+        {
+            "fullgraph": True,
+            "dynamic": False,
+            "options": {
+                "emulate_precision_casts": False,
+                "max_autotune": True,
+            },
+        },
     ]
 
 

--- a/fastvideo/train/models/wan/wan.py
+++ b/fastvideo/train/models/wan/wan.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+from functools import partial
 from typing import Any, Literal, TYPE_CHECKING
 
 import torch
@@ -19,7 +20,7 @@ from fastvideo.models.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler, )
 from fastvideo.pipelines import TrainingBatch
 from fastvideo.platforms import AttentionBackendEnum
-from fastvideo.training.activation_checkpoint import (
+from fastvideo.train.utils.activation_checkpoint import (
     apply_activation_checkpointing, )
 from fastvideo.training.training_utils import (
     compute_density_for_timestep_sampling,
@@ -124,6 +125,17 @@ class WanModel(ModelBase):
         transformer_override_safetensor: str | None = None,
         attention_backend: AttentionBackendEnum | str | None = None,
     ) -> torch.nn.Module:
+        ckpt_type = (enable_gradient_checkpointing_type or getattr(
+            getattr(training_config, "model", None),
+            "enable_gradient_checkpointing_type",
+            None,
+        ))
+        pre_fsdp_transform = None
+        if trainable and ckpt_type:
+            pre_fsdp_transform = partial(
+                apply_activation_checkpointing,
+                checkpointing_type=ckpt_type,
+            )
         transformer = load_module_from_path(
             model_path=init_from,
             module_type="transformer",
@@ -132,19 +144,8 @@ class WanModel(ModelBase):
             override_transformer_cls_name=(self._transformer_cls_name),
             transformer_override_safetensor=(transformer_override_safetensor),
             attention_backend=attention_backend,
+            pre_fsdp_transform=pre_fsdp_transform,
         )
-        # Fall back to training_config.model if not set on the
-        # model YAML section directly.
-        ckpt_type = (enable_gradient_checkpointing_type or getattr(
-            getattr(training_config, "model", None),
-            "enable_gradient_checkpointing_type",
-            None,
-        ))
-        if trainable and ckpt_type:
-            transformer = apply_activation_checkpointing(
-                transformer,
-                checkpointing_type=ckpt_type,
-            )
         if self._enable_lora_if_configured(transformer):
             return transformer
         transformer = apply_trainable(transformer, trainable=trainable)

--- a/fastvideo/train/utils/config.py
+++ b/fastvideo/train/utils/config.py
@@ -439,6 +439,8 @@ def _build_training_config(
             precondition_outputs=bool(m.get("precondition_outputs", False)),
             moba_config=dict(m.get("moba_config", {}) or {}),
             enable_gradient_checkpointing_type=(m.get("enable_gradient_checkpointing_type")),
+            enable_torch_compile=bool(m.get("enable_torch_compile", False)),
+            torch_compile_kwargs=dict(m.get("torch_compile_kwargs", {}) or {}),
         ),
         pipeline_config=pipeline_config,
         model_path=model_path,

--- a/fastvideo/train/utils/moduleloader.py
+++ b/fastvideo/train/utils/moduleloader.py
@@ -62,6 +62,9 @@ def _make_training_args(
         image_encoder_cpu_offload=False,
         use_fsdp_inference=False,
         enable_torch_compile=tc.model.enable_torch_compile,
+        # Modular stack opts into regional fullgraph compile; the legacy
+        # stack keeps whole-model torch.compile semantics (default False).
+        regional_compile=True,
         torch_compile_kwargs=tc.model.torch_compile_kwargs,
     )
 

--- a/fastvideo/train/utils/moduleloader.py
+++ b/fastvideo/train/utils/moduleloader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from contextlib import nullcontext
 from typing import Any, TYPE_CHECKING
+from collections.abc import Callable
 
 import torch
 
@@ -60,7 +61,8 @@ def _make_training_args(
         text_encoder_cpu_offload=False,
         image_encoder_cpu_offload=False,
         use_fsdp_inference=False,
-        enable_torch_compile=False,
+        enable_torch_compile=tc.model.enable_torch_compile,
+        torch_compile_kwargs=tc.model.torch_compile_kwargs,
     )
 
 
@@ -92,6 +94,7 @@ def load_module_from_path(
     override_transformer_cls_name: str | None = None,
     transformer_override_safetensor: str | None = None,
     attention_backend: AttentionBackendEnum | str | None = None,
+    pre_fsdp_transform: Callable[[torch.nn.Module], torch.nn.Module] | None = None,
 ) -> torch.nn.Module:
     """Load one pipeline component with its role-scoped attention policy.
 
@@ -129,6 +132,12 @@ def load_module_from_path(
 
     if transformer_override_safetensor:
         fastvideo_args.init_weights_from_safetensors = str(transformer_override_safetensor)
+
+    if pre_fsdp_transform is not None:
+        if module_type != "transformer":
+            raise ValueError("pre_fsdp_transform can only be set when loading "
+                             f"a transformer, got module_type={module_type!r}")
+        fastvideo_args._pre_fsdp_transform = pre_fsdp_transform
 
     if attention_backend is not None and module_type != "transformer":
         raise ValueError("attention_backend can only be set when loading "

--- a/fastvideo/train/utils/training_config.py
+++ b/fastvideo/train/utils/training_config.py
@@ -77,6 +77,8 @@ class ModelTrainingConfig:
     precondition_outputs: bool = False
     moba_config: dict = field(default_factory=dict)
     enable_gradient_checkpointing_type: str | None = None
+    enable_torch_compile: bool = False
+    torch_compile_kwargs: dict = field(default_factory=dict)
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
    ## Purpose

  Add opt-in regional `torch.compile` support to the YAML-driven modular Wan
  trainer, including compiled forward and backward execution with FA4, FSDP, and
  activation checkpointing.

  Fix an Inductor backward output-assembly issue that produced invalid Wan
  modulation gradients, and preserve eager-like BF16 numerical behavior without
  giving up steady-state compile performance.

  Fixes #

  ## Changes

  - Add modular trainer YAML options:
    - `training.model.enable_torch_compile`
    - `training.model.torch_compile_kwargs`
  - Apply activation checkpointing before FSDP for trainable Wan transformers.
  - Compile repeated DiT blocks after FSDP setup while keeping:
    - FSDP hooks outside compiled regions
    - activation-checkpoint control flow eager
    - checkpoint state-dict names unchanged
  - Require `fullgraph=True` to prevent silent partial-graph fallback.
  - Compile both gradient-bearing and no-grad block calls.
  - Enable attention compilation by default, with
    `FASTVIDEO_DISABLE_ATTENTION_COMPILE=1` as a debugging escape hatch.
  - Make FA4 forward and backward available through opaque custom operators:
    - explicitly retain LSE for AOTAutograd
    - support fixed-length and variable-length backward
  - Add opaque Wan modulation forward/backward operators:
    - materialize all six modulation outputs independently
    - explicitly assemble all six backward gradient slices
    - avoid the incomplete Inductor output buffer that previously corrupted
      `scale_shift_table` and timestep-embedding gradients
  - Enable Inductor `emulate_precision_casts` by default for regional training
    compile so fused BF16 operators retain eager's intermediate rounding points.
    Users may override it under `torch_compile_kwargs.options`.
  - Add compile policy, config propagation, checkpoint ordering, FA4 backward,
    Wan modulation gradient, and state-dict regression tests.
  - Document setup, warmup behavior, FA4 opt-in, numerical policy, and debugging
    options.

  ## Test Plan

  ```bash
  .venv/bin/pre-commit run --all-files

  PYTHONPATH=/tmp/fastvideo-memory-cap \
  FASTVIDEO_BENCH_MEMORY_CAP_GIB=73 \
  .venv/bin/pytest -q \
    fastvideo/tests/attention/test_compile_policy.py \
    fastvideo/tests/attention/test_flash_attn_cute_custom_op.py \
    fastvideo/tests/models/test_wan_modulation_custom_op.py \
    fastvideo/tests/train/models/test_wan_compile_setup.py \
    fastvideo/tests/train/utils/test_config.py \
    fastvideo/tests/train/utils/test_moduleloader_attention_backend.py \
    fastvideo/tests/train/utils/test_torch_compile.py

  PYTHONPATH=/tmp/fastvideo-memory-cap \
  FASTVIDEO_BENCH_MEMORY_CAP_GIB=73 \
  .venv/bin/pytest -q \
    fastvideo/tests/train/models \
    fastvideo/tests/train/utils

  # Run once with enable_torch_compile=false and once with true.
  PYTHONPATH=/tmp/fastvideo-memory-cap \
  FASTVIDEO_BENCH_MEMORY_CAP_GIB=73 \
  FASTVIDEO_ATTENTION_BACKEND=FLASH_ATTN \
  FASTVIDEO_FA4=1 \
  NUM_GPUS=4 \
  WANDB_MODE=offline \
  bash examples/train/run.sh \
    examples/train/configs/distribution_matching/wan/dmd2_t2v.yaml \
    --training.loop.max_train_steps 21 \
    --training.data.dataloader_num_workers 0 \
    --training.checkpoint.training_state_checkpointing_steps 0 \
    --callbacks.validation.every_steps 0 \
    --training.model.enable_torch_compile true

  TORCH_LOGS=graph_breaks,recompiles \
  PYTHONPATH=/tmp/fastvideo-memory-cap \
  FASTVIDEO_BENCH_MEMORY_CAP_GIB=73 \
  FASTVIDEO_ATTENTION_BACKEND=FLASH_ATTN \
  FASTVIDEO_FA4=1 \
  NUM_GPUS=4 \
  WANDB_MODE=offline \
  bash examples/train/run.sh \
    examples/train/configs/distribution_matching/wan/dmd2_t2v.yaml \
    --training.loop.max_train_steps 6 \
    --training.data.dataloader_num_workers 0 \
    --training.checkpoint.training_state_checkpointing_steps 0 \
    --callbacks.validation.every_steps 0 \
    --training.model.enable_torch_compile true

  ## Test Results
  <details>
  <summary>Test output and performance</summary>

  pre-commit run --all-files
  All hooks passed.

  47 passed, 686 warnings in 63.66s
  102 passed, 15 warnings in 422.99s

  All GPU runs used an allocator limit of 73 GiB per device.

  FA4 was selected explicitly with:

  FASTVIDEO_ATTENTION_BACKEND=FLASH_ATTN
  FASTVIDEO_FA4=1

  The runtime confirmed:

  Using FlashAttention-4 backend

  ### Performance

  Four-GB200, 21-step DMD2 comparison using the same seed and configuration:

   Metric                         Eager    Compile, warm cache             Change
  ━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━
   21-step total              101.606 s               82.207 s    -19.09% latency
  ─────────────────────────  ───────────  ─────────────────────  ─────────────────
   Steady-state mean            3.877 s                2.812 s    -27.48% latency
  ─────────────────────────  ───────────  ─────────────────────  ─────────────────
   Steady-state throughput            —                      —            +37.90%
  ─────────────────────────  ───────────  ─────────────────────  ─────────────────
   Regular critic step          3.108 s                2.297 s            -26.10%
  ─────────────────────────  ───────────  ─────────────────────  ─────────────────
   Student-update step          6.951 s                4.869 s            -29.95%
  ─────────────────────────  ───────────  ─────────────────────  ─────────────────
   First step                  24.065 s               25.975 s     compile warmup

  A completely cold Inductor cache increased the first step to 43.662 seconds
  and the 21-step total to 103.136 seconds. The compile path is therefore intended
  for longer training jobs where the steady-state improvement amortizes the
  one-time kernel-generation cost.

  ### Gradient correctness

  Before the fix, a one-step compiled critic update produced:

  Eager critic grad norm:     0.2645
  Compiled critic grad norm:  2870.1

  The generated Inductor backward buffer wrote only four of the six Wan
  modulation gradient slices. The missing slices left uninitialized data in the
  combined timestep/modulation gradient.

  After the fix:

  - all 21 critic gradients and all 4 student gradients were finite
  - no NaN or Inf was observed
  - no FSDP collective timeout occurred
  - the isolated rank-3 and rank-4 modulation regression tests matched eager
    gradients exactly

  Twenty-one-step numerical comparisons after enabling
  emulate_precision_casts:

   Metric                              Eager-to-eager variation    Compile-to-eager variation
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Total loss, mean relative                              1.08%                   0.76%–1.03%
  ──────────────────────────────────  ──────────────────────────  ────────────────────────────
   Critic grad norm, mean relative                        2.46%                   1.30%–2.38%
  ──────────────────────────────────  ──────────────────────────  ────────────────────────────
   Student grad norm, mean relative                       1.27%                   0.42%–2.37%

  The remaining differences are in the same low-single-digit range as repeated
  BF16/FA4 eager runs.

  TORCH_LOGS=graph_breaks,recompiles reported:

  Graph breaks: 0
  Steady-state recompiles: 0

  Each rank created the expected initial grad/no-grad and block-type
  specializations only.
  </details>

  ## Checklist

  - [x] I ran pre-commit run --all-files and fixed all issues
  - [x] I added or updated tests for my changes
  - [x] I updated documentation if needed
  - [x] I considered GPU memory impact of my changes

  Model/pipeline quality checks are not applicable: this changes only the
  opt-in modular training execution strategy, not model weights, inference
  pipeline wiring, or generated-output references. SSIM baselines and the support
  matrix do not require updates.