### PR TITLE
[bugfix] Fix dead NVFP4 QAT plumbing: bench imports, int8 error string, smooth_q crash

### DIFF
--- a/fastvideo-kernel/attn_qat_infer/quantization/bench/bench_quant_k.py
+++ b/fastvideo-kernel/attn_qat_infer/quantization/bench/bench_quant_k.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import torch
-import fp4quant
+import fp4quant_cuda as fp4quant
 from triton.tools.mxfp import MXFP4Tensor
 
 from bench_utils import bench_kineto

--- a/fastvideo-kernel/attn_qat_infer/quantization/bench/bench_quant_q.py
+++ b/fastvideo-kernel/attn_qat_infer/quantization/bench/bench_quant_q.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import torch
-import fp4quant
+import fp4quant_cuda as fp4quant
 from triton.tools.mxfp import MXFP4Tensor
 
 from bench_utils import bench_kineto

--- a/fastvideo-kernel/attn_qat_infer/quantization/bench/bench_quant_v.py
+++ b/fastvideo-kernel/attn_qat_infer/quantization/bench/bench_quant_v.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import torch
-import fp4quant
+import fp4quant_cuda as fp4quant
 from triton.tools.mxfp import MXFP4Tensor
 
 from bench_utils import bench_kineto

--- a/fastvideo-kernel/csrc/turbodiffusion/quant/quant.cu
+++ b/fastvideo-kernel/csrc/turbodiffusion/quant/quant.cu
@@ -63,7 +63,7 @@ auto quant(
 
     default: {
       std::cerr << "Observing: " << Input.scalar_type() << " for the input datatype which is invalid";
-      throw std::runtime_error("Unsupported input data type for quantize_to_fp4.");
+      throw std::runtime_error("Unsupported input data type for quant_cuda (int8 quantization).");
     }
   }
   

--- a/fastvideo-kernel/csrc/turbodiffusion/quant/quant.cu
+++ b/fastvideo-kernel/csrc/turbodiffusion/quant/quant.cu
@@ -31,6 +31,11 @@ auto quant(
   std::optional<torch::Tensor>& Output_S
 ) {
 
+  TORCH_CHECK(
+    Input.scalar_type() == torch::kHalf || Input.scalar_type() == torch::kBFloat16,
+    "Unsupported input data type for quant_cuda (int8 quantization)."
+  );
+
   using ElementOut = int8_t;
   static constexpr int BlockSize = 128;
   static constexpr int NumThrPerCta = 256;
@@ -62,8 +67,7 @@ auto quant(
     }
 
     default: {
-      std::cerr << "Observing: " << Input.scalar_type() << " for the input datatype which is invalid";
-      throw std::runtime_error("Unsupported input data type for quant_cuda (int8 quantization).");
+      TORCH_CHECK(false, "Unsupported input data type for quant_cuda (int8 quantization).");
     }
   }
   

--- a/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/attn_qat_train.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/attn_qat_train.py
@@ -1054,6 +1054,13 @@ class _attention(torch.autograd.Function):
         use_global_sf_P=True,
         use_global_sf_QKV=True,
     ):
+        if smooth_q:
+            # The backward path needs triton_group_mean (attn_qat_infer),
+            # whose import is currently disabled; fail fast instead of
+            # crashing mid-backward on a None q_m.
+            raise NotImplementedError("smooth_q=True is not supported: it requires "
+                                      "triton_group_mean from attn_qat_infer, which is currently disabled")
+
         # shape constraints
         HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]
         # when v is in float8_e5m2 it is transposed.
@@ -1364,10 +1371,8 @@ class _attention(torch.autograd.Function):
                                        BLOCK_M=PRE_BLOCK,
                                        HEAD_DIM=ctx.HEAD_DIM)
 
+        # smooth_q is rejected in forward(); ctx.smooth_q is always False here.
         q_m = None
-        if ctx.smooth_q:
-            # _, q_m = triton_group_mean(q)
-            q_m = q_m.repeat_interleave(q.shape[2] // q_m.shape[2], dim=2)  # B,H,L,D
 
         sm100_optimized_backward = (getattr(ctx, "sm100_optimized", False) and ctx.use_qat_qkv_backward
                                     and not ctx.smooth_k and not ctx.smooth_q and N_CTX_KV % 16 == 0)

--- a/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/attn_qat_train.py
+++ b/fastvideo-kernel/python/fastvideo_kernel/triton_kernels/attn_qat_train.py
@@ -1055,11 +1055,13 @@ class _attention(torch.autograd.Function):
         use_global_sf_QKV=True,
     ):
         if smooth_q:
-            # The backward path needs triton_group_mean (attn_qat_infer),
-            # whose import is currently disabled; fail fast instead of
-            # crashing mid-backward on a None q_m.
-            raise NotImplementedError("smooth_q=True is not supported: it requires "
-                                      "triton_group_mean from attn_qat_infer, which is currently disabled")
+            # Not implemented, not merely disabled: only the backward kernels
+            # carry a SMOOTH_Q path (_attn_fwd has none), so restoring the
+            # triton_group_mean wiring would yield silently wrong gradients
+            # rather than a feature. The flag is kept for signature
+            # compatibility only.
+            raise NotImplementedError("smooth_q=True is not supported: the forward kernel has no "
+                                      "SMOOTH_Q path, so enabling it would produce incorrect gradients")
 
         # shape constraints
         HEAD_DIM_Q, HEAD_DIM_K = q.shape[-1], k.shape[-1]

--- a/fastvideo-kernel/tests/test_attn_qat_train.py
+++ b/fastvideo-kernel/tests/test_attn_qat_train.py
@@ -4,6 +4,7 @@ Simple test for attn_qat_train.
 Tests forward and backward passes with and without QAT enabled.
 """
 
+import pytest
 import torch
 from fastvideo_kernel.triton_kernels.attn_qat_train import _attention
 from fastvideo_kernel.triton_kernels.fused_attention import attention as fused_attention
@@ -11,6 +12,27 @@ from math import sqrt
 
 attention = _attention.apply
 DEVICE = torch.device("cuda")
+
+
+def test_smooth_q_fails_before_tensor_or_kernel_work():
+    dummy = torch.empty((1, 1, 1, 16))
+
+    with pytest.raises(NotImplementedError, match="smooth_q=True is not supported"):
+        attention(
+            dummy,
+            dummy,
+            dummy,
+            False,
+            1.0,
+            True,
+            True,
+            True,
+            True,
+            True,
+            True,
+            False,
+            True,
+        )
 
 
 def attn_qat_train_wrapper(q_BLHD, k_BLHD, v_BLHD, is_causal=False, sm_scale=None):

--- a/fastvideo-kernel/tests/test_nvfp4_benchmark_imports.py
+++ b/fastvideo-kernel/tests/test_nvfp4_benchmark_imports.py
@@ -1,0 +1,21 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+BENCH_DIR = Path(__file__).resolve().parents[1] / "attn_qat_infer" / "quantization" / "bench"
+
+
+@pytest.mark.parametrize("script_name", ["bench_quant_q.py", "bench_quant_k.py", "bench_quant_v.py"])
+def test_quant_benchmark_imports_built_extension(script_name: str) -> None:
+    tree = ast.parse((BENCH_DIR / script_name).read_text())
+    imports = {
+        (alias.name, alias.asname)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    }
+
+    assert ("fp4quant_cuda", "fp4quant") in imports
+    assert ("fp4quant", None) not in imports

--- a/fastvideo-kernel/tests/test_turbodiffusion.py
+++ b/fastvideo-kernel/tests/test_turbodiffusion.py
@@ -26,6 +26,14 @@ def rms_norm_ref(x, w, eps=1e-6):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 class TestTurboDiffusion:
 
+    def test_quant_invalid_dtype_names_int8_operation(self):
+        if turbodiffusion_ops.quant_cuda is None:
+            pytest.skip("quant_cuda not available")
+
+        x = torch.ones((16, 128), dtype=torch.float32, device="cuda")
+        with pytest.raises(RuntimeError, match=r"Unsupported input data type for quant_cuda \(int8 quantization\)\."):
+            turbodiffusion_ops.quant_cuda(x, None, None)
+
     @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
     @pytest.mark.parametrize("shape", [(16, 128), (32, 256), (1, 1024)])
     def test_quant_correctness(self, dtype, shape):


### PR DESCRIPTION
## Purpose

Repair three defects in the NVFP4/QAT plumbing so the measurement tools fail correctly and the benchmark scripts import the extension they call. This is part of #1722, the preparation work for the DGX Spark QAT roadmap item in #1603.

## Changes

- Import `fp4quant_cuda` as `fp4quant` in the Q, K, and V quantization benchmarks. The call sites continue to use the extension's existing exported names.
- Correct the `quant_cuda` unsupported-dtype error so it identifies int8 quantization. Validate the dtype before allocating output tensors, which makes the error safe to observe from Python instead of entering an invalid native path.
- Reject `smooth_q=True` at the start of `_attention.forward`. The flag was never implemented end to end: only the backward kernels carry a `SMOOTH_Q` path (`_attn_fwd` has none), so the previous code dereferenced `None` in backward, and re-enabling the `triton_group_mean` wiring would produce silently wrong gradients rather than a working feature (thanks @alexzms). The error message and comment say so. The default `smooth_q=False` path is unchanged.
- Add regression tests for all three behaviors.

## Validation

Run on an NVIDIA GB10 (compute capability 12.1) with CUDA 13:

```text
MAX_JOBS=2 ./fastvideo-kernel/build.sh
  built and installed fastvideo-kernel for sm_121

pytest fastvideo-kernel/tests/test_turbodiffusion.py -q
  27 passed

pytest fastvideo-kernel/tests/test_attn_qat_train.py -q
  24 passed

pytest fastvideo-kernel/tests/test_nvfp4_benchmark_imports.py -q
  3 passed

python -m py_compile <three benchmark scripts> attn_qat_train.py
  passed

pre-commit run --files <changed paths>
  filename check passed; fastvideo-kernel is intentionally excluded from the other hooks
```

The current build configuration does not compile the FP4 extension on compute capability 12.1, so the benchmark regression test validates the extension import contract statically. This PR repairs the measurement plumbing; it does not claim to enable the SM120-only FP4 kernels on GB10.

## Checklist

- [x] Added regression tests for each repaired path.
- [x] Built the native extension and ran the relevant GPU tests on GB10.
- [x] Ran the repository pre-commit entrypoint for every changed path.
- [x] No user-facing documentation changes are required for these internal kernel tools.