### PR TITLE
[perf] benchmark_attn_qat_train: device peak-TFLOPS table instead of silent RTX 5090 default

### DIFF
--- a/fastvideo-kernel/README.md
+++ b/fastvideo-kernel/README.md
@@ -145,8 +145,11 @@ python benchmarks/benchmark_attn_qat_train.py
 ```
 
 The benchmark reports both conventional attention FLOPs and the extra matrix
-multiplications executed by the QAT straight-through path. Override
-`--peak-tflops` when running on a GPU other than RTX 5090.
+multiplications executed by the QAT straight-through path. It resolves dense
+BF16 peak throughput for the full-GPU variants listed in
+`benchmarks/device_specs.py`. Unknown or partitioned devices still report
+timing and achieved TFLOPS, with MFU shown as `N/A`; pass a positive, finite
+`--peak-tflops` value to report MFU for those devices.
 
 The QAT kernel is entirely Triton and routes by architecture at runtime. SM100
 uses a large-tile forward and split 64x64 backward for the production

--- a/fastvideo-kernel/benchmarks/benchmark_attn_qat_train.py
+++ b/fastvideo-kernel/benchmarks/benchmark_attn_qat_train.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 
 import torch
 
-from device_specs import resolve_peak_tflops
+from device_specs import format_tflops_with_mfu, resolve_peak_tflops
 
 from fastvideo_kernel.triton_kernels.attn_qat_train import attention
 
@@ -62,14 +62,15 @@ def _format_result(
     timing_ms: tuple[float, float, float],
     algorithmic_flops: int,
     executed_matmul_flops: int,
-    peak_tflops: float,
+    peak_tflops: float | None,
 ) -> str:
     median_ms, min_ms, max_ms = timing_ms
     algorithmic_tflops = algorithmic_flops / (median_ms * 1e9)
     executed_tflops = executed_matmul_flops / (median_ms * 1e9)
+    algorithmic_result = format_tflops_with_mfu(algorithmic_tflops, peak_tflops)
+    executed_result = format_tflops_with_mfu(executed_tflops, peak_tflops)
     return (f"{label}: {median_ms:.3f} ms (min={min_ms:.3f}, max={max_ms:.3f}), "
-            f"algorithmic={algorithmic_tflops:.2f} TFLOPS/{100 * algorithmic_tflops / peak_tflops:.2f}% MFU, "
-            f"executed_matmul={executed_tflops:.2f} TFLOPS/{100 * executed_tflops / peak_tflops:.2f}% MFU")
+            f"algorithmic={algorithmic_result}, executed_matmul={executed_result}")
 
 
 def main() -> None:
@@ -86,7 +87,7 @@ def main() -> None:
         type=float,
         default=None,
         help="Dense BF16 Tensor TFLOPS with FP32 accumulation. Defaults to the "
-        "device table in device_specs.py; required for devices not listed there.",
+        "device table in device_specs.py. Unknown devices report MFU as N/A.",
     )
     args = parser.parse_args()
     kv_length = args.kv_length or args.query_length
@@ -119,7 +120,10 @@ def main() -> None:
     # QAT additionally computes the STE high-precision P@V path in forward and
     # the quantized-P dV path in backward, for 6*base and 14*base matmul FLOPs.
     print(f"device: {device_name}")
-    print(f"peak: {peak_tflops:.1f} dense BF16 TFLOPS ({peak_source})")
+    if peak_tflops is None:
+        print(f"peak: unavailable ({peak_source})")
+    else:
+        print(f"peak: {peak_tflops:.2f} dense BF16 TFLOPS ({peak_source})")
     print(f"q: {q_shape}; k/v: {kv_shape}; compile+first-forward: {compile_seconds:.3f} s")
     print(_format_result("forward", forward_ms, 4 * base_flops, 6 * base_flops, peak_tflops))
     print(_format_result("backward", backward_ms, 10 * base_flops, 14 * base_flops, peak_tflops))

--- a/fastvideo-kernel/benchmarks/benchmark_attn_qat_train.py
+++ b/fastvideo-kernel/benchmarks/benchmark_attn_qat_train.py
@@ -14,9 +14,9 @@ from collections.abc import Callable
 
 import torch
 
-from fastvideo_kernel.triton_kernels.attn_qat_train import attention
+from device_specs import resolve_peak_tflops
 
-RTX_5090_DENSE_BF16_TFLOPS = 209.5
+from fastvideo_kernel.triton_kernels.attn_qat_train import attention
 
 
 def _qat_attention(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
@@ -84,11 +84,15 @@ def main() -> None:
     parser.add_argument(
         "--peak-tflops",
         type=float,
-        default=RTX_5090_DENSE_BF16_TFLOPS,
-        help="Dense BF16 Tensor TFLOPS with FP32 accumulation; default is RTX 5090 boost-clock peak.",
+        default=None,
+        help="Dense BF16 Tensor TFLOPS with FP32 accumulation. Defaults to the "
+        "device table in device_specs.py; required for devices not listed there.",
     )
     args = parser.parse_args()
     kv_length = args.kv_length or args.query_length
+
+    device_name = torch.cuda.get_device_name()
+    peak_tflops, peak_source = resolve_peak_tflops(device_name, args.peak_tflops)
 
     torch.manual_seed(0)
     q_shape = (args.batch_size, args.heads, args.query_length, args.head_dim)
@@ -114,10 +118,11 @@ def main() -> None:
     # Conventional attention FLOPs are 4*base forward and 10*base backward.
     # QAT additionally computes the STE high-precision P@V path in forward and
     # the quantized-P dV path in backward, for 6*base and 14*base matmul FLOPs.
-    print(f"device: {torch.cuda.get_device_name()}")
+    print(f"device: {device_name}")
+    print(f"peak: {peak_tflops:.1f} dense BF16 TFLOPS ({peak_source})")
     print(f"q: {q_shape}; k/v: {kv_shape}; compile+first-forward: {compile_seconds:.3f} s")
-    print(_format_result("forward", forward_ms, 4 * base_flops, 6 * base_flops, args.peak_tflops))
-    print(_format_result("backward", backward_ms, 10 * base_flops, 14 * base_flops, args.peak_tflops))
+    print(_format_result("forward", forward_ms, 4 * base_flops, 6 * base_flops, peak_tflops))
+    print(_format_result("backward", backward_ms, 10 * base_flops, 14 * base_flops, peak_tflops))
 
 
 if __name__ == "__main__":

--- a/fastvideo-kernel/benchmarks/device_specs.py
+++ b/fastvideo-kernel/benchmarks/device_specs.py
@@ -1,37 +1,56 @@
 # SPDX-License-Identifier: Apache-2.0
 """Per-device peak throughput used to turn benchmark timings into %MFU.
 
-Values are dense (non-sparse) BF16 Tensor Core TFLOPS with FP32 accumulation,
-from vendor datasheets. Only devices with well-established numbers are listed;
-for anything else pass an explicit override (--peak-tflops in the benchmarks)
-rather than silently assuming another GPU's peak.
+Values are dense (non-sparse) BF16 Tensor Core TFLOPS with FP32 accumulation.
+Only unambiguous full-GPU names with published peaks are listed. Timings and
+achieved TFLOPS remain useful on other devices, so unknown devices report MFU
+as unavailable unless the user supplies an explicit peak.
 """
 
 from __future__ import annotations
 
-# Keyed by substring of torch.cuda.get_device_name(). First match wins;
-# more specific names must come before less specific ones.
+import math
+
+# Exact torch.cuda.get_device_name() values for supported full GPUs. H100 form
+# factors have different published peaks, and exact matching also prevents MIG,
+# vGPU, or future variants from silently inheriting a full-GPU denominator.
 DENSE_BF16_TFLOPS: dict[str, float] = {
-    "RTX 5090": 209.5,  # boost clock; matches the value this benchmark historically used
-    "H100": 989.0,
-    "A100": 312.0,
-    "L40S": 362.0,
+    "NVIDIA H100 80GB HBM3": 989.0,
+    "NVIDIA H100 NVL": 835.5,
+    "NVIDIA H100 PCIe": 756.5,
+    "NVIDIA GeForce RTX 5090": 209.5,  # Matches the value this benchmark historically used.
+    "NVIDIA A100-SXM4-80GB": 312.0,
+    "NVIDIA A100-SXM4-40GB": 312.0,
+    "NVIDIA A100-PCIE-80GB": 312.0,
+    "NVIDIA A100-PCIE-40GB": 312.0,
+    "NVIDIA L40S": 362.05,
 }
 
 
-def resolve_peak_tflops(device_name: str, override: float | None = None) -> tuple[float, str]:
+def resolve_peak_tflops(device_name: str, override: float | None = None) -> tuple[float | None, str]:
     """Return (peak_tflops, source_description) for *device_name*.
 
-    An explicit *override* always wins. An unknown device without an override
-    raises instead of guessing, since %MFU against the wrong peak is worse
-    than no %MFU at all.
+    An explicit positive, finite *override* always wins. Unknown and partitioned
+    devices return ``None`` so the benchmark can still report timing and
+    achieved TFLOPS without presenting a misleading MFU value.
     """
     if override is not None:
-        return override, "explicit --peak-tflops override"
-    for key, tflops in DENSE_BF16_TFLOPS.items():
-        if key in device_name:
-            return tflops, f"device table entry {key!r}"
-    known = ", ".join(DENSE_BF16_TFLOPS)
-    raise ValueError(f"No dense BF16 peak-TFLOPS entry for device {device_name!r} "
-                     f"(known: {known}). Pass --peak-tflops explicitly, or add the "
-                     "device to DENSE_BF16_TFLOPS in benchmarks/device_specs.py.")
+        if not math.isfinite(override) or override <= 0:
+            raise ValueError("--peak-tflops must be finite and greater than zero")
+        return float(override), "explicit --peak-tflops override"
+
+    normalized_name = device_name.strip()
+    if "MIG" in normalized_name.upper():
+        return None, "MIG/partitioned device; pass --peak-tflops for this partition to report MFU"
+
+    if normalized_name in DENSE_BF16_TFLOPS:
+        return DENSE_BF16_TFLOPS[normalized_name], f"exact device table entry {normalized_name!r}"
+
+    return None, f"no dense BF16 peak for {device_name!r}; pass --peak-tflops to report MFU"
+
+
+def format_tflops_with_mfu(achieved_tflops: float, peak_tflops: float | None) -> str:
+    """Format achieved throughput, including MFU only when its denominator is known."""
+    if peak_tflops is None:
+        return f"{achieved_tflops:.2f} TFLOPS/MFU N/A"
+    return f"{achieved_tflops:.2f} TFLOPS/{100 * achieved_tflops / peak_tflops:.2f}% MFU"

--- a/fastvideo-kernel/benchmarks/device_specs.py
+++ b/fastvideo-kernel/benchmarks/device_specs.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-device peak throughput used to turn benchmark timings into %MFU.
+
+Values are dense (non-sparse) BF16 Tensor Core TFLOPS with FP32 accumulation,
+from vendor datasheets. Only devices with well-established numbers are listed;
+for anything else pass an explicit override (--peak-tflops in the benchmarks)
+rather than silently assuming another GPU's peak.
+"""
+
+from __future__ import annotations
+
+# Keyed by substring of torch.cuda.get_device_name(). First match wins;
+# more specific names must come before less specific ones.
+DENSE_BF16_TFLOPS: dict[str, float] = {
+    "RTX 5090": 209.5,  # boost clock; matches the value this benchmark historically used
+    "H100": 989.0,
+    "A100": 312.0,
+    "L40S": 362.0,
+}
+
+
+def resolve_peak_tflops(device_name: str, override: float | None = None) -> tuple[float, str]:
+    """Return (peak_tflops, source_description) for *device_name*.
+
+    An explicit *override* always wins. An unknown device without an override
+    raises instead of guessing, since %MFU against the wrong peak is worse
+    than no %MFU at all.
+    """
+    if override is not None:
+        return override, "explicit --peak-tflops override"
+    for key, tflops in DENSE_BF16_TFLOPS.items():
+        if key in device_name:
+            return tflops, f"device table entry {key!r}"
+    known = ", ".join(DENSE_BF16_TFLOPS)
+    raise ValueError(f"No dense BF16 peak-TFLOPS entry for device {device_name!r} "
+                     f"(known: {known}). Pass --peak-tflops explicitly, or add the "
+                     "device to DENSE_BF16_TFLOPS in benchmarks/device_specs.py.")

--- a/fastvideo-kernel/tests/test_device_specs.py
+++ b/fastvideo-kernel/tests/test_device_specs.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only tests for benchmarks/device_specs.py (no torch, no GPU)."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "benchmarks"))
+
+from device_specs import DENSE_BF16_TFLOPS, resolve_peak_tflops  # noqa: E402
+
+
+def test_known_devices_resolve_from_table():
+    tflops, source = resolve_peak_tflops("NVIDIA GeForce RTX 5090")
+    assert tflops == DENSE_BF16_TFLOPS["RTX 5090"]
+    assert "RTX 5090" in source
+
+    tflops, source = resolve_peak_tflops("NVIDIA L40S")
+    assert tflops == DENSE_BF16_TFLOPS["L40S"]
+    assert "L40S" in source
+
+
+def test_override_wins_even_for_known_device():
+    tflops, source = resolve_peak_tflops("NVIDIA H100 80GB HBM3", override=123.4)
+    assert tflops == 123.4
+    assert "override" in source
+
+
+def test_unknown_device_without_override_raises_with_guidance():
+    with pytest.raises(ValueError, match="peak-tflops"):
+        resolve_peak_tflops("NVIDIA GB10")
+
+
+def test_unknown_device_with_override_resolves():
+    tflops, source = resolve_peak_tflops("NVIDIA GB10", override=99.0)
+    assert tflops == 99.0
+    assert "override" in source

--- a/fastvideo-kernel/tests/test_device_specs.py
+++ b/fastvideo-kernel/tests/test_device_specs.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CPU-only tests for benchmarks/device_specs.py (no torch, no GPU)."""
+"""CPU-only tests for benchmarks/device_specs.py (no torch or GPU required)."""
 
+import math
 import os
 import sys
 
@@ -8,17 +9,25 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "benchmarks"))
 
-from device_specs import DENSE_BF16_TFLOPS, resolve_peak_tflops  # noqa: E402
+from device_specs import DENSE_BF16_TFLOPS, format_tflops_with_mfu, resolve_peak_tflops  # noqa: E402
 
 
-def test_known_devices_resolve_from_table():
-    tflops, source = resolve_peak_tflops("NVIDIA GeForce RTX 5090")
-    assert tflops == DENSE_BF16_TFLOPS["RTX 5090"]
-    assert "RTX 5090" in source
-
-    tflops, source = resolve_peak_tflops("NVIDIA L40S")
-    assert tflops == DENSE_BF16_TFLOPS["L40S"]
-    assert "L40S" in source
+@pytest.mark.parametrize(
+    "device_name",
+    [
+        "NVIDIA GeForce RTX 5090",
+        "NVIDIA H100 80GB HBM3",
+        "NVIDIA H100 NVL",
+        "NVIDIA H100 PCIe",
+        "NVIDIA A100-SXM4-80GB",
+        "NVIDIA A100-PCIE-40GB",
+        "NVIDIA L40S",
+    ],
+)
+def test_known_full_gpus_resolve_from_table(device_name):
+    tflops, source = resolve_peak_tflops(device_name)
+    assert tflops == DENSE_BF16_TFLOPS[device_name]
+    assert device_name in source
 
 
 def test_override_wins_even_for_known_device():
@@ -27,12 +36,33 @@ def test_override_wins_even_for_known_device():
     assert "override" in source
 
 
-def test_unknown_device_without_override_raises_with_guidance():
-    with pytest.raises(ValueError, match="peak-tflops"):
-        resolve_peak_tflops("NVIDIA GB10")
+@pytest.mark.parametrize(
+    "device_name",
+    [
+        "NVIDIA GB10",
+        "NVIDIA H100",
+        "NVIDIA H100 80GB HBM3 MIG 1g.10gb",
+        "NVIDIA A100-SXM4-80GB MIG 1g.10gb",
+    ],
+)
+def test_unknown_or_partitioned_device_keeps_benchmark_available(device_name):
+    tflops, source = resolve_peak_tflops(device_name)
+    assert tflops is None
+    assert "peak-tflops" in source
 
 
 def test_unknown_device_with_override_resolves():
     tflops, source = resolve_peak_tflops("NVIDIA GB10", override=99.0)
     assert tflops == 99.0
     assert "override" in source
+
+
+@pytest.mark.parametrize("override", [0.0, -1.0, math.nan, math.inf, -math.inf])
+def test_override_must_be_positive_and_finite(override):
+    with pytest.raises(ValueError, match="finite and greater than zero"):
+        resolve_peak_tflops("NVIDIA GB10", override=override)
+
+
+def test_format_tflops_reports_mfu_only_with_a_valid_denominator():
+    assert format_tflops_with_mfu(123.456, None) == "123.46 TFLOPS/MFU N/A"
+    assert format_tflops_with_mfu(123.456, 200.0) == "123.46 TFLOPS/61.73% MFU"


### PR DESCRIPTION
## Purpose

Make the Attn-QAT benchmark's %MFU trustworthy across GPUs. It computed MFU against a hardcoded `RTX_5090_DENSE_BF16_TFLOPS = 209.5` on every device unless the user knew to pass `--peak-tflops` — numbers that look plausible and are wrong on H100/L40S/GB10. With GB10 baselines underway (#1632) and the #1603 roadmap item "Optimize nvfp4 QAT kernel for DGX Spark", cross-device MFU comparison is about to matter. Part of #1722.

## Changes

- New `fastvideo-kernel/benchmarks/device_specs.py`: dense BF16 TFLOPS table keyed by **exact** `torch.cuda.get_device_name()` (H100 80GB HBM3: 989 / H100 NVL: 835.5 / H100 PCIe: 756.5 / RTX 5090: 209.5 — the benchmark's historical value / A100 SXM4 & PCIe variants: 312 / L40S: 362.05), plus `resolve_peak_tflops(device_name, override)`:
  - explicit, positive, finite `--peak-tflops` always wins (invalid values are rejected),
  - exact known device → table value,
  - unknown or MIG/partitioned device → timing and achieved TFLOPS still reported, MFU shown as `N/A` with guidance, instead of a wrong %MFU.
  (Exact matching, the H100 form-factor split, MIG handling, and override validation were added by @SolitaryThinker in c76ba0af — the original substring table would have matched `H100 PCIe` against the SXM peak, as @alexzms noted.)
- `benchmark_attn_qat_train.py` auto-resolves from the device name and prints which peak it used and why (`peak: 362.05 dense BF16 TFLOPS (exact device table entry 'NVIDIA L40S')`, or `peak: unavailable (...)`).
- `fastvideo-kernel/README.md` documents the behavior.
- **GB10/GB200 entries deliberately absent** — no guessed numbers; validated entries are what #1722's DGX Spark access request is for.
- Behavior on RTX 5090 is unchanged (resolved value identical to the old constant); other known GPUs previously got the 5090 default silently, now get their correct peak.

## Test Plan

```bash
pytest fastvideo-kernel/tests/test_device_specs.py -v   # CPU-only, no torch/GPU needed
python -m py_compile fastvideo-kernel/benchmarks/{device_specs,benchmark_attn_qat_train}.py
```

## Test Results

<details>
<summary>Test output</summary>

```
test_device_specs.py: exact lookups for every listed GPU (incl. the three H100 variants),
override precedence + validation (0, negative, nan, inf rejected), unknown/MIG -> MFU N/A,
format_tflops_with_mfu — all passing locally; kernel-tests CI lane green on the current head.
py_compile: OK
```

</details>

Developed on Apple Silicon — an end-to-end benchmark run needs a CUDA box; the only output change there is the new header line(s).

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues (`fastvideo-kernel/` is pre-commit-excluded; style kept consistent by hand)
- [x] I added or updated tests for my changes (CPU-only tests in `test_device_specs.py`)
- [x] I updated documentation if needed (`fastvideo-kernel/README.md`, module docstring)
- [x] I considered GPU memory impact of my changes (none — host-side arithmetic only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)