### PR TITLE
[feat]: Add MiniMax H3 T2VA LoRA tuning

### DIFF
--- a/examples/train/configs/overfit_minimax_h3_t2va_lora.yaml
+++ b/examples/train/configs/overfit_minimax_h3_t2va_lora.yaml
@@ -1,0 +1,98 @@
+# MiniMax H3 T2VA 400-step overfit experiment on one Crush-Smol record.
+#
+# Submit eight H200 nodes through the fixed launch script:
+#   bash examples/train/launch_minimax_h3_t2va_lora_crush_smol_validation.sh
+
+models:
+  student:
+    _target_: fastvideo.train.models.minimax_h3.minimax_h3.MiniMaxH3LoraModel
+    init_from: data/models/MiniMax-H3
+    trainable: true
+    enable_gradient_checkpointing_type: full
+    attention_backend: TORCH_SDPA
+    lora:
+      enable: true
+      rank: 32
+      alpha: 32
+      target_modules:
+        - attn.to_q
+        - attn.to_k
+        - attn.to_v
+        - attn.to_out
+        - ff.fc_in
+        - ff.fc_out
+    expected_lora_layers: 312
+
+method:
+  _target_: fastvideo.train.methods.fine_tuning.finetune.FineTuneMethod
+
+training:
+  distributed:
+    num_gpus: 64
+    sp_size: 8
+    tp_size: 1
+    hsdp_replicate_dim: 8
+    hsdp_shard_dim: 8
+    pin_cpu_memory: true
+
+  data:
+    data_path:
+      data/crush-smol_h3_t2va_single_sample_preprocessed: 8
+    preprocessed_data_type: t2va
+    dataloader_num_workers: 0
+    train_batch_size: 1
+    training_cfg_rate: 0.0
+    seed: 42
+    num_latent_t: 37
+    num_height: 768
+    num_width: 1344
+    num_frames: 124
+
+  optimizer:
+    learning_rate: 5.0e-4
+    betas: [0.9, 0.999]
+    weight_decay: 0.0
+    lr_scheduler: constant
+    lr_warmup_steps: 0
+
+  loop:
+    max_train_steps: 400
+    gradient_accumulation_steps: 1
+
+  checkpoint:
+    output_dir: runs/minimax_h3_t2va_lora_crush_smol_single_sample_overfit/checkpoints
+    training_state_checkpointing_steps: 20
+    checkpoints_total_limit: 2
+    resume_from_checkpoint: ""
+
+  tracker:
+    trackers: [wandb]
+    project_name: fastvideo_minimax_h3
+    run_name: minimax_h3_t2va_lora_crush_smol_single_sample_overfit
+
+  model:
+    precondition_outputs: false
+    enable_gradient_checkpointing_type: full
+
+  dit_precision: bf16
+
+callbacks:
+  grad_clip:
+    _target_: fastvideo.train.callbacks.grad_clip.GradNormClipCallback
+    max_grad_norm: 1.0
+  validation:
+    _target_: fastvideo.train.callbacks.validation.ValidationCallback
+    pipeline_target: fastvideo.pipelines.basic.minimax_h3.minimax_h3_pipeline.MiniMaxH3Pipeline
+    dataset_file: examples/training/finetune/Wan2.1-Fun-1.3B-InP/crush_smol/validation.json
+    every_steps: 20
+    run_at_start: true
+    sampling_steps: [50]
+    guidance_scale: 1.0
+    num_frames: 124
+    num_videos_per_prompt: 1
+    use_validation_media_conditioning: false
+    offload_training_state: true
+    text_encoder_cpu_offload: true
+    vae_cpu_offload: true
+
+pipeline: {}

--- a/examples/train/launch_minimax_h3_t2va_lora_crush_smol_validation.sh
+++ b/examples/train/launch_minimax_h3_t2va_lora_crush_smol_validation.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Submit the 400-step MiniMax H3 single-sample LoRA experiment on eight H200 nodes.
+
+set -euo pipefail
+set +x
+
+WORKTREE_ROOT=/mnt/weka/shrd/wm/junda/fv-hub/fastvideo-add-h3-sft
+ENV_FILE=/mnt/weka/shrd/wm/junda/fv-hub/.env
+CONFIG_FILE="${WORKTREE_ROOT}/examples/train/configs/overfit_minimax_h3_t2va_lora.yaml"
+PROMPT_FILE="${WORKTREE_ROOT}/examples/training/finetune/Wan2.1-Fun-1.3B-InP/crush_smol/validation.json"
+DATASET_MANIFEST="${WORKTREE_ROOT}/data/crush-smol/videos2caption.json"
+TRAINING_VIDEO="${WORKTREE_ROOT}/data/crush-smol/videos/1gGQy4nxyUo-Scene-016.mp4"
+TRAINING_PARQUET="${WORKTREE_ROOT}/data/crush-smol_h3_t2va_single_sample_preprocessed/data_00000.parquet"
+MODEL_INDEX="${WORKTREE_ROOT}/data/models/MiniMax-H3/model_index.json"
+RESULT_DIR="${WORKTREE_ROOT}/runs/minimax_h3_t2va_lora_crush_smol_single_sample_overfit"
+SNAPSHOT_DIR="${RESULT_DIR}/snapshot"
+VENV_BIN=/mnt/weka/shrd/wm/junda/fv-hub/.venv/bin
+
+[[ -f "${ENV_FILE}" ]] || { echo "Missing environment file: ${ENV_FILE}" >&2; exit 1; }
+[[ -f "${CONFIG_FILE}" ]] || { echo "Missing experiment config: ${CONFIG_FILE}" >&2; exit 1; }
+[[ -f "${PROMPT_FILE}" ]] || { echo "Missing validation prompts: ${PROMPT_FILE}" >&2; exit 1; }
+[[ -f "${DATASET_MANIFEST}" ]] || { echo "Missing Crush-Smol manifest: ${DATASET_MANIFEST}" >&2; exit 1; }
+[[ -f "${TRAINING_VIDEO}" ]] || { echo "Missing Crush-Smol training video: ${TRAINING_VIDEO}" >&2; exit 1; }
+[[ -f "${TRAINING_PARQUET}" ]] || { echo "Missing training parquet: ${TRAINING_PARQUET}" >&2; exit 1; }
+[[ -f "${MODEL_INDEX}" ]] || { echo "Missing MiniMax H3 checkpoint: ${MODEL_INDEX}" >&2; exit 1; }
+[[ -x "${VENV_BIN}/python" ]] || { echo "Missing validation environment: ${VENV_BIN}" >&2; exit 1; }
+[[ -x "${VENV_BIN}/torchrun" ]] || { echo "Missing training environment: ${VENV_BIN}" >&2; exit 1; }
+
+set -a
+source "${ENV_FILE}"
+set +a
+: "${WANDB_API_KEY:?WANDB_API_KEY is required in ${ENV_FILE}}"
+
+export WANDB_MODE=online
+export PYTHONPATH="${WORKTREE_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+export PATH="${VENV_BIN}:${PATH}"
+export PARTITION=main
+export NUM_GPUS=8
+export CPUS_PER_TASK=128
+export MEM=1440G
+export JOB_NAME=minimax_h3_t2va_lora_crush_smol_single_sample_overfit
+export OUTPUT_DIR="${RESULT_DIR}/slurm"
+export SBATCH_CONSTRAINT=nvidia_h200
+export SBATCH_TIMELIMIT=72:00:00
+
+cd "${WORKTREE_ROOT}"
+"${VENV_BIN}/python" -m fastvideo.pipelines.preprocess.preprocess_minimax_h3_overfit \
+    --validate-only
+
+mkdir -p "${OUTPUT_DIR}" "${SNAPSHOT_DIR}"
+
+cp "${CONFIG_FILE}" "${SNAPSHOT_DIR}/experiment-config.yaml"
+cp "${PROMPT_FILE}" "${SNAPSHOT_DIR}/validation.json"
+cp "${WORKTREE_ROOT}/new-sft-plan-h3.md" "${SNAPSHOT_DIR}/implementation-plan.md"
+git rev-parse HEAD > "${SNAPSHOT_DIR}/source-revision.txt"
+git status --short > "${SNAPSHOT_DIR}/worktree-status.txt"
+git diff --binary > "${SNAPSHOT_DIR}/tracked-source.patch"
+git ls-files --modified --others --exclude-standard \
+    | awk '$0 !~ /^(archived|data|runs)\//' \
+    > "${SNAPSHOT_DIR}/source-files.txt"
+tar -czf "${SNAPSHOT_DIR}/source-files.tar.gz" \
+    -T "${SNAPSHOT_DIR}/source-files.txt"
+printf '%s\n' 'bash examples/train/launch_minimax_h3_t2va_lora_crush_smol_validation.sh' \
+    > "${SNAPSHOT_DIR}/launch-command.txt"
+
+echo "Experiment:   ${JOB_NAME}"
+echo "Allocation:   8 nodes, 64 NVIDIA H200 GPUs, 1024 CPUs, 11520 GiB host memory"
+echo "Result dir:   ${RESULT_DIR}"
+echo "W&B project:  fastvideo_minimax_h3"
+echo "W&B run:      minimax_h3_t2va_lora_crush_smol_single_sample_overfit"
+
+bash examples/train/run_slurm.sh "${CONFIG_FILE}" 8

--- a/fastvideo/train/models/minimax_h3/minimax_h3.py
+++ b/fastvideo/train/models/minimax_h3/minimax_h3.py
@@ -415,22 +415,14 @@ class MiniMaxH3LoraModel(MiniMaxH3Model):
     ) -> None:
         lora_config = LoraConfig.coerce(lora)
         if lora_config is None or not lora_config.enable:
-            raise ValueError(
-                "MiniMaxH3LoraModel requires models.student.lora.enable=true"
-            )
+            raise ValueError("MiniMaxH3LoraModel requires models.student.lora.enable=true")
         if not lora_config.target_modules:
-            raise ValueError(
-                "MiniMaxH3LoraModel requires a non-empty "
-                "models.student.lora.target_modules list"
-            )
+            raise ValueError("MiniMaxH3LoraModel requires a non-empty "
+                             "models.student.lora.target_modules list")
         if not trainable:
             raise ValueError("MiniMaxH3LoraModel requires trainable=true")
 
-        expected_layers = (
-            int(expected_lora_layers)
-            if expected_lora_layers is not None
-            else None
-        )
+        expected_layers = (int(expected_lora_layers) if expected_lora_layers is not None else None)
         if expected_layers is not None and expected_layers <= 0:
             raise ValueError("expected_lora_layers must be positive")
 
@@ -451,26 +443,17 @@ class MiniMaxH3LoraModel(MiniMaxH3Model):
         if not self._enable_lora_if_configured(self.transformer):
             raise RuntimeError("Failed to enable MiniMax H3 LoRA training")
 
-        if (
-            expected_layers is not None
-            and self._num_lora_layers != expected_layers
-        ):
-            raise ValueError(
-                "Unexpected MiniMax H3 LoRA layer count: "
-                f"expected {expected_layers}, got {self._num_lora_layers}"
-            )
+        if (expected_layers is not None and self._num_lora_layers != expected_layers):
+            raise ValueError("Unexpected MiniMax H3 LoRA layer count: "
+                             f"expected {expected_layers}, got {self._num_lora_layers}")
 
         unexpected_trainable = [
-            name
-            for name, parameter in self.transformer.named_parameters()
-            if parameter.requires_grad
-            and name.rsplit(".", maxsplit=1)[-1] not in {"lora_A", "lora_B"}
+            name for name, parameter in self.transformer.named_parameters()
+            if parameter.requires_grad and name.rsplit(".", maxsplit=1)[-1] not in {"lora_A", "lora_B"}
         ]
         if unexpected_trainable:
-            raise ValueError(
-                "MiniMax H3 LoRA enabled non-LoRA trainable parameters: "
-                f"{unexpected_trainable[:10]}"
-            )
+            raise ValueError("MiniMax H3 LoRA enabled non-LoRA trainable parameters: "
+                             f"{unexpected_trainable[:10]}")
 
 
 __all__ = ["MiniMaxH3LoraModel", "MiniMaxH3Model", "shift_noise_amount"]

--- a/fastvideo/train/models/minimax_h3/minimax_h3.py
+++ b/fastvideo/train/models/minimax_h3/minimax_h3.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MiniMax H3 joint text-to-video-and-audio training plugin."""
+"""MiniMax H3 joint text-to-video-and-audio training (full-tuning and LoRA tuning) plugin"""
 
 from __future__ import annotations
 
@@ -23,11 +23,11 @@ from fastvideo.pipelines.basic.minimax_h3.packing import (
     unpatchify_video_tokens,
 )
 from fastvideo.platforms import AttentionBackendEnum
-
 from fastvideo.train.models.base import ModelBase, NoisePrediction
 from fastvideo.train.utils.activation_checkpoint import apply_activation_checkpointing
 from fastvideo.train.utils.module_state import apply_trainable
 from fastvideo.train.utils.moduleloader import load_module_from_path
+from fastvideo.train.utils.lora import LoraConfig
 
 if TYPE_CHECKING:
     from fastvideo.train.utils.training_config import TrainingConfig
@@ -397,4 +397,80 @@ class MiniMaxH3Model(ModelBase):
             (loss / max(1, int(grad_accum_rounds))).backward()
 
 
-__all__ = ["MiniMaxH3Model", "shift_noise_amount"]
+class MiniMaxH3LoraModel(MiniMaxH3Model):
+    """Enable LoRA-only training for the MiniMax H3 transformer."""
+
+    def __init__(
+        self,
+        *,
+        init_from: str,
+        training_config: TrainingConfig,
+        trainable: bool = True,
+        disable_custom_init_weights: bool = False,
+        enable_gradient_checkpointing_type: str | None = None,
+        transformer_override_safetensor: str | None = None,
+        lora: LoraConfig | dict[str, Any] | None = None,
+        expected_lora_layers: int | None = None,
+        attention_backend: AttentionBackendEnum | str | None = AttentionBackendEnum.TORCH_SDPA,
+    ) -> None:
+        lora_config = LoraConfig.coerce(lora)
+        if lora_config is None or not lora_config.enable:
+            raise ValueError(
+                "MiniMaxH3LoraModel requires models.student.lora.enable=true"
+            )
+        if not lora_config.target_modules:
+            raise ValueError(
+                "MiniMaxH3LoraModel requires a non-empty "
+                "models.student.lora.target_modules list"
+            )
+        if not trainable:
+            raise ValueError("MiniMaxH3LoraModel requires trainable=true")
+
+        expected_layers = (
+            int(expected_lora_layers)
+            if expected_lora_layers is not None
+            else None
+        )
+        if expected_layers is not None and expected_layers <= 0:
+            raise ValueError("expected_lora_layers must be positive")
+
+        super().__init__(
+            init_from=init_from,
+            training_config=training_config,
+            trainable=trainable,
+            disable_custom_init_weights=disable_custom_init_weights,
+            enable_gradient_checkpointing_type=enable_gradient_checkpointing_type,
+            transformer_override_safetensor=transformer_override_safetensor,
+            attention_backend=attention_backend,
+        )
+
+        # MiniMaxH3Model intentionally remains unchanged. The LoRA-specific
+        # subclass activates the shared modular-training LoRA implementation
+        # only after the sharded transformer has been loaded.
+        self._lora_config = lora_config
+        if not self._enable_lora_if_configured(self.transformer):
+            raise RuntimeError("Failed to enable MiniMax H3 LoRA training")
+
+        if (
+            expected_layers is not None
+            and self._num_lora_layers != expected_layers
+        ):
+            raise ValueError(
+                "Unexpected MiniMax H3 LoRA layer count: "
+                f"expected {expected_layers}, got {self._num_lora_layers}"
+            )
+
+        unexpected_trainable = [
+            name
+            for name, parameter in self.transformer.named_parameters()
+            if parameter.requires_grad
+            and name.rsplit(".", maxsplit=1)[-1] not in {"lora_A", "lora_B"}
+        ]
+        if unexpected_trainable:
+            raise ValueError(
+                "MiniMax H3 LoRA enabled non-LoRA trainable parameters: "
+                f"{unexpected_trainable[:10]}"
+            )
+
+
+__all__ = ["MiniMaxH3LoraModel", "MiniMaxH3Model", "shift_noise_amount"]


### PR DESCRIPTION
## Purpose

Add LoRA-only tuning support for MiniMax H3 T2VA in FastVideo's modular training framework. This provides a dedicated overfit configuration and Slurm launcher for distributed MiniMax H3 LoRA training while keeping the base transformer parameters frozen.

## Changes

- Add `MiniMaxH3LoraModel` as a LoRA-specific subclass of `MiniMaxH3Model`
- Reuse the modular training framework's shared LoRA implementation
- Require LoRA to be enabled with an explicit target-module list
- Validate the expected number of LoRA-enabled layers
- Add a MiniMax H3 T2VA LoRA single-sample overfit configuration
- Add a dedicated eight-node H200 Slurm launch script
- Keep the existing full-tuning MiniMax H3 path unchanged

## Test Plan

```
git diff --check
python3 -c "import ast, pathlib; ast.parse(pathlib.Path('fastvideo/train/models/minimax_h3/minimax_h3.py').read_text())"
ruby -e "require 'yaml'; YAML.load_file('examples/train/configs/overfit_minimax_h3_t2va_lora.yaml')"
bash -n examples/train/launch_minimax_h3_t2va_lora_crush_smol_validation.sh
bash examples/train/launch_minimax_h3_t2va_lora_crush_smol_validation.sh
```

The LoRA training workflow was validated successfully on both single- and dual- eight-node H200 Slurm runs.


## Test Results

<img width="2446" height="1020" alt="image" src="https://github.com/user-attachments/assets/1b30d89d-796c-4c65-8ee0-dd3422774df4" />

## Checklist

- [ ] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model
