### PR TITLE
[feat] Add VQeval long-video quality metric

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "fastvideo/third_party/eval/vbench"]
 	path = fastvideo/third_party/eval/vbench
 	url = https://github.com/Vchitect/VBench.git
+[submodule "fastvideo/third_party/eval/vqeval"]
+	path = fastvideo/third_party/eval/vqeval
+	url = https://github.com/JiusiServe/LongVideoSparseAttention.git

--- a/fastvideo/eval/README.md
+++ b/fastvideo/eval/README.md
@@ -4,7 +4,8 @@ In-process evaluation suite for video generations. Includes pixel
 metrics (SSIM, PSNR, LPIPS), Fréchet Video Distance (FVD), optical-flow
 comparisons, the full VBench suite, Physics-IQ, audio metrics, an
 absolute VLM scorer (`videoscore2`), and a pairwise VLM judge
-(`judge.third_person_separation`) — all behind a single registry-driven API.
+(`judge.third_person_separation`), plus VQeval long-video failure scoring —
+all behind a single registry-driven API.
 
 ## Install
 
@@ -12,9 +13,10 @@ absolute VLM scorer (`videoscore2`), and a pairwise VLM judge
 |---|---|
 | Default (common, optical_flow, vbench, physics_iq, videoscore2) | `uv pip install -e .[eval]` |
 | Just VBench (11 of 16 by default; +4 with detectron2) | `uv pip install -e .[eval-vbench]` |
+| VQeval long-video composite | `uv pip install -e .[eval-vqeval]` |
 | Just Physics-IQ (covered by `[eval]`) | `uv pip install -e .[eval-physics-iq]` |
 | Audio metrics (CLAP, FAD, KL, WER, AudioBox, DeSync, ImageBind) | `uv pip install -e .[eval-audio]` |
-| Everything: `[eval]` + `[eval-audio]` + `vbench.scene` (AVoCaDO) | `uv pip install -e .[eval-full]` |
+| Everything: `[eval]` + `[eval-audio]` + `[eval-vqeval]` + `vbench.scene` | `uv pip install -e .[eval-full]` |
 | Optional faster video decode (x86_64 only; opt-in) | `uv pip install -e .[eval-fast-decode]` |
 
 `[eval-audio]` covers every `audio.*` metric. ImageBind
@@ -80,6 +82,38 @@ The submodule is a clean upstream pin. Compat with current
 transformers/numpy/timm versions is applied at import time in
 `fastvideo/eval/metrics/vbench/__init__.py` via attribute-level
 monkey-patches; the submodule files are unchanged.
+
+### VQeval long-video scoring
+
+`vqeval.composite` wraps the six VQeval dimensions behind one metric so
+CLIP, DINOv2, pyiqa, and optical-flow state are shared. The composite score is
+0–100 (higher is better); individual dimension scores and raw metrics are
+returned under `MetricResult.details["dimensions"]`.
+
+Pull the pinned source and install the optional dependencies:
+
+```bash
+git submodule update --init fastvideo/third_party/eval/vqeval
+uv pip install -e '.[eval-vqeval]'
+```
+
+Frame rate is required because VQeval scores every frame through five seconds
+and samples longer videos at approximately 2 fps. Text alignment is included
+only when `--text-prompt` is provided.
+
+```bash
+fastvideo eval run \
+    --videos outputs/*.mp4 \
+    --metrics vqeval.composite \
+    --fps 16 \
+    --text-prompt "A dog running through a forest" \
+    --output vqeval.json
+```
+
+The upstream source is pinned as a submodule rather than copied into FastVideo.
+The LVSA root license and VQeval package metadata say Apache-2.0, while the
+VQeval README says MIT; keeping an unmodified gitlink preserves the exact
+upstream provenance while that documentation inconsistency remains.
 
 ## Public API
 
@@ -197,12 +231,14 @@ fastvideo/
 │       ├── videoscore2/           # VideoScore-2 (Qwen2.5-VL)
 │       ├── judge/                 # pairwise VLM judges (third_person_separation)
 │       ├── physics_iq/            # PhysicsIQ + sub-metrics
-│       └── vbench/                # adapter: sys.path bootstrap + shims
-│           ├── __init__.py
-│           └── <16 sub-metric pkgs>
+│       ├── vbench/                # adapter: sys.path bootstrap + shims
+│       │   ├── __init__.py
+│       │   └── <16 sub-metric pkgs>
+│       └── vqeval/                 # shared six-dimension composite adapter
 └── third_party/
     └── eval/
         ├── vbench/                # git submodule (Vchitect/VBench)
+        ├── vqeval/                 # git submodule (JiusiServe/LVSA)
         ├── synchformer/           # vendored (MIT), used by audio.desync
         └── glmasr/                # vendored (Apache-2.0), used by audio.wer (glm_asr)
 ```

--- a/fastvideo/eval/metrics/vqeval/__init__.py
+++ b/fastvideo/eval/metrics/vqeval/__init__.py
@@ -1,0 +1,18 @@
+"""Bootstrap the pinned VQeval source tree.
+
+VQeval ships as a nested package in the LongVideoSparseAttention repository.
+FastVideo keeps that repository as a submodule and imports the package directly,
+matching the existing third-party evaluation convention without installing the
+upstream project's broad dependency list.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_UPSTREAM_ROOT = Path(__file__).resolve().parents[3] / "third_party" / "eval" / "vqeval"
+_UPSTREAM_PACKAGE_ROOT = _UPSTREAM_ROOT / "vqeval"
+
+if _UPSTREAM_PACKAGE_ROOT.is_dir() and str(_UPSTREAM_PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_UPSTREAM_PACKAGE_ROOT))

--- a/fastvideo/eval/metrics/vqeval/metric.py
+++ b/fastvideo/eval/metrics/vqeval/metric.py
@@ -1,0 +1,198 @@
+"""VQeval composite long-video quality metric.
+
+The upstream implementation exposes six evaluators that share CLIP, DINOv2,
+pyiqa, and optical-flow state. Registering one FastVideo metric preserves that
+sharing and returns the individual dimension results under ``details``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import numpy as np
+import torch
+
+from fastvideo.eval.metrics.base import BaseMetric
+from fastvideo.eval.registry import register
+from fastvideo.eval.types import MetricResult
+
+_UPSTREAM_COMMIT = "100666e06026b98dfdab39036d9013e02319b479"
+_EVALUATOR_MODULES = (
+    "spatial_quality",
+    "temporal_coherence",
+    "loop_quality",
+    "artifact_detection",
+    "dynamic_quality",
+    "text_alignment",
+)
+
+
+@register("vqeval.composite")
+class VQevalCompositeMetric(BaseMetric):
+    """Run VQeval's active dimensions and return its weighted composite.
+
+    ``sample["fps"]`` is required because VQeval samples long videos based on
+    duration and frame rate. ``sample["text_prompt"]`` is optional; when it is
+    absent, VQeval omits text alignment and redistributes its weight exactly as
+    the upstream pipeline does.
+    """
+
+    name = "vqeval.composite"
+    requires_reference = False
+    higher_is_better = True
+    # VQeval owns its model transfers. Keep FastVideo's input tensor on CPU
+    # because this adapter must first build VQeval's uint8 RGB/BGR buffers.
+    needs_gpu = False
+    dependencies = ["vqeval", "cv2", "open_clip", "pyiqa", "mediapipe"]
+    backbone = "vqeval_shared"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._registry: Any = None
+        self._config_cls: Any = None
+        self._video_data_cls: Any = None
+        self._video_meta_cls: Any = None
+        self._evaluator_classes: dict[str, Any] = {}
+
+    def to(self, device: str | torch.device) -> VQevalCompositeMetric:
+        target = torch.device(device)
+        if self._registry is not None and target != self.device:
+            self._registry.clear()
+            self._registry = None
+        super().to(target)
+        return self
+
+    def setup(self) -> None:
+        if self._registry is not None:
+            return
+
+        for module in _EVALUATOR_MODULES:
+            importlib.import_module(f"vqeval.evaluators.{module}")
+
+        from vqeval.core.config import EvalConfig
+        from vqeval.core.video_loader import VideoData, VideoMeta
+        from vqeval.evaluators.base import get_evaluator_class
+        from vqeval.models.model_registry import ModelRegistry
+
+        self._config_cls = EvalConfig
+        self._video_data_cls = VideoData
+        self._video_meta_cls = VideoMeta
+        self._evaluator_classes = {name: get_evaluator_class(name) for name in _EVALUATOR_MODULES}
+
+        # Upstream uses a process-global singleton. FastVideo can hold one eval
+        # worker per GPU in the same process, so each metric replica needs its
+        # own registry to avoid binding every worker to the first CUDA device.
+        registry = object.__new__(ModelRegistry)
+        registry._initialized = False
+        ModelRegistry.__init__(registry, device=str(self.device))
+        self._registry = registry
+
+    @torch.no_grad()
+    def compute(self, sample: dict) -> MetricResult:
+        video = sample.get("video")
+        if video is None:
+            return self._skip(sample, "missing video")
+        if not isinstance(video, torch.Tensor) or video.ndim != 4:
+            return self._skip(sample, "video must be a (T, C, H, W) tensor")
+        if video.shape[0] < 2 or video.shape[1] != 3:
+            return self._skip(sample, "video must contain at least two RGB frames")
+
+        fps_value = sample.get("fps")
+        if fps_value is None:
+            return self._skip(sample, "missing fps (required for VQeval frame sampling)")
+        fps = float(fps_value)
+        if fps <= 0:
+            return self._skip(sample, "fps must be greater than zero")
+
+        if self._registry is None:
+            self.setup()
+
+        prompt = sample.get("text_prompt")
+        source = str(sample.get("video_path", "<tensor>"))
+        upstream_video, sampled_indices = self._to_upstream_video(video, fps=fps, source=source)
+        config = self._config_cls(
+            video_path=source,
+            prompt=prompt,
+            device=str(self.device),
+        )
+
+        active_dimensions = config.get_active_dimensions()
+        weights = config.get_effective_weights()
+        dimension_results: dict[str, dict[str, Any]] = {}
+        weighted_sum = 0.0
+        total_weight = 0.0
+
+        for dimension in active_dimensions:
+            evaluator = self._evaluator_classes[dimension](config=config, model_registry=self._registry)
+            if not evaluator.is_applicable(upstream_video):
+                continue
+            result = evaluator.evaluate(upstream_video)
+            dimension_results[dimension] = {
+                "score": float(result.score),
+                "verdict": result.verdict,
+                "metrics": result.metrics,
+            }
+            weight = float(weights.get(dimension, 0.0))
+            weighted_sum += float(result.score) * weight
+            total_weight += weight
+
+        if not dimension_results or total_weight == 0:
+            return self._skip(sample, "no VQeval dimensions were applicable")
+
+        score = weighted_sum / total_weight
+        return MetricResult(
+            name=self.name,
+            score=score,
+            details={
+                "dimensions": dimension_results,
+                "weights": {
+                    name: float(weights[name])
+                    for name in dimension_results
+                },
+                "source_frames": int(video.shape[0]),
+                "sampled_frames": len(sampled_indices),
+                "sampled_indices": sampled_indices,
+                "fps": fps,
+                "upstream_commit": _UPSTREAM_COMMIT,
+            },
+        )
+
+    def _to_upstream_video(self, video: torch.Tensor, *, fps: float, source: str):
+        source_frames, _, height, width = video.shape
+        sampled_indices = _sample_indices(source_frames, fps)
+        sampled = video.detach()[sampled_indices].float().clamp(0, 1)
+        frames_rgb = (sampled.permute(0, 2, 3, 1).cpu().numpy() * 255.0).round().astype(np.uint8)
+        frames_bgr = frames_rgb[..., ::-1].copy()
+
+        meta = self._video_meta_cls(
+            path=source,
+            width=int(width),
+            height=int(height),
+            fps=fps,
+            total_frames=int(source_frames),
+            duration=float(source_frames / fps),
+            codec="",
+            has_audio=False,
+        )
+        return (
+            self._video_data_cls(
+                meta=meta,
+                frames=frames_bgr,
+                frame_indices=np.asarray(sampled_indices),
+                frames_rgb=frames_rgb,
+            ),
+            sampled_indices,
+        )
+
+
+def _sample_indices(total_frames: int, fps: float) -> list[int]:
+    """Match VQeval's default all-frames/2-fps sampling policy."""
+    duration = total_frames / fps
+    if duration <= 5.0:
+        return list(range(total_frames))
+
+    interval = max(1, int(fps / 2.0))
+    indices = set(range(0, total_frames, interval))
+    indices.update((0, total_frames - 1, total_frames // 2))
+    return sorted(indices)

--- a/fastvideo/eval/registry.py
+++ b/fastvideo/eval/registry.py
@@ -74,11 +74,16 @@ def _install_hint(metric_name: str, dep: str) -> str:
         return ("uv pip install 'fastvideo[eval-vbench]' && "
                 "uv pip install --no-build-isolation "
                 "'git+https://github.com/facebookresearch/detectron2.git'")
+    if dep == "vqeval":
+        return ("git submodule update --init fastvideo/third_party/eval/vqeval && "
+                "uv pip install -e '.[eval-vqeval]'")
     return f"uv pip install -e '.[{_extra_for(metric_name)}]'"
 
 
 def _extra_for(metric_name: str) -> str:
     """Map a metric name to the smallest extra that satisfies its deps."""
+    if metric_name.startswith("vqeval."):
+        return "eval-vqeval"
     if metric_name.startswith("vbench."):
         return "eval-vbench"
     if metric_name.startswith("physics_iq"):

--- a/fastvideo/tests/eval/test_vqeval_adapter.py
+++ b/fastvideo/tests/eval/test_vqeval_adapter.py
@@ -1,0 +1,205 @@
+"""CPU-only contract tests for the VQeval adapter.
+
+These tests never download or initialize CLIP, DINOv2, or pyiqa weights.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from fastvideo.eval.metrics.vqeval.metric import VQevalCompositeMetric, _sample_indices
+from fastvideo.eval.registry import _install_hint
+
+
+@dataclass
+class _FakeMeta:
+    path: str
+    width: int
+    height: int
+    fps: float
+    total_frames: int
+    duration: float
+    codec: str
+    has_audio: bool
+
+
+class _FakeVideoData:
+
+    def __init__(self, *, meta, frames, frame_indices, frames_rgb):
+        self.meta = meta
+        self.frames = frames
+        self.frame_indices = frame_indices
+        self.frames_rgb = frames_rgb
+
+
+class _FakeConfig:
+
+    def __init__(self, *, video_path, prompt, device):
+        self.video_path = video_path
+        self.prompt = prompt
+        self.device = device
+
+    def get_active_dimensions(self):
+        return ["spatial_quality", "loop_quality"]
+
+    def get_effective_weights(self):
+        return {"spatial_quality": 0.6, "loop_quality": 0.4}
+
+
+class _FakeEvaluator:
+
+    def __init__(self, *, config, model_registry, score):
+        self.config = config
+        self.model_registry = model_registry
+        self.score = score
+
+    def is_applicable(self, video):
+        return True
+
+    def evaluate(self, video):
+        return SimpleNamespace(score=self.score, verdict="good", metrics={"raw": self.score / 100.0})
+
+
+def _evaluator(score):
+
+    class BoundFakeEvaluator(_FakeEvaluator):
+
+        def __init__(self, **kwargs):
+            super().__init__(score=score, **kwargs)
+
+    return BoundFakeEvaluator
+
+
+def _mocked_metric() -> VQevalCompositeMetric:
+    metric = VQevalCompositeMetric()
+    metric._registry = object()
+    metric._config_cls = _FakeConfig
+    metric._video_data_cls = _FakeVideoData
+    metric._video_meta_cls = _FakeMeta
+    metric._evaluator_classes = {
+        "spatial_quality": _evaluator(80.0),
+        "loop_quality": _evaluator(40.0),
+    }
+    return metric
+
+
+def test_sample_indices_matches_upstream_policy():
+    assert _sample_indices(total_frames=50, fps=10.0) == list(range(50))
+    assert _sample_indices(total_frames=60, fps=10.0) == [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 59]
+
+
+def test_missing_upstream_hint_includes_submodule_and_extra():
+    hint = _install_hint("vqeval.composite", "vqeval")
+    assert "git submodule update --init fastvideo/third_party/eval/vqeval" in hint
+    assert ".[eval-vqeval]" in hint
+
+
+def test_composite_preserves_dimensions_and_sampling_metadata():
+    metric = _mocked_metric()
+    video = torch.zeros(60, 3, 2, 3)
+    video[:, 0] = 1.0
+
+    result = metric.compute({
+        "video": video,
+        "video_path": "fixture.mp4",
+        "fps": 10.0,
+        "text_prompt": "a red field",
+    })
+
+    assert result.name == "vqeval.composite"
+    assert result.score == pytest.approx(64.0)
+    assert set(result.details["dimensions"]) == {"spatial_quality", "loop_quality"}
+    assert result.details["source_frames"] == 60
+    assert result.details["sampled_frames"] == 13
+    assert result.details["fps"] == 10.0
+
+
+def test_tensor_conversion_is_uint8_bgr_and_keeps_rgb_cache():
+    metric = _mocked_metric()
+    video = torch.zeros(2, 3, 1, 1)
+    video[:, 0] = 1.0
+
+    upstream, indices = metric._to_upstream_video(video, fps=1.0, source="fixture.mp4")
+
+    assert indices == [0, 1]
+    assert upstream.frames.dtype == np.uint8
+    assert upstream.frames_rgb.dtype == np.uint8
+    assert upstream.frames[0, 0, 0].tolist() == [0, 0, 255]
+    assert upstream.frames_rgb[0, 0, 0].tolist() == [255, 0, 0]
+    assert upstream.meta.width == 1
+    assert upstream.meta.height == 1
+
+
+@pytest.mark.parametrize(
+    "sample,reason",
+    [
+        ({}, "missing video"),
+        ({"video": torch.zeros(2, 3, 2, 2)}, "missing fps"),
+        ({"video": torch.zeros(2, 3, 2, 2), "fps": 0}, "fps must be greater than zero"),
+        ({"video": torch.zeros(1, 3, 2, 2), "fps": 8}, "at least two RGB frames"),
+    ],
+)
+def test_invalid_input_skips_cleanly(sample, reason):
+    result = _mocked_metric().compute(sample)
+    assert result.score is None
+    assert reason in result.details["skipped"]
+
+
+def test_setup_is_lazy_and_does_not_load_models():
+    pytest.importorskip("cv2")
+    metric = VQevalCompositeMetric().to("cpu")
+    metric.setup()
+
+    assert metric._registry._models == {}
+    assert metric._registry._processors == {}
+    assert set(metric._evaluator_classes) == {
+        "spatial_quality",
+        "temporal_coherence",
+        "loop_quality",
+        "artifact_detection",
+        "dynamic_quality",
+        "text_alignment",
+    }
+
+
+def test_upstream_loop_dimension_separates_repetition_without_model_downloads():
+    pytest.importorskip("cv2")
+    metric = VQevalCompositeMetric().to("cpu")
+    metric.setup()
+
+    class FakeRegistry:
+
+        def __init__(self, embeddings):
+            self.embeddings = embeddings
+
+        def compute_clip_image_embeddings(self, tensors):
+            return self.embeddings
+
+        def compute_optical_flow(self, frame1, frame2):
+            return torch.zeros(1, 2, 4, 4)
+
+    def loop_score(embeddings):
+        video = torch.zeros(len(embeddings), 3, 4, 4)
+        upstream, _ = metric._to_upstream_video(video, fps=8.0, source="synthetic")
+        config = metric._config_cls(device="cpu")
+        evaluator = metric._evaluator_classes["loop_quality"](
+            config=config,
+            model_registry=FakeRegistry(embeddings),
+        )
+        return evaluator.evaluate(upstream).score
+
+    n_frames, embedding_dim = 24, 16
+    static = torch.zeros(n_frames, embedding_dim)
+    static[:, 0] = 1
+    periodic = torch.eye(4).repeat(6, 1)
+    generator = torch.Generator().manual_seed(7)
+    unique = torch.randn(n_frames, embedding_dim, generator=generator)
+    unique = unique / unique.norm(dim=-1, keepdim=True)
+
+    assert loop_score(static) < loop_score(unique)
+    assert loop_score(periodic) < loop_score(unique)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,14 @@ test = [
 # judge.* metrics (eval-judge) call a remote API and need a key, so they
 # are opt-in and intentionally kept out of the default [eval] set.
 eval-vbench     = ["openai-clip", "pyiqa", "easydict"]
+eval-vqeval = [
+    # VQeval uses the legacy mp.solutions API removed in MediaPipe 1.x.
+    "mediapipe>=0.10.0,<1",
+    "open_clip_torch>=2.24.0",
+    # Includes cv2 + quality.BRISQUE; MediaPipe depends on this same wheel.
+    "opencv-contrib-python>=4.8.0",
+    "pyiqa>=0.1.10",
+]
 eval-physics-iq = []
 eval-audio = ["jiwer", "librosa", "pyloudnorm", "hear21passt", "audiobox_aesthetics", "imagebind", "pytorchvideo"]
 eval-judge = ["google-genai"]
@@ -170,7 +178,7 @@ eval = [
     "fastvideo[eval-vbench]", "fastvideo[eval-physics-iq]",
 ]
 eval-fast-decode = ["decord"]
-eval-full = ["fastvideo[eval]", "fastvideo[eval-audio]", "qwen-omni-utils"]
+eval-full = ["fastvideo[eval]", "fastvideo[eval-audio]", "fastvideo[eval-vqeval]", "qwen-omni-utils"]
 
 dev = [ "fastvideo[lint]", "fastvideo[test]", ]
 


### PR DESCRIPTION
## Purpose

Add VQeval as an optional, registry-driven FastVideo metric for long-video
failure modes that generic consistency scores can miss, especially frozen or
periodically repeated output.

The integration pins the upstream implementation at
`100666e06026b98dfdab39036d9013e02319b479` and exposes its six dimensions
through one `vqeval.composite` metric so CLIP, DINOv2, pyiqa, and optical-flow
state are shared.

## Changes

- add the pinned JiusiServe/LongVideoSparseAttention source as a git submodule
- register `vqeval.composite` with lazy imports and a dedicated optional extra
- preserve the upstream sampling, weighting, and applicability behavior
- return every dimension and raw metric under `MetricResult.details`
- add CPU-only adapter, conversion, sampling, error-path, and synthetic loop tests
- document installation, CLI use, output shape, and upstream provenance

The upstream repository root and package metadata identify Apache-2.0, while
the nested VQeval README says MIT. This PR keeps the source unmodified as a
pinned gitlink and documents that metadata inconsistency.

## Test Plan

```bash
pre-commit run --all-files
MPLBACKEND=Agg pytest fastvideo/tests/eval/test_vqeval_adapter.py -q
MPLBACKEND=Agg pytest fastvideo/third_party/eval/vqeval/vqeval/tests -q
```

The real-model gate used FastVideo's generic Modal runner on one L40S at the
exact pushed commit `83c55161ffae9f4137337c5bbb37b1e2f3c31cca`.

## Test Results

<details>
<summary>Validation output</summary>

```text
pre-commit run --all-files: all hooks passed
adapter tests on pushed commit: 10 passed
pinned upstream CPU suite: 116 passed

Three-video corruption gate (333 frames, 832x480, 16 fps):
                         original   frozen   repeated
composite                  60.05     56.35      54.05
dynamic_quality            48.24     12.16      43.76
loop_quality               43.23     46.37      25.52

Pinned upstream CLI parity on the same 44 sampled frames:
maximum composite/dimension absolute delta: 0.050 points
acceptance threshold: 0.5 points

Post-rebase real-model smoke:
pre-rebase composite:  60.050077566449
post-rebase composite: 60.050077566449
absolute delta:         0.000000000000
```

The frozen control is caught by `dynamic_quality`; the repeated control is
caught by `loop_quality`. No dimension was missing, silently zeroed, or invalid.

</details>

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

The metric and its dependencies are opt-in and lazy-loaded. Generation behavior
and model memory are unchanged unless `vqeval.composite` is explicitly selected.

**For model/pipeline changes:** not applicable; this PR adds an evaluation
adapter and does not add or modify a generation model or pipeline.
