### PR TITLE
[ci] Make Dreamverse provider race test deterministic

### DIFF
--- a/apps/dreamverse/dreamverse/tests/test_prompt_enhancer.py
+++ b/apps/dreamverse/dreamverse/tests/test_prompt_enhancer.py
@@ -331,11 +331,11 @@ def test_rewrite_prompt_sequence_accepts_numbered_prose_output():
     ]
 
 
-def test_enhance_prompt_prefers_cerebras_before_groq_fallback():
+def test_enhance_prompt_uses_groq_when_it_returns_first():
     enhancer = _build_staged_enhancer(
         cerebras_payload=_chat_payload_with_content('{"prompt":"Cerebras prompt"}'),
         groq_payload=_chat_payload_with_content('{"prompt":"Groq prompt"}'),
-        cerebras_delay_s=0.01,
+        cerebras_delay_s=0.08,
         groq_delay_s=0.01,
     )
 
@@ -346,12 +346,12 @@ def test_enhance_prompt_prefers_cerebras_before_groq_fallback():
 
     assert result.fallback_used is False
     assert result.error is None
-    assert result.provider == "cerebras"
+    assert result.provider == "groq"
     assert result.model == "gpt-test"
-    assert result.prompt == "Cerebras prompt"
+    assert result.prompt == "Groq prompt"
     assert enhancer.get_provider_success_counts() == {
-        "cerebras": 1,
-        "groq": 0,
+        "cerebras": 0,
+        "groq": 1,
     }
 
 


### PR DESCRIPTION
## Problem

`test_enhance_prompt_prefers_cerebras_before_groq_fallback` started Cerebras and Groq in the same parallel provider stage, gave both fake clients an identical 10 ms sleep, and required Cerebras to win.

The runtime intentionally returns the first successful provider result. Equal wall-clock sleeps do not define completion order across the two worker threads, so Groq can legitimately win. This made the Dreamverse fastcheck lane flaky; it surfaced on #1727 and reproduced locally on upstream `main`.

## Change

Turn the ambiguous equal-delay case into the missing deterministic half of the provider-race contract:

- Groq has the shorter delay and must win.
- The existing adjacent test already verifies that Cerebras wins when Cerebras returns first.
- Production provider orchestration is unchanged.

## Validation

- Repeated the repaired test in 50 fresh pytest processes: 50/50 passed.
- `pytest apps/dreamverse/dreamverse/tests/test_prompt_enhancer.py -q`: 39 passed.
- Complete Dreamverse Python backend suite on Modal L40S: passed.
  - https://modal.com/apps/hao-ai-lab/main/ap-aoLlACETIWKntvzKi9ZsWy
- `pre-commit run --all-files`: all hooks passed, including mypy.

## GPU memory impact

None. This is a test-only change.
