### PR TITLE
[perf] Add opt-in packed-varlen FA4 for MiniMax-H3

### DIFF
--- a/docs/inference/optimizations.md
+++ b/docs/inference/optimizations.md
@@ -97,6 +97,21 @@ sm90+) and GQA attention (FA4's `pack_gqa` fails to JIT-compile below sm90).
 On sm90+ both run on FA4. If FA4 is unusable while `FASTVIDEO_FA4=1` is set,
 FastVideo fails loudly instead of silently falling back.
 
+MiniMax-H3 can additionally use FA4's packed-varlen entry point for its long,
+single-sequence dense DiT self-attention:
+
+```bash
+export FASTVIDEO_FA4=1
+export FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN=1
+```
+
+This route is inference-only and remains disabled by default. Runtime guards
+keep masked attention, batch sizes above one, unequal query/key lengths,
+grad-enabled calls, and NVFP4 on their established paths. It does not apply to
+the Preview checkpoint's sparse VSA blocks. Packed-varlen changes floating-point
+reduction order relative to fixed-length FA4, so treat it as a speed/quality
+evaluation option rather than an exact-parity mode.
+
 ### FP4 Flash Attention 4 (Blackwell only)
 
 **`FLASH_ATTN`** with **`--nvfp4_fa4`**

--- a/fastvideo/attention/backends/flash_attn.py
+++ b/fastvideo/attention/backends/flash_attn.py
@@ -10,6 +10,14 @@ from fastvideo.attention.utils.flash_attn_default import (
     flash_attn_func_compilable,
 )
 
+if fa_version == "4":
+    # The FA4 varlen wrapper is already a compile-safe custom op. Keep the
+    # import conditional so FA2/FA3 environments do not need flash_attn.cute.
+    from fastvideo.attention.utils.flash_attn_cute import (
+        flash_attn_varlen_func as flash_attn_varlen_func_compilable, )
+else:
+    flash_attn_varlen_func_compilable = None
+
 from fastvideo.attention.backends.abstract import (
     AttentionBackend,
     AttentionImpl,
@@ -38,6 +46,21 @@ except ImportError:
     _FA4_FP4_AVAILABLE = False
 
 _FA4_QUANT_OPS: tuple | None = None
+_FA4_PACKED_VARLEN_CONFIG_LOGGED = False
+
+
+def _log_fa4_packed_varlen_config() -> None:
+    """Emit one configuration receipt per worker process.
+
+    This intentionally does not claim that a particular forward used the
+    kernel: masks, gradients, batch size, unequal Q/K lengths, and NVFP4 are
+    runtime guards evaluated later in ``_forward_impl``.
+    """
+    global _FA4_PACKED_VARLEN_CONFIG_LOGGED
+    if not _FA4_PACKED_VARLEN_CONFIG_LOGGED:
+        logger.info("MiniMax-H3 dense attention: FA4 packed-varlen route configured (runtime guards apply)",
+                    local_main_process_only=False)
+        _FA4_PACKED_VARLEN_CONFIG_LOGGED = True
 
 
 def _import_fa4_quant_ops() -> tuple:
@@ -228,6 +251,12 @@ class FlashAttentionImpl(AttentionImpl):
     ) -> None:
         self.causal = causal
         self.softmax_scale = softmax_scale
+        # MiniMax-H3's dense DiT explicitly enables this faster FA4 entry
+        # point. It remains off for every other model and for the H3 text
+        # refiner; grad-enabled calls stay on the established fixed path.
+        self.fa4_packed_varlen = bool(extra_impl_args.get("fa4_packed_varlen", False))
+        if self.fa4_packed_varlen and fa_version == "4":
+            _log_fa4_packed_varlen_config()
         # An explicit ``nvfp4_fa4`` impl arg wins over the process-wide
         # FASTVIDEO_NVFP4_FA4 env opt-in, so precision-sensitive layers (e.g.
         # the FP32-pinned H3 VAE attention) can force-disable FP4 Q/K
@@ -330,6 +359,29 @@ class FlashAttentionImpl(AttentionImpl):
             output = flash_attn_no_pad(qkv, attn_mask_padded, causal=self.causal, dropout_p=0, softmax_scale=None)
         elif self.nvfp4_fa4:
             output = self._forward_nvfp4(query, key, value)
+
+        elif (self.fa4_packed_varlen and fa_version == "4" and not torch.is_grad_enabled() and query.shape[0] == 1
+              and query.shape[1] == key.shape[1] == value.shape[1]):
+            # FA4's packed-varlen entry point is materially faster for H3's
+            # long, single-document self-attention. Flatten only the batch
+            # dimension and describe that one sequence with CUDA int32
+            # cumulative lengths; the existing custom-op wrapper keeps this
+            # route traceable under torch.compile(fullgraph=True).
+            assert flash_attn_varlen_func_compilable is not None
+            sequence_length = query.shape[1]
+            cu_seqlens = torch.arange(2, dtype=torch.int32, device=query.device) * sequence_length
+            output = flash_attn_varlen_func_compilable(
+                query.squeeze(0),
+                key.squeeze(0),
+                value.squeeze(0),
+                cu_seqlens,
+                cu_seqlens,
+                sequence_length,
+                sequence_length,
+                dropout_p=0.0,
+                softmax_scale=self.softmax_scale,
+                causal=self.causal,
+            ).unsqueeze(0)
 
         else:
             # Route through the compilable wrapper so dynamo sees a

--- a/fastvideo/envs.py
+++ b/fastvideo/envs.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     FASTVIDEO_TRACE_FUNCTION: int = 0
     FASTVIDEO_ATTENTION_BACKEND: str | None = None
     FASTVIDEO_FA4: bool = False
+    FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN: bool = False
     FASTVIDEO_MINIMAX_H3_FUSIONS: str = ""
     FASTVIDEO_WORKER_MULTIPROC_METHOD: str = "spawn"
     FASTVIDEO_TARGET_DEVICE: str = "cuda"
@@ -218,6 +219,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # (FA4's backward asserts sm90+ and its pack_gqa fails to JIT there).
     "FASTVIDEO_FA4":
     lambda: os.getenv("FASTVIDEO_FA4", "0") != "0",
+
+    # Use FA4's packed-varlen entry point for the long, single-document
+    # MiniMax-H3 dense DiT self-attention path. This changes floating-point
+    # reduction order relative to the fixed-length entry point, so it remains
+    # an explicit inference-only speed/quality opt-in.
+    "FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN":
+    lambda: os.getenv("FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN", "0") != "0",
 
     # Opt-in MiniMax-H3 inference-only Triton fusions adapted from the
     # NVlabs/Sana Sol-Engine implementation. Accepts `all`, `1`, or a

--- a/fastvideo/models/dits/minimax_h3.py
+++ b/fastvideo/models/dits/minimax_h3.py
@@ -144,6 +144,7 @@ class MiniMaxH3Attention(nn.Module):
         quant_config: QuantizationConfig | None,
         prefix: str,
         fuse_qknorm_rope: bool = False,
+        fa4_packed_varlen: bool = False,
     ) -> None:
         super().__init__()
         self.num_attention_heads = num_attention_heads
@@ -196,6 +197,7 @@ class MiniMaxH3Attention(nn.Module):
             causal=False,
             supported_attention_backends=supported_attention_backends,
             prefix=prefix,
+            fa4_packed_varlen=fa4_packed_varlen,
         )
         self.to_gate_compress: ReplicatedLinear | None = None
         # None = unchecked; the first forward tests the loaded weight once and
@@ -453,6 +455,7 @@ class MiniMaxH3TransformerBlock(nn.Module):
         fuse_modulate: bool = False,
         fuse_qknorm_rope: bool = False,
         fuse_swiglu: bool = False,
+        fa4_packed_varlen: bool = False,
     ) -> None:
         super().__init__()
         self.norm1 = nn.RMSNorm(hidden_size, eps=norm_eps)
@@ -465,6 +468,7 @@ class MiniMaxH3TransformerBlock(nn.Module):
             quant_config,
             prefix=f"{prefix}.attn",
             fuse_qknorm_rope=fuse_qknorm_rope,
+            fa4_packed_varlen=fa4_packed_varlen,
         )
         self.norm2 = nn.RMSNorm(hidden_size, eps=norm_eps)
         self.ff = MiniMaxH3FeedForward(
@@ -683,6 +687,7 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
                 fuse_modulate="modulate" in self.enabled_fusions,
                 fuse_qknorm_rope="qknorm_rope" in self.enabled_fusions,
                 fuse_swiglu="swiglu" in self.enabled_fusions,
+                fa4_packed_varlen=envs.FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN,
             ) for index in range(arch.num_layers)
         ])
         self.norm_out = MiniMaxH3AdaLayerNormOut(

--- a/fastvideo/tests/attention/test_flash_attn_h3_packed_varlen.py
+++ b/fastvideo/tests/attention/test_flash_attn_h3_packed_varlen.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Routing guards for MiniMax-H3's packed-varlen FA4 inference path."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+
+flash_attn_module = pytest.importorskip(
+    "fastvideo.attention.backends.flash_attn",
+    reason="no usable flash-attention package installed",
+    exc_type=ImportError,
+)
+FlashAttentionImpl = flash_attn_module.FlashAttentionImpl
+
+
+def _build_impl(*, fa4_packed_varlen: bool) -> FlashAttentionImpl:
+    return FlashAttentionImpl(
+        num_heads=2,
+        head_size=8,
+        causal=False,
+        softmax_scale=0.125,
+        num_kv_heads=2,
+        fa4_packed_varlen=fa4_packed_varlen,
+    )
+
+
+def _qkv(batch: int = 1) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    query = torch.randn(batch, 7, 2, 8)
+    return query, torch.randn_like(query), torch.randn_like(query)
+
+
+def test_h3_fa4_no_grad_uses_single_sequence_varlen(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def varlen(query, key, value, cu_q, cu_k, max_q, max_k, **kwargs):
+        calls.append((query.shape, key.shape, value.shape, cu_q.tolist(), cu_k.tolist(), max_q, max_k, kwargs))
+        return value + 1
+
+    def unexpected_fixed(*args, **kwargs):
+        raise AssertionError("H3 FA4 inference took the fixed-length path")
+
+    monkeypatch.setattr(flash_attn_module, "fa_version", "4")
+    monkeypatch.setattr(flash_attn_module, "flash_attn_varlen_func_compilable", varlen)
+    monkeypatch.setattr(flash_attn_module, "flash_attn_func_compilable", unexpected_fixed)
+    query, key, value = _qkv()
+
+    with torch.no_grad():
+        output = _build_impl(fa4_packed_varlen=True)._forward_impl(query, key, value, None)
+
+    torch.testing.assert_close(output, value + 1)
+    assert calls == [
+        (
+            torch.Size([7, 2, 8]),
+            torch.Size([7, 2, 8]),
+            torch.Size([7, 2, 8]),
+            [0, 7],
+            [0, 7],
+            7,
+            7,
+            {"dropout_p": 0.0, "softmax_scale": 0.125, "causal": False},
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("fa4_packed_varlen", "version", "batch", "requires_grad"),
+    [
+        (False, "4", 1, False),
+        (True, "3", 1, False),
+        (True, "4", 2, False),
+        (True, "4", 1, True),
+    ],
+)
+def test_h3_varlen_guard_preserves_fixed_path(
+    monkeypatch: pytest.MonkeyPatch,
+    fa4_packed_varlen: bool,
+    version: str,
+    batch: int,
+    requires_grad: bool,
+) -> None:
+    def unexpected_varlen(*args, **kwargs):
+        raise AssertionError("packed-varlen route escaped its H3 FA4 inference guard")
+
+    def fixed(query, key, value, **kwargs):
+        del key, value, kwargs
+        return query + 2
+
+    monkeypatch.setattr(flash_attn_module, "fa_version", version)
+    monkeypatch.setattr(flash_attn_module, "flash_attn_varlen_func_compilable", unexpected_varlen)
+    monkeypatch.setattr(flash_attn_module, "flash_attn_func_compilable", fixed)
+    query, key, value = _qkv(batch)
+    query.requires_grad_(requires_grad)
+
+    context = torch.enable_grad() if requires_grad else torch.no_grad()
+    with context:
+        output = _build_impl(fa4_packed_varlen=fa4_packed_varlen)._forward_impl(query, key, value, None)
+
+    torch.testing.assert_close(output, query + 2)
+    if requires_grad:
+        output.sum().backward()
+        torch.testing.assert_close(query.grad, torch.ones_like(query))
+
+
+def test_h3_varlen_guard_prioritizes_masked_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unexpected_varlen(*args, **kwargs):
+        raise AssertionError("packed-varlen route bypassed attention metadata")
+
+    def masked(qkv, key_padding_mask, **kwargs):
+        del key_padding_mask, kwargs
+        return qkv[:, :, 2]
+
+    monkeypatch.setattr(flash_attn_module, "fa_version", "4")
+    monkeypatch.setattr(flash_attn_module, "flash_attn_varlen_func_compilable", unexpected_varlen)
+    # Keep this routing test independent of whether an FA4-only environment
+    # also installed FA2's top-level packed-QKV helper. The production branch
+    # imports these names lazily only after observing attention metadata.
+    no_pad_module = ModuleType("fastvideo.attention.utils.flash_attn_no_pad")
+    no_pad_module.flash_attn_no_pad_compilable = masked
+    no_pad_module.flash_attn_varlen_qk_no_pad_compilable = unexpected_varlen
+    monkeypatch.setitem(sys.modules, no_pad_module.__name__, no_pad_module)
+    query, key, value = _qkv()
+    metadata = flash_attn_module.FlashAttnMetadata(
+        current_timestep=0,
+        attn_mask=torch.ones((1, query.shape[1]), dtype=torch.bool),
+    )
+
+    with torch.no_grad():
+        output = _build_impl(fa4_packed_varlen=True)._forward_impl(query, key, value, metadata)
+
+    torch.testing.assert_close(output, value)
+
+
+def test_h3_varlen_guard_prioritizes_nvfp4_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unexpected_varlen(*args, **kwargs):
+        raise AssertionError("packed-varlen route bypassed NVFP4")
+
+    monkeypatch.setattr(flash_attn_module, "fa_version", "4")
+    monkeypatch.setattr(flash_attn_module, "flash_attn_varlen_func_compilable", unexpected_varlen)
+    impl = _build_impl(fa4_packed_varlen=True)
+    impl.nvfp4_fa4 = True
+    monkeypatch.setattr(impl, "_forward_nvfp4", lambda query, key, value: value + 3)
+    query, key, value = _qkv()
+
+    with torch.no_grad():
+        output = impl._forward_impl(query, key, value, None)
+
+    torch.testing.assert_close(output, value + 3)
+
+
+def test_h3_varlen_guard_preserves_unequal_qk_fixed_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unexpected_varlen(*args, **kwargs):
+        raise AssertionError("packed-varlen route accepted unequal Q/K/V lengths")
+
+    def fixed(query, key, value, **kwargs):
+        del key, value, kwargs
+        return query + 4
+
+    monkeypatch.setattr(flash_attn_module, "fa_version", "4")
+    monkeypatch.setattr(flash_attn_module, "flash_attn_varlen_func_compilable", unexpected_varlen)
+    monkeypatch.setattr(flash_attn_module, "flash_attn_func_compilable", fixed)
+    query, _, _ = _qkv()
+    key = torch.randn(1, 5, 2, 8)
+    value = torch.randn_like(key)
+
+    with torch.no_grad():
+        output = _build_impl(fa4_packed_varlen=True)._forward_impl(query, key, value, None)
+
+    torch.testing.assert_close(output, query + 4)

--- a/fastvideo/tests/transformers/test_minimax_h3_fusion_routing.py
+++ b/fastvideo/tests/transformers/test_minimax_h3_fusion_routing.py
@@ -9,6 +9,93 @@ import torch
 from fastvideo.platforms import AttentionBackendEnum
 
 
+@pytest.mark.parametrize("enabled", [False, True])
+def test_only_opted_in_packed_minimax_h3_blocks_enable_fa4_varlen(
+    monkeypatch: pytest.MonkeyPatch,
+    enabled: bool,
+) -> None:
+    import fastvideo.models.dits.minimax_h3 as h3
+
+    routed: list[bool] = []
+
+    class RecordingAttention(torch.nn.Module):
+
+        def __init__(self, *args, fa4_packed_varlen: bool = False, **kwargs) -> None:
+            super().__init__()
+            del args, kwargs
+            routed.append(fa4_packed_varlen)
+
+    monkeypatch.setattr(h3, "MiniMaxH3Attention", RecordingAttention)
+    common = dict(
+        hidden_size=8,
+        num_attention_heads=1,
+        attention_head_dim=8,
+        ffn_dim=16,
+        norm_eps=1e-5,
+        qk_norm_eps=1e-5,
+        supported_attention_backends=(AttentionBackendEnum.FLASH_ATTN, ),
+        quant_config=None,
+    )
+    h3.MiniMaxH3TransformerBlock(
+        **common,
+        time_embed_dim=4,
+        prefix="minimax_h3.transformer_blocks.0",
+        fa4_packed_varlen=enabled,
+    )
+    h3.MiniMaxH3TokenRefinerBlock(
+        **common,
+        prefix="minimax_h3.token_refiner.refiner_blocks.0",
+    )
+
+    assert routed == [enabled, False]
+
+
+@pytest.mark.parametrize("fa4_packed_varlen", [False, True])
+def test_minimax_h3_varlen_flag_reaches_resolved_backend_impl(
+    monkeypatch: pytest.MonkeyPatch,
+    fa4_packed_varlen: bool,
+) -> None:
+    """Cover the H3-attention -> distributed-attention -> impl boundary."""
+    import fastvideo.attention.layer as attention_layer
+    import fastvideo.models.dits.minimax_h3 as h3
+
+    init_kwargs: dict = {}
+
+    class RecordingAttentionImpl:
+
+        def __init__(self, **kwargs) -> None:
+            init_kwargs.update(kwargs)
+
+    class RecordingAttentionBackend:
+
+        @staticmethod
+        def get_name() -> str:
+            return "FLASH_ATTN"
+
+        @staticmethod
+        def get_impl_cls() -> type[RecordingAttentionImpl]:
+            return RecordingAttentionImpl
+
+    def resolve_backend(*args, **kwargs):
+        del args, kwargs
+        return RecordingAttentionBackend
+
+    monkeypatch.setattr(h3, "get_attn_backend", resolve_backend)
+    monkeypatch.setattr(attention_layer, "get_attn_backend", resolve_backend)
+    h3.MiniMaxH3Attention(
+        hidden_size=8,
+        num_attention_heads=1,
+        attention_head_dim=8,
+        qk_norm_eps=1e-5,
+        supported_attention_backends=(AttentionBackendEnum.FLASH_ATTN, ),
+        quant_config=None,
+        prefix="minimax_h3.transformer_blocks.0.attn",
+        fa4_packed_varlen=fa4_packed_varlen,
+    )
+
+    assert init_kwargs["fa4_packed_varlen"] is fa4_packed_varlen
+
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [


### PR DESCRIPTION
## Purpose

MiniMax-H3's dense DiT spends most of its forward in long, batch-one self-attention. FlashAttention-4's packed-varlen entry point is faster for that shape than its fixed-length entry point, but the optimization must stay isolated from other models, training, masks, and precision-sensitive paths.

This change adds a MiniMax-H3-only, default-off inference route controlled by `FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN=1` alongside `FASTVIDEO_FA4=1`.

## Changes

- Route eligible dense MiniMax-H3 DiT self-attention through FA4 packed-varlen with one CUDA `int32` sequence descriptor.
- Preserve the existing path for grad-enabled calls, batch sizes above one, unequal Q/K/V lengths, masked attention, NVFP4, FA2/FA3, the H3 text refiner, and all other models.
- Keep the option disabled by default and emit a per-worker configuration receipt.
- Add backend guard and model-to-backend routing tests.
- Document requirements, scope, and the numerical caveat.

## Test Plan

```bash
git diff --check origin/main...HEAD
pre-commit run --files <changed files>
python -m pytest -q \
  fastvideo/tests/attention/test_flash_attn_h3_packed_varlen.py \
  fastvideo/tests/transformers/test_minimax_h3_fusion_routing.py
```

## Test Results

- Exact implementation head `282f99912`, GB200/FA4: **12 passed**; the remaining 10 parameterizations were intentionally deselected by the route-focused invocation (job 2984).
- Current composed head `9eb7b5d3a` after merging `main`/#1741: the same **12 passed** route gate (job 2992), and GitHub reports the PR mergeable.
- Full pre-commit suite on the composed head: passed.
- Direct FA4 API A/B, sequence length 38,224, head dimension 128, ten timed samples:
  - 56 heads: **36.873 ms -> 28.008 ms** mean (24.0% lower).
  - 14 heads: **9.236 ms -> 6.386 ms** mean (30.9% lower).
  - fixed-vs-varlen tensor delta: max **0.000244**, mean **1.80e-6**.

Packed-varlen changes floating-point reduction order. Full 49-forward videos can amplify that small attention-level difference, so this remains a speed/quality evaluation route rather than an exact-parity mode. It does not apply to sparse VSA blocks used by the Preview FastH3 checkpoint.

## Checklist

- [x] I ran pre-commit on the changed files
- [x] I added regression coverage for every fallback guard
- [x] I documented the opt-in and numerical behavior
- [x] I verified the implementation on GB200 with the FA4 runtime
- [ ] I changed any training behavior (the grad-enabled path remains unchanged)
