### PR TITLE
[bugfix] Classify MiniMax-H3 inference controls in schema inventory

### DIFF
--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -76,6 +76,8 @@ surfaces:
       lora_target_modules: "Legacy LoRA configuration surface pending dedicated component API."
       output_type: "Legacy output formatting surface pending GenerationResult cleanup."
       VSA_sparsity: "Model-specific inference optimization not yet represented in the typed public schema."
+      VSA_tile_size: "VSA-H3 tile geometry request; model-specific optimization not yet represented in the typed public schema."
+      inference_torch_compile: "Regional inference compile opt-in currently carried through PipelineSelection.experimental rather than CompileConfig."
       attention_backend: "Process-wide default attention-backend request applied per component at load time; kernel-selection knob not yet represented in the typed public schema."
       moba_config_path: "Model-specific MoBA optimization surface not yet represented in the typed public schema."
       master_port: "Executor/bootstrap compatibility field; not part of the canonical inference schema."


### PR DESCRIPTION
## Purpose

PR #1741 added `FastVideoArgs.inference_torch_compile`, while the earlier MiniMax-H3 VSA work added `VSA_tile_size`. Neither field was added to the required inference schema-parity inventory, so `test_fastvideo_args_fields_are_classified` fails on current `main`.

## Changes

- Classify `inference_torch_compile` as a compatibility surface carried through `PipelineSelection.experimental` until it has a first-class `CompileConfig` field.
- Classify `VSA_tile_size` as a model-specific compatibility surface.

This is inventory-only and changes no runtime or training behavior.

## Test Plan

```bash
pre-commit run --files docs/design/inference_schema_parity_inventory.yaml
python -m pytest -q \
  fastvideo/tests/api/test_schema_parity_inventory.py::test_fastvideo_args_fields_are_classified
```

## Test Results

- Documentation/pre-commit checks: passed.
- Exact-head schema classification test on GB200: **1 passed** (job 2995).

## Checklist

- [x] I ran pre-commit on the changed file
- [x] I reproduced the failure on current `main`
- [x] I verified the focused schema test after the fix
