### PR TITLE
[perf] Keep odd MiniMax-H3 VSA tiles on sm100a

### DIFF
--- a/fastvideo/attention/backends/video_sparse_attn_h3.py
+++ b/fastvideo/attention/backends/video_sparse_attn_h3.py
@@ -34,9 +34,13 @@ for the tile-64 FORWARD only: ``FASTVIDEO_VSA_SM100A=1`` sends no-grad
 forwards through the sm_100a CUDA block-sparse kernel
 (``fastvideo_kernel.block_sparse_attn_sm100a``, upstream PR #1719 plus
 our per-q-tile ``q2k_num`` fix) when the extension is built, the device
-is sm_100, and the geometry qualifies; grad-tracking forwards and every
-backward stay on Triton unchanged. If the env is set but a precondition
-fails, the route logs one warning and falls back.
+is sm_100, and the geometry qualifies. The CUDA kernel assigns adjacent
+pairs of query tiles to CTAs, so an odd logical tile count receives one
+internal, zero-valid partner tile for the no-grad call only. Score search,
+the trained mask, gate-compress, and the returned packed sequence remain on
+the original logical tiles. Grad-tracking forwards and every backward stay
+on Triton unchanged. If the env is set but a precondition fails, the route
+logs one warning and falls back.
 """
 
 import functools
@@ -225,6 +229,14 @@ class MiniMaxH3VSABackend(AttentionBackend):
         return MiniMaxH3VSAMetadataBuilder
 
 
+class _MiniMaxH3VSATileBufferHolder:
+    """Builder-owned no-grad tile scratch and its active geometry."""
+
+    def __init__(self) -> None:
+        self.buffer: torch.Tensor | None = None
+        self.untile_geometry: torch.Tensor | None = None
+
+
 @dataclass
 class MiniMaxH3VSAMetadata(AttentionMetadata):
     total_seq_length: int
@@ -238,18 +250,16 @@ class MiniMaxH3VSAMetadata(AttentionMetadata):
     tile_elems: int = _TILE_ELEMS
     # layers forced dense regardless of sparsity (probe-guided opt-outs)
     dense_layers: tuple[int, ...] = ()
-    # Single-slot holder for the padded tile buffer, owned by the BUILDER so
-    # one buffer serves the whole denoising loop (pad slots stay zero and
-    # every non-pad slot is fully overwritten per tile(), so cross-step reuse
-    # is valid; saves a ~1.4 GB alloc+memset per step at 720p). VSA-H3 runs
-    # eager today — revisit the reuse if it ever goes under cudagraphs.
-    tile_buf_holder: list = None  # type: ignore[assignment]
+    # Builder-owned padded tile buffer. It records the geometry that last
+    # populated the allocation so a same-shaped geometry change can clear
+    # stale pad rows once while steady-state denoising reuses the buffer.
+    tile_buf_holder: _MiniMaxH3VSATileBufferHolder | None = None
 
 
 class MiniMaxH3VSAMetadataBuilder(AttentionMetadataBuilder):
 
     def __init__(self) -> None:
-        self._tile_buf_holder: list = [None]
+        self._tile_buf_holder = _MiniMaxH3VSATileBufferHolder()
 
     def prepare(self) -> None:
         pass
@@ -372,20 +382,39 @@ class MiniMaxH3VSAImpl(AttentionImpl):
 
         The returned tensor aliases the builder-owned buffer; callers must
         consume it before the next ``tile()`` (both call sites in
-        ``forward()`` read it immediately).
+        ``forward()`` read it immediately). Odd tile-64 no-grad sm100a
+        requests carry one additional all-zero tile internally; metadata and
+        all observable outputs retain the logical geometry.
         """
         if x.shape[1] != attn_metadata.total_seq_length:
             raise ValueError(f"VSA-H3 metadata was built for sequence length {attn_metadata.total_seq_length}, "
                              f"got {x.shape[1]}. A non-packed sequence (e.g. the token refiner) is "
                              "routed to the VSA-H3 backend; exclude it from the supported backends.")
         n_tiles = attn_metadata.variable_block_sizes.numel()
-        target_shape = (x.shape[0], n_tiles * attn_metadata.tile_elems, x.shape[-2], x.shape[-1])
+        grad_mode = torch.is_grad_enabled() and x.requires_grad
+        needs_sm100a_pair = (attn_metadata.tile_elems == 64 and n_tiles % 2 != 0 and not grad_mode
+                             and os.environ.get(VSA_SM100A_ENV, "0") == "1")
+        kernel_tiles = n_tiles + int(needs_sm100a_pair)
+        target_shape = (x.shape[0], kernel_tiles * attn_metadata.tile_elems, x.shape[-2], x.shape[-1])
 
-        # single scatter: untile_combined_index maps original row i to its
-        # padded slot, so this is exactly the inverse of postprocess_output
+        # ``untile_combined_index`` maps each packed row to a logical tile
+        # slot. Different geometries can share one transport shape; clear a
+        # reused allocation once when the mapping identity changes so no old
+        # valid row can survive as padding.
         holder = attn_metadata.tile_buf_holder
-        holder[0] = scatter_into_tile_buf(x, target_shape, attn_metadata.untile_combined_index, holder[0])
-        return holder[0]
+        if holder is None:
+            raise RuntimeError("VSA-H3 metadata has no builder-owned tile buffer holder")
+        buffer_matches = (holder.buffer is not None and holder.buffer.shape == target_shape
+                          and holder.buffer.dtype == x.dtype and holder.buffer.device == x.device)
+        if buffer_matches and holder.untile_geometry is not attn_metadata.untile_combined_index:
+            holder.buffer.zero_()
+        holder.buffer = scatter_into_tile_buf(x, target_shape, attn_metadata.untile_combined_index, holder.buffer)
+        holder.untile_geometry = attn_metadata.untile_combined_index
+        if needs_sm100a_pair:
+            # A prior even geometry can reuse this allocation and may have
+            # written the last tile as logical data.
+            holder.buffer[:, n_tiles * attn_metadata.tile_elems:].zero_()
+        return holder.buffer
 
     def preprocess_qkv(self, qkv: torch.Tensor, attn_metadata: MiniMaxH3VSAMetadata) -> torch.Tensor:
         return self.tile(qkv, attn_metadata)
@@ -408,6 +437,33 @@ class MiniMaxH3VSAImpl(AttentionImpl):
         elif block_sparse_attn_256_bshd is None:
             raise NotImplementedError("fastvideo_kernel.block_sparse_attn_256 is not installed")
 
+        # The metadata always describes the trained logical geometry.
+        # ``tile()`` may append exactly one transport-only partner for an odd
+        # tile-64 sm100a call. Keep score selection and the gate branch on the
+        # logical prefix, and reject every other shape before a kernel sees it.
+        n_tiles = attn_metadata.variable_block_sizes.numel()
+        logical_seq_len = n_tiles * tile_elems
+        pair_pad_seq_len = logical_seq_len + tile_elems
+        pair_pad_is_valid = tile_elems == 64 and n_tiles % 2 != 0
+        allowed_seq_lengths = (logical_seq_len, pair_pad_seq_len) if pair_pad_is_valid else (logical_seq_len, )
+        if query.shape[1] not in allowed_seq_lengths:
+            expected = (f"the logical length {logical_seq_len} or one sm100a partner tile "
+                        f"({pair_pad_seq_len})" if pair_pad_is_valid else f"the logical length {logical_seq_len}")
+            raise ValueError(f"VSA-H3 tiled query has length {query.shape[1]}, expected {expected}.")
+        has_sm100a_pair = query.shape[1] == pair_pad_seq_len
+        for name, tensor in (("key", key), ("value", value)):
+            if tensor.shape[1] != query.shape[1]:
+                raise ValueError(f"VSA-H3 tiled {name} length {tensor.shape[1]} does not match query "
+                                 f"length {query.shape[1]}.")
+        if gate_compress is not None and gate_compress.shape[1] != query.shape[1]:
+            raise ValueError(f"VSA-H3 tiled gate length {gate_compress.shape[1]} does not match query "
+                             f"length {query.shape[1]}.")
+
+        logical_query = query[:, :logical_seq_len]
+        logical_key = key[:, :logical_seq_len]
+        logical_value = value[:, :logical_seq_len]
+        logical_gate = gate_compress[:, :logical_seq_len] if gate_compress is not None else None
+
         # probe-guided per-layer opt-out: diffuse layers run dense (all-True
         # mask) while the rest keep the configured sparsity
         layer_sparsity = 0.0 if self.layer_idx in attn_metadata.dense_layers else attn_metadata.VSA_sparsity
@@ -415,14 +471,13 @@ class MiniMaxH3VSAImpl(AttentionImpl):
 
         scores = None
         if layer_sparsity > 0.0 or gate_compress is not None or probe_dir is not None:
-            q_pooled = _pool_tiles(query, attn_metadata.variable_block_sizes, tile_elems)
-            k_pooled = _pool_tiles(key, attn_metadata.variable_block_sizes, tile_elems)
+            q_pooled = _pool_tiles(logical_query, attn_metadata.variable_block_sizes, tile_elems)
+            k_pooled = _pool_tiles(logical_key, attn_metadata.variable_block_sizes, tile_elems)
             scores = torch.matmul(q_pooled, k_pooled.transpose(-2, -1)) / (query.shape[-1]**0.5)
             if probe_dir is not None:
-                record_probe(probe_dir, self.layer_idx, query, key, scores, attn_metadata)
+                record_probe(probe_dir, self.layer_idx, logical_query, logical_key, scores, attn_metadata)
 
         if scores is None:
-            n_tiles = attn_metadata.variable_block_sizes.numel()
             mask = torch.ones(query.shape[0], query.shape[2], n_tiles, n_tiles, dtype=torch.bool, device=query.device)
         else:
             mask = _build_block_mask(
@@ -442,6 +497,19 @@ class MiniMaxH3VSAImpl(AttentionImpl):
             k_bhsd = key.transpose(1, 2).contiguous()
             v_bhsd = value.transpose(1, 2).contiguous()
 
+            sm100a_mask = mask
+            sm100a_variable_block_sizes = attn_metadata.variable_block_sizes
+            if has_sm100a_pair:
+                # The synthetic tile is neither a logical query nor key. Its
+                # all-False row yields q2k_num=0, the all-False column keeps it
+                # out of real rows, and vbs=0 masks all of its key slots.
+                sm100a_mask = torch.nn.functional.pad(mask, (0, 1, 0, 1), value=False)
+                sm100a_variable_block_sizes = torch.nn.functional.pad(
+                    attn_metadata.variable_block_sizes,
+                    (0, 1),
+                    value=0,
+                )
+
             # Opt-in sm_100a CUDA forward (upstream PR #1719 + per-q-tile
             # q2k_num fix). Forward-only: grad-tracking calls stay on Triton
             # so autograd keeps the Triton fwd+bwd pairing untouched. The
@@ -451,7 +519,7 @@ class MiniMaxH3VSAImpl(AttentionImpl):
             if os.environ.get(VSA_SM100A_ENV, "0") == "1":
                 grad_mode = torch.is_grad_enabled() and (query.requires_grad or key.requires_grad
                                                          or value.requires_grad)
-                reason = _sm100a_unavailable_reason(_sm100a, q_bhsd, attn_metadata.variable_block_sizes, grad_mode)
+                reason = _sm100a_unavailable_reason(_sm100a, q_bhsd, sm100a_variable_block_sizes, grad_mode)
                 if reason is None and map_to_index is None:
                     reason = "fastvideo_kernel.triton_kernels.index (map_to_index) is not importable"
                 if reason is None:
@@ -465,17 +533,21 @@ class MiniMaxH3VSAImpl(AttentionImpl):
                 # counts are NON-uniform here (prefix query tiles are dense,
                 # video tiles run prefix+top-k) -- legal for the fixed kernel,
                 # silently wrong on the pre-fix upstream one.
-                q2k_idx, q2k_num = map_to_index(mask)
+                q2k_idx, q2k_num = map_to_index(sm100a_mask)
                 out_bhsd, _ = _sm100a.block_sparse_attn_sm100a(
                     q_bhsd,
                     k_bhsd,
                     v_bhsd,
                     q2k_idx,
                     q2k_num,
-                    attn_metadata.variable_block_sizes.to(torch.int32),
+                    sm100a_variable_block_sizes.to(torch.int32),
                     need_lse=False,
                 )
             else:
+                if has_sm100a_pair:
+                    q_bhsd = q_bhsd[:, :, :logical_seq_len].contiguous()
+                    k_bhsd = k_bhsd[:, :, :logical_seq_len].contiguous()
+                    v_bhsd = v_bhsd[:, :, :logical_seq_len].contiguous()
                 out_bhsd, _ = block_sparse_attn_64_bhsd(
                     q_bhsd,
                     k_bhsd,
@@ -483,25 +555,32 @@ class MiniMaxH3VSAImpl(AttentionImpl):
                     mask,
                     attn_metadata.variable_block_sizes,
                 )
+            if has_sm100a_pair and use_sm100a:
+                out_bhsd = out_bhsd[:, :, :logical_seq_len]
             out = out_bhsd.transpose(1, 2).contiguous()
         else:
-            out, _ = block_sparse_attn_256_bshd(query, key, value, mask, attn_metadata.variable_block_sizes)
+            out, _ = block_sparse_attn_256_bshd(
+                logical_query,
+                logical_key,
+                logical_value,
+                mask,
+                attn_metadata.variable_block_sizes,
+            )
 
-        if gate_compress is not None:
+        if logical_gate is not None:
             # Wan-style compression branch: dense attention over pooled tiles,
             # broadcast to each tile's rows, scaled by the learned gate
             # (zero-initialized for H3 => branch contributes nothing until
             # finetuned; the model layer skips it entirely for all-zero gates).
-            v_pooled = _pool_tiles(value, attn_metadata.variable_block_sizes, tile_elems)
+            v_pooled = _pool_tiles(logical_value, attn_metadata.variable_block_sizes, tile_elems)
             out_c = torch.matmul(torch.softmax(scores, dim=-1), v_pooled)  # [B, H, n_tiles, D]
             out_c = out_c.permute(0, 2, 1, 3).to(out.dtype)  # [B, n_tiles, H, D]
             batch, seq_len, heads, dim = out.shape
-            n_tiles = attn_metadata.variable_block_sizes.numel()
             # Out-of-place: on the CuTe backend ``out`` is the tensor FA4's
             # autograd node saved for its backward, so an in-place add here
             # bumps its version counter and backward dies with "one of the
             # variables needed for gradient computation has been modified".
             out_tiled = out.view(batch, n_tiles, tile_elems, heads, dim)
-            gate_tiled = gate_compress.view(batch, n_tiles, tile_elems, heads, dim)
+            gate_tiled = logical_gate.view(batch, n_tiles, tile_elems, heads, dim)
             out = (out_tiled + out_c.unsqueeze(2) * gate_tiled).view(batch, seq_len, heads, dim)
         return out

--- a/fastvideo/attention/backends/video_sparse_attn_h3.py
+++ b/fastvideo/attention/backends/video_sparse_attn_h3.py
@@ -528,6 +528,7 @@ class MiniMaxH3VSAImpl(AttentionImpl):
                     logger.warning_once(f"{VSA_SM100A_ENV}=1 but falling back to the Triton-64 kernels: {reason}")
 
             if use_sm100a:
+                logger.info_once("MiniMax-H3 VSA tile-64 forward: using the sm100a CUDA block-sparse kernel")
                 # The sm_100a entry is index-native; compact the bool map the
                 # same way the Triton bool entry does internally. Per-row
                 # counts are NON-uniform here (prefix query tiles are dense,

--- a/fastvideo/logger.py
+++ b/fastvideo/logger.py
@@ -65,8 +65,9 @@ DEFAULT_LOGGING_CONFIG = {
 
 @lru_cache
 def _print_info_once(logger: Logger, msg: str) -> None:
-    # Set the stacklevel to 2 to print the original caller's line info
-    logger.info(msg, stacklevel=2)
+    # The process-aware info wrapper owns stacklevel; passing it here would
+    # supply the keyword twice when the wrapper delegates to Logger.log.
+    logger.info(msg)
 
 
 @lru_cache

--- a/fastvideo/tests/attention/test_vsa_h3_sm100a_route.py
+++ b/fastvideo/tests/attention/test_vsa_h3_sm100a_route.py
@@ -125,6 +125,8 @@ def test_default_off_routes_triton(routed, monkeypatch):
 def test_env_on_routes_sm100a_with_index_metadata(routed, monkeypatch):
     fake_sm, fake_triton, run, meta = routed
     monkeypatch.setenv(VSA_SM100A_ENV, "1")
+    messages = []
+    monkeypatch.setattr(vsa_h3.logger, "info_once", messages.append)
     out = run()
     assert fake_triton.calls == 0
     assert len(fake_sm.calls) == 1
@@ -135,6 +137,7 @@ def test_env_on_routes_sm100a_with_index_metadata(routed, monkeypatch):
     assert call["q2k_idx"].shape[-1] == n_tiles and call["q2k_idx"].dtype == torch.int32
     assert call["vbs"].dtype == torch.int32
     assert call["need_lse"] is False
+    assert messages == ["MiniMax-H3 VSA tile-64 forward: using the sm100a CUDA block-sparse kernel"]
     # BHSD kernel result comes back in the backend's BSHD layout
     assert out.shape == (1, n_tiles * 64, _HEADS, _DIM)
 

--- a/fastvideo/tests/attention/test_vsa_h3_sm100a_route.py
+++ b/fastvideo/tests/attention/test_vsa_h3_sm100a_route.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CPU checks for the VSA-H3 tile-64 sm_100a route selection.
+"""Checks for the VSA-H3 tile-64 sm_100a route and odd-tile transport.
 
 The opt-in third kernel route (``FASTVIDEO_VSA_SM100A=1``) must (a) stay off by
 default, (b) engage only when the extension is present, the device qualifies,
-and the forward carries no grad, and (c) fall back to the Triton-64 entry with
-one warning when the env is set but a precondition fails. All device/extension
-probes are monkeypatched; no GPU or kernel install needed.
+and the forward carries no grad, (c) add one zero-valid partner for an odd
+logical tile count, and (d) strip that partner before any fallback or returned
+output. Most probes are monkeypatched; the final test is a GB200 route receipt.
 """
 
 import pytest
@@ -20,14 +20,21 @@ _SPEC = dict(raw_latent_shape=(4, 8, 16), patch_size=(1, 2, 2), prefix_segments=
 _HEADS, _DIM = 2, 128
 
 
-def _build_meta():
-    return MiniMaxH3VSAMetadataBuilder().build(
+def _build_meta(
+    *,
+    device: torch.device = torch.device("cpu"),
+    prefix_segments: tuple[int, ...] = _SPEC["prefix_segments"],
+    sparsity: float = 0.0,
+    builder: MiniMaxH3VSAMetadataBuilder | None = None,
+):
+    builder = builder or MiniMaxH3VSAMetadataBuilder()
+    return builder.build(
         current_timestep=0,
         raw_latent_shape=_SPEC["raw_latent_shape"],
         patch_size=_SPEC["patch_size"],
-        VSA_sparsity=0.0,
-        prefix_segments=_SPEC["prefix_segments"],
-        device=torch.device("cpu"),
+        VSA_sparsity=sparsity,
+        prefix_segments=prefix_segments,
+        device=device,
         tile_size=64,
     )
 
@@ -179,3 +186,171 @@ def test_env_on_no_grad_context_detaches_route_from_leaf_flags(routed, monkeypat
         impl.forward(q, k, v, None, meta)
     assert len(fake_sm.calls) == 1
     assert fake_triton.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("env_enabled", "requires_grad", "extra_tiles"),
+    [
+        (False, False, 0),
+        (True, False, 1),
+        (True, True, 0),
+    ],
+)
+def test_preprocess_adds_partner_only_for_odd_no_grad_sm100a(
+    monkeypatch,
+    env_enabled,
+    requires_grad,
+    extra_tiles,
+):
+    if env_enabled:
+        monkeypatch.setenv(VSA_SM100A_ENV, "1")
+    else:
+        monkeypatch.delenv(VSA_SM100A_ENV, raising=False)
+    meta = _build_meta()
+    n_tiles = meta.variable_block_sizes.numel()
+    assert n_tiles % 2 == 1
+    raw = torch.randn(1,
+                      meta.total_seq_length,
+                      _HEADS,
+                      _DIM,
+                      dtype=torch.bfloat16,
+                      requires_grad=requires_grad)
+
+    tiled = MiniMaxH3VSAImpl(num_heads=_HEADS,
+                             head_size=_DIM,
+                             causal=False,
+                             softmax_scale=_DIM**-0.5).preprocess_qkv(raw, meta)
+
+    assert tiled.shape[1] == (n_tiles + extra_tiles) * 64
+    assert torch.equal(tiled[:, meta.untile_combined_index], raw)
+    if extra_tiles:
+        assert torch.count_nonzero(tiled[:, n_tiles * 64:]) == 0
+
+
+def test_odd_partner_is_visible_only_to_sm100a_transport(routed, monkeypatch):
+    fake_sm, fake_triton, _, meta = routed
+    monkeypatch.setenv(VSA_SM100A_ENV, "1")
+    impl = MiniMaxH3VSAImpl(num_heads=_HEADS, head_size=_DIM, causal=False, softmax_scale=_DIM**-0.5)
+    raw_qkv = torch.randn(3, meta.total_seq_length, _HEADS, _DIM, dtype=torch.bfloat16)
+    tiled_qkv = impl.preprocess_qkv(raw_qkv, meta)
+    query, key, value = tiled_qkv.chunk(3, dim=0)
+
+    output = impl.forward(query, key, value, None, meta)
+
+    n_tiles = meta.variable_block_sizes.numel()
+    logical_seq_len = n_tiles * 64
+    assert fake_triton.calls == 0 and len(fake_sm.calls) == 1
+    assert tiled_qkv.shape[1] == logical_seq_len + 64
+    assert torch.count_nonzero(tiled_qkv[:, logical_seq_len:]) == 0
+    call = fake_sm.calls[0]
+    assert call["q"].shape[2] == logical_seq_len + 64
+    assert call["vbs"].numel() == n_tiles + 1
+    assert torch.equal(call["vbs"][:-1], meta.variable_block_sizes.to(torch.int32))
+    assert call["vbs"][-1].item() == 0
+    assert (call["q2k_num"][..., :n_tiles] == n_tiles).all()
+    assert (call["q2k_num"][..., n_tiles] == 0).all()
+    assert (call["q2k_idx"][..., :n_tiles, n_tiles] == -1).all()
+    assert (call["q2k_idx"][..., n_tiles, :] == -1).all()
+    assert output.shape == (1, logical_seq_len, _HEADS, _DIM)
+
+
+def test_unsupported_odd_route_strips_partner_before_triton(routed, monkeypatch):
+    fake_sm, _, _, meta = routed
+    fake_sm.supported = False
+    monkeypatch.setenv(VSA_SM100A_ENV, "1")
+    monkeypatch.setattr(vsa_h3.logger, "warning_once", lambda *_args, **_kwargs: None)
+    calls = []
+
+    def capture_triton(q, k, v, mask, variable_block_sizes):
+        calls.append((q.shape, k.shape, v.shape, mask.shape, variable_block_sizes.clone()))
+        return q.clone(), None
+
+    monkeypatch.setattr(vsa_h3, "block_sparse_attn_64_bhsd", capture_triton)
+    impl = MiniMaxH3VSAImpl(num_heads=_HEADS, head_size=_DIM, causal=False, softmax_scale=_DIM**-0.5)
+    raw_qkv = torch.randn(3, meta.total_seq_length, _HEADS, _DIM, dtype=torch.bfloat16)
+    tiled_qkv = impl.preprocess_qkv(raw_qkv, meta)
+    query, key, value = tiled_qkv.chunk(3, dim=0)
+    output = impl.forward(query, key, value, None, meta)
+
+    n_tiles = meta.variable_block_sizes.numel()
+    assert tiled_qkv.shape[1] == (n_tiles + 1) * 64
+    assert output.shape[1] == n_tiles * 64
+    assert len(calls) == 1
+    q_shape, k_shape, v_shape, mask_shape, sizes = calls[0]
+    assert q_shape[2] == k_shape[2] == v_shape[2] == n_tiles * 64
+    assert mask_shape[-2:] == (n_tiles, n_tiles)
+    assert torch.equal(sizes, meta.variable_block_sizes)
+
+
+def test_geometry_change_clears_reused_partner_tile(monkeypatch):
+    monkeypatch.setenv(VSA_SM100A_ENV, "1")
+    builder = MiniMaxH3VSAMetadataBuilder()
+    even_meta = _build_meta(prefix_segments=(70, 70), builder=builder)
+    odd_meta = _build_meta(prefix_segments=(70, 30), builder=builder)
+    assert even_meta.variable_block_sizes.numel() == odd_meta.variable_block_sizes.numel() + 1
+    impl = MiniMaxH3VSAImpl(num_heads=_HEADS, head_size=_DIM, causal=False, softmax_scale=_DIM**-0.5)
+
+    even_raw = torch.ones(1, even_meta.total_seq_length, _HEADS, _DIM, dtype=torch.bfloat16)
+    even_tiled = impl.preprocess_qkv(even_raw, even_meta)
+    allocation = even_tiled.data_ptr()
+    assert torch.count_nonzero(even_tiled[:, -64:]) > 0
+
+    odd_raw = torch.randn(1, odd_meta.total_seq_length, _HEADS, _DIM, dtype=torch.bfloat16)
+    odd_tiled = impl.preprocess_qkv(odd_raw, odd_meta)
+    assert odd_tiled.data_ptr() == allocation
+    assert torch.count_nonzero(odd_tiled[:, -64:]) == 0
+    assert torch.equal(odd_tiled[:, odd_meta.untile_combined_index], odd_raw)
+
+
+def test_forward_rejects_non_contract_transport_shapes(routed):
+    del routed
+    impl = MiniMaxH3VSAImpl(num_heads=_HEADS, head_size=_DIM, causal=False, softmax_scale=_DIM**-0.5)
+    meta = _build_meta()
+    n_tiles = meta.variable_block_sizes.numel()
+    too_many = torch.zeros(1, (n_tiles + 2) * 64, _HEADS, _DIM, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="tiled query has length"):
+        impl.forward(too_many, too_many, too_many, None, meta)
+
+    logical = torch.zeros(1, n_tiles * 64, _HEADS, _DIM, dtype=torch.bfloat16)
+    partner = torch.zeros(1, (n_tiles + 1) * 64, _HEADS, _DIM, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="tiled key length"):
+        impl.forward(logical, partner, logical, None, meta)
+    with pytest.raises(ValueError, match="tiled gate length"):
+        impl.forward(logical, logical, logical, partner, meta)
+
+
+def test_real_sm100a_odd_route_matches_triton_oracle(monkeypatch):
+    """Exercise the padded route through the actual GB200 extension."""
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 0):
+        pytest.skip("requires a GB200 (sm_100a) compute node")
+    if vsa_h3._sm100a is None or not vsa_h3._sm100a._HAS_VSA_SM100A:
+        pytest.skip("requires a fastvideo_kernel build containing sm_100a VSA")
+
+    device = torch.device("cuda")
+    meta = _build_meta(device=device, sparsity=0.5)
+    assert meta.variable_block_sizes.numel() % 2 == 1
+    impl = MiniMaxH3VSAImpl(num_heads=_HEADS, head_size=_DIM, causal=False, softmax_scale=_DIM**-0.5)
+    torch.manual_seed(11)
+    raw_qkv = torch.randn(3, meta.total_seq_length, _HEADS, _DIM, device=device, dtype=torch.bfloat16)
+
+    with torch.inference_mode():
+        monkeypatch.delenv(VSA_SM100A_ENV, raising=False)
+        triton_tiled = impl.preprocess_qkv(raw_qkv, meta)
+        triton_query, triton_key, triton_value = triton_tiled.chunk(3, dim=0)
+        triton_output = impl.postprocess_output(
+            impl.forward(triton_query, triton_key, triton_value, None, meta), meta)
+
+        def reject_triton(*args, **kwargs):
+            raise AssertionError("odd no-grad VSA-H3 unexpectedly fell back to Triton-64")
+
+        monkeypatch.setattr(vsa_h3, "block_sparse_attn_64_bhsd", reject_triton)
+        monkeypatch.setenv(VSA_SM100A_ENV, "1")
+        sm100a_tiled = impl.preprocess_qkv(raw_qkv, meta)
+        sm100a_query, sm100a_key, sm100a_value = sm100a_tiled.chunk(3, dim=0)
+        sm100a_output = impl.postprocess_output(
+            impl.forward(sm100a_query, sm100a_key, sm100a_value, None, meta), meta)
+        torch.cuda.synchronize()
+
+    assert sm100a_tiled.shape[1] == triton_tiled.shape[1] + 64
+    assert sm100a_output.shape == triton_output.shape == (1, meta.total_seq_length, _HEADS, _DIM)
+    torch.testing.assert_close(sm100a_output.float(), triton_output.float(), atol=0.04, rtol=0.02)

--- a/fastvideo/tests/attention/test_vsa_h3_sm100a_route.py
+++ b/fastvideo/tests/attention/test_vsa_h3_sm100a_route.py
@@ -8,10 +8,13 @@ logical tile count, and (d) strip that partner before any fallback or returned
 output. Most probes are monkeypatched; the final test is a GB200 route receipt.
 """
 
+import logging
+
 import pytest
 import torch
 
 import fastvideo.attention.backends.video_sparse_attn_h3 as vsa_h3
+import fastvideo.logger as fastvideo_logger
 from fastvideo.attention.backends.video_sparse_attn_h3 import (VSA_SM100A_ENV, MiniMaxH3VSAImpl,
                                                                MiniMaxH3VSAMetadataBuilder, _sm100a_unavailable_reason)
 
@@ -140,6 +143,28 @@ def test_env_on_routes_sm100a_with_index_metadata(routed, monkeypatch):
     assert messages == ["MiniMax-H3 VSA tile-64 forward: using the sm100a CUDA block-sparse kernel"]
     # BHSD kernel result comes back in the backend's BSHD layout
     assert out.shape == (1, n_tiles * 64, _HEADS, _DIM)
+
+
+def test_sm100a_engagement_receipt_logs_once_without_stacklevel_conflict(routed, monkeypatch):
+    fake_sm, fake_triton, run, _ = routed
+    monkeypatch.setenv(VSA_SM100A_ENV, "1")
+    records = []
+
+    def capture_log(level, msg, *args, **kwargs):
+        records.append((level, msg, args, kwargs))
+
+    fastvideo_logger._print_info_once.cache_clear()
+    monkeypatch.setattr(vsa_h3.logger, "log", capture_log)
+    try:
+        run()
+        run()
+    finally:
+        fastvideo_logger._print_info_once.cache_clear()
+
+    assert fake_triton.calls == 0
+    assert len(fake_sm.calls) == 2
+    assert records == [(logging.INFO, "MiniMax-H3 VSA tile-64 forward: using the sm100a CUDA block-sparse kernel", (),
+                        {"stacklevel": 2})]
 
 
 def test_env_on_grad_inputs_fall_back_to_triton(routed, monkeypatch):


### PR DESCRIPTION
## Purpose

The MiniMax-H3 sm100a block-sparse kernel assigns adjacent query-tile pairs to each CTA. A tile-64 request with an odd logical tile count therefore fails the kernel support gate and falls back to Triton. Long Preview shapes such as 345 frames commonly have that odd geometry, leaving the faster CUDA path unused.

This change appends one internal, zero-valid partner tile for eligible no-grad sm100a calls. The trained score search, block mask, gate-compress branch, metadata, gradients, fallbacks, and returned packed sequence remain on the original logical tiles.

## Changes

- Add one transport-only partner to odd tile-64, no-grad sm100a requests.
- Give the partner an all-false query/key mask and zero variable block size.
- Trim the partner before every Triton fallback and before returning sm100a output.
- Preserve the existing logical geometry for dense/sparse score selection and gate-compress.
- Clear stale padding when a builder-owned buffer is reused across same-sized but different tile geometries.
- Add CPU routing/shape/buffer tests plus a real GB200 sm100a-vs-Triton oracle.

The feature remains behind the existing `FASTVIDEO_VSA_SM100A=1` opt-in. Tile-256, even-tile, grad-enabled, and default-off paths retain their previous behavior.

## Test Plan

```bash
pre-commit run --all-files
python -m pytest -q fastvideo/tests/attention/test_vsa_h3_sm100a_route.py
```

## Test Results

- Current composed head `286203d9e` (`main`/#1741 plus this change): **15 passed** on GB200, including the real odd-tile sm100a route compared with the Triton-64 numerical oracle (job 2997).
- Full pre-commit suite: passed.
- The real-kernel gate requires equal logical output shape and `torch.testing.assert_close(..., atol=0.04, rtol=0.02)` against Triton.
- Preview FastH3 F4, 768x1344x345, four DiT forwards, one excluded warmup plus three timed repeats:
  - 1x: **54.809 s -> 47.212 s** end to end; **39.998 s -> 29.699 s** denoising.
  - SP-4: **18.236 s -> 15.468 s** end to end; **11.428 s -> 9.107 s** denoising.

F4 changes floating-point operation order through its separate fusion opt-in and remains a report-only performance profile. This PR does not broaden that claim; it specifically removes the odd-tile fallback while retaining the established sm100a numerical envelope.

## Checklist

- [x] I ran pre-commit on the exact composed head
- [x] I added default-off, grad, even/odd, fallback, stale-buffer, and hardware coverage
- [x] I verified the actual sm100a extension on GB200
- [x] I kept training code and configuration out of the change
