### PR TITLE
[feat] Add external-launcher executor for multi-node inference

### DIFF
--- a/docs/inference/architecture.md
+++ b/docs/inference/architecture.md
@@ -337,25 +337,63 @@ Key APIs: `get_tp_rank()`, `get_tp_world_size()`, `get_sp_rank()`,
 `warmup_sequence_parallel_communication()` pre-warms NCCL communicators
 to avoid slow first forward passes.
 
-The default `mp` executor starts all workers locally. For a launcher-owned
-SPMD job (including multi-node inference), select the external-launcher
-executor and make `--num-gpus` equal the launcher's total world size:
+The default `mp` executor starts all workers locally. For synchronized offline
+SPMD generation (including multi-node inference), select the
+`external_launcher` executor in the typed run config and make
+`generator.engine.num_gpus` equal the launcher's total world size. The
+[MiniMax-H3 external-launcher example](https://github.com/hao-ai-lab/FastVideo/blob/main/examples/inference/basic/minimax_h3_external_launcher.yaml)
+contains a complete request:
 
 ```bash
 torchrun --standalone --nproc-per-node=4 \
   -m fastvideo.entrypoints.cli.main generate \
-  --model-path ... \
-  --num-gpus 4 \
-  --tp-size 1 \
-  --sp-size 4 \
-  --distributed-executor-backend external_launcher
+  --config examples/inference/basic/minimax_h3_external_launcher.yaml
 ```
 
-For multiple nodes, use torchrun's `--nnodes`, `--node-rank`,
-`--master-addr`, and `--master-port` arguments. Every rank must issue the
-same generation requests in the same order; world rank 0 saves and returns
-the generated media. `FASTVIDEO_EXTERNAL_LAUNCHER=1` is an equivalent opt-in
-for callers that leave the backend at its default `mp` value.
+For two nodes with four GPUs each, launch the same command on both nodes and
+set `NODE_RANK` to `0` or `1`:
+
+```bash
+torchrun --nnodes=2 --nproc-per-node=4 \
+  --node-rank="$NODE_RANK" \
+  --master-addr="$MASTER_ADDR" --master-port="$MASTER_PORT" \
+  -m fastvideo.entrypoints.cli.main generate \
+  --config examples/inference/basic/minimax_h3_external_launcher.yaml \
+  --generator.engine.num_gpus 8 \
+  --generator.engine.parallelism.sp_size 8
+```
+
+Native Slurm variables are also accepted: `SLURM_PROCID`, `SLURM_NTASKS`,
+and `SLURM_LOCALID` map to global rank, world size, and local rank. Slurm does
+not choose the env rendezvous endpoint, so export a reachable rank-zero host
+and a job-unique port. Preserve a scheduler/CI-provided `MASTER_PORT` when one
+already exists. This uniform `2 x 4` example exposes all four allocated GPUs
+to every task so `SLURM_LOCALID` is a valid device index:
+
+```bash
+export MASTER_ADDR="${MASTER_ADDR:-$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)}"
+export MASTER_PORT="${MASTER_PORT:-$((20000 + SLURM_JOB_ID % 20000))}"
+srun --nodes=2 --ntasks-per-node=4 --gpus-per-node=4 --gpu-bind=none \
+  --kill-on-bad-exit=1 \
+  python -m fastvideo.entrypoints.cli.main generate \
+  --config examples/inference/basic/minimax_h3_external_launcher.yaml \
+  --generator.engine.num_gpus 8 \
+  --generator.engine.parallelism.sp_size 8
+```
+
+Every rank must enter the same requests in the same order. The CLI config and
+model/media inputs therefore need to resolve identically on every node. Rank
+zero alone reads prompt-list files, creates output directories, saves media,
+and returns generated frames/audio/latents/trajectories; only that rank needs
+a writable output path. A local-rank error, an out-of-range rendezvous port,
+or a device index outside the process-visible accelerator set fails before
+model loading. `--kill-on-bad-exit=1` (or torchrun's worker-group supervision)
+then terminates peers after a rank failure.
+
+`FASTVIDEO_EXTERNAL_LAUNCHER=1` is an equivalent offline-only opt-in for
+callers that leave `execution_backend: mp`. External-launcher mode is rejected
+by REST and streaming servers because those request loops do not provide a
+rank-zero SPMD control plane.
 
 ### torch.compile Integration
 

--- a/docs/inference/architecture.md
+++ b/docs/inference/architecture.md
@@ -385,10 +385,21 @@ Every rank must enter the same requests in the same order. The CLI config and
 model/media inputs therefore need to resolve identically on every node. Rank
 zero alone reads prompt-list files, creates output directories, saves media,
 and returns generated frames/audio/latents/trajectories; only that rank needs
-a writable output path. A local-rank error, an out-of-range rendezvous port,
-or a device index outside the process-visible accelerator set fails before
-model loading. `--kill-on-bad-exit=1` (or torchrun's worker-group supervision)
-then terminates peers after a rank failure.
+a writable output path. For MiniMax-H3 parallel VAE decode, every rank in the
+SP group containing global rank zero participates in the decoder collectives,
+but only rank zero assembles the CPU output. All ranks in every other SP group
+skip the decode uniformly, so multiple SP groups do not materialize duplicate
+outputs.
+
+Set `generator.engine.parallelism.dist_timeout` to an optional positive
+integer number of **seconds** to apply one timeout to the default process
+group (when FastVideo initializes it) and every FastVideo-created device and
+Gloo control group. Omitting the key preserves PyTorch's backend defaults. A
+local-rank error, an out-of-range rendezvous port, or a device index outside
+the process-visible accelerator set fails before model loading. The process-
+group timeout bounds a missing collective participant;
+`--kill-on-bad-exit=1` (or torchrun's worker-group supervision) remains
+necessary to terminate the rest of the worker group after a rank failure.
 
 `FASTVIDEO_EXTERNAL_LAUNCHER=1` is an equivalent offline-only opt-in for
 callers that leave `execution_backend: mp`. External-launcher mode is rejected

--- a/docs/inference/architecture.md
+++ b/docs/inference/architecture.md
@@ -337,8 +337,25 @@ Key APIs: `get_tp_rank()`, `get_tp_world_size()`, `get_sp_rank()`,
 `warmup_sequence_parallel_communication()` pre-warms NCCL communicators
 to avoid slow first forward passes.
 
-Usage: `torchrun --nproc-per-node=N -m fastvideo.entrypoints.cli.main
-generate --model-path ... --tp-size N --sp-size M`.
+The default `mp` executor starts all workers locally. For a launcher-owned
+SPMD job (including multi-node inference), select the external-launcher
+executor and make `--num-gpus` equal the launcher's total world size:
+
+```bash
+torchrun --standalone --nproc-per-node=4 \
+  -m fastvideo.entrypoints.cli.main generate \
+  --model-path ... \
+  --num-gpus 4 \
+  --tp-size 1 \
+  --sp-size 4 \
+  --distributed-executor-backend external_launcher
+```
+
+For multiple nodes, use torchrun's `--nnodes`, `--node-rank`,
+`--master-addr`, and `--master-port` arguments. Every rank must issue the
+same generation requests in the same order; world rank 0 saves and returns
+the generated media. `FASTVIDEO_EXTERNAL_LAUNCHER=1` is an equivalent opt-in
+for callers that leave the backend at its default `mp` value.
 
 ### torch.compile Integration
 

--- a/docs/inference/cli.md
+++ b/docs/inference/cli.md
@@ -61,6 +61,11 @@ Notes:
 - `generator` and `request` are the top-level keys for generation configs.
 - `serve` configs use `generator`, `server`, and optional `default_request`.
 - Prompt text files belong under `request.inputs.prompt_path`.
+- Launcher-owned multi-node jobs set
+  `generator.engine.execution_backend: external_launcher` in this same nested
+  config. This backend is offline-only and is rejected by `fastvideo serve`;
+  see [Distributed Inference](architecture.md#distributed-inference) for
+  `torchrun` and native `srun` commands.
 
 ## Examples
 

--- a/docs/inference/configuration.md
+++ b/docs/inference/configuration.md
@@ -103,6 +103,13 @@ request:
     output_path: outputs/
 ```
 
+`generator.engine.execution_backend` accepts `mp`, `ray`, or
+`external_launcher`. The last option is for synchronized offline generation
+under `torchrun` or `srun`; it is not supported by `fastvideo serve`. Set
+`generator.engine.num_gpus` and the relevant parallelism sizes to the total
+launcher world size. See the [distributed inference contract](architecture.md#distributed-inference)
+and the [MiniMax-H3 run config](https://github.com/hao-ai-lab/FastVideo/blob/main/examples/inference/basic/minimax_h3_external_launcher.yaml).
+
 Override individual values from the CLI with dotted paths:
 
 ```bash

--- a/docs/inference/configuration.md
+++ b/docs/inference/configuration.md
@@ -110,6 +110,13 @@ under `torchrun` or `srun`; it is not supported by `fastvideo serve`. Set
 launcher world size. See the [distributed inference contract](architecture.md#distributed-inference)
 and the [MiniMax-H3 run config](https://github.com/hao-ai-lab/FastVideo/blob/main/examples/inference/basic/minimax_h3_external_launcher.yaml).
 
+`generator.engine.parallelism.dist_timeout` is an optional positive integer
+in **seconds**. FastVideo applies it to the default process group when
+FastVideo initializes that group, and to every FastVideo-created device and
+Gloo control group. If it is omitted, PyTorch's backend defaults apply. This
+timeout bounds a missing collective participant; external launchers should
+still supervise the full worker group and terminate peers when one rank exits.
+
 Override individual values from the CLI with dotted paths:
 
 ```bash

--- a/examples/inference/basic/minimax_h3_external_launcher.yaml
+++ b/examples/inference/basic/minimax_h3_external_launcher.yaml
@@ -7,6 +7,7 @@ generator:
     parallelism:
       tp_size: 1
       sp_size: 4
+      dist_timeout: 600  # seconds; applies to device and Gloo control groups
     offload:
       dit: false
       dit_layerwise: false

--- a/examples/inference/basic/minimax_h3_external_launcher.yaml
+++ b/examples/inference/basic/minimax_h3_external_launcher.yaml
@@ -1,0 +1,32 @@
+generator:
+  model_path: MiniMaxAI/MiniMax-H3
+  engine:
+    num_gpus: 4
+    execution_backend: external_launcher
+    use_fsdp_inference: true
+    parallelism:
+      tp_size: 1
+      sp_size: 4
+    offload:
+      dit: false
+      dit_layerwise: false
+      text_encoder: true
+      image_encoder: true
+      vae: true
+      pin_cpu_memory: false
+request:
+  prompt: A cinematic tracking shot of ocean waves at sunset
+  negative_prompt: ""
+  sampling:
+    height: 768
+    width: 1344
+    num_frames: 124
+    fps: 24
+    num_inference_steps: 50
+    guidance_scale: 1.0
+    batch_cfg: false
+    seed: 0
+  output:
+    output_path: outputs/minimax_h3_external_launcher.mp4
+    save_video: true
+    return_frames: false

--- a/fastvideo/api/schema.py
+++ b/fastvideo/api/schema.py
@@ -18,7 +18,7 @@ class ParallelismConfig:
     sp_size: int = -1
     hsdp_replicate_dim: int = 1
     hsdp_shard_dim: int = -1
-    dist_timeout: int | None = None
+    dist_timeout: int | None = None  # positive process-group timeout in seconds
 
 
 @dataclass

--- a/fastvideo/api/schema.py
+++ b/fastvideo/api/schema.py
@@ -74,7 +74,7 @@ class QuantizationConfig:
 @dataclass
 class EngineConfig:
     num_gpus: int = 1
-    execution_backend: Literal["mp", "ray"] = "mp"
+    execution_backend: Literal["mp", "ray", "external_launcher"] = "mp"
     parallelism: ParallelismConfig = field(default_factory=ParallelismConfig)
     offload: OffloadConfig = field(default_factory=OffloadConfig)
     compile: CompileConfig = field(default_factory=CompileConfig)

--- a/fastvideo/distributed/parallel_state.py
+++ b/fastvideo/distributed/parallel_state.py
@@ -31,6 +31,7 @@ from collections import namedtuple
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import timedelta
 from multiprocessing import shared_memory
 from typing import Any, Optional
 from unittest.mock import patch
@@ -139,6 +140,7 @@ class GroupCoordinator:
     rank_in_group: int  # rank inside the group
     cpu_group: ProcessGroup  # group for CPU communication
     device_group: ProcessGroup  # group for device communication
+    timeout: timedelta | None  # timeout applied to this coordinator's process groups
     use_device_communicator: bool  # whether to use device communicator
     device_communicator: DeviceCommunicatorBase  # device communicator
     mq_broadcaster: Any | None  # shared memory broadcaster
@@ -151,6 +153,7 @@ class GroupCoordinator:
         use_device_communicator: bool,
         use_message_queue_broadcaster: bool = False,
         group_name: str | None = None,
+        timeout: timedelta | None = None,
     ):
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
@@ -158,14 +161,18 @@ class GroupCoordinator:
 
         self.rank = torch.distributed.get_rank()
         self.local_rank = local_rank
+        self.timeout = timeout
         self.device_group = None
         self.cpu_group = None
 
         for ranks in group_ranks:
-            device_group = torch.distributed.new_group(ranks, backend=torch_distributed_backend)
+            group_kwargs: dict[str, Any] = {}
+            if timeout is not None:
+                group_kwargs["timeout"] = timeout
+            device_group = torch.distributed.new_group(ranks, backend=torch_distributed_backend, **group_kwargs)
             # a group with `gloo` backend, to allow direct coordination between
             # processes through the CPU.
-            cpu_group = torch.distributed.new_group(ranks, backend="gloo")
+            cpu_group = torch.distributed.new_group(ranks, backend="gloo", **group_kwargs)
             if self.rank in ranks:
                 self.ranks = ranks
                 self.world_size = len(ranks)
@@ -658,13 +665,19 @@ def get_world_group() -> GroupCoordinator:
     return _WORLD
 
 
-def init_world_group(ranks: list[int], local_rank: int, backend: str) -> GroupCoordinator:
+def init_world_group(
+    ranks: list[int],
+    local_rank: int,
+    backend: str,
+    timeout: timedelta | None = None,
+) -> GroupCoordinator:
     return GroupCoordinator(
         group_ranks=[ranks],
         local_rank=local_rank,
         torch_distributed_backend=backend,
         use_device_communicator=True,
         group_name="world",
+        timeout=timeout,
     )
 
 
@@ -694,7 +707,11 @@ def init_model_parallel_group(
     backend: str,
     use_message_queue_broadcaster: bool = False,
     group_name: str | None = None,
+    timeout: timedelta | None = None,
 ) -> GroupCoordinator:
+
+    if timeout is None and _WORLD is not None:
+        timeout = _WORLD.timeout
 
     return GroupCoordinator(
         group_ranks=group_ranks,
@@ -703,6 +720,7 @@ def init_model_parallel_group(
         use_device_communicator=True,
         use_message_queue_broadcaster=use_message_queue_broadcaster,
         group_name=group_name,
+        timeout=timeout,
     )
 
 
@@ -729,6 +747,7 @@ def init_distributed_environment(
     local_rank: int = 0,
     backend: str = "nccl",
     device_id: torch.device | None = None,
+    timeout: timedelta | None = None,
 ):
     # Determine the appropriate backend based on the platform
     from fastvideo.platforms import current_platform
@@ -749,10 +768,14 @@ def init_distributed_environment(
         assert distributed_init_method is not None, ("distributed_init_method must be provided when initializing "
                                                      "distributed environment")
 
+        init_kwargs: dict[str, Any] = {}
+        if timeout is not None:
+            init_kwargs["timeout"] = timeout
         torch.distributed.init_process_group(backend=backend,
                                              init_method=distributed_init_method,
                                              world_size=world_size,
-                                             rank=rank)
+                                             rank=rank,
+                                             **init_kwargs)
     # set the local rank
     # local_rank is not available in torch ProcessGroup,
     # see https://github.com/pytorch/pytorch/issues/122816
@@ -763,7 +786,7 @@ def init_distributed_environment(
     global _WORLD
     if _WORLD is None:
         ranks = list(range(torch.distributed.get_world_size()))
-        _WORLD = init_world_group(ranks, local_rank, backend)
+        _WORLD = init_world_group(ranks, local_rank, backend, timeout=timeout)
     else:
         assert _WORLD.world_size == torch.distributed.get_world_size(), (
             "world group already initialized with a different world size")
@@ -894,7 +917,8 @@ def get_local_torch_device() -> torch.device:
 
 def maybe_init_distributed_environment_and_model_parallel(tp_size: int,
                                                           sp_size: int,
-                                                          distributed_init_method: str = "env://"):
+                                                          distributed_init_method: str = "env://",
+                                                          timeout: timedelta | None = None):
     if _WORLD is not None and model_parallel_is_initialized():
         # make sure the tp and sp sizes are correct
         assert get_tp_world_size(
@@ -915,7 +939,8 @@ def maybe_init_distributed_environment_and_model_parallel(tp_size: int,
                                  rank=rank,
                                  local_rank=local_rank,
                                  distributed_init_method=distributed_init_method,
-                                 device_id=device)
+                                 device_id=device,
+                                 timeout=timeout)
     initialize_model_parallel(tensor_model_parallel_size=tp_size, sequence_model_parallel_size=sp_size)
 
     # set device if we're on a CUDA/NPU platform

--- a/fastvideo/entrypoints/cli/serve.py
+++ b/fastvideo/entrypoints/cli/serve.py
@@ -15,6 +15,15 @@ logger = init_logger(__name__)
 _VALIDATED_SERVE_CONFIG_ATTR = "_fastvideo_validated_serve_config"
 
 
+def _validate_execution_backend(serve_config) -> None:
+    from fastvideo.worker.executor import reject_external_launcher
+
+    reject_external_launcher(
+        serve_config.generator.engine.execution_backend,
+        entrypoint="fastvideo serve",
+    )
+
+
 class ServeSubcommand(CLISubcommand):
     """Starts an OpenAI-compatible API server."""
 
@@ -29,6 +38,7 @@ class ServeSubcommand(CLISubcommand):
                 args,
                 overrides=getattr(args, "_unknown", None),
             )
+        _validate_execution_backend(serve_config)
 
         logger.info("CLI serve config: %s", serve_config)
 
@@ -64,14 +74,12 @@ class ServeSubcommand(CLISubcommand):
                              "serve config plus optional dotted overrides")
         if not os.path.exists(args.config):
             raise ValueError(f"Config file not found: {args.config}")
-        setattr(
+        serve_config = build_serve_config(
             args,
-            _VALIDATED_SERVE_CONFIG_ATTR,
-            build_serve_config(
-                args,
-                overrides=getattr(args, "_unknown", None),
-            ),
+            overrides=getattr(args, "_unknown", None),
         )
+        _validate_execution_backend(serve_config)
+        setattr(args, _VALIDATED_SERVE_CONFIG_ATTR, serve_config)
 
     def subparser_init(self, subparsers: argparse._SubParsersAction) -> FlexibleArgumentParser:
         serve_parser = subparsers.add_parser(

--- a/fastvideo/entrypoints/openai/api_server.py
+++ b/fastvideo/entrypoints/openai/api_server.py
@@ -19,6 +19,7 @@ from fastvideo.entrypoints.video_generator import VideoGenerator
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
 from fastvideo.registry import get_preset_selection
+from fastvideo.worker.executor import reject_external_launcher
 
 logger = init_logger(__name__)
 
@@ -55,6 +56,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     output_dir: str = app.state.output_dir
     default_request: GenerationRequest | None = getattr(app.state, "default_request", None)
 
+    reject_external_launcher(
+        args.distributed_executor_backend,
+        entrypoint="the OpenAI-compatible server",
+    )
     logger.info("Loading model from %s ...", args.model_path)
     generator = VideoGenerator.from_fastvideo_args(args)
     logger.info("Model loaded successfully.")
@@ -75,6 +80,11 @@ def create_app(
     default_request: GenerationRequest | None = None,
 ) -> FastAPI:
     """Build the FastAPI application with all routers mounted"""
+
+    reject_external_launcher(
+        fastvideo_args.distributed_executor_backend,
+        entrypoint="the OpenAI-compatible server",
+    )
 
     app = FastAPI(
         title="FastVideo OpenAI-Compatible API",

--- a/fastvideo/entrypoints/streaming/server.py
+++ b/fastvideo/entrypoints/streaming/server.py
@@ -184,6 +184,12 @@ def run_server(serve_config: ServeConfig, *, generator: _GeneratorProto | None =
         raise ValueError("ServeConfig.streaming must be set to launch the streaming server; "
                          "got None. Add a `streaming:` block to your serve config.")
 
+    from fastvideo.worker.executor import reject_external_launcher
+    reject_external_launcher(
+        serve_config.generator.engine.execution_backend,
+        entrypoint="the streaming server",
+    )
+
     import uvicorn
 
     if generator is None:

--- a/fastvideo/entrypoints/streaming/worker.py
+++ b/fastvideo/entrypoints/streaming/worker.py
@@ -55,6 +55,12 @@ def worker_main(
     os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
     try:
         from fastvideo import VideoGenerator
+        from fastvideo.worker.executor import reject_external_launcher
+
+        reject_external_launcher(
+            generator_config.engine.execution_backend,
+            entrypoint="the streaming worker",
+        )
 
         generator = VideoGenerator.from_pretrained(config=generator_config)
         if warmup_config.enabled:

--- a/fastvideo/entrypoints/streaming_generator.py
+++ b/fastvideo/entrypoints/streaming_generator.py
@@ -15,6 +15,7 @@ from fastvideo.logger import init_logger
 from fastvideo.pipelines import ForwardBatch
 from fastvideo.utils import align_to, shallow_asdict
 from fastvideo.worker.executor import Executor
+from fastvideo.worker.executor import reject_external_launcher
 from fastvideo.worker.multiproc_executor import MultiprocExecutor
 
 logger = init_logger(__name__)
@@ -92,6 +93,10 @@ class StreamingVideoGenerator(VideoGenerator):
 
     @classmethod
     def from_fastvideo_args(cls, fastvideo_args: FastVideoArgs) -> "StreamingVideoGenerator":
+        reject_external_launcher(
+            fastvideo_args.distributed_executor_backend,
+            entrypoint="StreamingVideoGenerator",
+        )
         executor_class = Executor.get_class(fastvideo_args)
         return cls(
             fastvideo_args=fastvideo_args,

--- a/fastvideo/entrypoints/video_generator.py
+++ b/fastvideo/entrypoints/video_generator.py
@@ -15,10 +15,11 @@ import time
 import tempfile
 import types
 import warnings
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from copy import deepcopy
-from typing import Any
+from functools import partial
+from typing import Any, cast, TypeVar
 
 import imageio
 import numpy as np
@@ -64,6 +65,7 @@ except ImportError:
 
 logger = init_logger(__name__)
 _FFMPEG_ENCODER_OPTION_CACHE: dict[tuple[str, str, str], bool] = {}
+_T = TypeVar("_T")
 
 _BATCH_EXTRA_PASSTHROUGH_KEYS: tuple[str, ...] = (
     "ltx2_audio_latents",
@@ -286,13 +288,50 @@ class VideoGenerator:
         # Initialize distributed environment if needed
         # initialize_distributed_and_parallelism(fastvideo_args)
 
-        executor_class = Executor.get_class(fastvideo_args)
+        executor_class = Executor.get_class(fastvideo_args, allow_external_launcher=True)
         return cls(
             fastvideo_args=fastvideo_args,
             executor_class=executor_class,
             log_stats=False,  # TODO: implement
             log_queue=log_queue,
         )
+
+    def _run_on_output_rank(
+        self,
+        operation: Callable[[], _T],
+        *,
+        description: str,
+    ) -> _T:
+        """Run rank-local setup on rank zero and broadcast its result/error."""
+        if not self.executor.uses_spmd_execution:
+            return operation()
+
+        payload: tuple[bool, _T | str] | None = None
+        source_error: Exception | None = None
+        if self.executor.is_output_rank:
+            try:
+                payload = (True, operation())
+            except Exception as error:
+                source_error = error
+                payload = (False, f"{type(error).__name__}: {error}")
+
+        synchronized = self.executor.broadcast_from_output_rank(payload)
+        if not synchronized[0]:
+            propagated = RuntimeError(f"External-launcher {description} failed on output rank: {synchronized[1]}")
+            if source_error is not None:
+                raise propagated from source_error
+            raise propagated
+        return cast(_T, synchronized[1])
+
+    def _synchronize_request_prompt(self, request: GenerationRequest) -> GenerationRequest:
+        """Use rank zero's prompt selection for an offline SPMD request."""
+        if not self.executor.uses_spmd_execution:
+            return request
+        synchronized = deepcopy(request)
+        prompt_and_path = self.executor.broadcast_from_output_rank((
+            request.prompt, request.inputs.prompt_path) if self.executor.is_output_rank else None)
+        synchronized.prompt, synchronized.inputs.prompt_path = prompt_and_path
+        return synchronized
 
     def generate(
         self,
@@ -315,7 +354,7 @@ class VideoGenerator:
             `GenerationResult` objects when the request expands into multiple
             prompts.
         """
-        normalized_request = normalize_generation_request(request)
+        normalized_request = self._synchronize_request_prompt(normalize_generation_request(request))
         if log_queue:
             self.executor.set_log_queue(log_queue)
 
@@ -352,7 +391,7 @@ class VideoGenerator:
         """
         import asyncio
 
-        normalized = normalize_generation_request(request)
+        normalized = self._synchronize_request_prompt(normalize_generation_request(request))
         total_steps = max(1, normalized.sampling.num_inference_steps)
         yield VideoProgressEvent(step=0, total_steps=total_steps, stage="denoise")
 
@@ -544,6 +583,9 @@ class VideoGenerator:
         if sampling_param is None:
             sampling_param = SamplingParam.from_pretrained(fastvideo_args.model_path)
 
+        if self.executor.uses_spmd_execution:
+            prompt = self.executor.broadcast_from_output_rank(prompt if self.executor.is_output_rank else None)
+
         # Add action control inputs to kwargs if provided
         if mouse_cond is not None:
             kwargs['mouse_cond'] = mouse_cond
@@ -561,17 +603,26 @@ class VideoGenerator:
         sampling_param.update(kwargs)
         kwargs["_extra_overrides"] = extra_overrides
 
-        if fastvideo_args.prompt_txt is not None or sampling_param.prompt_path is not None:
-            prompt_txt_path = sampling_param.prompt_path or fastvideo_args.prompt_txt
-            if not prompt_txt_path or not os.path.exists(prompt_txt_path):
-                raise FileNotFoundError(f"Prompt text file not found: {prompt_txt_path}")
+        prompt_txt_path = sampling_param.prompt_path or fastvideo_args.prompt_txt
+        if self.executor.uses_spmd_execution:
+            prompt_txt_path = self.executor.broadcast_from_output_rank(
+                prompt_txt_path if self.executor.is_output_rank else None)
 
-            # Read prompts from file
-            with open(prompt_txt_path, encoding='utf-8') as f:
-                prompts = [line.strip() for line in f if line.strip()]
+        if prompt_txt_path is not None:
 
-            if not prompts:
-                raise ValueError(f"No prompts found in file: {prompt_txt_path}")
+            def _load_prompt_file() -> tuple[str, list[str]]:
+                if not prompt_txt_path or not os.path.exists(prompt_txt_path):
+                    raise FileNotFoundError(f"Prompt text file not found: {prompt_txt_path}")
+                with open(prompt_txt_path, encoding='utf-8') as f:
+                    prompts = [line.strip() for line in f if line.strip()]
+                if not prompts:
+                    raise ValueError(f"No prompts found in file: {prompt_txt_path}")
+                return prompt_txt_path, prompts
+
+            prompt_txt_path, prompts = self._run_on_output_rank(
+                _load_prompt_file,
+                description="prompt-file setup",
+            )
 
             logger.info("Found %d prompts in %s", len(prompts), prompt_txt_path)
 
@@ -580,7 +631,10 @@ class VideoGenerator:
                 logger.info("Processing prompt %d/%d: %s...", i + 1, len(prompts), batch_prompt[:100])
                 try:
                     # Generate video for this prompt using the same logic below
-                    output_path = self._prepare_output_path(sampling_param.output_path, batch_prompt)
+                    output_path = self._run_on_output_rank(
+                        partial(self._prepare_output_path, sampling_param.output_path, batch_prompt),
+                        description="output-path setup",
+                    )
                     kwargs["output_path"] = output_path
                     result = self._generate_single_video(
                         prompt=batch_prompt,
@@ -598,6 +652,8 @@ class VideoGenerator:
 
                 except Exception as e:
                     logger.error("Failed to generate video for prompt %d: %s", i + 1, e)
+                    if self.executor.uses_spmd_execution:
+                        raise
                     continue
 
             logger.info("Completed batch processing. Generated %d videos successfully.", len(results))
@@ -612,7 +668,10 @@ class VideoGenerator:
                 prompt = ""
             else:
                 raise ValueError("Either prompt or prompt_txt must be provided")
-        output_path = self._prepare_output_path(sampling_param.output_path, prompt)
+        output_path = self._run_on_output_rank(
+            lambda: self._prepare_output_path(sampling_param.output_path, prompt),
+            description="output-path setup",
+        )
         kwargs["output_path"] = output_path
         if prompt_embeds is not None:
             kwargs["prompt_embeds"] = prompt_embeds
@@ -792,6 +851,9 @@ class VideoGenerator:
         if not self.executor.is_output_rank:
             batch.save_video = False
             batch.return_frames = False
+            batch.return_trajectory_latents = False
+            batch.return_trajectory_decoded = False
+            batch.return_continuation_state = False
 
         # Run inference
         start_time = time.perf_counter()
@@ -1013,16 +1075,17 @@ class VideoGenerator:
             # Audio is the primary output for audio workloads — return it
             # whenever the pipeline produced one, regardless of
             # `return_frames` (which gates the video-shaped buffers).
-            "audio": output_batch.extra.get("audio"),
-            "audio_sample_rate": output_batch.extra.get("audio_sample_rate"),
-            "ltx2_audio_latents": output_batch.extra.get("ltx2_audio_latents"),
+            "audio": output_batch.extra.get("audio") if self.executor.is_output_rank else None,
+            "audio_sample_rate": output_batch.extra.get("audio_sample_rate") if self.executor.is_output_rank else None,
+            "ltx2_audio_latents":
+            output_batch.extra.get("ltx2_audio_latents") if self.executor.is_output_rank else None,
             "size": output_size,
             "generation_time": gen_time,
             "e2e_latency": e2e_time,
             "logging_info": logging_info,
-            "trajectory": output_batch.trajectory_latents,
-            "trajectory_timesteps": output_batch.trajectory_timesteps,
-            "trajectory_decoded": output_batch.trajectory_decoded,
+            "trajectory": output_batch.trajectory_latents if self.executor.is_output_rank else None,
+            "trajectory_timesteps": output_batch.trajectory_timesteps if self.executor.is_output_rank else None,
+            "trajectory_decoded": output_batch.trajectory_decoded if self.executor.is_output_rank else None,
             "video_path": output_path if save_to_disk else None,
             "peak_memory_mb": output_batch.extra.get("peak_memory_mb"),
         }

--- a/fastvideo/entrypoints/video_generator.py
+++ b/fastvideo/entrypoints/video_generator.py
@@ -785,6 +785,14 @@ class VideoGenerator:
         for _ek, _ev in extra_overrides.items():
             batch.extra[_ek] = _ev
 
+        # External-launcher mode is SPMD: every rank runs the same pipeline
+        # collectives, while only world rank 0 owns user-facing outputs. Keep
+        # non-output ranks in the forward pass but skip their decoded-tensor
+        # host copy and disk write.
+        if not self.executor.is_output_rank:
+            batch.save_video = False
+            batch.return_frames = False
+
         # Run inference
         start_time = time.perf_counter()
 

--- a/fastvideo/envs.py
+++ b/fastvideo/envs.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     FASTVIDEO_VAE_PARALLEL_DECODE_STRATEGY: str | None = None
     FASTVIDEO_ULYSSES_A2A: str = "off"
     FASTVIDEO_WORKER_MULTIPROC_METHOD: str = "spawn"
+    FASTVIDEO_EXTERNAL_LAUNCHER: bool = False
     FASTVIDEO_TARGET_DEVICE: str = "cuda"
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
@@ -273,6 +274,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Use dedicated multiprocess context for workers.
     "FASTVIDEO_WORKER_MULTIPROC_METHOD":
     lambda: os.getenv("FASTVIDEO_WORKER_MULTIPROC_METHOD", "spawn"),
+
+    # If set (=1), inference does not spawn worker subprocesses. Each process
+    # started by an external launcher (for example, torchrun or srun) becomes
+    # one worker and initializes the distributed group through env://. All
+    # ranks must call generate() collectively; world rank 0 owns user-facing
+    # outputs.
+    "FASTVIDEO_EXTERNAL_LAUNCHER":
+    lambda: os.getenv("FASTVIDEO_EXTERNAL_LAUNCHER", "0") != "0",
 
     # Emit lightweight NVTX ranges for external profilers such as Nsight Systems.
     "FASTVIDEO_NVTX_PROFILE":

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -110,7 +110,7 @@ class FastVideoArgs:
     sp_size: int = -1
     hsdp_replicate_dim: int = 1
     hsdp_shard_dim: int = -1
-    dist_timeout: int | None = None  # timeout for torch.distributed
+    dist_timeout: int | None = None  # torch.distributed timeout in seconds
 
     pipeline_config: PipelineConfig = field(default_factory=PipelineConfig)
     preprocess_config: PreprocessConfig | None = None
@@ -523,7 +523,7 @@ class FastVideoArgs:
             "--dist-timeout",
             type=int,
             default=FastVideoArgs.dist_timeout,
-            help="Set timeout for torch.distributed initialization.",
+            help="Set the torch.distributed process-group timeout in seconds.",
         )
 
         # Output type
@@ -865,6 +865,9 @@ class FastVideoArgs:
     def check_fastvideo_args(self) -> None:
         """Validate inference arguments for consistency"""
         from fastvideo.platforms import current_platform
+
+        if self.dist_timeout is not None and self.dist_timeout <= 0:
+            raise ValueError(f"dist_timeout must be greater than zero seconds, got {self.dist_timeout}")
 
         if current_platform.is_mps():
             self.use_fsdp_inference = False

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -286,6 +286,20 @@ class FastVideoArgs:
     def training_mode(self) -> bool:
         return not self.inference_mode
 
+    @property
+    def is_output_rank(self) -> bool:
+        """Whether this process may materialize user-facing outputs.
+
+        This is runtime state assigned by an SPMD executor, not a public
+        configuration field, so dataclass serialization and typed config
+        parsing deliberately ignore it.
+        """
+        return getattr(self, "_is_output_rank", True)
+
+    @is_output_rank.setter
+    def is_output_rank(self, value: bool) -> None:
+        self._is_output_rank = bool(value)
+
     def __post_init__(self):
         if self.moba_config_path:
             try:
@@ -448,7 +462,7 @@ class FastVideoArgs:
         parser.add_argument(
             "--distributed-executor-backend",
             type=str,
-            choices=["mp", "external_launcher"],
+            choices=["mp", "ray", "external_launcher"],
             default=FastVideoArgs.distributed_executor_backend,
             help="The distributed executor backend to use",
         )

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -448,7 +448,7 @@ class FastVideoArgs:
         parser.add_argument(
             "--distributed-executor-backend",
             type=str,
-            choices=["mp"],
+            choices=["mp", "external_launcher"],
             default=FastVideoArgs.distributed_executor_backend,
             help="The distributed executor backend to use",
         )

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_audio_decoding.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_audio_decoding.py
@@ -49,6 +49,11 @@ class LTX2AudioDecodingStage(PipelineStage):
         audio_latents = batch.extra.get("ltx2_audio_latents")
         if audio_latents is None:
             return batch
+        if not fastvideo_args.is_output_rank:
+            batch.extra.pop("audio", None)
+            batch.extra.pop("audio_sample_rate", None)
+            batch.extra.pop("ltx2_audio_latents", None)
+            return batch
 
         device = get_local_torch_device()
         self.audio_decoder = self.audio_decoder.to(device)

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_denoising.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_denoising.py
@@ -378,7 +378,7 @@ class LTX2DenoisingStage(PipelineStage):
                         audio_shape.channels,
                         audio_shape.mel_bins,
                     ).permute(0, 2, 1, 3).contiguous()
-                if audio_latent_path:
+                if audio_latent_path and fastvideo_args.is_output_rank:
                     self._save_audio_latents(audio_latent_path, audio_latents)
             audio_timestep_template = torch.ones(
                 (latents.shape[0], audio_shape.frames, 1),

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_latent_preparation.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_latent_preparation.py
@@ -167,7 +167,8 @@ class LTX2LatentPreparationStage(PipelineStage):
                         device=device,
                         dtype=dtype,
                     )
-                    self._save_initial_latent(latent_path, latents)
+                    if fastvideo_args.is_output_rank:
+                        self._save_initial_latent(latent_path, latents)
                 else:
                     latents = _randn_ltx2_video_latents(
                         shape=shape,
@@ -176,7 +177,8 @@ class LTX2LatentPreparationStage(PipelineStage):
                         device=device,
                         dtype=dtype,
                     )
-                    self._save_initial_latent(latent_path, latents)
+                    if fastvideo_args.is_output_rank:
+                        self._save_initial_latent(latent_path, latents)
             else:
                 if fastvideo_args.ltx2_legacy_native_noise_order:
                     latents = randn_tensor(

--- a/fastvideo/pipelines/basic/ltx2/stages/ltx2_refine.py
+++ b/fastvideo/pipelines/basic/ltx2/stages/ltx2_refine.py
@@ -227,7 +227,7 @@ class LTX2UpsampleStage(PipelineStage):
                     device=latents.device,
                     dtype=latents.dtype,
                 )
-                if noise_path:
+                if noise_path and fastvideo_args.is_output_rank:
                     self._save_noise(noise_path, noise)
             elif (patchifier is not None and patch_noise_shape is not None and video_shape is not None
                   and noise.shape == patch_noise_shape):
@@ -266,7 +266,7 @@ class LTX2UpsampleStage(PipelineStage):
                             device=audio_latents.device,
                             dtype=audio_latents.dtype,
                         )
-                        if audio_noise_path:
+                        if audio_noise_path and fastvideo_args.is_output_rank:
                             self._save_noise(audio_noise_path, audio_noise)
                     elif audio_noise.shape == audio_latents.shape:
                         audio_noise = audio_patchifier.patchify(audio_noise)
@@ -287,7 +287,7 @@ class LTX2UpsampleStage(PipelineStage):
                             device=audio_latents.device,
                             dtype=audio_latents.dtype,
                         )
-                        if audio_noise_path:
+                        if audio_noise_path and fastvideo_args.is_output_rank:
                             self._save_noise(audio_noise_path, audio_noise)
                     # Same noise mixing as video latents for the
                     # distilled refinement schedule.

--- a/fastvideo/pipelines/basic/magi_human/stages/audio_decoding.py
+++ b/fastvideo/pipelines/basic/magi_human/stages/audio_decoding.py
@@ -88,6 +88,12 @@ class MagiHumanAudioDecodingStage(PipelineStage):
             raise ValueError("MagiHumanAudioDecodingStage requires batch.audio_latents to be set. "
                              "Did the denoising stage produce them? Joint AV pipeline expects "
                              "both video and audio latents from MagiHumanDenoisingStage.")
+        if not fastvideo_args.is_output_rank:
+            batch.extra.pop("audio", None)
+            batch.extra.pop("audio_sample_rate", None)
+            batch.latents = None
+            batch.audio_latents = None
+            return batch
 
         # Upstream shape: `[B, L, C_latent]` from the DiT; AutoencoderOobleck
         # expects `[B, C_latent, L]`. MagiEvaluator.post_process does

--- a/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_decoding.py
+++ b/fastvideo/pipelines/basic/minimax_h3/stages/minimax_h3_decoding.py
@@ -40,16 +40,19 @@ def _decode_participation(fastvideo_args: FastVideoArgs, want_parallel: bool) ->
     """Resolve (sp_group, is_output_rank, parallel) for the VAE decode stages.
 
     The existing serial path keeps its global-rank-zero output ownership.
-    Parallel decode assembles once per sequence-parallel group, on that
-    group's first rank. ``parallel`` is only true when every group rank will
-    run the decode body — the collectives inside require uniform
-    participation, so no rank-dependent branch may guard them.
+    Parallel decode runs only in the sequence-parallel group containing the
+    global output rank and assembles on that rank. Every rank in any other SP
+    group skips the decode uniformly. ``parallel`` is only true when every
+    rank in the active group will run the decode body, because its collectives
+    require group-uniform participation.
     """
     if not model_parallel_is_initialized():
         return None, True, False
     sp_group = get_sp_group()
     if bool(want_parallel) and sp_group.world_size > 1:
-        return sp_group, sp_group.is_first_rank, True
+        world_group = get_world_group()
+        active_group = world_group.first_rank in sp_group.ranks
+        return sp_group, world_group.is_first_rank, active_group
     return sp_group, get_world_group().is_first_rank, False
 
 

--- a/fastvideo/pipelines/basic/mmaudio/stages.py
+++ b/fastvideo/pipelines/basic/mmaudio/stages.py
@@ -425,6 +425,15 @@ class MMAudioDecodingStage(PipelineStage):
     @torch.inference_mode()
     def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
         assert batch.latents is not None
+        if not fastvideo_args.is_output_rank:
+            batch.extra.pop("audio", None)
+            batch.extra.pop("audio_sample_rate", None)
+            batch.extra.pop("decoded_audio", None)
+            batch.extra["audio_only"] = True
+            batch.data_type = "audio"
+            batch.output = torch.empty(0, device="cpu")
+            batch.latents = None
+            return batch
         if fastvideo_args.output_type == "latent":
             batch.output = batch.latents.detach().cpu()
             return batch

--- a/fastvideo/pipelines/basic/stable_audio/stages/decoding.py
+++ b/fastvideo/pipelines/basic/stable_audio/stages/decoding.py
@@ -33,6 +33,15 @@ class StableAudioDecodingStage(PipelineStage):
         pc = fastvideo_args.pipeline_config
         latents = batch.latents
 
+        if not fastvideo_args.is_output_rank:
+            batch.extra.pop("audio", None)
+            batch.extra.pop("audio_sample_rate", None)
+            batch.extra.pop("decoded_audio", None)
+            batch.extra["audio_only"] = True
+            batch.output = torch.empty(0, device="cpu")
+            batch.latents = None
+            return batch
+
         # Latent regression path: hand back the un-decoded denoised latent
         # so the LatentSimilarityUtils harness can compare on pre-VAE
         # numerics. Mirrors the bypass in `pipelines/stages/decoding.py`

--- a/fastvideo/pipelines/stages/flux_stages.py
+++ b/fastvideo/pipelines/stages/flux_stages.py
@@ -384,6 +384,13 @@ class FluxDecodingStage(PipelineStage):
 
     @torch.no_grad()
     def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        if not fastvideo_args.is_output_rank:
+            # Flux decoding has no collectives. Avoid duplicating the VAE
+            # forward and device-to-host pixel copy on SPMD worker ranks whose
+            # result is discarded by the executor.
+            batch.output = torch.empty((0, 3, 0, 0, 0), device="cpu", dtype=torch.float32)
+            return batch
+
         packed = batch.latents
         if packed is None:
             raise ValueError("latents must be set before FluxDecodingStage")

--- a/fastvideo/pipelines/stages/sd35_conditioning.py
+++ b/fastvideo/pipelines/stages/sd35_conditioning.py
@@ -308,6 +308,12 @@ class SD35DecodingStage(PipelineStage):
 
     @torch.no_grad()
     def forward(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        if not fastvideo_args.is_output_rank:
+            # SD3.5 decoding has no collectives. Avoid duplicating the VAE
+            # forward and device-to-host pixel copy on non-output SPMD ranks.
+            batch.output = torch.empty((0, 3, 0, 0, 0), device="cpu", dtype=torch.float32)
+            return batch
+
         if batch.latents is None:
             raise ValueError("latents must be set before SD35DecodingStage")
 

--- a/fastvideo/tests/api/test_cli_translation.py
+++ b/fastvideo/tests/api/test_cli_translation.py
@@ -376,6 +376,35 @@ def test_serve_subcommand_rejects_non_positive_num_gpus(tmp_path):
         ServeSubcommand().validate(args)
 
 
+def test_serve_subcommand_rejects_external_launcher_backend(tmp_path):
+    config_path = tmp_path / "serve.yaml"
+    config_path.write_text(
+        "generator:\n"
+        "  model_path: serve-model\n"
+        "  engine:\n"
+        "    execution_backend: external_launcher\n",
+        encoding="utf-8",
+    )
+    args, _ = _parse_serve_args(["--config", str(config_path)])
+
+    with pytest.raises(ValueError, match="synchronized offline generation"):
+        ServeSubcommand().validate(args)
+
+
+def test_serve_subcommand_rejects_external_launcher_env_opt_in(tmp_path, monkeypatch):
+    config_path = tmp_path / "serve.yaml"
+    config_path.write_text(
+        "generator:\n"
+        "  model_path: serve-model\n",
+        encoding="utf-8",
+    )
+    args, _ = _parse_serve_args(["--config", str(config_path)])
+    monkeypatch.setenv("FASTVIDEO_EXTERNAL_LAUNCHER", "1")
+
+    with pytest.raises(ValueError, match="synchronized offline generation"):
+        ServeSubcommand().validate(args)
+
+
 def test_generate_subcommand_dispatches_via_typed_config(tmp_path, monkeypatch):
     config_path = tmp_path / "run.yaml"
     config_path.write_text(
@@ -557,3 +586,17 @@ def test_streaming_run_server_rejects_missing_streaming_block():
             match="ServeConfig.streaming must be set",
     ):
         streaming_server.run_server(config)
+
+
+def test_streaming_run_server_rejects_external_launcher():
+    from fastvideo.api.schema import GeneratorConfig, ServeConfig, StreamingConfig
+
+    generator = GeneratorConfig(model_path="x")
+    generator.engine.execution_backend = "external_launcher"
+    config = ServeConfig(
+        generator=generator,
+        streaming=StreamingConfig(),
+    )
+
+    with pytest.raises(ValueError, match="synchronized offline generation"):
+        streaming_server.run_server(config, generator=SimpleNamespace())

--- a/fastvideo/tests/api/test_parser.py
+++ b/fastvideo/tests/api/test_parser.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import json
+from pathlib import Path
 
 import yaml
 
@@ -73,6 +74,36 @@ def test_parse_config_accepts_existing_typed_instance() -> None:
     )
 
     assert parse_config(RunConfig, typed) is typed
+
+
+def test_parse_config_accepts_external_launcher_backend() -> None:
+    config = parse_config(
+        GeneratorConfig,
+        {
+            "model_path": "/models/minimax-h3",
+            "engine": {
+                "num_gpus": 8,
+                "execution_backend": "external_launcher",
+                "parallelism": {
+                    "sp_size": 8
+                },
+            },
+        },
+    )
+
+    assert config.engine.execution_backend == "external_launcher"
+    assert config.engine.num_gpus == 8
+    assert config.engine.parallelism.sp_size == 8
+
+
+def test_external_launcher_example_is_a_valid_run_config() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    config = load_run_config(repo_root / "examples/inference/basic/minimax_h3_external_launcher.yaml")
+
+    assert config.generator.engine.execution_backend == "external_launcher"
+    assert config.generator.engine.num_gpus == 4
+    assert config.generator.engine.parallelism.sp_size == 4
+    assert config.request.output.return_frames is False
 
 
 def test_load_run_config_supports_yaml_roundtrip(tmp_path) -> None:

--- a/fastvideo/tests/api/test_parser.py
+++ b/fastvideo/tests/api/test_parser.py
@@ -103,6 +103,7 @@ def test_external_launcher_example_is_a_valid_run_config() -> None:
     assert config.generator.engine.execution_backend == "external_launcher"
     assert config.generator.engine.num_gpus == 4
     assert config.generator.engine.parallelism.sp_size == 4
+    assert config.generator.engine.parallelism.dist_timeout == 600
     assert config.request.output.return_frames is False
 
 

--- a/fastvideo/tests/api/test_validation_errors.py
+++ b/fastvideo/tests/api/test_validation_errors.py
@@ -40,7 +40,8 @@ def test_missing_required_field_error_includes_path() -> None:
 def test_invalid_literal_error_includes_path() -> None:
     with pytest.raises(
             ConfigValidationError,
-            match=r"generator\.engine\.execution_backend: expected one of \['mp', 'ray'\]",
+            match=(r"generator\.engine\.execution_backend: expected one of "
+                   r"\['external_launcher', 'mp', 'ray'\]"),
     ):
         parse_config(
             RunConfig,

--- a/fastvideo/tests/contract/test_generate_async.py
+++ b/fastvideo/tests/contract/test_generate_async.py
@@ -28,11 +28,17 @@ from fastvideo.api.schema import (
 
 class _FakeExecutor:
 
+    is_output_rank = True
+    uses_spmd_execution = False
+
     def set_log_queue(self, q):
         self.log_queue = q
 
     def clear_log_queue(self):
         self.log_queue = None
+
+    def broadcast_from_output_rank(self, value):
+        return value
 
 
 class _FakeVideoGenerator:
@@ -50,6 +56,9 @@ class _FakeVideoGenerator:
         request: GenerationRequest,
     ) -> GenerationResult | list[GenerationResult]:
         return self._result
+
+    def _synchronize_request_prompt(self, request):
+        return request
 
     @staticmethod
     def _wrap_legacy_result(result):

--- a/fastvideo/tests/entrypoints/streaming/test_worker.py
+++ b/fastvideo/tests/entrypoints/streaming/test_worker.py
@@ -13,17 +13,21 @@ the in-process pieces:
 """
 from __future__ import annotations
 
+import queue
+import threading
 from dataclasses import dataclass, field
 from typing import Any
 
 from fastvideo.api.schema import (
     ContinuationState,
+    GeneratorConfig,
     GenerationRequest,
     WarmupConfig,
 )
 from fastvideo.entrypoints.streaming.worker import (
     _extract_continuation_state,
     _warmup_worker,
+    worker_main,
 )
 
 
@@ -87,3 +91,24 @@ class TestExtractContinuationState:
     def test_returns_none_for_missing(self) -> None:
         assert _extract_continuation_state({}) is None
         assert _extract_continuation_state(object()) is None
+
+
+def test_worker_rejects_external_launcher_before_generator_construction() -> None:
+    result_queue: queue.Queue = queue.Queue()
+    config = GeneratorConfig(model_path="/models/fake")
+    config.engine.execution_backend = "external_launcher"
+
+    worker_main(
+        gpu_id=0,
+        worker_id="worker-0",
+        generator_config=config,
+        warmup_config=WarmupConfig(enabled=False),
+        job_queue=queue.Queue(),
+        result_queue=result_queue,
+        shutdown_event=threading.Event(),
+    )
+
+    result = result_queue.get_nowait()
+    assert result["kind"] == "error"
+    assert "external_launcher is supported only" in result["error"]
+    assert "streaming worker" in result["error"]

--- a/fastvideo/tests/entrypoints/test_openai_api.py
+++ b/fastvideo/tests/entrypoints/test_openai_api.py
@@ -378,6 +378,18 @@ class TestValidateDefaultRequestAgainstPreset:
                 _validate_default_request_against_preset(default_request, "Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
 
 
+def test_openai_app_rejects_external_launcher_before_server_start():
+    from fastvideo.entrypoints.openai.api_server import create_app
+    from fastvideo.fastvideo_args import FastVideoArgs
+
+    args = FastVideoArgs(
+        model_path="test-model",
+        distributed_executor_backend="external_launcher",
+    )
+    with pytest.raises(ValueError, match="synchronized offline generation"):
+        create_app(args)
+
+
 # ---------------------------------------------------------------------------
 # Server state accessors
 # ---------------------------------------------------------------------------

--- a/fastvideo/tests/entrypoints/test_video_generator.py
+++ b/fastvideo/tests/entrypoints/test_video_generator.py
@@ -40,6 +40,9 @@ def _new_runtime_video_generator() -> VideoGenerator:
     generator.executor = SimpleNamespace(
         set_log_queue=lambda queue: None,
         clear_log_queue=lambda: None,
+        is_output_rank=True,
+        uses_spmd_execution=False,
+        broadcast_from_output_rank=lambda value: value,
     )
     generator.config = None
     return generator
@@ -140,9 +143,41 @@ def _single_video_output_batch(output, *, extra=None):
 def _single_video_generator(output_batch, fastvideo_args):
     generator = _new_video_generator()
     generator.fastvideo_args = fastvideo_args
-    generator.executor = SimpleNamespace(execute_forward=lambda batch, args: output_batch)
+    generator.executor = SimpleNamespace(
+        execute_forward=lambda batch, args: output_batch,
+        is_output_rank=True,
+        uses_spmd_execution=False,
+        broadcast_from_output_rank=lambda value: value,
+    )
     generator.config = None
     return generator
+
+
+def test_run_on_output_rank_non_root_does_not_touch_local_filesystem():
+    generator = _new_video_generator()
+    operation = pytest.fail
+    generator.executor = SimpleNamespace(
+        is_output_rank=False,
+        uses_spmd_execution=True,
+        broadcast_from_output_rank=lambda value: (True, "/rank-zero/output.mp4"),
+    )
+
+    assert generator._run_on_output_rank(operation, description="output-path setup") == "/rank-zero/output.mp4"
+
+
+def test_run_on_output_rank_propagates_rank_zero_error():
+    generator = _new_video_generator()
+    generator.executor = SimpleNamespace(
+        is_output_rank=True,
+        uses_spmd_execution=True,
+        broadcast_from_output_rank=lambda value: value,
+    )
+
+    def fail_setup():
+        raise PermissionError("output mount is read-only")
+
+    with pytest.raises(RuntimeError, match="output mount is read-only"):
+        generator._run_on_output_rank(fail_setup, description="output-path setup")
 
 
 def test_resolve_output_size_uses_produced_pixel_geometry() -> None:
@@ -468,7 +503,7 @@ def test_generate_single_video_ray_audio_only_save_preserves_worker_metadata(mon
         },
     )
     worker = Worker.__new__(Worker)
-    worker.fastvideo_args = SimpleNamespace()
+    worker.fastvideo_args = SimpleNamespace(is_output_rank=True)
     worker.pipeline = SimpleNamespace(forward=lambda batch, args: worker_output)
 
     monkeypatch.setattr(RayDistributedExecutor, "__abstractmethods__", frozenset())
@@ -530,6 +565,95 @@ def test_generate_single_video_latent_metadata_skips_cpu_materialization(tmp_pat
     assert result["video_path"] is None
 
 
+def test_generate_single_video_non_output_rank_suppresses_all_user_payloads(tmp_path):
+    audio = torch.ones(8)
+    audio_latents = torch.ones(2)
+    output_batch = _single_video_output_batch(
+        torch.empty(0),
+        extra={
+            "audio": audio,
+            "audio_sample_rate": 24000,
+            "ltx2_audio_latents": audio_latents,
+        },
+    )
+    output_batch.trajectory_latents = torch.ones(1)
+    output_batch.trajectory_timesteps = [torch.ones(1)]
+    output_batch.trajectory_decoded = [torch.ones(1)]
+    fastvideo_args = _single_video_args(output_type="latent")
+    generator = _single_video_generator(output_batch, fastvideo_args)
+    captured = {}
+
+    def execute_forward(batch, args):
+        captured["batch"] = batch
+        return output_batch
+
+    generator.executor = SimpleNamespace(
+        execute_forward=execute_forward,
+        is_output_rank=False,
+        uses_spmd_execution=True,
+        broadcast_from_output_rank=lambda value: value,
+    )
+    sampling = _small_sampling_param(save_video=True, return_frames=True)
+    sampling.return_trajectory_latents = True
+    sampling.return_trajectory_decoded = True
+
+    result = generator._generate_single_video(
+        prompt="non-output rank",
+        sampling_param=sampling,
+        fastvideo_args=fastvideo_args,
+        output_path=str(tmp_path / "must-not-exist.mp4"),
+    )
+
+    batch = captured["batch"]
+    assert not batch.save_video
+    assert not batch.return_frames
+    assert not batch.return_trajectory_latents
+    assert not batch.return_trajectory_decoded
+    assert result["samples"] is None
+    assert result["frames"] is None
+    assert result["audio"] is None
+    assert result["audio_sample_rate"] is None
+    assert result["ltx2_audio_latents"] is None
+    assert result["trajectory"] is None
+    assert result["trajectory_timesteps"] is None
+    assert result["trajectory_decoded"] is None
+    assert result["video_path"] is None
+
+
+def test_prompt_batch_failure_is_not_swallowed_in_spmd_mode(tmp_path, monkeypatch):
+    generator = _new_runtime_video_generator()
+    generator.executor = SimpleNamespace(
+        set_log_queue=lambda queue: None,
+        clear_log_queue=lambda: None,
+        is_output_rank=True,
+        uses_spmd_execution=True,
+        broadcast_from_output_rank=lambda value: value,
+    )
+    _patch_sampling_param_from_pretrained(monkeypatch)
+    prompt_file = tmp_path / "prompts.txt"
+    prompt_file.write_text("first prompt\nsecond prompt\n", encoding="utf-8")
+    calls = []
+
+    def fail_first_prompt(prompt, **kwargs):
+        calls.append(prompt)
+        raise RuntimeError("injected forward failure")
+
+    monkeypatch.setattr(generator, "_generate_single_video", fail_first_prompt)
+
+    with pytest.raises(RuntimeError, match="injected forward failure"):
+        generator.generate({
+            "inputs": {
+                "prompt_path": str(prompt_file)
+            },
+            "output": {
+                "output_path": str(tmp_path / "outputs"),
+                "save_video": False,
+                "return_frames": False,
+            },
+        })
+    assert calls == ["first prompt"]
+
+
 def test_from_config_normalizes_and_translates(monkeypatch):
     captured = _patch_from_fastvideo_args(monkeypatch)
     _patch_fastvideo_args_from_kwargs(monkeypatch)
@@ -543,6 +667,17 @@ def test_from_config_normalizes_and_translates(monkeypatch):
     assert captured["fastvideo_args"].num_gpus == 2
     assert captured["fastvideo_args"].workload_type.value == "t2v"
     assert generator.config == config
+
+
+def test_from_config_translates_external_launcher_backend(monkeypatch):
+    _patch_from_fastvideo_args(monkeypatch)
+    captured = _patch_fastvideo_args_from_kwargs(monkeypatch)
+    config = GeneratorConfig(model_path="test-model")
+    config.engine.execution_backend = "external_launcher"
+
+    VideoGenerator.from_config(config)
+
+    assert captured["kwargs"]["distributed_executor_backend"] == "external_launcher"
 
 
 def test_from_file_loads_generator_from_run_config(tmp_path, monkeypatch):
@@ -592,6 +727,20 @@ def test_from_pretrained_convenience_kwargs_do_not_warn(monkeypatch):
     assert generator.config is not None
     assert generator.config.model_path == "test-model"
     assert generator.config.engine.num_gpus == 4
+
+
+def test_from_pretrained_accepts_external_launcher_backend(monkeypatch):
+    _patch_from_fastvideo_args(monkeypatch)
+    captured = _patch_fastvideo_args_from_kwargs(monkeypatch)
+
+    VideoGenerator.from_pretrained(
+        "test-model",
+        num_gpus=2,
+        sp_size=2,
+        distributed_executor_backend="external_launcher",
+    )
+
+    assert captured["kwargs"]["distributed_executor_backend"] == "external_launcher"
 
 
 def test_from_pretrained_legacy_only_kwargs_warn(monkeypatch):

--- a/fastvideo/tests/stages/test_external_launcher_output_ownership.py
+++ b/fastvideo/tests/stages/test_external_launcher_output_ownership.py
@@ -4,6 +4,7 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
 import torch
 
 from fastvideo.pipelines import ForwardBatch
@@ -11,6 +12,8 @@ from fastvideo.pipelines.basic.ltx2.stages.ltx2_audio_decoding import LTX2AudioD
 from fastvideo.pipelines.basic.magi_human.stages.audio_decoding import MagiHumanAudioDecodingStage
 from fastvideo.pipelines.basic.mmaudio.stages import MMAudioDecodingStage
 from fastvideo.pipelines.basic.stable_audio.stages.decoding import StableAudioDecodingStage
+from fastvideo.pipelines.stages.flux_stages import FluxDecodingStage
+from fastvideo.pipelines.stages.sd35_conditioning import SD35DecodingStage
 
 
 def _non_output_args(*, output_type="pil"):
@@ -100,3 +103,17 @@ def test_magi_human_non_output_rank_skips_audio_decode():
     assert result.latents is None
     assert result.audio_latents is None
     assert "audio" not in result.extra
+
+
+@pytest.mark.parametrize("stage_cls", [FluxDecodingStage, SD35DecodingStage])
+def test_image_decoder_non_output_rank_skips_vae_and_host_payload(stage_cls):
+    vae = Mock()
+    stage = stage_cls(vae)
+
+    result = stage.forward(ForwardBatch(data_type="image"), _non_output_args())
+
+    vae.decode.assert_not_called()
+    vae.parameters.assert_not_called()
+    assert result.output is not None
+    assert result.output.device.type == "cpu"
+    assert result.output.shape == (0, 3, 0, 0, 0)

--- a/fastvideo/tests/stages/test_external_launcher_output_ownership.py
+++ b/fastvideo/tests/stages/test_external_launcher_output_ownership.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Non-output SPMD ranks must not decode or materialize audio payloads."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import torch
+
+from fastvideo.pipelines import ForwardBatch
+from fastvideo.pipelines.basic.ltx2.stages.ltx2_audio_decoding import LTX2AudioDecodingStage
+from fastvideo.pipelines.basic.magi_human.stages.audio_decoding import MagiHumanAudioDecodingStage
+from fastvideo.pipelines.basic.mmaudio.stages import MMAudioDecodingStage
+from fastvideo.pipelines.basic.stable_audio.stages.decoding import StableAudioDecodingStage
+
+
+def _non_output_args(*, output_type="pil"):
+    return SimpleNamespace(
+        is_output_rank=False,
+        output_type=output_type,
+        pipeline_config=SimpleNamespace(),
+    )
+
+
+def test_ltx2_non_output_rank_skips_audio_decoder_and_host_payload():
+    audio_decoder = Mock()
+    vocoder = Mock()
+    stage = LTX2AudioDecodingStage(audio_decoder, vocoder)
+    batch = ForwardBatch(
+        data_type="video",
+        extra={
+            "ltx2_audio_latents": torch.ones(2),
+            "audio": torch.ones(1),
+            "audio_sample_rate": 24000,
+        },
+    )
+
+    result = stage.forward(batch, _non_output_args())
+
+    audio_decoder.to.assert_not_called()
+    vocoder.to.assert_not_called()
+    assert "audio" not in result.extra
+    assert "audio_sample_rate" not in result.extra
+    assert "ltx2_audio_latents" not in result.extra
+
+
+def test_stable_audio_non_output_rank_skips_latent_and_waveform_cpu_copy():
+    vae = Mock()
+    stage = StableAudioDecodingStage(vae)
+    batch = ForwardBatch(
+        data_type="audio",
+        latents=torch.ones(1, 2, 3),
+        extra={
+            "audio": torch.ones(1),
+            "decoded_audio": torch.ones(1),
+        },
+    )
+
+    result = stage.forward(batch, _non_output_args(output_type="latent"))
+
+    vae.to.assert_not_called()
+    assert result.output is not None and result.output.numel() == 0
+    assert result.latents is None
+    assert "audio" not in result.extra
+    assert "decoded_audio" not in result.extra
+
+
+def test_mmaudio_non_output_rank_skips_decoder_and_vocoder():
+    audio_vae = Mock()
+    vocoder = Mock()
+    stage = MMAudioDecodingStage(audio_vae, vocoder)
+    batch = ForwardBatch(
+        data_type="audio",
+        latents=torch.ones(1, 2, 3),
+        extra={"audio": torch.ones(1)},
+    )
+
+    result = stage.forward(batch, _non_output_args(output_type="latent"))
+
+    audio_vae.to.assert_not_called()
+    vocoder.to.assert_not_called()
+    assert result.output is not None and result.output.numel() == 0
+    assert result.latents is None
+    assert "audio" not in result.extra
+
+
+def test_magi_human_non_output_rank_skips_audio_decode():
+    audio_vae = Mock()
+    stage = MagiHumanAudioDecodingStage(audio_vae)
+    batch = ForwardBatch(
+        data_type="video",
+        audio_latents=torch.ones(1, 2, 3),
+        output=torch.ones(1, 3, 1, 2, 2),
+        extra={"audio": torch.ones(1)},
+    )
+
+    result = stage.forward(batch, _non_output_args())
+
+    audio_vae.decode.assert_not_called()
+    assert result.output is not None and result.output.numel() > 0
+    assert result.latents is None
+    assert result.audio_latents is None
+    assert "audio" not in result.extra

--- a/fastvideo/tests/stages/test_minimax_h3_vae_streaming.py
+++ b/fastvideo/tests/stages/test_minimax_h3_vae_streaming.py
@@ -134,9 +134,8 @@ def test_decode_stages_skip_vae_on_non_output_rank(monkeypatch) -> None:
 
 
 def test_parallel_decode_runs_on_every_rank(monkeypatch) -> None:
-    """With vae_parallel_decode, non-leader ranks must enter the decode body
-    (the collectives inside require uniform participation) and only the
-    leader owns the CPU output buffer."""
+    """Every rank in the output rank's SP group enters the collective decode,
+    while only the global output rank owns the CPU output buffer."""
     latent_shape = (1, 4, 2, 4, 4)
     rows = patchify_video_latents(torch.randn(latent_shape), (1, 1, 1))
     calls = []
@@ -168,11 +167,14 @@ def test_parallel_decode_runs_on_every_rank(monkeypatch) -> None:
                            vae_parallel_decode_strategy="gather")
 
     for rank, is_first in ((0, True), (2, False)):
+        monkeypatch.setattr(minimax_h3_decoding, "get_world_group",
+                            lambda is_first=is_first: SimpleNamespace(first_rank=0, is_first_rank=is_first))
         monkeypatch.setattr(
             minimax_h3_decoding, "get_sp_group",
             lambda rank=rank, is_first=is_first: SimpleNamespace(is_first_rank=is_first,
                                                                  world_size=4,
-                                                                 rank_in_group=rank))
+                                                                 rank_in_group=rank,
+                                                                 ranks=[0, 1, 2, 3]))
         batch = ForwardBatch(data_type="video", latents=rows.clone(), raw_latent_shape=latent_shape)
         batch.extra[MINIMAX_H3_LAYOUT_KEY] = _layout(rows.shape[0], latent_shape)
         result = MiniMaxH3VideoDecodingStage(VAE(), SimpleNamespace(patch_size=(1, 1, 1))).forward(batch, args)
@@ -184,3 +186,28 @@ def test_parallel_decode_runs_on_every_rank(monkeypatch) -> None:
 
     assert [(rank, output is not None) for rank, output, _ in calls] == [(0, True), (2, False)]
     assert all(strategy == "gather" for _, _, strategy in calls)
+
+
+def test_parallel_decode_skips_entire_sp_group_without_output_rank(monkeypatch) -> None:
+    class VAE:
+
+        def to(self, device):
+            raise AssertionError("an SP group without the output rank must not execute the VAE")
+
+    monkeypatch.setattr(minimax_h3_decoding, "model_parallel_is_initialized", lambda: True)
+    monkeypatch.setattr(minimax_h3_decoding, "get_world_group",
+                        lambda: SimpleNamespace(first_rank=0, is_first_rank=False))
+    args = SimpleNamespace(output_type="pil",
+                           pin_cpu_memory=False,
+                           vae_cpu_offload=False,
+                           vae_parallel_decode=True)
+
+    for rank, is_first in ((0, True), (2, False)):
+        monkeypatch.setattr(
+            minimax_h3_decoding, "get_sp_group",
+            lambda rank=rank, is_first=is_first: SimpleNamespace(is_first_rank=is_first,
+                                                                 world_size=4,
+                                                                 rank_in_group=rank,
+                                                                 ranks=[4, 5, 6, 7]))
+        result = MiniMaxH3VideoDecodingStage(VAE(), SimpleNamespace()).forward(ForwardBatch(data_type="video"), args)
+        assert result.output.shape == (0, 3, 0, 0, 0)

--- a/fastvideo/tests/worker/external_launcher_lifecycle_smoke.py
+++ b/fastvideo/tests/worker/external_launcher_lifecycle_smoke.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real two-process Gloo lifecycle smoke for ExternalLauncherExecutor."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import torch
+
+import fastvideo.worker.external_launcher_executor as external_launcher
+from fastvideo.api.schema import GenerationRequest
+from fastvideo.entrypoints.video_generator import VideoGenerator
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.pipelines import ForwardBatch
+
+
+class _GlooWorld:
+
+    @property
+    def cpu_group(self):
+        return torch.distributed.group.WORLD
+
+    def broadcast_object(self, value, src=0):
+        values = [value]
+        torch.distributed.broadcast_object_list(values, src=src, group=self.cpu_group)
+        return values[0]
+
+
+class _SmokeWorkerWrapper:
+
+    def __init__(self, fastvideo_args, rpc_rank):
+        self.fastvideo_args = fastvideo_args
+        self.rpc_rank = rpc_rank
+        self.rank = rpc_rank
+        self.device = torch.device("cpu")
+        self.worker = self
+        self._shutdown = False
+
+    def init_worker(self, all_kwargs):
+        kwargs = all_kwargs[self.rpc_rank]
+        self.rank = kwargs["rank"]
+        self.local_rank = kwargs["local_rank"]
+
+    def init_device(self):
+        torch.distributed.init_process_group(
+            backend="gloo",
+            init_method="env://",
+            rank=self.rank,
+            world_size=int(os.environ["WORLD_SIZE"]),
+        )
+
+    def execute_method(self, method, *args, **kwargs):
+        if method == "rank_failure" and self.rank == 1:
+            raise ValueError("injected rank-one control failure")
+        if method == "identity":
+            return {
+                "rank": self.rank,
+                "local_rank": self.local_rank,
+            }
+        raise ValueError(f"unsupported smoke method: {method}")
+
+    def execute_forward(self, forward_batch, fastvideo_args):
+        del fastvideo_args
+        return forward_batch
+
+    def shutdown(self):
+        if self._shutdown:
+            return
+        self._shutdown = True
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def _run(mode: str) -> None:
+    external_launcher.WorkerWrapperBase = _SmokeWorkerWrapper
+    external_launcher.get_world_group = lambda: _GlooWorld()
+    external_launcher.torch.cuda.is_available = lambda: False
+
+    world_size = int(os.environ["WORLD_SIZE"])
+    args = FastVideoArgs(model_path="external-launcher-smoke", num_gpus=world_size, sp_size=world_size)
+    executor = external_launcher.ExternalLauncherExecutor(args)
+    try:
+        generator = VideoGenerator.__new__(VideoGenerator)
+        generator.executor = executor
+
+        if mode == "rank-exit":
+            if executor.rank == 1:
+                raise RuntimeError("injected pre-request rank exit")
+            torch.distributed.barrier(group=external_launcher.get_world_group().cpu_group)
+            raise AssertionError("rank-zero barrier unexpectedly survived the peer exit")
+
+        divergent_request = GenerationRequest(prompt=f"rank-{executor.rank}-request")
+        synchronized_request = generator._synchronize_request_prompt(divergent_request)
+        assert synchronized_request.prompt == "rank-0-request"
+
+        if mode == "rank-failure":
+            def fail_output_setup():
+                assert executor.is_output_rank
+                raise PermissionError("injected output-rank setup failure")
+
+            try:
+                generator._run_on_output_rank(fail_output_setup, description="smoke setup")
+            except RuntimeError as error:
+                assert "PermissionError: injected output-rank setup failure" in str(error)
+            else:
+                raise AssertionError("output-rank setup failure was not propagated to every process")
+
+            try:
+                executor.collective_rpc("rank_failure")
+            except RuntimeError as error:
+                assert "rank 1 ValueError: injected rank-one control failure" in str(error)
+            else:
+                raise AssertionError("rank-local failure was not propagated to every process")
+            print(f"coordinated_failure rank={executor.rank}", flush=True)
+            return
+
+        identities = executor.collective_rpc("identity")
+        assert [identity["rank"] for identity in identities] == list(range(world_size))
+
+        output = ForwardBatch(
+            data_type="video",
+            output=torch.ones((1, 3, 1, 2, 2)),
+            latents=torch.ones(2),
+            audio_latents=torch.ones(2),
+            extra={
+                "audio": torch.ones(8),
+                "audio_sample_rate": 24000,
+                "ltx2_audio_latents": torch.ones(2),
+            },
+            trajectory_latents=torch.ones(1),
+            trajectory_timesteps=[torch.ones(1)],
+            trajectory_decoded=[torch.ones(1)],
+        )
+        result = executor.execute_forward(output, args)
+        if executor.is_output_rank:
+            assert result.output is not None and result.output.numel() > 0
+            assert result.extra["audio_sample_rate"] == 24000
+            assert result.trajectory_latents is not None
+        else:
+            assert result.output is not None and result.output.numel() == 0
+            assert "audio" not in result.extra
+            assert "audio_sample_rate" not in result.extra
+            assert "ltx2_audio_latents" not in result.extra
+            assert result.latents is None
+            assert result.audio_latents is None
+            assert result.trajectory_latents is None
+            assert result.trajectory_timesteps is None
+            assert result.trajectory_decoded is None
+        print(f"lifecycle_ok rank={executor.rank}", flush=True)
+    finally:
+        executor.shutdown()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("success", "rank-failure", "rank-exit"), required=True)
+    parsed = parser.parse_args()
+    _run(parsed.mode)
+
+
+if __name__ == "__main__":
+    main()

--- a/fastvideo/tests/worker/external_launcher_lifecycle_smoke.py
+++ b/fastvideo/tests/worker/external_launcher_lifecycle_smoke.py
@@ -4,27 +4,21 @@
 from __future__ import annotations
 
 import argparse
+from datetime import timedelta
 import os
+import time
 
 import torch
 
+import fastvideo.distributed.parallel_state as parallel_state
+import fastvideo.platforms as platforms
 import fastvideo.worker.external_launcher_executor as external_launcher
 from fastvideo.api.schema import GenerationRequest
+from fastvideo.distributed import cleanup_dist_env_and_memory, init_distributed_environment
 from fastvideo.entrypoints.video_generator import VideoGenerator
 from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.platforms.cpu import CpuPlatform
 from fastvideo.pipelines import ForwardBatch
-
-
-class _GlooWorld:
-
-    @property
-    def cpu_group(self):
-        return torch.distributed.group.WORLD
-
-    def broadcast_object(self, value, src=0):
-        values = [value]
-        torch.distributed.broadcast_object_list(values, src=src, group=self.cpu_group)
-        return values[0]
 
 
 class _SmokeWorkerWrapper:
@@ -43,11 +37,14 @@ class _SmokeWorkerWrapper:
         self.local_rank = kwargs["local_rank"]
 
     def init_device(self):
-        torch.distributed.init_process_group(
-            backend="gloo",
-            init_method="env://",
+        timeout = (timedelta(seconds=self.fastvideo_args.dist_timeout)
+                   if self.fastvideo_args.dist_timeout is not None else None)
+        init_distributed_environment(
             rank=self.rank,
             world_size=int(os.environ["WORLD_SIZE"]),
+            distributed_init_method="env://",
+            local_rank=self.local_rank,
+            timeout=timeout,
         )
 
     def execute_method(self, method, *args, **kwargs):
@@ -69,17 +66,25 @@ class _SmokeWorkerWrapper:
             return
         self._shutdown = True
         if torch.distributed.is_initialized():
-            torch.distributed.destroy_process_group()
+            cleanup_dist_env_and_memory()
 
 
 def _run(mode: str) -> None:
+    # Keep this lifecycle test CPU/Gloo-only even when the host exposes GPUs.
+    # Platform selection is lazy but another imported module may have already
+    # resolved it, so replace both the cached platform and device resolver.
+    platforms._current_platform = CpuPlatform()
+    parallel_state.get_local_torch_device = lambda: torch.device("cpu")
     external_launcher.WorkerWrapperBase = _SmokeWorkerWrapper
-    external_launcher.get_world_group = lambda: _GlooWorld()
     external_launcher.torch.cuda.is_available = lambda: False
 
     world_size = int(os.environ["WORLD_SIZE"])
-    args = FastVideoArgs(model_path="external-launcher-smoke", num_gpus=world_size, sp_size=world_size)
+    args = FastVideoArgs(model_path="external-launcher-smoke",
+                         num_gpus=world_size,
+                         sp_size=world_size,
+                         dist_timeout=3)
     executor = external_launcher.ExternalLauncherExecutor(args)
+    assert external_launcher.get_world_group().timeout == timedelta(seconds=3)
     try:
         generator = VideoGenerator.__new__(VideoGenerator)
         generator.executor = executor
@@ -93,6 +98,27 @@ def _run(mode: str) -> None:
         divergent_request = GenerationRequest(prompt=f"rank-{executor.rank}-request")
         synchronized_request = generator._synchronize_request_prompt(divergent_request)
         assert synchronized_request.prompt == "rank-0-request"
+
+        if mode == "collective-timeout":
+            if executor.rank == 1:
+                # Stay alive but deliberately never enter rank zero's
+                # collective. torchrun will terminate this process after rank
+                # zero observes the configured process-group timeout.
+                time.sleep(30)
+                raise AssertionError("sleeping peer unexpectedly survived rank-zero timeout")
+
+            started = time.monotonic()
+            try:
+                executor.collective_rpc("identity")
+            except RuntimeError as error:
+                elapsed = time.monotonic() - started
+                assert 1.0 <= elapsed < 15.0, f"unexpected collective timeout latency: {elapsed:.3f}s"
+                assert "timed out" in str(error).lower(), str(error)
+                print(f"collective_timeout rank=0 elapsed={elapsed:.3f}s", flush=True)
+                # Avoid teardown collectives on a failed process group and let
+                # torchrun promptly supervise the intentionally sleeping peer.
+                os._exit(17)
+            raise AssertionError("missing collective participant did not time out")
 
         if mode == "rank-failure":
             def fail_output_setup():
@@ -154,7 +180,8 @@ def _run(mode: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", choices=("success", "rank-failure", "rank-exit"), required=True)
+    parser.add_argument("--mode", choices=("success", "rank-failure", "rank-exit", "collective-timeout"),
+                        required=True)
     parsed = parser.parse_args()
     _run(parsed.mode)
 

--- a/fastvideo/tests/worker/test_external_launcher_executor.py
+++ b/fastvideo/tests/worker/test_external_launcher_executor.py
@@ -490,3 +490,32 @@ def test_external_launcher_real_two_process_peer_exit_is_bounded():
 
     assert completed.returncode != 0
     assert "injected pre-request rank exit" in completed.stderr
+
+
+def test_external_launcher_real_two_process_missing_collective_honors_dist_timeout():
+    helper = Path(__file__).with_name("external_launcher_lifecycle_smoke.py")
+    repo_root = Path(__file__).resolve().parents[3]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    env["FASTVIDEO_TARGET_DEVICE"] = "cpu"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--standalone",
+            "--nproc-per-node=2",
+            str(helper),
+            "--mode",
+            "collective-timeout",
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "collective_timeout rank=0" in completed.stdout, completed.stdout + completed.stderr

--- a/fastvideo/tests/worker/test_external_launcher_executor.py
+++ b/fastvideo/tests/worker/test_external_launcher_executor.py
@@ -2,6 +2,8 @@
 """CPU-only coverage for the external-launcher inference executor."""
 
 import os
+from pathlib import Path
+import subprocess
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import Mock
@@ -16,11 +18,13 @@ from fastvideo.worker.external_launcher_executor import (
     ExternalLauncherExecutor,
     resolve_external_launcher_env,
 )
+from fastvideo.worker.gpu_worker import Worker
 from fastvideo.worker.multiproc_executor import MultiprocExecutor
 
 TORCHRUN_ENV = {
     "RANK": "5",
     "LOCAL_RANK": "1",
+    "LOCAL_WORLD_SIZE": "4",
     "WORLD_SIZE": "8",
     "MASTER_ADDR": "10.0.0.1",
     "MASTER_PORT": "29500",
@@ -31,10 +35,16 @@ def _clear_launcher_env(monkeypatch):
     for name in (
         "RANK",
         "LOCAL_RANK",
+        "LOCAL_WORLD_SIZE",
         "WORLD_SIZE",
         "MASTER_ADDR",
         "MASTER_PORT",
         "SLURM_LOCALID",
+        "SLURM_PROCID",
+        "SLURM_NTASKS",
+        "SLURM_NTASKS_PER_NODE",
+        "SLURM_STEP_TASKS_PER_NODE",
+        "SLURM_TASKS_PER_NODE",
         "FASTVIDEO_EXTERNAL_LAUNCHER",
     ):
         monkeypatch.delenv(name, raising=False)
@@ -64,6 +74,20 @@ def test_resolve_falls_back_to_slurm_localid(monkeypatch):
     context = resolve_external_launcher_env(os.environ)
 
     assert context.local_rank == 3
+
+
+def test_resolve_native_slurm_identity_mapping():
+    context = resolve_external_launcher_env({
+        "SLURM_PROCID": "5",
+        "SLURM_LOCALID": "1",
+        "SLURM_NTASKS": "8",
+        "SLURM_NTASKS_PER_NODE": "4(x2)",
+        "MASTER_ADDR": "10.0.0.1",
+        "MASTER_PORT": "29500",
+    })
+
+    assert (context.rank, context.local_rank, context.world_size) == (5, 1, 8)
+    assert context.local_world_size == 4
 
 
 def test_resolve_single_process_defaults_local_rank():
@@ -101,6 +125,30 @@ def test_resolve_missing_local_rank_for_multiple_processes_errors():
         resolve_external_launcher_env(environ)
 
 
+@pytest.mark.parametrize("master_port", ["0", "65536", "not-a-port"])
+def test_resolve_rejects_invalid_master_port(master_port):
+    environ = dict(TORCHRUN_ENV, MASTER_PORT=master_port)
+
+    with pytest.raises(ValueError, match="MASTER_PORT"):
+        resolve_external_launcher_env(environ)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("RANK", "not-a-rank"),
+        ("WORLD_SIZE", "many"),
+        ("LOCAL_RANK", "local"),
+        ("LOCAL_WORLD_SIZE", "several"),
+    ],
+)
+def test_resolve_rejects_non_integer_identity_with_field_name(name, value):
+    environ = dict(TORCHRUN_ENV, **{name: value})
+
+    with pytest.raises(ValueError, match=name):
+        resolve_external_launcher_env(environ)
+
+
 @pytest.mark.parametrize(
     ("name", "value"),
     [
@@ -130,14 +178,31 @@ def test_get_class_env_flag_selects_external_launcher(monkeypatch):
     monkeypatch.setenv("FASTVIDEO_EXTERNAL_LAUNCHER", "1")
     args = FastVideoArgs(model_path="test")
 
-    assert Executor.get_class(args) is ExternalLauncherExecutor
+    assert Executor.get_class(args, allow_external_launcher=True) is ExternalLauncherExecutor
 
 
 def test_get_class_explicit_backend_selects_external_launcher(monkeypatch):
     _clear_launcher_env(monkeypatch)
     args = FastVideoArgs(model_path="test", distributed_executor_backend="external_launcher")
 
-    assert Executor.get_class(args) is ExternalLauncherExecutor
+    assert Executor.get_class(args, allow_external_launcher=True) is ExternalLauncherExecutor
+
+
+def test_get_class_rejects_external_launcher_without_spmd_opt_in(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    args = FastVideoArgs(model_path="test", distributed_executor_backend="external_launcher")
+
+    with pytest.raises(ValueError, match="synchronized offline generation"):
+        Executor.get_class(args)
+
+
+def test_streaming_generator_rejects_external_launcher(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    from fastvideo.entrypoints.streaming_generator import StreamingVideoGenerator
+    args = FastVideoArgs(model_path="test", distributed_executor_backend="external_launcher")
+
+    with pytest.raises(ValueError, match="StreamingVideoGenerator"):
+        StreamingVideoGenerator.from_fastvideo_args(args)
 
 
 def test_env_flag_does_not_override_explicit_ray_backend(monkeypatch):
@@ -202,11 +267,15 @@ def test_init_normalizes_slurm_localid_before_worker_device_init(monkeypatch):
 
     monkeypatch.setattr(external_launcher, "WorkerWrapperBase", StubWorkerWrapper)
     monkeypatch.setattr(external_launcher.atexit, "register", Mock())
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 8)
     args = FastVideoArgs(model_path="test", num_gpus=8, sp_size=8)
 
     executor = ExternalLauncherExecutor(args)
 
     assert os.environ["LOCAL_RANK"] == "3"
+    assert os.environ["RANK"] == "5"
+    assert os.environ["WORLD_SIZE"] == "8"
+    assert not args.is_output_rank
     assert wrappers[0].local_rank_at_init_device == "3"
     assert wrappers[0].init_kwargs == {
         "fastvideo_args": args,
@@ -216,6 +285,48 @@ def test_init_normalizes_slurm_localid_before_worker_device_init(monkeypatch):
     }
     executor.shutdown()
     assert wrappers[0].shutdown_called
+
+
+def test_init_rejects_local_rank_outside_visible_cuda_devices(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    environ = dict(TORCHRUN_ENV, LOCAL_RANK="3")
+    _set_env(monkeypatch, environ)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 2)
+    args = FastVideoArgs(model_path="test", num_gpus=8, sp_size=8)
+
+    with pytest.raises(ValueError, match="process-visible CUDA"):
+        ExternalLauncherExecutor(args)
+
+
+def test_init_failure_cleans_up_partially_initialized_worker(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    _set_env(monkeypatch, TORCHRUN_ENV)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    shutdown = Mock()
+
+    class FailingWorkerWrapper:
+
+        def __init__(self, fastvideo_args, rpc_rank):
+            self.fastvideo_args = fastvideo_args
+            self.rpc_rank = rpc_rank
+            self.worker = SimpleNamespace()
+
+        def init_worker(self, all_kwargs):
+            self.kwargs = all_kwargs[self.rpc_rank]
+
+        def init_device(self):
+            raise RuntimeError("injected device initialization failure")
+
+        def shutdown(self):
+            shutdown()
+
+    monkeypatch.setattr(external_launcher, "WorkerWrapperBase", FailingWorkerWrapper)
+    args = FastVideoArgs(model_path="test", num_gpus=8, sp_size=8)
+
+    with pytest.raises(RuntimeError, match="injected device initialization failure"):
+        ExternalLauncherExecutor(args)
+    shutdown.assert_called_once_with()
 
 
 def test_bind_worker_device_in_request_thread(monkeypatch):
@@ -238,4 +349,144 @@ def test_is_output_rank_property():
     assert executor.is_output_rank
     executor.rank = 3
     assert not executor.is_output_rank
+    assert executor.uses_spmd_execution
     assert MultiprocExecutor.__new__(MultiprocExecutor).is_output_rank
+
+
+def test_collective_rpc_rejects_unsupported_timeout():
+    executor = ExternalLauncherExecutor.__new__(ExternalLauncherExecutor)
+    executor.rank = 0
+    executor.world_size = 1
+    executor.shutting_down = True
+    executor.worker = SimpleNamespace(execute_method=Mock())
+
+    with pytest.raises(NotImplementedError, match="does not support per-call timeouts"):
+        executor.collective_rpc("probe", timeout=0.01)
+    executor.worker.execute_method.assert_not_called()
+
+
+def test_collective_rpc_single_rank_returns_rank_ordered_result(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    executor = ExternalLauncherExecutor.__new__(ExternalLauncherExecutor)
+    executor.rank = 0
+    executor.world_size = 1
+    executor.shutting_down = True
+    executor.worker = SimpleNamespace(
+        device=torch.device("cpu"),
+        execute_method=lambda method, *args, **kwargs: {
+            "method": method,
+            "args": args,
+            "kwargs": kwargs,
+        },
+    )
+
+    assert executor.collective_rpc("probe", args=(1, ), kwargs={"two": 2}) == [{
+        "method": "probe",
+        "args": (1, ),
+        "kwargs": {
+            "two": 2
+        },
+    }]
+
+
+def test_worker_non_output_rank_clears_latents_audio_and_trajectories():
+    args = SimpleNamespace(is_output_rank=False, output_type="latent")
+    batch = external_launcher.ForwardBatch(
+        data_type="video",
+        output=torch.ones(1),
+        latents=torch.ones(1),
+        audio_latents=torch.ones(1),
+        save_video=True,
+        return_frames=True,
+        return_trajectory_latents=True,
+        return_trajectory_decoded=True,
+        extra={
+            "audio": torch.ones(1),
+            "audio_sample_rate": 24000,
+            "decoded_audio": torch.ones(1),
+            "ltx2_audio_latents": torch.ones(1),
+        },
+        trajectory_latents=torch.ones(1),
+        trajectory_timesteps=[torch.ones(1)],
+        trajectory_decoded=[torch.ones(1)],
+    )
+    worker = Worker.__new__(Worker)
+    worker.fastvideo_args = args
+    worker.pipeline = SimpleNamespace(forward=lambda forward_batch, fastvideo_args: forward_batch)
+
+    result = worker.execute_forward(batch, args)
+
+    assert not batch.save_video
+    assert not batch.return_frames
+    assert not batch.return_trajectory_latents
+    assert not batch.return_trajectory_decoded
+    assert result.output is not None and result.output.numel() == 0
+    assert result.latents is None
+    assert result.audio_latents is None
+    assert "audio" not in result.extra
+    assert "audio_sample_rate" not in result.extra
+    assert "decoded_audio" not in result.extra
+    assert "ltx2_audio_latents" not in result.extra
+    assert result.trajectory_latents is None
+    assert result.trajectory_timesteps is None
+    assert result.trajectory_decoded is None
+
+
+@pytest.mark.parametrize("mode", ["success", "rank-failure"])
+def test_external_launcher_real_two_process_lifecycle(mode):
+    helper = Path(__file__).with_name("external_launcher_lifecycle_smoke.py")
+    repo_root = Path(__file__).resolve().parents[3]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    env["FASTVIDEO_TARGET_DEVICE"] = "cpu"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--standalone",
+            "--nproc-per-node=2",
+            str(helper),
+            "--mode",
+            mode,
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=45,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    marker = "lifecycle_ok" if mode == "success" else "coordinated_failure"
+    assert completed.stdout.count(marker) == 2
+
+
+def test_external_launcher_real_two_process_peer_exit_is_bounded():
+    helper = Path(__file__).with_name("external_launcher_lifecycle_smoke.py")
+    repo_root = Path(__file__).resolve().parents[3]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    env["FASTVIDEO_TARGET_DEVICE"] = "cpu"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--standalone",
+            "--nproc-per-node=2",
+            str(helper),
+            "--mode",
+            "rank-exit",
+        ],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "injected pre-request rank exit" in completed.stderr

--- a/fastvideo/tests/worker/test_external_launcher_executor.py
+++ b/fastvideo/tests/worker/test_external_launcher_executor.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only coverage for the external-launcher inference executor."""
+
+import os
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+import fastvideo.worker.external_launcher_executor as external_launcher
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.worker.executor import Executor
+from fastvideo.worker.external_launcher_executor import (
+    ExternalLauncherExecutor,
+    resolve_external_launcher_env,
+)
+from fastvideo.worker.multiproc_executor import MultiprocExecutor
+
+TORCHRUN_ENV = {
+    "RANK": "5",
+    "LOCAL_RANK": "1",
+    "WORLD_SIZE": "8",
+    "MASTER_ADDR": "10.0.0.1",
+    "MASTER_PORT": "29500",
+}
+
+
+def _clear_launcher_env(monkeypatch):
+    for name in (
+        "RANK",
+        "LOCAL_RANK",
+        "WORLD_SIZE",
+        "MASTER_ADDR",
+        "MASTER_PORT",
+        "SLURM_LOCALID",
+        "FASTVIDEO_EXTERNAL_LAUNCHER",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _set_env(monkeypatch, environ):
+    for name, value in environ.items():
+        monkeypatch.setenv(name, value)
+
+
+def test_resolve_torchrun_env(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    _set_env(monkeypatch, TORCHRUN_ENV)
+
+    context = resolve_external_launcher_env(os.environ)
+
+    assert (context.rank, context.local_rank, context.world_size) == (5, 1, 8)
+
+
+def test_resolve_falls_back_to_slurm_localid(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    environ = dict(TORCHRUN_ENV)
+    del environ["LOCAL_RANK"]
+    environ["SLURM_LOCALID"] = "3"
+    _set_env(monkeypatch, environ)
+
+    context = resolve_external_launcher_env(os.environ)
+
+    assert context.local_rank == 3
+
+
+def test_resolve_single_process_defaults_local_rank():
+    environ = {
+        "RANK": "0",
+        "WORLD_SIZE": "1",
+        "MASTER_ADDR": "127.0.0.1",
+        "MASTER_PORT": "29500",
+    }
+
+    context = resolve_external_launcher_env(environ)
+
+    assert (context.rank, context.local_rank, context.world_size) == (0, 0, 1)
+
+
+def test_resolve_missing_vars_lists_them():
+    with pytest.raises(RuntimeError) as excinfo:
+        resolve_external_launcher_env({"RANK": "0", "WORLD_SIZE": "4"})
+
+    message = str(excinfo.value)
+    assert "MASTER_ADDR" in message
+    assert "MASTER_PORT" in message
+    assert "torchrun/srun" in message
+
+
+def test_resolve_missing_local_rank_for_multiple_processes_errors():
+    environ = {
+        "RANK": "2",
+        "WORLD_SIZE": "4",
+        "MASTER_ADDR": "10.0.0.1",
+        "MASTER_PORT": "29500",
+    }
+
+    with pytest.raises(RuntimeError, match="LOCAL_RANK"):
+        resolve_external_launcher_env(environ)
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("RANK", "8"),
+        ("RANK", "-1"),
+        ("WORLD_SIZE", "0"),
+        ("LOCAL_RANK", "8"),
+        ("LOCAL_RANK", "-1"),
+    ],
+)
+def test_resolve_rejects_out_of_bounds_identity(name, value):
+    environ = dict(TORCHRUN_ENV, **{name: value})
+
+    with pytest.raises(ValueError, match=name):
+        resolve_external_launcher_env(environ)
+
+
+def test_get_class_default_stays_multiproc(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    args = FastVideoArgs(model_path="test")
+
+    assert Executor.get_class(args) is MultiprocExecutor
+
+
+def test_get_class_env_flag_selects_external_launcher(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    monkeypatch.setenv("FASTVIDEO_EXTERNAL_LAUNCHER", "1")
+    args = FastVideoArgs(model_path="test")
+
+    assert Executor.get_class(args) is ExternalLauncherExecutor
+
+
+def test_get_class_explicit_backend_selects_external_launcher(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    args = FastVideoArgs(model_path="test", distributed_executor_backend="external_launcher")
+
+    assert Executor.get_class(args) is ExternalLauncherExecutor
+
+
+def test_env_flag_does_not_override_explicit_ray_backend(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    monkeypatch.setenv("FASTVIDEO_EXTERNAL_LAUNCHER", "1")
+
+    class StubRayExecutor:
+        pass
+
+    ray_module = ModuleType("fastvideo.worker.ray_distributed_executor")
+    ray_module.RayDistributedExecutor = StubRayExecutor
+    monkeypatch.setitem(sys.modules, ray_module.__name__, ray_module)
+    args = FastVideoArgs(model_path="test", distributed_executor_backend="ray")
+
+    assert Executor.get_class(args) is StubRayExecutor
+
+
+def test_init_rejects_num_gpus_world_size_mismatch(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    _set_env(monkeypatch, TORCHRUN_ENV)
+    args = FastVideoArgs(model_path="test", num_gpus=4, sp_size=4)
+
+    with pytest.raises(ValueError, match="WORLD_SIZE"):
+        ExternalLauncherExecutor(args)
+
+
+def test_init_requires_launcher_env(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    args = FastVideoArgs(model_path="test", num_gpus=8, sp_size=8)
+
+    with pytest.raises(RuntimeError, match="torchrun/srun"):
+        ExternalLauncherExecutor(args)
+
+
+def test_init_normalizes_slurm_localid_before_worker_device_init(monkeypatch):
+    _clear_launcher_env(monkeypatch)
+    environ = dict(TORCHRUN_ENV)
+    del environ["LOCAL_RANK"]
+    environ["SLURM_LOCALID"] = "3"
+    _set_env(monkeypatch, environ)
+
+    wrappers = []
+
+    class StubWorkerWrapper:
+
+        def __init__(self, fastvideo_args, rpc_rank):
+            self.fastvideo_args = fastvideo_args
+            self.rpc_rank = rpc_rank
+            self.init_kwargs = None
+            self.local_rank_at_init_device = None
+            self.shutdown_called = False
+            wrappers.append(self)
+
+        def init_worker(self, all_kwargs):
+            self.init_kwargs = all_kwargs[self.rpc_rank]
+
+        def init_device(self):
+            self.local_rank_at_init_device = os.environ.get("LOCAL_RANK")
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    monkeypatch.setattr(external_launcher, "WorkerWrapperBase", StubWorkerWrapper)
+    monkeypatch.setattr(external_launcher.atexit, "register", Mock())
+    args = FastVideoArgs(model_path="test", num_gpus=8, sp_size=8)
+
+    executor = ExternalLauncherExecutor(args)
+
+    assert os.environ["LOCAL_RANK"] == "3"
+    assert wrappers[0].local_rank_at_init_device == "3"
+    assert wrappers[0].init_kwargs == {
+        "fastvideo_args": args,
+        "local_rank": 3,
+        "rank": 5,
+        "distributed_init_method": "env://",
+    }
+    executor.shutdown()
+    assert wrappers[0].shutdown_called
+
+
+def test_bind_worker_device_in_request_thread(monkeypatch):
+    set_device = Mock()
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "set_device", set_device)
+    executor = ExternalLauncherExecutor.__new__(ExternalLauncherExecutor)
+    executor.worker = SimpleNamespace(device=torch.device("cuda:2"), shutdown=Mock())
+
+    executor._bind_worker_device()
+
+    set_device.assert_called_once_with(torch.device("cuda:2"))
+    executor.shutting_down = True
+
+
+def test_is_output_rank_property():
+    executor = ExternalLauncherExecutor.__new__(ExternalLauncherExecutor)
+    executor.shutting_down = True
+    executor.rank = 0
+    assert executor.is_output_rank
+    executor.rank = 3
+    assert not executor.is_output_rank
+    assert MultiprocExecutor.__new__(MultiprocExecutor).is_output_rank

--- a/fastvideo/tests/worker/test_gpu_worker.py
+++ b/fastvideo/tests/worker/test_gpu_worker.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -7,6 +8,32 @@ import torch
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.pipelines import ForwardBatch
 from fastvideo.worker.gpu_worker import Worker, _log_cuda_device_uuid
+
+
+@pytest.mark.parametrize("dist_timeout", [0, -1])
+def test_fastvideo_args_rejects_non_positive_dist_timeout(dist_timeout) -> None:
+    with pytest.raises(ValueError, match="greater than zero seconds"):
+        FastVideoArgs(model_path="test", dist_timeout=dist_timeout)
+
+
+def test_worker_threads_dist_timeout_to_distributed_groups(monkeypatch) -> None:
+    init_distributed = Mock()
+    monkeypatch.setattr("fastvideo.worker.gpu_worker.get_local_torch_device", lambda: torch.device("cpu"))
+    monkeypatch.setattr("fastvideo.platforms.current_platform",
+                        SimpleNamespace(is_mps=lambda: False, is_cuda_alike=lambda: False, is_cuda=lambda: False))
+    monkeypatch.setattr("fastvideo.worker.gpu_worker.maybe_init_distributed_environment_and_model_parallel",
+                        init_distributed)
+    monkeypatch.setattr("fastvideo.worker.gpu_worker.build_pipeline", lambda args: SimpleNamespace())
+    args = FastVideoArgs(model_path="test",
+                         num_gpus=2,
+                         sp_size=2,
+                         dist_timeout=7,
+                         distributed_executor_backend="external_launcher")
+    worker = Worker(args, local_rank=1, rank=1, distributed_init_method="env://")
+
+    worker.init_device()
+
+    init_distributed.assert_called_once_with(1, 2, "env://", timeout=timedelta(seconds=7))
 
 
 def test_cuda_device_uuid_receipt_is_disabled_without_nvtx_profiling(monkeypatch) -> None:

--- a/fastvideo/tests/worker/test_gpu_worker.py
+++ b/fastvideo/tests/worker/test_gpu_worker.py
@@ -39,7 +39,7 @@ def test_cuda_device_uuid_receipt_identifies_profiled_worker(monkeypatch) -> Non
 
 def _worker_returning(output_batch: ForwardBatch) -> Worker:
     worker = Worker.__new__(Worker)
-    worker.fastvideo_args = SimpleNamespace()
+    worker.fastvideo_args = SimpleNamespace(is_output_rank=True)
     worker.pipeline = SimpleNamespace(forward=lambda batch, args: output_batch)
     return worker
 

--- a/fastvideo/worker/executor.py
+++ b/fastvideo/worker/executor.py
@@ -12,6 +12,21 @@ from fastvideo.utils import init_logger
 logger = init_logger(__name__)
 
 _R = TypeVar("_R")
+EXTERNAL_LAUNCHER_BACKEND = "external_launcher"
+
+
+def external_launcher_requested(backend: str) -> bool:
+    """Return whether ``backend`` opts into launcher-owned SPMD execution."""
+    return backend == EXTERNAL_LAUNCHER_BACKEND or (backend == "mp" and envs.FASTVIDEO_EXTERNAL_LAUNCHER)
+
+
+def reject_external_launcher(backend: str, *, entrypoint: str) -> None:
+    """Reject external-launcher mode from an entrypoint without an SPMD control plane."""
+    if external_launcher_requested(backend):
+        raise ValueError(
+            "external_launcher is supported only for synchronized offline generation; "
+            f"it cannot be used by {entrypoint}. Launch `fastvideo generate` or the offline VideoGenerator API instead."
+        )
 
 
 class Executor(ABC):
@@ -32,24 +47,43 @@ class Executor(ABC):
         raise NotImplementedError
 
     @staticmethod
-    def get_class(fastvideo_args: FastVideoArgs) -> type["Executor"]:
+    def get_class(
+        fastvideo_args: FastVideoArgs,
+        *,
+        allow_external_launcher: bool = False,
+    ) -> type["Executor"]:
         backend = fastvideo_args.distributed_executor_backend
-        if backend == "external_launcher" or (backend == "mp" and envs.FASTVIDEO_EXTERNAL_LAUNCHER):
+        if external_launcher_requested(backend):
+            if not allow_external_launcher:
+                reject_external_launcher(backend, entrypoint="this entrypoint")
             from fastvideo.worker.external_launcher_executor import ExternalLauncherExecutor
             return cast(type["Executor"], ExternalLauncherExecutor)
-        if fastvideo_args.distributed_executor_backend == "mp":
+        if backend == "mp":
             from fastvideo.worker.multiproc_executor import MultiprocExecutor
             return cast(type["Executor"], MultiprocExecutor)
-        elif fastvideo_args.distributed_executor_backend == "ray":
+        elif backend == "ray":
             from fastvideo.worker.ray_distributed_executor import RayDistributedExecutor
             return cast(type["Executor"], RayDistributedExecutor)
         else:
-            raise ValueError(f"Unsupported distributed executor backend: {fastvideo_args.distributed_executor_backend}")
+            raise ValueError(f"Unsupported distributed executor backend: {backend}")
 
     @property
     def is_output_rank(self) -> bool:
         """Whether this process owns user-facing generated outputs."""
         return True
+
+    @property
+    def uses_spmd_execution(self) -> bool:
+        """Whether every launcher process must call this executor in lockstep."""
+        return False
+
+    def broadcast_from_output_rank(self, value: _R | None) -> _R:
+        """Broadcast a small control-plane value from the output rank.
+
+        Controller-owned executors already have one caller, so their default
+        implementation simply returns the supplied value.
+        """
+        return cast(_R, value)
 
     def execute_forward(
         self,
@@ -104,8 +138,9 @@ class Executor(ABC):
                 If the method is a callable, it should accept an additional
                 `self` argument, in addition to the arguments passed in `args`
                 and `kwargs`. The `self` argument will be the worker object.
-            timeout: Maximum time in seconds to wait for execution. Raises a
-                :exc:`TimeoutError` on timeout. `None` means wait indefinitely.
+            timeout: Maximum time in seconds to wait for execution. `None`
+                means wait indefinitely. Implementations that cannot enforce
+                a per-call timeout must reject a non-`None` value explicitly.
             args: Positional arguments to pass to the worker method.
             kwargs: Keyword arguments to pass to the worker method.
 

--- a/fastvideo/worker/executor.py
+++ b/fastvideo/worker/executor.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from queue import Queue
 from typing import Any, TypeVar, cast
 
+import fastvideo.envs as envs
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.pipelines import ForwardBatch
 from fastvideo.utils import init_logger
@@ -32,6 +33,10 @@ class Executor(ABC):
 
     @staticmethod
     def get_class(fastvideo_args: FastVideoArgs) -> type["Executor"]:
+        backend = fastvideo_args.distributed_executor_backend
+        if backend == "external_launcher" or (backend == "mp" and envs.FASTVIDEO_EXTERNAL_LAUNCHER):
+            from fastvideo.worker.external_launcher_executor import ExternalLauncherExecutor
+            return cast(type["Executor"], ExternalLauncherExecutor)
         if fastvideo_args.distributed_executor_backend == "mp":
             from fastvideo.worker.multiproc_executor import MultiprocExecutor
             return cast(type["Executor"], MultiprocExecutor)
@@ -40,6 +45,11 @@ class Executor(ABC):
             return cast(type["Executor"], RayDistributedExecutor)
         else:
             raise ValueError(f"Unsupported distributed executor backend: {fastvideo_args.distributed_executor_backend}")
+
+    @property
+    def is_output_rank(self) -> bool:
+        """Whether this process owns user-facing generated outputs."""
+        return True
 
     def execute_forward(
         self,

--- a/fastvideo/worker/external_launcher_executor.py
+++ b/fastvideo/worker/external_launcher_executor.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+"""In-process executor for externally launched SPMD inference.
+
+Unlike :class:`MultiprocExecutor`, which starts local subprocesses, this
+executor turns each process started by torchrun or srun into one inline
+worker. The launcher owns ``RANK``, ``WORLD_SIZE``, ``LOCAL_RANK``,
+``MASTER_ADDR``, and ``MASTER_PORT``; FastVideo initializes through the
+``env://`` rendezvous.
+
+Every rank must call generation collectively with the same requests in the
+same order. World rank 0 owns saved media and returned frames; other ranks
+still execute the full pipeline so sequence-parallel collectives stay
+uniform.
+"""
+
+from __future__ import annotations
+
+import atexit
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+import os
+from queue import Queue
+from typing import Any
+
+import torch
+
+import fastvideo.envs as envs
+from fastvideo.fastvideo_args import FastVideoArgs
+from fastvideo.logger import init_logger
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.worker.executor import Executor
+from fastvideo.worker.worker_base import WorkerWrapperBase
+
+logger = init_logger(__name__)
+
+EXTERNAL_LAUNCHER_BACKEND = "external_launcher"
+_REQUIRED_LAUNCHER_VARS = ("RANK", "WORLD_SIZE", "MASTER_ADDR", "MASTER_PORT")
+
+
+@dataclass(frozen=True)
+class ExternalLauncherEnv:
+    """Distributed identity assigned to this process by its launcher."""
+
+    rank: int
+    local_rank: int
+    world_size: int
+
+
+def resolve_external_launcher_env(environ: Mapping[str, str]) -> ExternalLauncherEnv:
+    """Parse and validate a torchrun/srun distributed environment."""
+
+    missing = [name for name in _REQUIRED_LAUNCHER_VARS if not environ.get(name)]
+    if missing:
+        raise RuntimeError("External-launcher inference requires the launcher to provide "
+                           f"{missing}. Launch with torchrun/srun and an env:// rendezvous.")
+
+    rank = int(environ["RANK"])
+    world_size = int(environ["WORLD_SIZE"])
+    local_rank_str = environ.get("LOCAL_RANK") or environ.get("SLURM_LOCALID")
+    if local_rank_str is None:
+        if world_size == 1:
+            local_rank_str = "0"
+        else:
+            raise RuntimeError("External-launcher inference requires LOCAL_RANK (torchrun) "
+                               "or SLURM_LOCALID (srun) so each process can select its GPU.")
+    local_rank = int(local_rank_str)
+
+    if world_size < 1:
+        raise ValueError(f"WORLD_SIZE must be >= 1, got {world_size}.")
+    if not 0 <= rank < world_size:
+        raise ValueError(f"RANK must be in [0, WORLD_SIZE); got RANK={rank}, WORLD_SIZE={world_size}.")
+    if not 0 <= local_rank < world_size:
+        raise ValueError(
+            f"LOCAL_RANK must be in [0, WORLD_SIZE); got LOCAL_RANK={local_rank}, WORLD_SIZE={world_size}.")
+    return ExternalLauncherEnv(rank=rank, local_rank=local_rank, world_size=world_size)
+
+
+class ExternalLauncherExecutor(Executor):
+    """Run this externally launched process's single worker inline."""
+
+    def _init_executor(self) -> None:
+        env_ctx = resolve_external_launcher_env(os.environ)
+        if self.fastvideo_args.num_gpus != env_ctx.world_size:
+            raise ValueError(
+                f"num_gpus={self.fastvideo_args.num_gpus} does not match the external launcher's "
+                f"WORLD_SIZE={env_ctx.world_size}. Pass num_gpus equal to the total number of launched processes.")
+
+        # get_local_torch_device() reads LOCAL_RANK through fastvideo.envs.
+        # torchrun already provides it; normalize SLURM_LOCALID for native
+        # srun launchers before Worker.init_device() performs any CUDA work.
+        os.environ["LOCAL_RANK"] = str(env_ctx.local_rank)
+
+        # Downstream Worker initialization must preserve the launcher's
+        # global rank/world rather than deriving a local multiprocess layout.
+        self.fastvideo_args.distributed_executor_backend = EXTERNAL_LAUNCHER_BACKEND
+        self.rank = env_ctx.rank
+        self.world_size = env_ctx.world_size
+        self.shutting_down = False
+
+        logger.info(
+            "External-launcher executor: rank=%d local_rank=%d world_size=%d "
+            "(env:// rendezvous at %s:%s)",
+            env_ctx.rank,
+            env_ctx.local_rank,
+            env_ctx.world_size,
+            os.environ.get("MASTER_ADDR"),
+            os.environ.get("MASTER_PORT"),
+            local_main_process_only=False,
+        )
+
+        wrapper = WorkerWrapperBase(fastvideo_args=self.fastvideo_args, rpc_rank=env_ctx.rank)
+        all_kwargs: list[dict[str, Any]] = [{} for _ in range(env_ctx.world_size)]
+        all_kwargs[env_ctx.rank] = {
+            "fastvideo_args": self.fastvideo_args,
+            "local_rank": env_ctx.local_rank,
+            "rank": env_ctx.rank,
+            "distributed_init_method": "env://",
+        }
+        wrapper.init_worker(all_kwargs)
+        self.worker = wrapper
+        wrapper.init_device()
+
+        atexit.register(self.shutdown)
+
+    @property
+    def is_output_rank(self) -> bool:
+        return self.rank == 0
+
+    def _bind_worker_device(self) -> None:
+        """Bind the request thread to this worker's CUDA device.
+
+        VideoGenerator executes forwards in a fresh thread. CUDA device
+        selection is thread-local, so the inline executor must repeat the
+        binding performed by Worker.init_device() before request-thread CUDA
+        work begins.
+        """
+
+        device = getattr(self.worker, "device", None)
+        if device is not None and device.type == "cuda" and torch.cuda.is_available():
+            torch.cuda.set_device(device)
+
+    def execute_forward(self, forward_batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        self._bind_worker_device()
+        output_batch = self.worker.execute_forward(forward_batch, fastvideo_args)
+
+        logging_info = output_batch.logging_info if envs.FASTVIDEO_STAGE_LOGGING else None
+        extra = output_batch.extra or {}
+        if torch.cuda.is_available():
+            extra["peak_memory_mb"] = torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+        return ForwardBatch(
+            data_type=forward_batch.data_type,
+            output=output_batch.output,
+            logging_info=logging_info,
+            extra=extra,
+            trajectory_latents=output_batch.trajectory_latents,
+            trajectory_timesteps=output_batch.trajectory_timesteps,
+        )
+
+    def collective_rpc(
+            self,
+            method: str | Callable,
+            timeout: float | None = None,
+            args: tuple = (),
+            kwargs: dict | None = None,
+    ) -> list[Any]:
+        """Execute one local worker method in every SPMD process."""
+
+        del timeout
+        self._bind_worker_device()
+        return [self.worker.execute_method(method, *args, **(kwargs or {}))]
+
+    def set_lora_adapter(
+        self,
+        lora_nickname: str,
+        lora_path: str | None = None,
+        strength: float = 1.0,
+        accumulate: bool = False,
+    ) -> None:
+        responses = self.collective_rpc(
+            "set_lora_adapter",
+            kwargs={
+                "lora_nickname": lora_nickname,
+                "lora_path": lora_path,
+                "strength": strength,
+                "accumulate": accumulate,
+            },
+        )
+        if responses[0]["status"] != "lora_adapter_set":
+            raise RuntimeError(f"Rank {self.rank} failed to set LoRA adapter to {lora_path}")
+
+    def unmerge_lora_weights(self) -> None:
+        responses = self.collective_rpc("unmerge_lora_weights")
+        if responses[0]["status"] != "lora_adapter_unmerged":
+            raise RuntimeError(f"Rank {self.rank} failed to unmerge LoRA weights")
+
+    def merge_lora_weights(self) -> None:
+        responses = self.collective_rpc("merge_lora_weights")
+        if responses[0]["status"] != "lora_adapter_merged":
+            raise RuntimeError(f"Rank {self.rank} failed to merge LoRA weights")
+
+    def set_log_queue(self, log_queue: Queue | None) -> None:
+        # The worker is in this process, so its logs already reach the local
+        # handlers and do not need forwarding through a multiprocessing queue.
+        del log_queue
+
+    def clear_log_queue(self) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        if getattr(self, "shutting_down", False):
+            return
+        self.shutting_down = True
+        worker = getattr(self, "worker", None)
+        if worker is not None:
+            worker.shutdown()
+
+    def __del__(self) -> None:
+        self.shutdown()

--- a/fastvideo/worker/external_launcher_executor.py
+++ b/fastvideo/worker/external_launcher_executor.py
@@ -302,7 +302,8 @@ class ExternalLauncherExecutor(Executor):
         if timeout is not None:
             raise NotImplementedError(
                 "ExternalLauncherExecutor.collective_rpc does not support per-call timeouts; "
-                "configure the distributed process-group timeout and launcher kill-on-failure policy instead.")
+                "set generator.engine.parallelism.dist_timeout in seconds and configure the launcher's "
+                "kill-on-failure policy instead.")
         self._bind_worker_device()
         try:
             response = self.worker.execute_method(method, *args, **(kwargs or {}))

--- a/fastvideo/worker/external_launcher_executor.py
+++ b/fastvideo/worker/external_launcher_executor.py
@@ -20,21 +20,27 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 import os
 from queue import Queue
+import re
 from typing import Any
 
 import torch
 
 import fastvideo.envs as envs
+from fastvideo.distributed import get_world_group
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
-from fastvideo.worker.executor import Executor
+from fastvideo.worker.executor import EXTERNAL_LAUNCHER_BACKEND, Executor
 from fastvideo.worker.worker_base import WorkerWrapperBase
 
 logger = init_logger(__name__)
 
-EXTERNAL_LAUNCHER_BACKEND = "external_launcher"
-_REQUIRED_LAUNCHER_VARS = ("RANK", "WORLD_SIZE", "MASTER_ADDR", "MASTER_PORT")
+_NON_OUTPUT_EXTRA_KEYS = frozenset({
+    "audio",
+    "audio_sample_rate",
+    "decoded_audio",
+    "ltx2_audio_latents",
+})
 
 
 @dataclass(frozen=True)
@@ -44,35 +50,115 @@ class ExternalLauncherEnv:
     rank: int
     local_rank: int
     world_size: int
+    local_world_size: int | None
+    master_addr: str
+    master_port: int
+
+
+def _first_env_value(environ: Mapping[str, str], *names: str) -> tuple[str | None, str | None]:
+    for name in names:
+        value = environ.get(name)
+        if value:
+            return value, name
+    return None, None
+
+
+def _parse_int(name: str, value: str) -> int:
+    try:
+        return int(value)
+    except ValueError:
+        raise ValueError(f"{name} must be an integer, got {value!r}.") from None
+
+
+def _slurm_local_world_size(environ: Mapping[str, str]) -> int | None:
+    """Resolve a uniform Slurm tasks-per-node value when one is available."""
+    value, source = _first_env_value(
+        environ,
+        "SLURM_NTASKS_PER_NODE",
+        "SLURM_STEP_TASKS_PER_NODE",
+        "SLURM_TASKS_PER_NODE",
+    )
+    if value is None or source is None:
+        return None
+    match = re.fullmatch(r"\s*(\d+)(?:\(x\d+\))?\s*", value)
+    if match is None:
+        # Heterogeneous encodings such as ``4(x2),2`` do not identify the
+        # current node's task count. Device-count validation still applies.
+        return None
+    return _parse_int(source, match.group(1))
 
 
 def resolve_external_launcher_env(environ: Mapping[str, str]) -> ExternalLauncherEnv:
     """Parse and validate a torchrun/srun distributed environment."""
 
-    missing = [name for name in _REQUIRED_LAUNCHER_VARS if not environ.get(name)]
+    rank_value, rank_source = _first_env_value(environ, "RANK", "SLURM_PROCID")
+    world_size_value, world_size_source = _first_env_value(environ, "WORLD_SIZE", "SLURM_NTASKS")
+    master_addr, _ = _first_env_value(environ, "MASTER_ADDR")
+    master_port_value, _ = _first_env_value(environ, "MASTER_PORT")
+    missing = []
+    if rank_value is None:
+        missing.append("RANK (or SLURM_PROCID)")
+    if world_size_value is None:
+        missing.append("WORLD_SIZE (or SLURM_NTASKS)")
+    if master_addr is None:
+        missing.append("MASTER_ADDR")
+    if master_port_value is None:
+        missing.append("MASTER_PORT")
     if missing:
         raise RuntimeError("External-launcher inference requires the launcher to provide "
                            f"{missing}. Launch with torchrun/srun and an env:// rendezvous.")
 
-    rank = int(environ["RANK"])
-    world_size = int(environ["WORLD_SIZE"])
-    local_rank_str = environ.get("LOCAL_RANK") or environ.get("SLURM_LOCALID")
-    if local_rank_str is None:
+    assert rank_value is not None and rank_source is not None
+    assert world_size_value is not None and world_size_source is not None
+    assert master_addr is not None and master_port_value is not None
+    rank = _parse_int(rank_source, rank_value)
+    world_size = _parse_int(world_size_source, world_size_value)
+    master_port = _parse_int("MASTER_PORT", master_port_value)
+
+    local_rank_value, local_rank_source = _first_env_value(environ, "LOCAL_RANK", "SLURM_LOCALID")
+    if local_rank_value is None:
         if world_size == 1:
-            local_rank_str = "0"
+            local_rank = 0
         else:
             raise RuntimeError("External-launcher inference requires LOCAL_RANK (torchrun) "
                                "or SLURM_LOCALID (srun) so each process can select its GPU.")
-    local_rank = int(local_rank_str)
+    else:
+        assert local_rank_source is not None
+        local_rank = _parse_int(local_rank_source, local_rank_value)
+
+    local_world_size_value, local_world_size_source = _first_env_value(environ, "LOCAL_WORLD_SIZE")
+    local_world_size: int | None
+    if local_world_size_value is not None:
+        assert local_world_size_source is not None
+        local_world_size = _parse_int(local_world_size_source, local_world_size_value)
+    else:
+        local_world_size = _slurm_local_world_size(environ)
 
     if world_size < 1:
         raise ValueError(f"WORLD_SIZE must be >= 1, got {world_size}.")
     if not 0 <= rank < world_size:
         raise ValueError(f"RANK must be in [0, WORLD_SIZE); got RANK={rank}, WORLD_SIZE={world_size}.")
-    if not 0 <= local_rank < world_size:
+    if local_rank < 0:
+        raise ValueError(f"LOCAL_RANK must be >= 0, got {local_rank}.")
+    if local_world_size is not None:
+        if local_world_size < 1:
+            raise ValueError(f"LOCAL_WORLD_SIZE must be >= 1, got {local_world_size}.")
+        if local_rank >= local_world_size:
+            raise ValueError("LOCAL_RANK must be in [0, LOCAL_WORLD_SIZE); "
+                             f"got LOCAL_RANK={local_rank}, LOCAL_WORLD_SIZE={local_world_size}.")
+    elif local_rank >= world_size:
         raise ValueError(
             f"LOCAL_RANK must be in [0, WORLD_SIZE); got LOCAL_RANK={local_rank}, WORLD_SIZE={world_size}.")
-    return ExternalLauncherEnv(rank=rank, local_rank=local_rank, world_size=world_size)
+    if not 1 <= master_port <= 65535:
+        raise ValueError(f"MASTER_PORT must be in [1, 65535], got {master_port}.")
+    return ExternalLauncherEnv(
+        rank=rank,
+        local_rank=local_rank,
+        world_size=world_size,
+        local_world_size=local_world_size,
+        master_addr=master_addr,
+        master_port=master_port,
+    )
 
 
 class ExternalLauncherExecutor(Executor):
@@ -85,14 +171,27 @@ class ExternalLauncherExecutor(Executor):
                 f"num_gpus={self.fastvideo_args.num_gpus} does not match the external launcher's "
                 f"WORLD_SIZE={env_ctx.world_size}. Pass num_gpus equal to the total number of launched processes.")
 
+        if torch.cuda.is_available():
+            visible_device_count = torch.cuda.device_count()
+            if env_ctx.local_rank >= visible_device_count:
+                raise ValueError(
+                    f"LOCAL_RANK={env_ctx.local_rank} cannot select from the {visible_device_count} "
+                    "process-visible CUDA device(s). Configure launcher GPU visibility so each process can address "
+                    "its local rank before model loading.")
+
         # get_local_torch_device() reads LOCAL_RANK through fastvideo.envs.
-        # torchrun already provides it; normalize SLURM_LOCALID for native
-        # srun launchers before Worker.init_device() performs any CUDA work.
+        # Normalize both torchrun and native Slurm names before
+        # Worker.init_device() performs any accelerator or process-group work.
+        os.environ["RANK"] = str(env_ctx.rank)
+        os.environ["WORLD_SIZE"] = str(env_ctx.world_size)
         os.environ["LOCAL_RANK"] = str(env_ctx.local_rank)
+        if env_ctx.local_world_size is not None:
+            os.environ["LOCAL_WORLD_SIZE"] = str(env_ctx.local_world_size)
 
         # Downstream Worker initialization must preserve the launcher's
         # global rank/world rather than deriving a local multiprocess layout.
         self.fastvideo_args.distributed_executor_backend = EXTERNAL_LAUNCHER_BACKEND
+        self.fastvideo_args.is_output_rank = env_ctx.rank == 0
         self.rank = env_ctx.rank
         self.world_size = env_ctx.world_size
         self.shutting_down = False
@@ -103,8 +202,8 @@ class ExternalLauncherExecutor(Executor):
             env_ctx.rank,
             env_ctx.local_rank,
             env_ctx.world_size,
-            os.environ.get("MASTER_ADDR"),
-            os.environ.get("MASTER_PORT"),
+            env_ctx.master_addr,
+            env_ctx.master_port,
             local_main_process_only=False,
         )
 
@@ -116,15 +215,32 @@ class ExternalLauncherExecutor(Executor):
             "rank": env_ctx.rank,
             "distributed_init_method": "env://",
         }
-        wrapper.init_worker(all_kwargs)
         self.worker = wrapper
-        wrapper.init_device()
+        try:
+            wrapper.init_worker(all_kwargs)
+            wrapper.init_device()
+        except BaseException:
+            self.shutting_down = True
+            if getattr(wrapper, "worker", None) is not None:
+                try:
+                    wrapper.shutdown()
+                except Exception:
+                    logger.exception("Failed to clean up rank %d after launcher initialization error", self.rank)
+            raise
 
         atexit.register(self.shutdown)
 
     @property
     def is_output_rank(self) -> bool:
         return self.rank == 0
+
+    @property
+    def uses_spmd_execution(self) -> bool:
+        return True
+
+    def broadcast_from_output_rank(self, value):
+        """Broadcast a small control-plane value from global rank zero."""
+        return get_world_group().broadcast_object(value, src=0)
 
     def _bind_worker_device(self) -> None:
         """Bind the request thread to this worker's CUDA device.
@@ -147,6 +263,15 @@ class ExternalLauncherExecutor(Executor):
         extra = output_batch.extra or {}
         if torch.cuda.is_available():
             extra["peak_memory_mb"] = torch.cuda.max_memory_allocated() / (1024 * 1024)
+        if not self.is_output_rank:
+            for key in _NON_OUTPUT_EXTRA_KEYS:
+                extra.pop(key, None)
+            output_batch.output = torch.empty(0, device="cpu")
+            output_batch.latents = None
+            output_batch.audio_latents = None
+            output_batch.trajectory_latents = None
+            output_batch.trajectory_timesteps = None
+            output_batch.trajectory_decoded = None
 
         return ForwardBatch(
             data_type=forward_batch.data_type,
@@ -155,6 +280,7 @@ class ExternalLauncherExecutor(Executor):
             extra=extra,
             trajectory_latents=output_batch.trajectory_latents,
             trajectory_timesteps=output_batch.trajectory_timesteps,
+            trajectory_decoded=output_batch.trajectory_decoded,
         )
 
     def collective_rpc(
@@ -164,11 +290,49 @@ class ExternalLauncherExecutor(Executor):
             args: tuple = (),
             kwargs: dict | None = None,
     ) -> list[Any]:
-        """Execute one local worker method in every SPMD process."""
+        """Execute a control call locally and return rank-ordered world results.
 
-        del timeout
+        Every launcher process must enter this method with the same call. A
+        local exception is gathered before any rank raises, so ordinary
+        control-plane failures are reported consistently instead of leaving a
+        successful peer behind. Per-call timeouts are unsupported; the
+        process-group timeout and launcher failure policy bound hard failures.
+        """
+
+        if timeout is not None:
+            raise NotImplementedError(
+                "ExternalLauncherExecutor.collective_rpc does not support per-call timeouts; "
+                "configure the distributed process-group timeout and launcher kill-on-failure policy instead.")
         self._bind_worker_device()
-        return [self.worker.execute_method(method, *args, **(kwargs or {}))]
+        try:
+            response = self.worker.execute_method(method, *args, **(kwargs or {}))
+            local_status: dict[str, Any] = {
+                "ok": True,
+                "rank": self.rank,
+                "response": response,
+            }
+        except Exception as error:
+            local_status = {
+                "ok": False,
+                "rank": self.rank,
+                "error_type": type(error).__name__,
+                "error": str(error),
+            }
+
+        statuses: list[dict[str, Any] | None]
+        if self.world_size == 1:
+            statuses = [local_status]
+        else:
+            statuses = [None] * self.world_size
+            torch.distributed.all_gather_object(statuses, local_status, group=get_world_group().cpu_group)
+
+        failures = [status for status in statuses if status is not None and not status["ok"]]
+        if failures:
+            details = "; ".join(f"rank {failure['rank']} {failure['error_type']}: {failure['error']}"
+                                for failure in failures)
+            method_name = method if isinstance(method, str) else getattr(method, "__name__", repr(method))
+            raise RuntimeError(f"Collective RPC {method_name!r} failed: {details}")
+        return [status["response"] for status in statuses if status is not None]
 
     def set_lora_adapter(
         self,
@@ -186,18 +350,21 @@ class ExternalLauncherExecutor(Executor):
                 "accumulate": accumulate,
             },
         )
-        if responses[0]["status"] != "lora_adapter_set":
-            raise RuntimeError(f"Rank {self.rank} failed to set LoRA adapter to {lora_path}")
+        for rank, response in enumerate(responses):
+            if response["status"] != "lora_adapter_set":
+                raise RuntimeError(f"Rank {rank} failed to set LoRA adapter to {lora_path}")
 
     def unmerge_lora_weights(self) -> None:
         responses = self.collective_rpc("unmerge_lora_weights")
-        if responses[0]["status"] != "lora_adapter_unmerged":
-            raise RuntimeError(f"Rank {self.rank} failed to unmerge LoRA weights")
+        for rank, response in enumerate(responses):
+            if response["status"] != "lora_adapter_unmerged":
+                raise RuntimeError(f"Rank {rank} failed to unmerge LoRA weights")
 
     def merge_lora_weights(self) -> None:
         responses = self.collective_rpc("merge_lora_weights")
-        if responses[0]["status"] != "lora_adapter_merged":
-            raise RuntimeError(f"Rank {self.rank} failed to merge LoRA weights")
+        for rank, response in enumerate(responses):
+            if response["status"] != "lora_adapter_merged":
+                raise RuntimeError(f"Rank {rank} failed to merge LoRA weights")
 
     def set_log_queue(self, log_queue: Queue | None) -> None:
         # The worker is in this process, so its logs already reach the local

--- a/fastvideo/worker/gpu_worker.py
+++ b/fastvideo/worker/gpu_worker.py
@@ -12,6 +12,12 @@ from fastvideo.logger import init_logger
 from fastvideo.pipelines import ForwardBatch, LoRAPipeline, build_pipeline
 
 logger = init_logger(__name__)
+_NON_OUTPUT_EXTRA_KEYS = frozenset({
+    "audio",
+    "audio_sample_rate",
+    "decoded_audio",
+    "ltx2_audio_latents",
+})
 
 
 def _log_cuda_device_uuid(rank: int, device: torch.device) -> None:
@@ -86,6 +92,12 @@ class Worker:
         self.pipeline = build_pipeline(self.fastvideo_args)
 
     def execute_forward(self, forward_batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> ForwardBatch:
+        if not self.fastvideo_args.is_output_rank:
+            forward_batch.save_video = False
+            forward_batch.return_frames = False
+            forward_batch.return_trajectory_latents = False
+            forward_batch.return_trajectory_decoded = False
+            forward_batch.return_continuation_state = False
         output_batch = self.pipeline.forward(forward_batch, self.fastvideo_args)
         needs_output = forward_batch.return_frames or (forward_batch.save_video
                                                        and fastvideo_args.output_type != "latent"
@@ -94,6 +106,15 @@ class Worker:
             # Drop the decoded tensor before multiprocessing or Ray transports
             # the worker result back to the generator.
             output_batch.output = torch.empty(0, device="cpu")
+        if not self.fastvideo_args.is_output_rank:
+            for key in _NON_OUTPUT_EXTRA_KEYS:
+                output_batch.extra.pop(key, None)
+            output_batch.latents = None
+            output_batch.audio_latents = None
+            output_batch.trajectory_latents = None
+            output_batch.trajectory_timesteps = None
+            output_batch.trajectory_decoded = None
+            output_batch.continuation_state = None
         return cast(ForwardBatch, output_batch)
 
     def shutdown(self) -> dict[str, Any]:

--- a/fastvideo/worker/gpu_worker.py
+++ b/fastvideo/worker/gpu_worker.py
@@ -58,8 +58,11 @@ class Worker:
         # so that each worker uses the correct device
         if self.fastvideo_args.distributed_executor_backend == "mp":
             os.environ["LOCAL_RANK"] = str(self.local_rank)
-        os.environ["RANK"] = str(self.rank)
-        os.environ["WORLD_SIZE"] = str(self.fastvideo_args.num_gpus)
+        if self.fastvideo_args.distributed_executor_backend != "external_launcher":
+            # torchrun/srun already assigned the possibly multi-node global
+            # identity. Keep it intact for the env:// rendezvous.
+            os.environ["RANK"] = str(self.rank)
+            os.environ["WORLD_SIZE"] = str(self.fastvideo_args.num_gpus)
 
         # Platform-agnostic device initialization
         self.device = get_local_torch_device()

--- a/fastvideo/worker/gpu_worker.py
+++ b/fastvideo/worker/gpu_worker.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
+from datetime import timedelta
 from typing import Any, cast
 
 import torch
@@ -86,8 +87,12 @@ class Worker:
             self.init_gpu_memory = 0
 
         # Initialize the distributed environment.
-        maybe_init_distributed_environment_and_model_parallel(self.fastvideo_args.tp_size, self.fastvideo_args.sp_size,
-                                                              self.distributed_init_method)
+        dist_timeout = (timedelta(
+            seconds=self.fastvideo_args.dist_timeout) if self.fastvideo_args.dist_timeout is not None else None)
+        maybe_init_distributed_environment_and_model_parallel(self.fastvideo_args.tp_size,
+                                                              self.fastvideo_args.sp_size,
+                                                              self.distributed_init_method,
+                                                              timeout=dist_timeout)
 
         self.pipeline = build_pipeline(self.fastvideo_args)
 


### PR DESCRIPTION
## Purpose

FastVideo's `mp` executor owns local worker processes, so sequence-parallel inference cannot span launcher-managed nodes. This change adds an opt-in `external_launcher` executor that joins the `env://` process group provided by `torchrun` or `srun`; the default single-node `mp` path remains unchanged.

## Changes

- Add `generator.engine.execution_backend: external_launcher` and the equivalent `FASTVIDEO_EXTERNAL_LAUNCHER=1` opt-in for offline inference.
- Preserve launcher-provided global and local rank identity, validate topology and device visibility before model loading, and support native Slurm variables.
- Execute requests collectively on every rank while assigning saved/returned output to world rank 0.
- Avoid non-output VAE work for noncollective Flux and SD3.5 decoders. MiniMax-H3 parallel VAE collectives run only in the SP group containing world rank 0; other SP groups skip uniformly and only rank 0 assembles host output.
- Coordinate startup, prompt-list ownership, errors, control RPCs, shutdown, and media ownership across ranks.
- Add `generator.engine.parallelism.dist_timeout` as a validated positive number of seconds. FastVideo applies it to the default group when it owns initialization and to all FastVideo device/Gloo child groups.
- Reject REST, streaming, and incompatible launcher configurations explicitly.

This PR changes inference/runtime code, tests, examples, and documentation. It does not migrate either training stack.

## Exact-head review evidence

Reviewed head: `019cd164c2d469883693c90904501d9fe0601f65`

- Canonical unit lane: `1011 passed, 7 skipped`.
- Focused output-ownership and worker coverage: `23 passed`.
- Schema and executor coverage: `67 passed` (real-process cases run separately).
- Real two-process Gloo lifecycle: success, coordinated failure, and peer-exit cases passed.
- Missing-collective timeout: configured `3s`, observed failure after `3.009s`.
- Pre-commit, mypy, PyMarkdown, shell syntax, and `git diff --check`: passed.
- Contributor attribution is preserved and every commit is trailer-free.

The full Buildkite suite is requested on this exact head. A new physical multi-node Slurm/GB200 run was not available during the final rebase review.

## Prior contributor hardware evidence

Before the final rebase and contract hardening, the contributor recorded a two-node `2 x 4` GB200 SP8 run: ranks and CUDA bindings validated; Preview FastH3 generated 124-frame video/audio; external-launcher SP4 versus stock multiprocess mean MS-SSIM was `0.98824` (minimum `0.97668`) with exact decoded audio; SP8 eager and compiled-VAE paths completed with no Triton fallbacks; compiled-VAE versus eager mean MS-SSIM was `0.98543` (minimum `0.97485`) with exact decoded audio. This is retained as prior hardware evidence, not represented as an exact-head rerun.

## Launch contract

Every rank must enter requests in the same order. Launchers own `RANK`, `WORLD_SIZE`, `LOCAL_RANK`, `MASTER_ADDR`, and `MASTER_PORT`; Slurm-native equivalents are normalized before worker initialization. Use launcher supervision such as `--kill-on-bad-exit=1` in addition to the process-group timeout.
