### PR TITLE
[bugfix] tests: include ltx2_3_base in local LTX-2 preset set

### DIFF
--- a/tests/local_tests/ltx2/test_ltx2_pipeline_smoke.py
+++ b/tests/local_tests/ltx2/test_ltx2_pipeline_smoke.py
@@ -316,9 +316,9 @@ def test_ltx2_typed_surface_preflight() -> None:
         LTX2AudioDecodingStage, LTX2DenoisingStage, LTX2LatentPreparationStage, LTX2TextEncodingStage,
     )
 
-    # All three LTX-2 presets registered.
+    # All four LTX-2 presets registered.
     names = {p.name for p in get_presets_for_family("ltx2")}
-    assert names == {"ltx2_base", "ltx2_distilled", "ltx2_two_stage"}
+    assert names == {"ltx2_base", "ltx2_3_base", "ltx2_distilled", "ltx2_two_stage"}
 
     # Two-stage preset has the denoise + refine topology and pulls its
     # refine allowed_overrides from the typed dataclass.


### PR DESCRIPTION
`test_ltx2_typed_surface_preflight` asserts an exact set of registered ltx2 presets. #1397 added a fourth (`ltx2_3_base`), so the assertion has been failing since then:

```
assert names == {"ltx2_base", "ltx2_distilled", "ltx2_two_stage"}
AssertionError: Extra items in the left set: 'ltx2_3_base'
```

#1428 already fixed the identical assertion in `fastvideo/tests/api/test_presets.py`. This applies the same one-line change to the copy in `tests/local_tests/`, which was missed because local_tests don't run in CI.

Before, on main:

```
tests/local_tests/ltx2/  ->  8 passed, 1 failed, 8 skipped
```

After:

```
tests/local_tests/ltx2/                ->  9 passed, 8 skipped
fastvideo/tests/api/test_presets.py    ->  64 passed
```

Env: torch 2.12.0+cu130, H20, single node. The 8 skips are the weight-dependent parity tests; unrelated to this change.