### PR TITLE
[bugfix] registry: register magi_human presets

### DIFF
--- a/fastvideo/registry.py
+++ b/fastvideo/registry.py
@@ -1313,6 +1313,8 @@ def _register_presets() -> None:
         ALL_PRESETS as LONGCAT_PRESETS, )
     from fastvideo.pipelines.basic.ltx2.presets import (
         ALL_PRESETS as LTX2_PRESETS, )
+    from fastvideo.pipelines.basic.magi_human.presets import (
+        ALL_PRESETS as MAGI_HUMAN_PRESETS, )
     from fastvideo.pipelines.basic.matrixgame2.presets import (
         ALL_PRESETS as MATRIXGAME2_PRESETS, )
     from fastvideo.pipelines.basic.matrixgame3.presets import (
@@ -1349,6 +1351,7 @@ def _register_presets() -> None:
         LINGBOTWORLD2_PRESETS,
         LONGCAT_PRESETS,
         LTX2_PRESETS,
+        MAGI_HUMAN_PRESETS,
         MATRIXGAME2_PRESETS,
         MATRIXGAME3_PRESETS,
         MINIMAX_H3_PRESETS,


### PR DESCRIPTION
`fastvideo/pipelines/basic/magi_human/presets.py` defines eight presets, but `_register_presets()` in `fastvideo/registry.py` never imports them, so none of them reach the registry:

```python
>>> import fastvideo.registry
>>> from fastvideo.api.presets import get_preset, get_presets_for_family
>>> [p.name for p in get_presets_for_family("magi_human")]
[]
>>> get_preset("magi_human_base", "magi_human")
ConfigValidationError: pipeline.preset: unknown preset 'magi_human_base'
for model family 'magi_human'; registered: (none)
```

Every other family in that function is wired up; magi_human is the only one whose `ALL_PRESETS` is missing from both the import block and `all_preset_groups`. It looks like it was simply missed when the pipeline landed in #1299 — `MAGI_HUMAN_PRESETS` has never appeared in `registry.py` in the repo's history.

After this change:

```python
>>> sorted(p.name for p in get_presets_for_family("magi_human"))
['magi_human_base', 'magi_human_base_ti2v', 'magi_human_distill',
 'magi_human_distill_ti2v', 'magi_human_sr_1080p', 'magi_human_sr_1080p_ti2v',
 'magi_human_sr_540p', 'magi_human_sr_540p_ti2v']
```

`tests/local_tests/magi_human/test_magi_human_pipeline_smoke.py::test_magi_human_typed_surface_preflight` already asserts exactly this set and has been failing on main; it passes now. Preset counts for the other families are unchanged (ltx2 4, wan 15, zimage 1, flux2 3, minimax_h3 3).

`fastvideo/tests/api/` gives 5 failed / 249 passed both with and without this patch — those failures are pre-existing (`test_attn_qat_infer_capability_gate`, `test_schema_parity_inventory`) and unrelated.

Env: torch 2.12.0+cu130, H20, single node.