### PR TITLE
[feat] Support training_cfg_rate > 0 for LTX-2

### DIFF
--- a/fastvideo/tests/train/models/test_ltx2_cfg_dropout.py
+++ b/fastvideo/tests/train/models/test_ltx2_cfg_dropout.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CFG dropout on LTX-2 swaps in the unconditional embedding, not zeros.
+
+LTX-2 builds its unconditional branch from an empty prompt run through
+Gemma and the Embeddings1D connector.  The shared parquet path drops text
+conditioning by zeroing the stored embedding, which would train against a
+different unconditional than the sampler uses, so ``LTX2Model`` performs
+the drop itself.  These tests cover the substitution in isolation; they do
+not load the 22B transformer or Gemma.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29527")
+
+import torch
+
+from fastvideo.train.models.ltx2.ltx2 import LTX2Model
+
+BATCH, TOKENS, DIM = 4, 8, 16
+
+
+def _model(cfg_rate: float) -> LTX2Model:
+    """An LTX2Model shell carrying only what ``_apply_cfg_dropout`` reads."""
+    model = LTX2Model.__new__(LTX2Model)
+    model._training_cfg_rate = cfg_rate
+    model.negative_prompt_embeds = torch.full((1, TOKENS, DIM), 7.0)
+    model.negative_prompt_attention_mask = torch.ones((1, TOKENS))
+    # The cache is already populated, so no encoder needs loading.
+    model.ensure_negative_conditioning = lambda: None  # type: ignore[method-assign]
+    return model
+
+
+def _conditioning() -> tuple[torch.Tensor, torch.Tensor]:
+    embeds = torch.arange(BATCH * TOKENS * DIM, dtype=torch.float32)
+    return embeds.view(BATCH, TOKENS, DIM), torch.ones((BATCH, TOKENS))
+
+
+def test_cfg_rate_zero_is_a_no_op() -> None:
+    model = _model(0.0)
+    embeds, mask = _conditioning()
+    out_embeds, out_mask = model._apply_cfg_dropout(
+        embeds, mask, generator=torch.Generator().manual_seed(0))
+    assert out_embeds is embeds
+    assert out_mask is mask
+
+
+def test_dropped_samples_carry_the_unconditional_embedding() -> None:
+    model = _model(1.0)  # drop every sample
+    embeds, mask = _conditioning()
+    out_embeds, out_mask = model._apply_cfg_dropout(
+        embeds, mask, generator=torch.Generator().manual_seed(0))
+
+    expected = model.negative_prompt_embeds[0]
+    for i in range(BATCH):
+        assert torch.equal(out_embeds[i], expected)
+        # The pre-fix behaviour zeroed the embedding; make sure we do not.
+        assert not torch.equal(out_embeds[i], torch.zeros_like(out_embeds[i]))
+    assert torch.equal(out_mask, model.negative_prompt_attention_mask.expand(BATCH, TOKENS))
+
+
+def test_kept_samples_are_untouched() -> None:
+    model = _model(1.0)
+    embeds, mask = _conditioning()
+    original = embeds.clone()
+    model._apply_cfg_dropout(embeds, mask, generator=torch.Generator().manual_seed(0))
+    # The input tensors are cloned before substitution.
+    assert torch.equal(embeds, original)

--- a/fastvideo/train/models/ltx2/ltx2.py
+++ b/fastvideo/train/models/ltx2/ltx2.py
@@ -34,6 +34,7 @@ from typing import Any, Literal, TYPE_CHECKING
 import torch
 
 import fastvideo.envs as envs
+from fastvideo.train.utils.negative_prompt import encode_negative_prompt
 from fastvideo.forward_context import set_forward_context
 from fastvideo.logger import init_logger
 from fastvideo.models.dits.ltx2 import VideoLatentShape
@@ -77,6 +78,8 @@ _SIGMA_Z_HI = 3.0902
 # metadata so training RoPE still matches validation inference.
 _DEFAULT_ROPE_FPS = 24.0
 
+LTX2_UNCONDITIONAL_PROMPT = ""
+
 
 class LTX2Model(WanModel):
     """LTX-2 per-role model for the modular trainer."""
@@ -105,12 +108,7 @@ class LTX2Model(WanModel):
                                       "and loss plumbing.")
 
         cfg_rate = float(getattr(training_config.data, "training_cfg_rate", 0.0) or 0.0)
-        if cfg_rate > 0.0:
-            raise NotImplementedError("LTX2Model only supports training_cfg_rate=0. CFG dropout "
-                                      "zeroes the post-connector text embeddings, which is not "
-                                      "what LTX-2 inference uses as the unconditional input "
-                                      "(an empty prompt encoded through Gemma + connector). Set "
-                                      "training.data.training_cfg_rate: 0.0.")
+        self._training_cfg_rate = cfg_rate
 
         self._timestep_uniform_prob = float(timestep_uniform_prob)
         self._rope_fps: float = _DEFAULT_ROPE_FPS
@@ -134,10 +132,9 @@ class LTX2Model(WanModel):
         if trainable:
             self._freeze_audio_parameters()
 
-        # No negative-prompt cache: cfg_rate is forced to 0 above and
-        # loading Gemma (~23GB) on every rank just for an unused
-        # negative embedding is wasteful.
-        self.set_requires_negative_conditioning(False)
+        # Gemma is ~23GB per rank, so only pay for the unconditional
+        # embedding when CFG dropout is actually enabled.
+        self.set_requires_negative_conditioning(cfg_rate > 0.0)
 
     # ------------------------------------------------------------------
     # Loading
@@ -198,8 +195,27 @@ class LTX2Model(WanModel):
     # ------------------------------------------------------------------
 
     def ensure_negative_conditioning(self) -> None:
-        raise NotImplementedError("LTX2Model does not implement negative conditioning; "
-                                  "training_cfg_rate must stay 0.")
+        """Cache the unconditional conditioning used by CFG dropout.
+
+        LTX-2 inference feeds an empty prompt through Gemma + the
+        Embeddings1D connector to build its unconditional branch, so the
+        dropped samples have to carry that embedding rather than zeros.
+        ``LTX2GemmaTextEncoderModel`` owns the connector, which means the
+        shared ``encode_negative_prompt`` helper already produces the
+        post-connector tensor.
+        """
+        if self.negative_prompt_embeds is not None:  # type: ignore[has-type]
+            return
+
+        assert self.training_config is not None
+        embeds, mask = encode_negative_prompt(
+            self.training_config,
+            prompt=LTX2_UNCONDITIONAL_PROMPT,
+            device=self.device,
+            dtype=self._get_training_dtype(),
+        )
+        self.negative_prompt_embeds = embeds
+        self.negative_prompt_attention_mask = mask
 
     @torch.no_grad()
     def decode_latents(
@@ -229,6 +245,45 @@ class LTX2Model(WanModel):
     # ------------------------------------------------------------------
     # Runtime primitives
     # ------------------------------------------------------------------
+
+    def _apply_cfg_dropout(
+        self,
+        encoder_hidden_states: torch.Tensor,
+        encoder_attention_mask: torch.Tensor,
+        *,
+        generator: torch.Generator,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Replace a fraction of the batch with the unconditional embedding.
+
+        The shared parquet path drops text conditioning by zeroing the
+        stored embedding. For LTX-2 that trains an unconditional branch the
+        sampler never sees, so the drop is done here instead and swaps in
+        the cached empty-prompt embedding.
+        """
+        if self._training_cfg_rate <= 0.0:
+            return encoder_hidden_states, encoder_attention_mask
+
+        self.ensure_negative_conditioning()
+        neg_embeds = self.negative_prompt_embeds
+        neg_mask = self.negative_prompt_attention_mask
+        if neg_embeds is None or neg_mask is None:
+            raise RuntimeError("ensure_negative_conditioning() did not populate the "
+                               "LTX-2 unconditional embedding")
+
+        batch_size = encoder_hidden_states.shape[0]
+        keep = torch.rand(batch_size, generator=generator, device=generator.device)
+        drop = (keep < self._training_cfg_rate).to(encoder_hidden_states.device)
+        if not bool(drop.any()):
+            return encoder_hidden_states, encoder_attention_mask
+
+        embeds = encoder_hidden_states.clone()
+        mask = encoder_attention_mask.clone()
+        neg_embeds = neg_embeds.to(device=embeds.device, dtype=embeds.dtype)
+        neg_mask = neg_mask.to(device=mask.device, dtype=mask.dtype)
+        for idx in torch.nonzero(drop, as_tuple=False).flatten().tolist():
+            embeds[idx] = neg_embeds[0, :embeds.shape[1]]
+            mask[idx] = neg_mask[0, :mask.shape[1]]
+        return embeds, mask
 
     def prepare_batch(
         self,
@@ -282,6 +337,12 @@ class LTX2Model(WanModel):
                              f"{latents_source!r}")
 
         self._check_text_embedding_dim(encoder_hidden_states)
+
+        encoder_hidden_states, encoder_attention_mask = (self._apply_cfg_dropout(
+            encoder_hidden_states,
+            encoder_attention_mask,
+            generator=generator,
+        ))
 
         # LTX-2 VAE encode() already applies per-channel normalization
         # (scaling_factor is 1.0); latents are used as stored.

--- a/fastvideo/training/ltx2_training_pipeline.py
+++ b/fastvideo/training/ltx2_training_pipeline.py
@@ -114,12 +114,14 @@ class LTX2TrainingPipeline(TrainingPipeline):
         else:
             text_padding_length = (training_args.pipeline_config.text_encoder_configs[0].arch_config.text_len)
             self.with_audio = False
+            # cfg_rate stays 0 here: LTX2Model.prepare_batch does the CFG drop
+            # so dropped samples carry the empty-prompt embedding, not zeros.
             self.train_dataset, self.train_dataloader = (build_parquet_map_style_dataloader(
                 training_args.data_path,
                 training_args.train_batch_size,
                 num_data_workers=training_args.dataloader_num_workers,
                 parquet_schema=pyarrow_schema_text_only,
-                cfg_rate=training_args.training_cfg_rate,
+                cfg_rate=0.0,
                 drop_last=True,
                 text_padding_length=text_padding_length,
                 seed=self.seed,


### PR DESCRIPTION
Draft — the implementation and unit tests are in place, but I have one semantics question for you before this is ready, and I have not run a convergence check yet. Details at the bottom.

## Problem

`LTX2Model.__init__` rejects CFG dropout outright:

```python
raise NotImplementedError("LTX2Model only supports training_cfg_rate=0. CFG dropout "
                          "zeroes the post-connector text embeddings, which is not "
                          "what LTX-2 inference uses as the unconditional input "
                          "(an empty prompt encoded through Gemma + connector). ...")
```

That is accurate. The drop happens in the data layer, in `get_torch_tensors_from_row_dict`:

```python
if key == 'text_embedding' and (rng.random() if rng else random.random()) < cfg_rate:
    data = np.zeros(shape, dtype=np.float32)
```

Zeros are not what the LTX-2 sampler feeds its unconditional branch, so training that way teaches an unconditional the sampler never uses.

## Approach

Do the drop in `LTX2Model.prepare_batch` instead, substituting the cached unconditional embedding.

- `ensure_negative_conditioning()` encodes the unconditional prompt via the shared `encode_negative_prompt` helper. `LTX2GemmaTextEncoderModel` owns `Embeddings1DConnector`, so what comes back is already the post-connector tensor — no separate connector pass is needed.
- `_apply_cfg_dropout()` picks samples with `torch.rand(..., generator=generator)` and swaps in that embedding and its mask. It is a no-op when `training_cfg_rate == 0`, and it clones rather than mutating the batch in place.
- `set_requires_negative_conditioning(cfg_rate > 0.0)` keeps the existing "don't pay 23GB of Gemma per rank for an unused embedding" property — nothing is loaded unless CFG dropout is on.
- `ltx2_training_pipeline.py` passes `cfg_rate=0.0` to the parquet loader so the drop happens once, in the model. This also gives the precomputed `.pt` path CFG dropout, which it never had (`ltx2_precomputed_dataset.py` has no `cfg_rate`).

## Question before this leaves draft

What should the unconditional prompt be? I used `""`, following the wording in the `NotImplementedError`, exposed as `LTX2_UNCONDITIONAL_PROMPT`.

But the presets disagree with each other — `ltx2_base` and `ltx2_distilled` set `negative_prompt` to `_LTX2_NEGATIVE_PROMPT`, while `ltx2_two_stage` and `ltx2_3_base` set it to `""`. So "the unconditional LTX-2 samples with" is not one fixed string. Options as I see them:

1. Always `""` (what this PR does).
2. Read `SamplingParam.from_pretrained(model_path).negative_prompt`, the way `WanModel.ensure_negative_conditioning` does — then training matches whichever preset the checkpoint ships.
3. Make it a training config field.

I did not want to guess, since option 2 changes what gets trained depending on the checkpoint.

## Verified

New unit tests in `fastvideo/tests/train/models/test_ltx2_cfg_dropout.py` (3 passed) cover the rate-0 no-op, that dropped samples carry the unconditional embedding and specifically not zeros, and that the caller's tensors are not mutated. They construct the model shell directly, so nothing large is loaded.

`pre-commit run --files ...` is clean on all three files (yapf, ruff, codespell, mypy).

`pytest fastvideo/tests/train/ -k ltx2` gives the same 4 failures with and without this patch — `test_ltx2_finetune_single_train_step[ltx2|ltx2_3]` and `test_ltx2_model_loads_and_forwards[ltx2|ltx2_3]`, all `Could not find model at FastVideo/LTX-2.3-Distilled-Diffusers and failed to download from HF Hub`. Pre-existing, environment-side.

## Not verified

No convergence run. I can put a short LoRA finetune with `training_cfg_rate=0.1` against `cfg_rate=0` on H20 once the prompt question above is settled, so the run measures the intended behaviour.

Env: torch 2.12.0+cu130, H20, single node.