### PR TITLE
[bugfix] FastMetal-QAD MLX support: refuse CUDA QAD trees, use packed mlx_dit config, stream loads (#1736)

### DIFF
--- a/.github/workflows/ci-macos-mlx.yml
+++ b/.github/workflows/ci-macos-mlx.yml
@@ -78,6 +78,7 @@ jobs:
             fastvideo/tests/mlx/test_mlx_dit_parity.py \
             fastvideo/tests/mlx/test_mlx_compile_parity.py \
             fastvideo/tests/mlx/test_mlx_checkpoint.py \
+            fastvideo/tests/mlx/test_mlx_checkpoint_compat.py \
             fastvideo/tests/mlx/test_mlx_fastwan_benchmark.py \
             fastvideo/tests/mlx/test_taehv_decode.py \
             fastvideo/tests/mlx/test_frame_upsample.py \
@@ -134,6 +135,7 @@ jobs:
             fastvideo/tests/mlx/test_mlx_dit_parity.py \
             fastvideo/tests/mlx/test_mlx_compile_parity.py \
             fastvideo/tests/mlx/test_mlx_checkpoint.py \
+            fastvideo/tests/mlx/test_mlx_checkpoint_compat.py \
             fastvideo/tests/mlx/test_mlx_fastwan_benchmark.py \
             fastvideo/tests/mlx/test_taehv_decode.py \
             fastvideo/tests/mlx/test_frame_upsample.py \

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ UV_TORCH_BACKEND=cu126 uv pip install fastvideo
 Use `UV_TORCH_BACKEND=cu130` on CUDA 13. Apple silicon users should follow the
 [MPS installation guide](https://hao-ai-lab.github.io/FastVideo/getting_started/installation/mps/).
 
-> **On an Apple Silicon Mac?** FastVideo runs FastWan text-to-video natively
-> through an MLX runtime — a 5-second 480p clip generated locally, no cloud,
-> no discrete GPU. Install with `uv pip install -e '.[mlx]'` and follow the
+> **On an Apple Silicon Mac?** FastVideo runs FastMetal-QAD through an MLX
+> runtime. Install with `uv pip install -e '.[mlx]'`, download
+> [`FastVideo/FastMetal-1.3B-QAD`](https://huggingface.co/FastVideo/FastMetal-1.3B-QAD),
+> and follow the
 > [Apple Silicon guide](https://hao-ai-lab.github.io/FastVideo/getting_started/installation/mps/).
 
 Please see our [docs](https://hao-ai-lab.github.io/FastVideo/getting_started/installation/) for more detailed installation instructions.

--- a/docs/design/apple_silicon_fast_mode.md
+++ b/docs/design/apple_silicon_fast_mode.md
@@ -8,7 +8,7 @@ compute ~3.7×, so the wall-clock drops far more than 2×. RIFE (which estimates
 its own optical flow — no motion vectors needed) fills the dropped frames back
 in for ~1.4 s, and a light unsharp pass counters its softening.
 
-Measured on the 1.3B INT8 QAD model (fox, 480×832×81, M4): generate 41 + RIFE→81
+Measured on the 1.3B INT8 QAD model (480×832×81, M4): generate 41 + RIFE→81
 runs in ~35 s of denoise vs ~90 s full, at reconstruction MS-SSIM **0.97**.
 Reproduce with `python -m fastvideo.benchmarks.eval_metalfx_rife --mode int8`.
 
@@ -26,10 +26,11 @@ uv pip install -e ".[mlx]"   # RIFE ships vendored; this only needs MLX
 
 ```bash
 python examples/inference/basic/mlx_wan_prompt_to_video.py \
-  --mlx-checkpoint <FastWan2.1-T2V-1.3B-INT8-QAD> \
-  --prompt "A red fox trotting through a snowy pine forest at golden hour, cinematic" \
+  --model-root ./FastMetal-1.3B-QAD \
+  --mlx-checkpoint ./FastMetal-1.3B-QAD \
+  --prompt "A bird's-eye view of a misty forest valley at dawn." \
   --num-frames 81 --fast \
-  --output-path video_samples/fox_fast.mp4
+  --output-path video_samples/forest_fast.mp4
 ```
 
 `--num-frames` stays the *target* length; fast mode generates the smallest
@@ -57,9 +58,9 @@ of denoise. It composes with `--fast`; both together run the same clip in
 
 ```bash
 python examples/inference/basic/mlx_wan_prompt_to_video.py \
-  --prompt "A red fox trotting through a snowy pine forest at golden hour, cinematic" \
+  --prompt "A bird's-eye view of a misty forest valley at dawn." \
   --height 480 --width 832 --num-frames 81 --fast-spatial \
-  --output-path video_samples/fox_fast_spatial.mp4
+  --output-path video_samples/forest_fast_spatial.mp4
 ```
 
 | Flag | Default | Meaning |

--- a/docs/getting_started/installation/mps.md
+++ b/docs/getting_started/installation/mps.md
@@ -1,6 +1,10 @@
 # MPS (Apple Silicon)
 
-Instructions to install FastVideo for Apple Silicon.
+Install FastVideo on Apple Silicon and run FastMetal-QAD.
+
+Apple Silicon uses the MLX runtime and the FastMetal-QAD INT8 checkpoints.
+See the [FastMetal-QAD blog](https://haoailab.com/blogs/fastmetal/) and the
+[FastMetal collection](https://huggingface.co/collections/FastVideo/fastmetal).
 
 ## Requirements
 
@@ -49,7 +53,7 @@ brew install ffmpeg
 
 ### Installation
 
-FastWan's native Apple Silicon runtime requires the `mlx` extra.
+FastMetal's native Apple Silicon runtime requires the `mlx` extra.
 
 #### With uv (recommended)
 
@@ -87,6 +91,47 @@ Alternative with Conda environment:
 uv pip install -e ".[mlx]"
 ```
 
+## Run FastMetal-QAD
+
+Each release is self-contained. Download one checkpoint and point both
+`--model-root` and `--mlx-checkpoint` at it (the example also auto-detects
+`mlx_dit.json` under `--model-root`).
+
+| Checkpoint | Script | Mac tier |
+| --- | --- | --- |
+| [`FastVideo/FastMetal-1.3B-QAD`](https://huggingface.co/FastVideo/FastMetal-1.3B-QAD) | `mlx_wan_prompt_to_video.py` | 16 GB+ |
+| [`FastVideo/FastMetal-5B-QAD`](https://huggingface.co/FastVideo/FastMetal-5B-QAD) | `mlx_wan22_generate.py` | 16 GB+ |
+| [`FastVideo/FastMetal-14B-QAD`](https://huggingface.co/FastVideo/FastMetal-14B-QAD) | `mlx_wan_prompt_to_video.py` | 36 GB+ |
+
+```bash
+hf download FastVideo/FastMetal-1.3B-QAD --local-dir ./FastMetal-1.3B-QAD
+
+python examples/inference/basic/mlx_wan_prompt_to_video.py \
+  --model-root ./FastMetal-1.3B-QAD \
+  --mlx-checkpoint ./FastMetal-1.3B-QAD \
+  --height 480 --width 832 --num-frames 81 \
+  --prompt "A bird's-eye view of a misty forest valley at dawn."
+```
+
+14B uses the same script. Point both flags at `./FastMetal-14B-QAD`. That repo also ships an EMA variant: keep `--model-root` at the repo root and set `--mlx-checkpoint ./FastMetal-14B-QAD/ema`.
+
+Wan2.2 5B uses a different latent layout, so it has its own entrypoint:
+
+```bash
+hf download FastVideo/FastMetal-5B-QAD --local-dir ./FastMetal-5B-QAD
+
+python examples/inference/basic/mlx_wan22_generate.py \
+  --mlx-checkpoint ./FastMetal-5B-QAD \
+  --text-encoder-root ./FastMetal-5B-QAD \
+  --vae-root ./FastMetal-5B-QAD/vae \
+  --height 704 --width 1280 --num-frames 81 \
+  --prompt "A cinematic portrait with soft neon lighting and smooth camera motion."
+```
+
+CUDA FastWan-QAD (`FastVideo/FastWan-QAD-1.3B`, `FastVideo/FastWan-QAD-FP8-1.3B`) is a separate NVIDIA release. The MLX examples look for FastMetal packed weights (`mlx_dit.json`).
+
+`basic_mps.py` is a generic PyTorch MPS demo. For local video on Mac, use the FastMetal commands above.
+
 ## Development Environment Setup
 
 If you're planning to contribute to FastVideo please see the following page:
@@ -94,9 +139,9 @@ If you're planning to contribute to FastVideo please see the following page:
 
 ## Hardware Requirements
 
-### For Basic Inference
-
-- Mac M1, M2, M3, or M4 (at least 32 GB RAM is preferable for high quality video generation)
+- **1.3B / 5B:** 16 GB unified memory and up (M1 and later)
+- **14B:** 36 GB unified memory and up
+- Fanless 13-inch MacBook Air can run 1.3B and 5B at the same resolutions
 
 ## Troubleshooting
 

--- a/docs/inference/support_matrix.md
+++ b/docs/inference/support_matrix.md
@@ -182,12 +182,14 @@ optimizations: absence means **untested**, not incompatible.
 
 | Release path | Model | Mode | Validated hardware | Status |
 | --- | --- | --- | --- | --- |
-| MLX FastWan T2V | FastWan-QAD-INT8-1.3B `[release model ID pending]` | 480x832, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 36 GB unified-memory class, MLX 0.31.2 | Release candidate; requires release-owner visual sign-off |
+| MLX FastMetal T2V 1.3B | [`FastVideo/FastMetal-1.3B-QAD`](https://huggingface.co/FastVideo/FastMetal-1.3B-QAD) | 480x832, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 16 GB+ unified memory | Released |
+| MLX FastMetal TI2V 5B | [`FastVideo/FastMetal-5B-QAD`](https://huggingface.co/FastVideo/FastMetal-5B-QAD) | 480p / 720p, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 16 GB+ unified memory | Released |
+| MLX FastMetal T2V 14B | [`FastVideo/FastMetal-14B-QAD`](https://huggingface.co/FastVideo/FastMetal-14B-QAD) | 480p / 720p, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 36 GB+ unified memory | Released |
 
-This is a text-to-video-only source-install release. It is validated on the
-hardware listed above; MLX allocator caps are not evidence of support for a
-physical 16 GB Mac. See [Apple Silicon FastWan](../getting_started/installation/mps.md)
-for the supported command and release gates.
+Apple Silicon uses FastMetal-QAD. CUDA FastWan-QAD (`FastVideo/FastWan-QAD-1.3B`,
+`FastVideo/FastWan-QAD-FP8-1.3B`) is the NVIDIA release. See the
+[Apple Silicon guide](../getting_started/installation/mps.md) and the
+[FastMetal-QAD blog](https://haoailab.com/blogs/fastmetal/).
 
 **Note**: Wan2.2 TI2V 5B has some quality issues when performing I2V generation. We are working on fixing this issue.
 
@@ -216,9 +218,10 @@ Per the installation guides:
   [GPU install guide](../getting_started/installation/gpu.md).
 - **NVIDIA DGX Spark (GB10, aarch64)** — CUDA 13, from-source kernel build; see
   the [DGX Spark install guide](../getting_started/installation/spark.md).
-- **Apple silicon (MPS)** — macOS 14 or newer; see the
-  [MPS install guide](../getting_started/installation/mps.md) and
-  [`basic_mps.py`](https://github.com/hao-ai-lab/FastVideo/blob/main/examples/inference/basic/basic_mps.py).
+- **Apple silicon** — macOS 14 or newer; FastMetal-QAD via the MLX runtime. See the
+  [Apple Silicon guide](../getting_started/installation/mps.md). The older
+  [`basic_mps.py`](https://github.com/hao-ai-lab/FastVideo/blob/main/examples/inference/basic/basic_mps.py)
+  demo is PyTorch MPS only.
 
 Optimization-specific hardware constraints (e.g. STA requiring Hopper) are
 listed under [Special requirements](#special-requirements).

--- a/examples/inference/basic/README.md
+++ b/examples/inference/basic/README.md
@@ -18,10 +18,24 @@ git clone https://github.com/hao-ai-lab/FastVideo.git && cd FastVideo
 python examples/inference/basic/basic.py
 ```
 
-For an example on Apple silicon: 
+### Apple Silicon (FastMetal-QAD)
+
+Use the MLX runtime with FastMetal-QAD. See the
+[Apple Silicon guide](https://hao-ai-lab.github.io/FastVideo/getting_started/installation/mps/).
+
+```bash
+hf download FastVideo/FastMetal-1.3B-QAD --local-dir ./FastMetal-1.3B-QAD
+
+python examples/inference/basic/mlx_wan_prompt_to_video.py \
+  --model-root ./FastMetal-1.3B-QAD \
+  --mlx-checkpoint ./FastMetal-1.3B-QAD \
+  --prompt "A bird's-eye view of a misty forest valley at dawn."
 ```
-python examples/inference/basic/basic_mps.py
-```
+
+5B uses [`mlx_wan22_generate.py`](mlx_wan22_generate.py) with
+`FastVideo/FastMetal-5B-QAD`.
+
+`examples/inference/basic/basic_mps.py` is the older PyTorch MPS demo.
 
 For an example running DMD+VSA inference:
 ```

--- a/examples/inference/basic/mlx_wan22_generate.py
+++ b/examples/inference/basic/mlx_wan22_generate.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
-"""End-to-end Wan2.2-TI2V-5B generation on Apple Silicon (MLX DiT + MLX TAEHV).
+"""End-to-end FastMetal-5B-QAD generation on Apple Silicon (MLX DiT + MLX TAEHV).
+
+This is the Wan2.2 TI2V entrypoint. Use FastVideo/FastMetal-5B-QAD:
+
+    hf download FastVideo/FastMetal-5B-QAD --local-dir ./FastMetal-5B-QAD
+    python examples/inference/basic/mlx_wan22_generate.py \\
+      --mlx-checkpoint ./FastMetal-5B-QAD \\
+      --text-encoder-root ./FastMetal-5B-QAD \\
+      --vae-root ./FastMetal-5B-QAD/vae
 
 Pipeline: torch/MPS UMT5 encode (shared with 1.3B) → MLXWan22DiT 3-step DMD
 (warped schedule, flow_shift=5) → MLX TAEHV decode (taew2_2.pth). Fully MLX
 on the heavy DiT + decode path.
-
-    PYTHONPATH=$PWD python examples/inference/basic/mlx_wan22_generate.py \
-      --prompt "A red fox trotting through a snowy pine forest at golden hour" \
-      --output-path video_samples/demo_5b/fox_5b_mlx.mp4
 
 Decoder backends: ``taehv`` (default, MLX, ~seconds), ``taehv-torch`` (parity),
 ``wan-vae`` (full AutoencoderKLWan on MPS, slow).
@@ -30,6 +34,11 @@ from fastvideo.mlx_runtime.prompt_cache import (
     load_prompt_cache,
     save_prompt_cache,
     text_encoder_fingerprint,
+)
+from fastvideo.mlx_runtime.checkpoint_compat import (
+    UnsupportedMLXCheckpointError,
+    raise_if_unsupported_mlx_checkpoint,
+    resolve_mlx_checkpoint,
 )
 from fastvideo.mlx_runtime.rife_interp import aligned_keyframe_count
 
@@ -165,7 +174,9 @@ def main() -> None:
         "--mlx-checkpoint",
         type=Path,
         default=None,
-        help="Pre-quantized MLX DiT checkpoint directory. Rewrapped with Wan2.2 per-token conditioning.",
+        help="Packed FastMetal-5B-QAD MLX DiT directory (mlx_dit.json + mlx_dit.safetensors). "
+        "If omitted, a FastMetal directory passed as --text-encoder-root is used when it "
+        "already contains those files.",
     )
     parser.add_argument("--vae-root", type=Path, default=None)
     parser.add_argument("--height", type=int, default=DEFAULT_HEIGHT)
@@ -241,6 +252,18 @@ def main() -> None:
     # latent never leaves the grid it was denoised on and the mode is usable.
     if args.refine and args.fast_spatial:
         print("[wan22] --refine takes precedence over --fast-spatial")
+
+    args.mlx_checkpoint = resolve_mlx_checkpoint(args.mlx_checkpoint, args.text_encoder_root)
+    if args.mlx_checkpoint is not None:
+        if args.text_encoder_root is None and (args.mlx_checkpoint / "text_encoder").is_dir():
+            args.text_encoder_root = args.mlx_checkpoint
+        if args.vae_root is None and (args.mlx_checkpoint / "vae").is_dir():
+            args.vae_root = args.mlx_checkpoint / "vae"
+    try:
+        raise_if_unsupported_mlx_checkpoint(args.mlx_checkpoint, args.dit_checkpoint)
+    except UnsupportedMLXCheckpointError as exc:
+        raise SystemExit(str(exc)) from exc
+
     args.text_encoder_root, args.dit_checkpoint, args.dit_config, args.vae_root = _resolve_model_paths(
         text_encoder_root=args.text_encoder_root,
         dit_checkpoint=args.dit_checkpoint,

--- a/examples/inference/basic/mlx_wan_prompt_to_video.py
+++ b/examples/inference/basic/mlx_wan_prompt_to_video.py
@@ -1,11 +1,20 @@
-"""Generate a FastWan text-to-video clip with the Apple Silicon MLX runtime.
+"""Generate a FastMetal text-to-video clip with the Apple Silicon MLX runtime.
 
-This is the supported source-tree entrypoint for the FastWan-QAD-INT8-1.3B
-Apple release:
+This is the supported source-tree entrypoint for FastMetal-QAD (Wan2.1 1.3B
+and 14B). Use ``mlx_wan22_generate.py`` for FastMetal-5B-QAD.
+
+Download FastMetal-QAD and point ``--model-root`` / ``--mlx-checkpoint`` at it:
+
+    hf download FastVideo/FastMetal-1.3B-QAD --local-dir ./FastMetal-1.3B-QAD
+    python examples/inference/basic/mlx_wan_prompt_to_video.py \\
+      --model-root ./FastMetal-1.3B-QAD --mlx-checkpoint ./FastMetal-1.3B-QAD
+
+CUDA FastWan-QAD (``FastVideo/FastWan-QAD-1.3B``, ``FastVideo/FastWan-QAD-FP8-1.3B``)
+is a separate NVIDIA release.
 
 - Hugging Face/torch encodes the prompt with UMT5 (bf16 by default: fp32
   exponent range without fp16 overflow risk, at fp16 memory cost).
-- MLX runs the FastWan DiT denoising loop (INT8 by default, compiled with
+- MLX runs the FastMetal DiT denoising loop (INT8 by default, compiled with
   ``mx.compile`` unless ``--no-mlx-compile``).
 - TAEHV (default, fast/low-memory) or the full Wan VAE (``--decode-backend
   wan-vae``, higher fidelity, bf16) decodes the final latents.
@@ -56,13 +65,18 @@ from fastvideo.mlx_runtime.prompt_cache import (
     save_prompt_cache,
     text_encoder_fingerprint,
 )
+from fastvideo.mlx_runtime.checkpoint_compat import (
+    UnsupportedMLXCheckpointError,
+    raise_if_unsupported_mlx_checkpoint,
+    resolve_mlx_checkpoint,
+)
 from fastvideo.mlx_runtime.rife_interp import aligned_keyframe_count
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from fastvideo.mlx_runtime.fast_spatial import FastSpatialPlan
 
 
-DEFAULT_MODEL_ID = "FastVideo/FastWan2.1-T2V-1.3B-Diffusers"
+DEFAULT_MODEL_ID = "FastVideo/FastMetal-1.3B-QAD"
 
 # Legacy pinned-snapshot location, kept for callers that import it (the MLX
 # benchmark harness). New code should prefer resolve_model_root(None), which
@@ -99,6 +113,10 @@ def resolve_model_root(
         "tokenizer/*",
         "text_encoder/*",
         "vae/*",
+        "mlx_dit.json",
+        "mlx_dit.safetensors",
+        "ema/mlx_dit.json",
+        "ema/mlx_dit.safetensors",
         "transformer/*" if include_transformer else "transformer/config.json",
     ]
     return Path(snapshot_download(
@@ -471,11 +489,16 @@ def _rife_interpolate_video(*, video_path: Path, target_frames: int, factor: int
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Prompt-to-video FastWan generation using MLX for the DiT")
+    parser = argparse.ArgumentParser(
+        description="Prompt-to-video FastMetal-QAD generation using the Apple Silicon MLX runtime")
     parser.add_argument("--model-root", type=Path, default=None,
-                        help=f"Model directory. Defaults to the local HF cache for {DEFAULT_MODEL_ID} "
+                        help="FastMetal-QAD directory (tokenizer, UMT5, VAE, packed MLX DiT). "
+                        f"Defaults to the local HF cache for {DEFAULT_MODEL_ID} "
                         "(downloading it if missing).")
-    parser.add_argument("--prompt", default="A paper boat sails through a shallow stream in a mossy forest.")
+    parser.add_argument(
+        "--prompt",
+        default="A bird's-eye view of a misty forest valley at dawn.",
+    )
     parser.add_argument("--output-path", type=Path, default=Path("video_samples/mlx_fastwan_prompt_to_video.mp4"))
     parser.add_argument("--height", type=int, default=480)
     parser.add_argument("--width", type=int, default=832)
@@ -639,9 +662,8 @@ def main() -> None:
                         "keyed by (model, prompt, length, dtype), so repeat runs skip "
                         "the text encoder entirely. Default: on.")
     parser.add_argument("--mlx-checkpoint", type=Path, default=None,
-                        help="Load the DiT from a pre-quantized MLX checkpoint directory "
-                        "(created with --save-mlx-checkpoint) instead of casting/quantizing "
-                        "the Diffusers weights on every run.")
+                        help="Packed FastMetal MLX DiT directory (mlx_dit.json + mlx_dit.safetensors). "
+                        "Defaults to --model-root when that directory already contains those files.")
     parser.add_argument("--save-mlx-checkpoint", type=Path, default=None,
                         help="After loading the DiT, save it (cast + quantized) as an MLX "
                         "checkpoint directory for fast reloads via --mlx-checkpoint.")
@@ -690,6 +712,12 @@ def main() -> None:
         np.save(args.encode_prompt_only, prompt_embeds.cpu().numpy())
         return
 
+    mlx_checkpoint = resolve_mlx_checkpoint(args.mlx_checkpoint, model_root)
+    try:
+        raise_if_unsupported_mlx_checkpoint(mlx_checkpoint or model_root)
+    except UnsupportedMLXCheckpointError as exc:
+        raise SystemExit(str(exc)) from exc
+
     import mlx.core as mx
     import torch
     from diffusers import UniPCMultistepScheduler
@@ -719,17 +747,20 @@ def main() -> None:
 
     config_path = model_root / "transformer/config.json"
     checkpoint_path = model_root / "transformer/diffusion_pytorch_model.safetensors"
-    config = json.loads(config_path.read_text())
-    # A pre-quantized MLX DiT can be paired with a lightweight asset root for
-    # UMT5/TAEHV.  In that case the model root is *not* the architecture
-    # authority: use the checkpoint's embedded transformer config for the
-    # sampler guard and latent geometry.
-    dit_config = config
-    if args.mlx_checkpoint is not None:
-        mlx_config_path = Path(args.mlx_checkpoint) / "mlx_dit.json"
-        if mlx_config_path.is_file():
-            mlx_checkpoint_config = json.loads(mlx_config_path.read_text())
-            dit_config = mlx_checkpoint_config.get("config", mlx_checkpoint_config)
+    # Packed FastMetal checkpoints are the architecture authority. Do not
+    # require transformer/config.json when mlx_dit.json is already present.
+    if mlx_checkpoint is not None:
+        mlx_checkpoint_config = json.loads((mlx_checkpoint / "mlx_dit.json").read_text())
+        dit_config = mlx_checkpoint_config.get("config", mlx_checkpoint_config)
+        config = dit_config
+    else:
+        if not config_path.is_file():
+            raise SystemExit(
+                f"No packed MLX DiT (mlx_dit.json) and no Diffusers transformer config at {config_path}. "
+                "Download FastVideo/FastMetal-1.3B-QAD and pass --model-root / --mlx-checkpoint at that directory."
+            )
+        config = json.loads(config_path.read_text())
+        dit_config = config
     if int(dit_config.get("in_channels", 0)) == 48 and int(dit_config.get("out_channels", 0)) == 48:
         raise SystemExit(
             "Wan2.2-TI2V-5B uses 48-channel, per-token timestep conditioning. "
@@ -835,10 +866,10 @@ def main() -> None:
     load_start = time.perf_counter()
     mx.clear_cache()
     mx.reset_peak_memory()
-    if args.mlx_checkpoint is not None:
+    if mlx_checkpoint is not None:
         from fastvideo.mlx_runtime.checkpoint import load_mlx_dit_checkpoint
 
-        dit = load_mlx_dit_checkpoint(args.mlx_checkpoint, compile=args.mlx_compile)
+        dit = load_mlx_dit_checkpoint(mlx_checkpoint, compile=args.mlx_compile)
         config = dit.config
     else:
         dit = mlx_dit_from_diffusers_safetensors(

--- a/examples/inference/basic/mlx_wan_prompt_to_video.py
+++ b/examples/inference/basic/mlx_wan_prompt_to_video.py
@@ -161,6 +161,7 @@ def encode_prompt(
     text_encoder = UMT5EncoderModel.from_pretrained(
         model_root / "text_encoder",
         torch_dtype=dtype,
+        low_cpu_mem_usage=True,
         local_files_only=True,
     ).to(device)
     text_encoder.eval()
@@ -402,6 +403,7 @@ def decode_latents_to_video(
     vae = AutoencoderKLWan.from_pretrained(
         model_root / "vae",
         torch_dtype=dtype,
+        low_cpu_mem_usage=True,
         local_files_only=True,
     ).to(device)
     vae.eval()

--- a/examples/inference/basic/mlx_wan_prompt_to_video.py
+++ b/examples/inference/basic/mlx_wan_prompt_to_video.py
@@ -12,6 +12,11 @@ Download FastMetal-QAD and point ``--model-root`` / ``--mlx-checkpoint`` at it:
 CUDA FastWan-QAD (``FastVideo/FastWan-QAD-1.3B``, ``FastVideo/FastWan-QAD-FP8-1.3B``)
 is a separate NVIDIA release.
 
+FastMetal-QAD Hugging Face repos ship ``mlx_dit.json`` + ``mlx_dit.safetensors``,
+not a Diffusers ``transformer/`` tree. Do not copy ``transformer/config.json``
+from Wan2.1 or other checkpoints; point ``--mlx-checkpoint`` at the FastMetal
+directory and the example reads the DiT config from ``mlx_dit.json``.
+
 - Hugging Face/torch encodes the prompt with UMT5 (bf16 by default: fp32
   exponent range without fp16 overflow risk, at fp16 memory cost).
 - MLX runs the FastMetal DiT denoising loop (INT8 by default, compiled with
@@ -757,7 +762,8 @@ def main() -> None:
         if not config_path.is_file():
             raise SystemExit(
                 f"No packed MLX DiT (mlx_dit.json) and no Diffusers transformer config at {config_path}. "
-                "Download FastVideo/FastMetal-1.3B-QAD and pass --model-root / --mlx-checkpoint at that directory."
+                "FastMetal-QAD checkpoints intentionally omit transformer/; download "
+                "FastVideo/FastMetal-1.3B-QAD and pass --model-root / --mlx-checkpoint at that directory."
             )
         config = json.loads(config_path.read_text())
         dit_config = config

--- a/fastvideo/mlx_runtime/__init__.py
+++ b/fastvideo/mlx_runtime/__init__.py
@@ -24,6 +24,12 @@ from fastvideo.mlx_runtime.checkpoint import (
     load_mlx_dit_checkpoint,
     save_mlx_dit_checkpoint,
 )
+from fastvideo.mlx_runtime.checkpoint_compat import (
+    UnsupportedMLXCheckpointError,
+    discover_mlx_checkpoint,
+    raise_if_unsupported_mlx_checkpoint,
+    resolve_mlx_checkpoint,
+)
 from fastvideo.mlx_runtime.memory import (
     AppliedMemoryLimits,
     add_memory_limit_args,
@@ -81,6 +87,7 @@ __all__ = [
     "MLXWanTransformerBlock",
     "RefinePlan",
     "TwoPassResult",
+    "UnsupportedMLXCheckpointError",
     "UnsupportedMLXQuantizationError",
     "add_memory_limit_args",
     "apply_fast_spatial_upsample",
@@ -92,8 +99,11 @@ __all__ = [
     "fastwan_shape",
     "fastwan_shape_from_config",
     "gib_to_bytes",
+    "discover_mlx_checkpoint",
     "load_mlx_dit_checkpoint",
     "load_or_enhance_prompt",
+    "raise_if_unsupported_mlx_checkpoint",
+    "resolve_mlx_checkpoint",
     "mlx_dit_from_diffusers_safetensors",
     "mlx_block_weights_from_diffusers_safetensors",
     "mlx_block_weights_from_torch",

--- a/fastvideo/mlx_runtime/checkpoint.py
+++ b/fastvideo/mlx_runtime/checkpoint.py
@@ -197,8 +197,8 @@ def load_mlx_dit_checkpoint(checkpoint_dir: str | Path, *, compile: bool = False
     manifest_path = checkpoint_dir / MANIFEST_FILENAME
     weights_path = checkpoint_dir / WEIGHTS_FILENAME
     if not manifest_path.exists() or not weights_path.exists():
-        raise FileNotFoundError(f"Not an MLX DiT checkpoint directory: {checkpoint_dir} "
-                                f"(expected {MANIFEST_FILENAME} and {WEIGHTS_FILENAME}).")
+        from fastvideo.mlx_runtime.checkpoint_compat import mlx_checkpoint_missing_hint
+        raise FileNotFoundError(mlx_checkpoint_missing_hint(checkpoint_dir))
 
     manifest = json.loads(manifest_path.read_text())
     version = manifest.get("format_version")

--- a/fastvideo/mlx_runtime/checkpoint_compat.py
+++ b/fastvideo/mlx_runtime/checkpoint_compat.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reject NVIDIA FastWan-QAD checkpoints on the Apple Silicon MLX path.
+
+FastMetal-QAD is the Apple Silicon release: DMD2 students trained on the affine
+INT8 grid, shipped as packed ``mlx_dit.safetensors`` + ``mlx_dit.json``.
+``FastVideo/FastWan-QAD-1.3B`` and ``FastVideo/FastWan-QAD-FP8-1.3B`` are
+NVIDIA-only QAD checkpoints (NVFP4 / FP8). Loading them through the MLX
+Diffusers path silently requantizes the wrong weights and produces videos that
+ignore the prompt. Fail loudly instead.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+FASTMETAL_COLLECTION_URL = "https://huggingface.co/collections/FastVideo/fastmetal"
+FASTMETAL_BLOG_URL = "https://haoailab.com/blogs/fastmetal/"
+
+FASTMETAL_MODEL_IDS = (
+    "FastVideo/FastMetal-1.3B-QAD",
+    "FastVideo/FastMetal-5B-QAD",
+    "FastVideo/FastMetal-14B-QAD",
+)
+
+MLX_DIT_MANIFEST = "mlx_dit.json"
+MLX_DIT_WEIGHTS = "mlx_dit.safetensors"
+CUDA_QAD_OVERLAY_DIR = "generator_inference_transformer"
+
+# Directory / HF-cache names for the NVIDIA FastWan-QAD family. The INT8 Apple
+# snapshots used an older FastWan-QAD-INT8-* name; ``int8`` in the path is
+# excluded below so those packed MLX checkpoints still load.
+_NVIDIA_FASTWAN_QAD_RE = re.compile(
+    r"(?:^|[/\\._-]|--)fastwan-qad-(?:fp8-)?1\.3b(?:-sa2)?(?:$|[/\\._-]|--)",
+    re.IGNORECASE,
+)
+
+_NVIDIA_QUANT_MARKERS = (
+    "nvfp4",
+    "nv_fp4",
+    "sageattention3",
+    "attn_qat_infer",
+)
+
+
+class UnsupportedMLXCheckpointError(ValueError):
+    """Raised when an NVIDIA FastWan-QAD (or similarly incompatible) tree is used on MLX."""
+
+
+def is_mlx_dit_checkpoint(path: str | Path) -> bool:
+    """Return True if ``path`` is a packed FastMetal / MLX DiT directory."""
+    checkpoint_dir = Path(path)
+    return (checkpoint_dir / MLX_DIT_MANIFEST).is_file() and (checkpoint_dir / MLX_DIT_WEIGHTS).is_file()
+
+
+def discover_mlx_checkpoint(*candidates: str | Path | None) -> Path | None:
+    """Return the first candidate that is a packed MLX DiT directory."""
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        path = Path(candidate)
+        if is_mlx_dit_checkpoint(path):
+            return path
+    return None
+
+
+def resolve_mlx_checkpoint(explicit: str | Path | None, *search_roots: str | Path | None) -> Path | None:
+    """Prefer an explicit ``--mlx-checkpoint``, otherwise scan search roots."""
+    if explicit is not None:
+        return Path(explicit)
+    return discover_mlx_checkpoint(*search_roots)
+
+
+def mlx_checkpoint_missing_hint(checkpoint_dir: str | Path) -> str:
+    """Extra FileNotFoundError text when a directory is not a packed MLX DiT."""
+    nvidia_reason = nvidia_fastwan_qad_reason(checkpoint_dir)
+    prefix = (f"Not an MLX DiT checkpoint directory: {checkpoint_dir} "
+              f"(expected {MLX_DIT_MANIFEST} and {MLX_DIT_WEIGHTS}).")
+    if nvidia_reason is not None:
+        return prefix + "\n\n" + _nvidia_fastwan_qad_message(Path(checkpoint_dir), nvidia_reason)
+    return prefix + "\n\n" + _fastmetal_howto()
+
+
+def raise_if_unsupported_mlx_checkpoint(*paths: str | Path | None) -> None:
+    """Raise if any path is an NVIDIA FastWan-QAD tree that must not run on MLX.
+
+    Packed FastMetal / MLX DiT directories are always allowed, including the
+    older FastWan-QAD-INT8 directory name, because those already contain
+    ``mlx_dit.json``.
+    """
+    for path in paths:
+        if path is None:
+            continue
+        checkpoint = Path(path)
+        if is_mlx_dit_checkpoint(checkpoint):
+            continue
+        reason = nvidia_fastwan_qad_reason(checkpoint)
+        if reason is None:
+            continue
+        raise UnsupportedMLXCheckpointError(_nvidia_fastwan_qad_message(checkpoint, reason))
+
+
+def nvidia_fastwan_qad_reason(path: str | Path) -> str | None:
+    """Return a short reason if ``path`` looks like NVIDIA FastWan-QAD, else None."""
+    checkpoint = Path(path)
+    haystack = _path_haystack(checkpoint)
+    if "int8" in haystack and is_mlx_dit_checkpoint(checkpoint):
+        return None
+    if _NVIDIA_FASTWAN_QAD_RE.search(haystack) and "int8" not in haystack:
+        return "NVIDIA FastWan-QAD checkpoint name (NVFP4/FP8, not FastMetal INT8)"
+    if (checkpoint / CUDA_QAD_OVERLAY_DIR).is_dir() or (checkpoint.parent / CUDA_QAD_OVERLAY_DIR).is_dir():
+        return f"CUDA QAD overlay directory ({CUDA_QAD_OVERLAY_DIR}/)"
+    for config_path in _config_candidates(checkpoint):
+        marker = _quant_marker_in_file(config_path)
+        if marker is not None:
+            return f"{config_path.name} contains NVIDIA quantization marker {marker!r}"
+    return None
+
+
+def _path_haystack(path: Path) -> str:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path
+    return str(resolved).replace("\\", "/").lower()
+
+
+def _config_candidates(path: Path) -> list[Path]:
+    roots = [path.parent, path.parent.parent] if path.is_file() else [path, path.parent, path / "transformer"]
+    seen: set[Path] = set()
+    files: list[Path] = []
+    for root in roots:
+        for candidate in (root / "config.json", root / "model_index.json", root / "transformer" / "config.json"):
+            if candidate in seen or not candidate.is_file():
+                continue
+            seen.add(candidate)
+            files.append(candidate)
+    return files
+
+
+def _quant_marker_in_file(config_path: Path) -> str | None:
+    try:
+        payload = config_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    lowered = payload.lower()
+    for marker in _NVIDIA_QUANT_MARKERS:
+        if marker in lowered:
+            return marker
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+    quant = parsed.get("quantization_config") if isinstance(parsed, dict) else None
+    if isinstance(quant, dict):
+        blob = json.dumps(quant).lower()
+        for marker in ("fp8", "float8", "nvfp4", "fp4"):
+            if marker in blob:
+                return marker
+    return None
+
+
+def _fastmetal_howto() -> str:
+    models = ", ".join(FASTMETAL_MODEL_IDS)
+    return ("The Apple Silicon MLX runtime requires FastMetal-QAD INT8 checkpoints, "
+            f"not CUDA FastWan-QAD weights.\n"
+            f"  Download: hf download FastVideo/FastMetal-1.3B-QAD --local-dir ./FastMetal-1.3B-QAD\n"
+            f"  Run: python examples/inference/basic/mlx_wan_prompt_to_video.py "
+            f"--model-root ./FastMetal-1.3B-QAD --mlx-checkpoint ./FastMetal-1.3B-QAD\n"
+            f"  5B uses examples/inference/basic/mlx_wan22_generate.py with FastMetal-5B-QAD.\n"
+            f"  Models: {models}\n"
+            f"  Guide: {FASTMETAL_BLOG_URL}\n"
+            f"  Collection: {FASTMETAL_COLLECTION_URL}\n"
+            "FastVideo/FastWan-QAD-1.3B and FastVideo/FastWan-QAD-FP8-1.3B are "
+            "NVIDIA NVFP4/FP8 QAD checkpoints.")
+
+
+def _nvidia_fastwan_qad_message(path: Path, reason: str) -> str:
+    return (f"Refusing to load {path} on the Apple Silicon MLX runtime ({reason}).\n\n" + _fastmetal_howto())

--- a/fastvideo/mlx_runtime/checkpoint_compat.py
+++ b/fastvideo/mlx_runtime/checkpoint_compat.py
@@ -166,6 +166,7 @@ def _fastmetal_howto() -> str:
     return ("The Apple Silicon MLX runtime requires FastMetal-QAD INT8 checkpoints, "
             f"not CUDA FastWan-QAD weights.\n"
             f"  Download: hf download FastVideo/FastMetal-1.3B-QAD --local-dir ./FastMetal-1.3B-QAD\n"
+            "  FastMetal repos ship mlx_dit.json (not transformer/config.json).\n"
             f"  Run: python examples/inference/basic/mlx_wan_prompt_to_video.py "
             f"--model-root ./FastMetal-1.3B-QAD --mlx-checkpoint ./FastMetal-1.3B-QAD\n"
             f"  5B uses examples/inference/basic/mlx_wan22_generate.py with FastMetal-5B-QAD.\n"

--- a/fastvideo/mlx_runtime/fastwan.py
+++ b/fastvideo/mlx_runtime/fastwan.py
@@ -885,6 +885,10 @@ def mlx_dit_from_diffusers_safetensors(
     import mlx.core as mx
     from safetensors import safe_open
 
+    from fastvideo.mlx_runtime.checkpoint_compat import raise_if_unsupported_mlx_checkpoint
+
+    raise_if_unsupported_mlx_checkpoint(checkpoint_path, config_path)
+
     config = json.loads(Path(config_path).read_text())
     total_blocks = int(config["num_layers"])
     if num_blocks is None:

--- a/fastvideo/tests/mlx/test_mlx_checkpoint_compat.py
+++ b/fastvideo/tests/mlx/test_mlx_checkpoint_compat.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Guard: NVIDIA FastWan-QAD checkpoints must not silently load on MLX."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fastvideo.mlx_runtime.checkpoint_compat import (
+    UnsupportedMLXCheckpointError,
+    discover_mlx_checkpoint,
+    is_mlx_dit_checkpoint,
+    mlx_checkpoint_missing_hint,
+    nvidia_fastwan_qad_reason,
+    raise_if_unsupported_mlx_checkpoint,
+    resolve_mlx_checkpoint,
+)
+
+
+def _write(path: Path, text: str = "{}") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+def test_packed_mlx_dit_is_detected(tmp_path: Path) -> None:
+    _write(tmp_path / "mlx_dit.json")
+    _write(tmp_path / "mlx_dit.safetensors", "x")
+    assert is_mlx_dit_checkpoint(tmp_path)
+    assert discover_mlx_checkpoint(tmp_path / "missing", tmp_path) == tmp_path
+    assert resolve_mlx_checkpoint(None, tmp_path) == tmp_path
+    raise_if_unsupported_mlx_checkpoint(tmp_path)
+
+
+def test_explicit_mlx_checkpoint_wins_over_search_root(tmp_path: Path) -> None:
+    packed = tmp_path / "packed"
+    _write(packed / "mlx_dit.json")
+    _write(packed / "mlx_dit.safetensors", "x")
+    explicit = tmp_path / "explicit"
+    explicit.mkdir()
+    assert resolve_mlx_checkpoint(explicit, packed) == explicit
+
+
+def test_fastwan_qad_1_3b_directory_is_rejected(tmp_path: Path) -> None:
+    nvidia = tmp_path / "FastWan-QAD-1.3B"
+    nvidia.mkdir()
+    with pytest.raises(UnsupportedMLXCheckpointError, match="FastMetal-QAD"):
+        raise_if_unsupported_mlx_checkpoint(nvidia)
+    assert nvidia_fastwan_qad_reason(nvidia) is not None
+
+
+def test_fastwan_qad_fp8_hf_cache_path_is_rejected(tmp_path: Path) -> None:
+    nvidia = tmp_path / "models--FastVideo--FastWan-QAD-FP8-1.3B" / "snapshots" / "abc"
+    nvidia.mkdir(parents=True)
+    with pytest.raises(UnsupportedMLXCheckpointError, match="FastWan-QAD-FP8"):
+        raise_if_unsupported_mlx_checkpoint(nvidia)
+
+
+def test_cuda_overlay_layout_is_rejected_even_without_qad_name(tmp_path: Path) -> None:
+    root = tmp_path / "some-local-qad"
+    (root / "generator_inference_transformer").mkdir(parents=True)
+    with pytest.raises(UnsupportedMLXCheckpointError, match="generator_inference_transformer"):
+        raise_if_unsupported_mlx_checkpoint(root)
+
+
+def test_nvfp4_quantization_config_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "mystery-wan"
+    _write(
+        root / "transformer" / "config.json",
+        json.dumps({"quantization_config": {"quant_method": "nvfp4_qat"}}),
+    )
+    with pytest.raises(UnsupportedMLXCheckpointError, match="nvfp4"):
+        raise_if_unsupported_mlx_checkpoint(root)
+
+
+def test_legacy_int8_name_with_packed_mlx_dit_is_allowed(tmp_path: Path) -> None:
+    apple = tmp_path / "FastWan-QAD-INT8-1.3B"
+    _write(apple / "mlx_dit.json")
+    _write(apple / "mlx_dit.safetensors", "x")
+    raise_if_unsupported_mlx_checkpoint(apple)
+    assert nvidia_fastwan_qad_reason(apple) is None
+
+
+def test_plain_diffusers_wan_is_not_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "FastWan2.1-T2V-1.3B-Diffusers"
+    _write(root / "transformer" / "config.json", json.dumps({"num_layers": 2}))
+    raise_if_unsupported_mlx_checkpoint(root)
+    assert nvidia_fastwan_qad_reason(root) is None
+
+
+def test_missing_mlx_dit_hint_mentions_fastmetal(tmp_path: Path) -> None:
+    nvidia = tmp_path / "FastWan-QAD-1.3B"
+    nvidia.mkdir()
+    hint = mlx_checkpoint_missing_hint(nvidia)
+    assert "Not an MLX DiT checkpoint directory" in hint
+    assert "FastMetal-1.3B-QAD" in hint
+    assert "FastWan-QAD-FP8-1.3B" in hint

--- a/fastvideo/tests/mlx/test_mlx_prompt_to_video_decode.py
+++ b/fastvideo/tests/mlx/test_mlx_prompt_to_video_decode.py
@@ -78,8 +78,12 @@ def test_default_model_resolution_downloads_only_needed_transformer(monkeypatch,
     monkeypatch.setattr(huggingface_hub, "snapshot_download", fake_snapshot_download)
 
     assert module.resolve_model_root(None, include_transformer=True) == tmp_path
+    assert calls[-1][0] == module.DEFAULT_MODEL_ID
+    assert module.DEFAULT_MODEL_ID == "FastVideo/FastMetal-1.3B-QAD"
     assert "transformer/*" in calls[-1][1]
+    assert "mlx_dit.json" in calls[-1][1]
     assert module.resolve_model_root(None, include_transformer=False) == tmp_path
     assert "transformer/*" not in calls[-1][1]
+    assert "mlx_dit.json" in calls[-1][1]
     assert module.resolve_model_root(tmp_path) == tmp_path
     assert len(calls) == 2


### PR DESCRIPTION
## Summary

Fixes #1736 — make the FastMetal-QAD MLX path correct and robust:

- **Refuse CUDA FastWan-QAD / FP8 trees on the MLX runtime** — a Mac run can no longer silently requantize the wrong weights and ignore the prompt.
- **Packed FastMetal-QAD checkpoints (`mlx_dit.json` + `mlx_dit.safetensors`) are the supported path**, with auto-discovery under `--model-root`. `transformer/config.json` is intentionally absent from the FastMetal repos — the DiT config lives inside `mlx_dit.json`. Diffusers trees with `transformer/config.json` still work on the non-MLX path.
- **Streamed text-encoder/VAE loads (`low_cpu_mem_usage=True`)** — UMT5 loads at 22 GB fp32 before casting by default, which exceeds the 16 GB-class Macs this runtime targets; streaming keeps the peak at the target dtype (~11 GB).
- **Docs + error message clarity** — the example explains that FastMetal repos ship `mlx_dit.json` (not a `transformer/` tree) and tells users to point `--model-root` / `--mlx-checkpoint` at the downloaded `FastVideo/FastMetal-1.3B-QAD` directory. Do not copy `config.json` from `Wan-AI/Wan2.1-T2V-1.3B` (different schema).
- Docs, examples, and the support matrix point at `FastVideo/FastMetal-{1.3B,5B,14B}-QAD`.

## Test plan
- [x] `pytest fastvideo/tests/mlx/test_mlx_checkpoint_compat.py fastvideo/tests/mlx/test_mlx_prompt_to_video_decode.py`
- [x] 1.3B FastMetal generation with `--model-root ./FastMetal-1.3B-QAD --mlx-checkpoint ./FastMetal-1.3B-QAD` (no `transformer/` folder)
- [ ] Reporter retry on the PR branch
