### PR TITLE
[perf]: MiniMax H3 on GB10 - load pipeline components on demand instead of all at once

### DIFF
--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -30,6 +30,7 @@ surfaces:
       image_encoder_cpu_offload: generator.engine.offload.image_encoder
       vae_cpu_offload: generator.engine.offload.vae
       pin_cpu_memory: generator.engine.offload.pin_cpu_memory
+      lazy_module_load: generator.engine.offload.lazy_module_load
       enable_torch_compile: generator.engine.compile.enabled
       enable_torch_compile_text_encoder: generator.engine.compile.text_encoder_enabled
       enable_torch_compile_vae: generator.engine.compile.vae_enabled

--- a/docs/inference/offloading.md
+++ b/docs/inference/offloading.md
@@ -152,6 +152,15 @@ the model already fits.
 This option applies to inference only. Training keeps every component resident
 and logs a warning if the flag is set.
 
+Deferral is opt-in per pipeline. Releasing a component and loading it again is
+only safe when nothing outside the loader has changed it, and two common habits
+break that without raising: mutating a component after load, as LongCat does
+when it enables block-sparse attention, and reading a component's attributes
+while stages are built, as the shared denoising stage does to pick an attention
+backend. A pipeline therefore lists the components it has checked in
+`_lazy_module_names`, which is empty in the base class. MiniMax-H3 opts in. On
+a pipeline that has not, the flag logs a warning and changes nothing.
+
 ## General Recommendations
 
 ### Single GPU Inference

--- a/docs/inference/offloading.md
+++ b/docs/inference/offloading.md
@@ -139,7 +139,9 @@ pipeline that is roughly `max(text encoder, DiT + VAE)` rather than
 
 A freed component is read from disk again on the next generation, so a
 multi-prompt run pays one reload per component per request. For a large text
-encoder that is tens of seconds.
+encoder that is tens of seconds. If pipeline-level `torch.compile` is enabled,
+the compile setup is reapplied after each reload; PyTorch can reuse its graph
+and kernel caches when the component structure and input shapes are unchanged.
 
 #### Usage Recommendation
 

--- a/docs/inference/offloading.md
+++ b/docs/inference/offloading.md
@@ -12,6 +12,7 @@ text_encoder_cpu_offload: bool = True
 image_encoder_cpu_offload: bool = True
 vae_cpu_offload: bool = True
 pin_cpu_memory: bool = True
+lazy_module_load: bool = False
 ```
 
 On unified-memory accelerators such as NVIDIA GB10 and Apple silicon, FastVideo
@@ -121,6 +122,36 @@ These options introduce performance overhead due to PCIe data transfer.
 
 We recommend enabling these options when OOM happens.
 
+### `lazy_module_load`
+
+Every option above moves weights between host and device. This one changes
+whether they are in memory at all.
+
+By default a pipeline loads every component before the first stage runs, so
+peak memory is the sum of all of them even though no two are needed at the same
+moment. With `lazy_module_load` enabled, each heavy component loads on first use
+and is freed once the last stage that needs it has returned, so peak memory
+becomes the largest overlapping set instead of the sum. For a text-to-video
+pipeline that is roughly `max(text encoder, DiT + VAE)` rather than
+`text encoder + DiT + VAE`.
+
+#### Performance Impact
+
+A freed component is read from disk again on the next generation, so a
+multi-prompt run pays one reload per component per request. For a large text
+encoder that is tens of seconds.
+
+#### Usage Recommendation
+
+Enable this when a model does not fit at load time, which the CPU offload
+options above cannot help with because they act after loading. It is
+particularly relevant on unified-memory devices, where host and device draw on
+the same pool and moving weights to the host frees nothing. Leave it off when
+the model already fits.
+
+This option applies to inference only. Training keeps every component resident
+and logs a warning if the flag is set.
+
 ## General Recommendations
 
 ### Single GPU Inference
@@ -130,6 +161,12 @@ We recommend enabling `dit_layerwise_offload`. If OOM happens, also enable `imag
 ### Multi-GPU Inference
 
 We recommend enabling `use_fsdp_inference` and disabling both `dit_layerwise_offload` and `dit_cpu_offload`. If OOM happens, consider enabling `text_encoder_cpu_offload`, `image_encoder_cpu_offload`, and `vae_cpu_offload`. If OOM still happens, consider enabling `dit_cpu_offload`.
+
+### When the Model Does Not Fit at Load Time
+
+The offload options only help once loading has finished. If the run dies while
+components are still being placed, or if the machine has unified memory so
+there is no separate host pool to offload into, enable `lazy_module_load`.
 
 ## Examples
 

--- a/examples/inference/basic/basic_fasth3.py
+++ b/examples/inference/basic/basic_fasth3.py
@@ -48,6 +48,12 @@ def build_parser(description: str | None = None) -> argparse.ArgumentParser:
     # License review completes. A local snapshot can be passed here instead.
     parser.add_argument("--prompt", required=True)
     parser.add_argument("--output", default="outputs/fasth3")
+    parser.add_argument("--lazy-module-load",
+                        action="store_true",
+                        help="load each heavy component on first use and free it after the last stage that "
+                        "needs it, so peak memory is the largest overlapping set instead of the sum of every "
+                        "component. Enable when the model does not fit at load time; costs a reload per "
+                        "generation, so leave it off when it does fit")
     parser.add_argument("--profile",
                         choices=("all", "strict"),
                         default="all",
@@ -260,6 +266,7 @@ def build_generator_config(args: argparse.Namespace) -> GeneratorConfig:
                 text_encoder=True,
                 vae=True,
                 pin_cpu_memory=args.pin_cpu_memory,
+                lazy_module_load=args.lazy_module_load,
             ),
             compile=CompileConfig(
                 enabled=args.torch_compile,

--- a/examples/inference/basic/basic_minimax_h3_t2v.py
+++ b/examples/inference/basic/basic_minimax_h3_t2v.py
@@ -48,6 +48,12 @@ def parse_args() -> argparse.Namespace:
                         "training-port semantics: no kwargs; fullgraph + emulate_precision_casts injected). "
                         "First generation pays the inductor JIT (~1-2 min); use --repeats >= 2 and time "
                         "the last repeat. FASTVIDEO_INFERENCE_TORCH_COMPILE=1 is equivalent")
+    parser.add_argument("--lazy-module-load",
+                        action="store_true",
+                        help="load each heavy component on first use and free it after the last stage that "
+                        "needs it, so peak memory is the largest overlapping set instead of the sum of every "
+                        "component. Enable when the model does not fit at load time; costs a reload per "
+                        "generation, so leave it off when it does fit")
     parser.add_argument("--repeats",
                         type=int,
                         default=1,
@@ -81,6 +87,7 @@ def main() -> None:
                     text_encoder=True,
                     vae=True,
                     pin_cpu_memory=False,
+                    lazy_module_load=args.lazy_module_load,
                 ),
                 compile=CompileConfig(
                     enabled=args.torch_compile,

--- a/fastvideo/api/compat.py
+++ b/fastvideo/api/compat.py
@@ -126,6 +126,8 @@ def legacy_from_pretrained_to_config(
             offload["vae"] = value
         elif key == "pin_cpu_memory":
             offload["pin_cpu_memory"] = value
+        elif key == "lazy_module_load":
+            offload["lazy_module_load"] = value
         elif key == "enable_torch_compile":
             compile_config["enabled"] = value
         elif key == "enable_torch_compile_text_encoder":
@@ -253,6 +255,7 @@ def generator_config_to_fastvideo_args(config: GeneratorConfig | Mapping[str, An
         "image_encoder_cpu_offload": engine.offload.image_encoder,
         "vae_cpu_offload": engine.offload.vae,
         "pin_cpu_memory": engine.offload.pin_cpu_memory,
+        "lazy_module_load": engine.offload.lazy_module_load,
         "enable_torch_compile": engine.compile.enabled,
         "torch_compile_kwargs": _compile_config_to_torch_kwargs(engine.compile),
         "enable_stage_verification": engine.enable_stage_verification,

--- a/fastvideo/api/schema.py
+++ b/fastvideo/api/schema.py
@@ -30,6 +30,12 @@ class OffloadConfig:
     image_encoder: bool = True
     vae: bool = True
     pin_cpu_memory: bool = True
+    # Not a CPU offload: loads each heavy component on first use and frees it
+    # after the last stage that needs it, so peak memory is the largest
+    # overlapping set rather than the sum. Grouped here because it is the same
+    # decision the offload knobs answer, which is how much of the model has to
+    # be resident at once.
+    lazy_module_load: bool = False
 
 
 @dataclass

--- a/fastvideo/attention/backends/video_sparse_attn_h3.py
+++ b/fastvideo/attention/backends/video_sparse_attn_h3.py
@@ -442,12 +442,21 @@ class MiniMaxH3VSAImpl(AttentionImpl):
         self.prefix = prefix
         self.layer_idx = layer_idx_from_prefix(prefix, default=-1)
         self.head_size = head_size
+        # Generic torch.compile must not specialize the shared VSA forward on
+        # the Python ``layer_idx`` value of each of H3's 50 blocks. This
+        # tensor is prepared after weights load and drives only the compiled
+        # dense-layer decision; it does not opt the module into sm_100a.
+        self._compile_layer_idx: torch.Tensor | None = None
         # None means the regional-compile preparation hook has not run.  The
         # eager path deliberately ignores this cache and preserves its
         # request-time env/probe/fallback behavior; only Dynamo capture reads
         # the prepared, static route.
         self._regional_compile_sm100a_enabled: bool | None = None
         self._regional_compile_layer_idx: torch.Tensor | None = None
+
+    def prepare_for_compile(self, device: torch.device) -> None:
+        """Tensorize per-layer state shared by every torch.compile route."""
+        self._compile_layer_idx = torch.tensor(self.layer_idx, device=device, dtype=torch.int64)
 
     def prepare_for_regional_compile(self, device: torch.device) -> str | None:
         """Resolve the inference-only sm_100a route before fullgraph capture.
@@ -459,6 +468,7 @@ class MiniMaxH3VSAImpl(AttentionImpl):
         the loaded model's device now, then let ``forward`` specialize on the
         resulting plain bool while Dynamo is compiling.
         """
+        self.prepare_for_compile(device)
         requested = os.environ.get(VSA_SM100A_ENV, "0") == "1"
         enabled = False
         reason = None if requested else f"{VSA_SM100A_ENV}=1 is required for compile-safe VSA-H3 attention"
@@ -603,13 +613,14 @@ class MiniMaxH3VSAImpl(AttentionImpl):
         logical_gate = gate_compress[:, :logical_seq_len] if gate_compress is not None else None
 
         # Probe-guided per-layer opt-out: diffuse layers run dense (all-True
-        # mask) while the rest keep the configured sparsity. During regional
-        # capture, keep the layer decision tensor-valued so the 50 block
-        # instances reuse one graph instead of specializing on layer_idx.
+        # mask) while the rest keep the configured sparsity. During any
+        # prepared capture, keep the layer decision tensor-valued so the 50
+        # block instances reuse one graph instead of specializing on the
+        # Python layer_idx attribute.
         force_dense = None
-        if regional_compiling:
-            assert self._regional_compile_layer_idx is not None
-            force_dense = (attn_metadata.dense_layers_tensor == self._regional_compile_layer_idx).any()
+        compile_layer_idx = self._compile_layer_idx if compiling else None
+        if compile_layer_idx is not None:
+            force_dense = (attn_metadata.dense_layers_tensor == compile_layer_idx).any()
             layer_sparsity = attn_metadata.VSA_sparsity
         else:
             layer_sparsity = 0.0 if self.layer_idx in attn_metadata.dense_layers else attn_metadata.VSA_sparsity

--- a/fastvideo/fastvideo_args.py
+++ b/fastvideo/fastvideo_args.py
@@ -166,6 +166,15 @@ class FastVideoArgs:
     # False overrides the probe. Training never defers.
     h3_sequential_load: bool | None = None
 
+    # Load each heavy component on first use and free it once the last stage
+    # that holds it has run, instead of keeping every component resident from
+    # load time to shutdown. Peak memory becomes the largest overlapping set
+    # rather than the sum of all components. Off by default: a released
+    # component is re-read from disk on the next generation, so this trades
+    # per-request latency for headroom and only pays off when the sum does not
+    # fit. Inference only; training keeps every component resident.
+    lazy_module_load: bool = False
+
     # Sequence-parallel MiniMax-H3 VAE (opt-in, default off). With SP > 1 the
     # video VAE's temporal chunks (decode) and clips (reference encode) are
     # round-robined across the sequence-parallel ranks and reassembled
@@ -713,6 +722,13 @@ class FastVideoArgs:
             "--vae-cpu-offload",
             action=StoreBoolean,
             help="Use CPU offload for VAE. Enable if run out of memory.",
+        )
+        parser.add_argument(
+            "--lazy-module-load",
+            action=StoreBoolean,
+            help="Load each heavy component on first use and free it after the last stage that needs it, "
+            "so peak memory is the largest overlapping set of components instead of their sum. Enable when a "
+            "model does not fit at load time. Costs a reload per generation, so leave it off when it does fit.",
         )
         parser.add_argument(
             "--pin-cpu-memory",

--- a/fastvideo/models/dits/minimax_h3.py
+++ b/fastvideo/models/dits/minimax_h3.py
@@ -733,31 +733,49 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
         )
         self.__post_init__()
 
+    @staticmethod
+    def _compile_setup_device(attention: MiniMaxH3Attention) -> torch.device:
+        """Return the loaded device even when FP8 replaced the query weight."""
+        query_state = next(attention.to_q.parameters(), None)
+        if query_state is None:
+            query_state = next(attention.to_q.buffers(), None)
+        if query_state is None:
+            raise RuntimeError("MiniMax H3 to_q has no materialized parameter or buffer for compile setup.")
+        return query_state.device
+
     def prepare_for_compile(self) -> None:
         """Pipeline hook, called once right before torch.compile wraps the blocks.
 
-        Resolve each loaded VSA compression gate eagerly. Generic and training
-        compile retain their established attention dispatch; only the
-        inference loader's separate ``prepare_for_regional_compile`` hook may
-        preselect the inference-only sm_100a path.
+        Resolve each loaded VSA compression gate eagerly and tensorize its
+        layer identity so repeated blocks share one Dynamo graph. Generic and
+        training compile retain their established attention dispatch; only
+        the inference loader's separate ``prepare_for_regional_compile`` hook
+        may preselect the inference-only sm_100a path.
 
         The inference-only Triton fusions expose fake-backed custom operators,
         so Dynamo can keep them active as opaque nodes inside each fullgraph
         block instead of tracing into their launcher implementation.
         """
         gate_states: list[bool] = []
+        prepared_vsa_impls = 0
         for block in self.transformer_blocks:
             attention = block.attn
             if attention.to_gate_compress is not None:
                 attention._resolve_gate_compress_for_compile()
                 assert attention._gate_compress_active is not None
                 gate_states.append(attention._gate_compress_active)
+            prepare_vsa = getattr(attention.distributed_attention.attn_impl, "prepare_for_compile", None)
+            if callable(prepare_vsa):
+                prepare_vsa(self._compile_setup_device(attention))
+                prepared_vsa_impls += 1
         if gate_states:
             logger.info(
                 "Resolved MiniMax H3 VSA compression gates before torch.compile: %d active, %d inactive",
                 sum(gate_states),
                 len(gate_states) - sum(gate_states),
             )
+        if prepared_vsa_impls:
+            logger.info("Prepared %d MiniMax H3 VSA layer indices for torch.compile", prepared_vsa_impls)
         if self.enabled_fusions:
             logger.info(
                 "MiniMax H3 inference fusions remain active under torch.compile through custom-op boundaries: %s",
@@ -774,14 +792,7 @@ class MiniMaxH3Transformer3DModel(BaseDiT):
             prepare_vsa = getattr(attention.distributed_attention.attn_impl, "prepare_for_regional_compile", None)
             if not callable(prepare_vsa):
                 continue
-            # Post-load FP8 conversion may replace to_q.weight with packed
-            # buffers. Either representation identifies the local device.
-            query_state = next(attention.to_q.parameters(), None)
-            if query_state is None:
-                query_state = next(attention.to_q.buffers(), None)
-            if query_state is None:
-                raise RuntimeError("MiniMax H3 to_q has no materialized parameter or buffer for compile setup.")
-            unsupported = prepare_vsa(query_state.device)
+            unsupported = prepare_vsa(self._compile_setup_device(attention))
             if unsupported:
                 unsupported_reasons.add(str(unsupported))
             prepared_vsa_impls += 1

--- a/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
+++ b/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
@@ -92,6 +92,10 @@ class MiniMaxH3BasePipeline(LoRAPipeline, ComposedPipelineBase):
         "scheduler",
         "audio_scheduler",
     ]
+    # Deferral is safe here: no stage reads a component's attributes while it
+    # is being constructed, and `initialize_pipeline` only inspects the
+    # schedulers, which are never deferred.
+    _lazy_module_names = ("text_encoder", "transformer", "vae", "audio_vae")
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._ref2va = False

--- a/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
+++ b/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
@@ -119,6 +119,15 @@ class MiniMaxH3BasePipeline(LoRAPipeline, ComposedPipelineBase):
     def _defer_denoise_modules(self, fastvideo_args: FastVideoArgs) -> bool:
         if not fastvideo_args.inference_mode or bool(getattr(fastvideo_args, "training_mode", False)):
             return False
+        # Both mechanisms defer the same four modules and both decide when to
+        # free them. Running them together interleaves two owners over one set
+        # of components: this override would strip the denoise modules from the
+        # load list while the base wrapped the encoder in a proxy, and both
+        # would then release it. `lazy_module_load` is asked for explicitly and
+        # is the more general path, so it wins when it is on.
+        if bool(getattr(fastvideo_args, "lazy_module_load", False)):
+            logger.info("MiniMax-H3 sequential module load off: lazy_module_load owns deferral")
+            return False
         requested = fastvideo_args.h3_sequential_load
         if requested is True:
             return True

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -52,6 +52,10 @@ class ComposedPipelineBase(ABC):
     trainable_transformer_names: list[str] = ["transformer"]
     trainable_transformer_modules: dict[str, torch.nn.Module] = {}
     post_init_called: bool = False
+    # Set once the deferred-release schedule has been derived from the stage
+    # list, so a stage added afterwards can rebuild it instead of running
+    # against a plan that predates it.
+    _lazy_release_hooks_installed: bool = False
     # Components eligible for deferred loading under ``lazy_module_load``.
     # These are the weight-bearing ones; tokenizers, processors, and
     # schedulers are cheap and stay resident so the pipeline can inspect them
@@ -612,11 +616,13 @@ class ComposedPipelineBase(ABC):
                 "lazy_module_load is on but no deferred module is held by a stage, so nothing will be "
                 "freed mid-run. Pipeline %s may load its modules eagerly or hold them outside its stages.",
                 type(self).__name__)
+            self._lazy_release_hooks_installed = True
             return
 
         for index, names in sorted(schedule.items()):
             logger.info("Deferred modules to free after stage %d (%s): %s", index,
                         getattr(self._stages[index], "_pipeline_stage_name", "?"), names)
+        self._lazy_release_hooks_installed = True
 
     def add_stage(self, stage_name: str, stage: PipelineStage):
         assert self.modules is not None, "No modules are registered"
@@ -627,6 +633,15 @@ class ComposedPipelineBase(ABC):
         self._stages.append(stage)
         self._stage_name_mapping[stage_name] = stage
         setattr(self, stage_name, stage)
+
+        if self._lazy_release_hooks_installed:
+            # The schedule maps each deferred module to its last holder. A
+            # stage appended afterwards may hold a module an earlier stage has
+            # already been told to free, which would hand it a released
+            # component mid-run. Rebuild rather than trust the stale plan.
+            logger.warning("Stage %s was added after the deferred-release schedule was built; rebuilding the schedule",
+                           stage_name)
+            self._install_lazy_release_hooks()
 
     # TODO(will): don't hardcode no_grad
     @torch.no_grad()

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -8,6 +8,7 @@ This module defines the base class for pipelines that are composed of multiple s
 import argparse
 import os
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from typing import Any, cast
 
 import torch
@@ -33,6 +34,40 @@ from fastvideo.utils import (maybe_download_model, verify_model_config_and_direc
 logger = init_logger(__name__)
 
 
+def _iter_held_objects(stage: PipelineStage) -> Iterator[Any]:
+    """Yield everything a stage holds, walking into nested stages.
+
+    A stage can compose others rather than hold a component directly:
+    ``Cosmos25AutoDenoisingStage`` keeps the transformer inside its ``_t2w``
+    and ``_v2w`` children. A scan that stopped at the outer stage would call
+    that transformer unreferenced and never free it, so the flag would quietly
+    deliver less than it promises on those pipelines.
+    """
+    stack: list[Any] = [stage]
+    visited: set[int] = set()
+    while stack:
+        obj = stack.pop()
+        # is_lazy_module first: isinstance() on a proxy forwards __class__ and
+        # would load every deferred component just to work out where to free it.
+        if is_lazy_module(obj):
+            yield obj
+            continue
+        if isinstance(obj, PipelineStage | list | tuple | dict):
+            if id(obj) in visited:
+                continue
+            visited.add(id(obj))
+        if isinstance(obj, PipelineStage):
+            for key, value in vars(obj).items():
+                if key == "_lazy_modules_to_release":
+                    # Installed by this schedule, not a real use.
+                    continue
+                stack.append(value)
+        elif isinstance(obj, list | tuple):
+            stack.extend(obj)
+        elif isinstance(obj, dict):
+            stack.extend(obj.values())
+
+
 class ComposedPipelineBase(ABC):
     """
     Base class for pipelines composed of multiple stages.
@@ -56,23 +91,23 @@ class ComposedPipelineBase(ABC):
     # list, so a stage added afterwards can rebuild it instead of running
     # against a plan that predates it.
     _lazy_release_hooks_installed: bool = False
-    # Components eligible for deferred loading under ``lazy_module_load``.
-    # These are the weight-bearing ones; tokenizers, processors, and
-    # schedulers are cheap and stay resident so the pipeline can inspect them
-    # at construction time. Names follow the diffusers manifest convention, so
-    # the default list covers most pipelines; override per pipeline if a
-    # component is named differently or must never be released.
-    _lazy_module_names: tuple[str, ...] = (
-        "transformer",
-        "transformer_2",
-        "transformer_ref",
-        "transformer_refine",
-        "text_encoder",
-        "text_encoder_2",
-        "image_encoder",
-        "vae",
-        "audio_vae",
-    )
+    # Components this pipeline allows ``lazy_module_load`` to defer and free.
+    # Empty by default: deferral is opt-in per pipeline, because releasing a
+    # component and loading it again is only safe when nothing outside the
+    # loader has changed it. Two habits break that and neither raises:
+    #
+    #   * mutating a component after load. ``LongCatPipeline.initialize_pipeline``
+    #     turns on block-sparse attention and writes parameters into every
+    #     transformer block. That runs once, so a re-materialized component
+    #     silently comes back with the feature off.
+    #   * reading a component's attributes while building stages. The shared
+    #     ``DenoisingStage.__init__`` derives the attention backend from
+    #     ``transformer.hidden_size``, which materializes the DiT before the
+    #     first request and defeats the deferral it was meant to gain.
+    #
+    # A pipeline opts in by listing the components it has checked. Names match
+    # the diffusers manifest.
+    _lazy_module_names: tuple[str, ...] = ()
 
     @classmethod
     def get_hf_download_component_dirs(cls) -> tuple[str, ...] | None:
@@ -175,14 +210,12 @@ class ComposedPipelineBase(ABC):
         if module_name not in self.modules:
             return
 
-        module = self.modules[module_name]
-        if is_lazy_module(module):
-            # torch.compile replaces the entry in self.modules, which would
-            # drop the proxy and with it the ability to release. Load now and
-            # keep this component resident for the run.
-            logger.info("torch.compile requested for %s; loading it eagerly instead of deferring", module_name)
-            module = module.materialize()
-            self.modules[module_name] = module
+        entry = self.modules[module_name]
+        # Materialize into a local. The dict keeps the proxy until we know a
+        # compiled callable is actually going to replace it, so a component
+        # that turns out to be FSDP-wrapped is neither compiled nor stripped of
+        # its release hook.
+        module = entry.materialize() if is_lazy_module(entry) else entry
         if fsdp_module_cls is not None and isinstance(module, fsdp_module_cls):
             logger.info(
                 "%s is already FSDP-wrapped; skipping torch.compile in pipeline",
@@ -207,6 +240,9 @@ class ComposedPipelineBase(ABC):
 
         # Backward-compatible fallback: compile full module if no condition matched.
         logger.info("Enabling torch.compile for %s with kwargs=%s", module_name, compile_kwargs)
+        if is_lazy_module(entry):
+            logger.info("Whole-module torch.compile replaces the deferred %s, so it stays resident for the run",
+                        module_name)
         self.modules[module_name] = torch.compile(module, **compile_kwargs)
 
     def post_init(self) -> None:
@@ -299,7 +335,15 @@ class ComposedPipelineBase(ABC):
                     )
                     logger.info("Torch Compile enabled for audio VAE")
 
-        self._trace_mgr = attach_activation_trace(self.modules.get("transformer"))
+        trace_target = self.modules.get("transformer")
+        if is_lazy_module(trace_target):
+            # The hook manager keeps a strong reference to every module it
+            # wraps, so attaching here would materialize the DiT before the
+            # first request and pin that instance past any release.
+            logger.warning("Activation trace is not attached to a deferred transformer; "
+                           "turn off lazy_module_load to trace it")
+            trace_target = None
+        self._trace_mgr = attach_activation_trace(trace_target)
 
         if not self.fastvideo_args.training_mode:
             logger.info("Creating pipeline stages...")
@@ -573,25 +617,10 @@ class ComposedPipelineBase(ABC):
 
         last_use: dict[str, int] = {}
         for index, stage in enumerate(self._stages):
-            for key, value in vars(stage).items():
-                if key == "_lazy_modules_to_release":
-                    # Installed by this schedule, not a real use.
-                    continue
-                # is_lazy_module first: isinstance() on a proxy forwards
-                # __class__ and would load every deferred module just to work
-                # out where to release it.
-                if is_lazy_module(value):
-                    candidates: tuple[Any, ...] = (value, )
-                elif isinstance(value, list | tuple):
-                    candidates = tuple(value)
-                elif isinstance(value, dict):
-                    candidates = tuple(value.values())
-                else:
-                    continue
-                for candidate in candidates:
-                    name = lazy_names_by_id.get(id(candidate))
-                    if name is not None:
-                        last_use[name] = index
+            for held in _iter_held_objects(stage):
+                name = lazy_names_by_id.get(id(held))
+                if name is not None:
+                    last_use[name] = index
 
         schedule: dict[int, list[str]] = {}
         for name, index in sorted(last_use.items()):
@@ -623,6 +652,17 @@ class ComposedPipelineBase(ABC):
             logger.info("Deferred modules to free after stage %d (%s): %s", index,
                         getattr(self._stages[index], "_pipeline_stage_name", "?"), names)
         self._lazy_release_hooks_installed = True
+
+    def _release_all_lazy_modules(self) -> None:
+        """Free every deferred component that is currently materialized."""
+        for module_name, module in self.modules.items():
+            if not is_lazy_module(module):
+                continue
+            try:
+                module.release()
+            except Exception:
+                # Never let cleanup replace the exception being propagated.
+                logger.exception("Failed to release deferred module %s", module_name)
 
     def add_stage(self, stage_name: str, stage: PipelineStage):
         assert self.modules is not None, "No modules are registered"
@@ -665,8 +705,17 @@ class ComposedPipelineBase(ABC):
         # Execute each stage
         logger.info("Running pipeline stages: %s", self._stage_name_mapping.keys())
         # logger.info("Batch: %s", batch)
-        for stage in self.stages:
-            batch = stage(batch, fastvideo_args)
+        try:
+            for stage in self.stages:
+                batch = stage(batch, fastvideo_args)
+        except BaseException:
+            # A stage's own hook frees only what that stage was the last user
+            # of. When the run aborts earlier, everything already materialized
+            # stays for the life of the generator, and the retry a
+            # memory-constrained caller is most likely to attempt starts from a
+            # worse position than the request that just failed.
+            self._release_all_lazy_modules()
+            raise
 
         # Return the output
         return batch

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -9,6 +9,7 @@ import argparse
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
+from functools import partial
 from typing import Any, cast
 
 import torch
@@ -201,6 +202,40 @@ class ComposedPipelineBase(ABC):
                 compiled_count += 1
         return compiled_count
 
+    @staticmethod
+    def _compile_pipeline_module_instance(
+        module_name: str,
+        module: torch.nn.Module,
+        fsdp_module_cls: type | None,
+        compile_kwargs: dict[str, Any],
+    ) -> Any:
+        """Apply pipeline-level compile setup to one loaded component."""
+        if fsdp_module_cls is not None and isinstance(module, fsdp_module_cls):
+            logger.info(
+                "%s is already FSDP-wrapped; skipping torch.compile in pipeline",
+                module_name.capitalize(),
+            )
+            return module
+
+        prepare_for_compile = getattr(module, "prepare_for_compile", None)
+        if callable(prepare_for_compile):
+            logger.info("Running prepare_for_compile for %s", module_name)
+            prepare_for_compile()
+
+        compiled_count = ComposedPipelineBase._compile_with_conditions(module, compile_kwargs)
+        if compiled_count > 0:
+            logger.info(
+                "Enabled torch.compile for %d submodules in %s via _compile_conditions with kwargs=%s",
+                compiled_count,
+                module_name,
+                compile_kwargs,
+            )
+            return module
+
+        # Backward-compatible fallback: compile full module if no condition matched.
+        logger.info("Enabling torch.compile for %s with kwargs=%s", module_name, compile_kwargs)
+        return torch.compile(module, **compile_kwargs)
+
     def _maybe_compile_pipeline_module(
         self,
         module_name: str,
@@ -211,39 +246,27 @@ class ComposedPipelineBase(ABC):
             return
 
         entry = self.modules[module_name]
-        # Materialize into a local. The dict keeps the proxy until we know a
-        # compiled callable is actually going to replace it, so a component
-        # that turns out to be FSDP-wrapped is neither compiled nor stripped of
-        # its release hook.
-        module = entry.materialize() if is_lazy_module(entry) else entry
-        if fsdp_module_cls is not None and isinstance(module, fsdp_module_cls):
-            logger.info(
-                "%s is already FSDP-wrapped; skipping torch.compile in pipeline",
-                module_name.capitalize(),
-            )
-            return
-
-        prepare_for_compile = getattr(module, "prepare_for_compile", None)
-        if callable(prepare_for_compile):
-            logger.info("Running prepare_for_compile for %s", module_name)
-            prepare_for_compile()
-
-        compiled_count = self._compile_with_conditions(module, compile_kwargs)
-        if compiled_count > 0:
-            logger.info(
-                "Enabled torch.compile for %d submodules in %s via _compile_conditions with kwargs=%s",
-                compiled_count,
-                module_name,
-                compile_kwargs,
-            )
-            return
-
-        # Backward-compatible fallback: compile full module if no condition matched.
-        logger.info("Enabling torch.compile for %s with kwargs=%s", module_name, compile_kwargs)
         if is_lazy_module(entry):
-            logger.info("Whole-module torch.compile replaces the deferred %s, so it stays resident for the run",
-                        module_name)
-        self.modules[module_name] = torch.compile(module, **compile_kwargs)
+            # Compilation is part of materialization, not a one-time mutation
+            # of the first loaded instance. The proxy remains in the module
+            # map, so whole-module and conditional compile both survive every
+            # release/reload cycle without making initialization eager.
+            entry.set_materialize_transform(
+                partial(
+                    ComposedPipelineBase._compile_pipeline_module_instance,
+                    module_name,
+                    fsdp_module_cls=fsdp_module_cls,
+                    compile_kwargs=dict(compile_kwargs),
+                ))
+            logger.info("Configured torch.compile for every materialization of deferred %s", module_name)
+            return
+
+        self.modules[module_name] = self._compile_pipeline_module_instance(
+            module_name,
+            entry,
+            fsdp_module_cls,
+            compile_kwargs,
+        )
 
     def post_init(self) -> None:
         assert self.fastvideo_args is not None, "fastvideo_args must be set"

--- a/fastvideo/pipelines/composed_pipeline_base.py
+++ b/fastvideo/pipelines/composed_pipeline_base.py
@@ -24,6 +24,7 @@ from fastvideo.hooks.activation_trace import attach_activation_trace, detach_act
 from fastvideo.logger import init_logger
 from fastvideo.profiler import get_or_create_profiler
 from fastvideo.models.loader.component_loader import PipelineComponentLoader
+from fastvideo.pipelines.lazy_module import LazyModule, is_lazy_module
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages import PipelineStage
 import fastvideo.envs as envs
@@ -51,6 +52,23 @@ class ComposedPipelineBase(ABC):
     trainable_transformer_names: list[str] = ["transformer"]
     trainable_transformer_modules: dict[str, torch.nn.Module] = {}
     post_init_called: bool = False
+    # Components eligible for deferred loading under ``lazy_module_load``.
+    # These are the weight-bearing ones; tokenizers, processors, and
+    # schedulers are cheap and stay resident so the pipeline can inspect them
+    # at construction time. Names follow the diffusers manifest convention, so
+    # the default list covers most pipelines; override per pipeline if a
+    # component is named differently or must never be released.
+    _lazy_module_names: tuple[str, ...] = (
+        "transformer",
+        "transformer_2",
+        "transformer_ref",
+        "transformer_refine",
+        "text_encoder",
+        "text_encoder_2",
+        "image_encoder",
+        "vae",
+        "audio_vae",
+    )
 
     @classmethod
     def get_hf_download_component_dirs(cls) -> tuple[str, ...] | None:
@@ -154,6 +172,13 @@ class ComposedPipelineBase(ABC):
             return
 
         module = self.modules[module_name]
+        if is_lazy_module(module):
+            # torch.compile replaces the entry in self.modules, which would
+            # drop the proxy and with it the ability to release. Load now and
+            # keep this component resident for the run.
+            logger.info("torch.compile requested for %s; loading it eagerly instead of deferring", module_name)
+            module = module.materialize()
+            self.modules[module_name] = module
         if fsdp_module_cls is not None and isinstance(module, fsdp_module_cls):
             logger.info(
                 "%s is already FSDP-wrapped; skipping torch.compile in pipeline",
@@ -275,6 +300,9 @@ class ComposedPipelineBase(ABC):
         if not self.fastvideo_args.training_mode:
             logger.info("Creating pipeline stages...")
             self.create_pipeline_stages(self.fastvideo_args)
+
+            if self._lazy_module_load_enabled(self.fastvideo_args):
+                self._install_lazy_release_hooks()
 
             # Warmup NCCL communicators for sequence parallelism to avoid
             # slow first forward pass due to lazy initialization
@@ -486,13 +514,23 @@ class ComposedPipelineBase(ABC):
                 load_module_name = module_name
 
             component_model_path = os.path.join(self.model_path, load_module_name)
-            module = PipelineComponentLoader.load_module(
-                module_name=load_module_name,
-                component_model_path=component_model_path,
-                transformers_or_diffusers=transformers_or_diffusers,
-                fastvideo_args=fastvideo_args,
-            )
-            logger.info("Loaded module %s from %s", module_name, component_model_path)
+
+            def load_component(load_module_name: str = load_module_name,
+                               component_model_path: str = component_model_path,
+                               transformers_or_diffusers: str = transformers_or_diffusers) -> Any:
+                return PipelineComponentLoader.load_module(
+                    module_name=load_module_name,
+                    component_model_path=component_model_path,
+                    transformers_or_diffusers=transformers_or_diffusers,
+                    fastvideo_args=fastvideo_args,
+                )
+
+            if self._lazy_module_load_enabled(fastvideo_args) and module_name in self._lazy_module_names:
+                module = LazyModule(module_name, load_component)
+                logger.info("Deferred module %s from %s", module_name, component_model_path)
+            else:
+                module = load_component()
+                logger.info("Loaded module %s from %s", module_name, component_model_path)
 
             if module_name in modules:
                 logger.warning("Overwriting module %s", module_name)
@@ -506,6 +544,79 @@ class ComposedPipelineBase(ABC):
                 )
 
         return modules
+
+    @staticmethod
+    def _lazy_module_load_enabled(fastvideo_args: FastVideoArgs) -> bool:
+        """Deferred loading is inference only; training needs every component."""
+        if not fastvideo_args.lazy_module_load:
+            return False
+        if fastvideo_args.training_mode:
+            logger.warning("lazy_module_load is not supported in training mode; loading all modules eagerly")
+            return False
+        return True
+
+    def _build_lazy_release_schedule(self) -> dict[int, list[str]]:
+        """Map each stage index to the deferred modules it is the last user of.
+
+        Derived from what the stages actually hold rather than declared per
+        pipeline, so a stage added later cannot have its module freed out from
+        under it. A module no stage references is never released, which is the
+        safe direction: it stays loaded rather than disappearing mid-run.
+        """
+        lazy_names_by_id = {id(module): name for name, module in self.modules.items() if is_lazy_module(module)}
+        if not lazy_names_by_id:
+            return {}
+
+        last_use: dict[str, int] = {}
+        for index, stage in enumerate(self._stages):
+            for key, value in vars(stage).items():
+                if key == "_lazy_modules_to_release":
+                    # Installed by this schedule, not a real use.
+                    continue
+                # is_lazy_module first: isinstance() on a proxy forwards
+                # __class__ and would load every deferred module just to work
+                # out where to release it.
+                if is_lazy_module(value):
+                    candidates: tuple[Any, ...] = (value, )
+                elif isinstance(value, list | tuple):
+                    candidates = tuple(value)
+                elif isinstance(value, dict):
+                    candidates = tuple(value.values())
+                else:
+                    continue
+                for candidate in candidates:
+                    name = lazy_names_by_id.get(id(candidate))
+                    if name is not None:
+                        last_use[name] = index
+
+        schedule: dict[int, list[str]] = {}
+        for name, index in sorted(last_use.items()):
+            schedule.setdefault(index, []).append(name)
+
+        unreferenced = sorted(set(lazy_names_by_id.values()) - set(last_use))
+        if unreferenced:
+            logger.info("Deferred modules held by no stage, so never released: %s", unreferenced)
+        return schedule
+
+    def _install_lazy_release_hooks(self) -> None:
+        """Tell each stage which deferred modules to free once it returns."""
+        schedule = self._build_lazy_release_schedule()
+        for index, stage in enumerate(self._stages):
+            stage._lazy_modules_to_release = tuple(self.modules[name] for name in schedule.get(index, ()))
+
+        if not schedule:
+            # Deferring without releasing still lowers the load-time peak, but
+            # it is not what the flag promises, so say so rather than let a
+            # no-op look like a win.
+            logger.warning(
+                "lazy_module_load is on but no deferred module is held by a stage, so nothing will be "
+                "freed mid-run. Pipeline %s may load its modules eagerly or hold them outside its stages.",
+                type(self).__name__)
+            return
+
+        for index, names in sorted(schedule.items()):
+            logger.info("Deferred modules to free after stage %d (%s): %s", index,
+                        getattr(self._stages[index], "_pipeline_stage_name", "?"), names)
 
     def add_stage(self, stage_name: str, stage: PipelineStage):
         assert self.modules is not None, "No modules are registered"

--- a/fastvideo/pipelines/lazy_module.py
+++ b/fastvideo/pipelines/lazy_module.py
@@ -43,11 +43,12 @@ class LazyModule:
     early is a latency cost, never a correctness one.
     """
 
-    __slots__ = ("_lazy_name", "_lazy_loader", "_lazy_module")
+    __slots__ = ("_lazy_name", "_lazy_loader", "_lazy_materialize_transform", "_lazy_module")
 
     def __init__(self, name: str, loader: Callable[[], Any]) -> None:
         object.__setattr__(self, "_lazy_name", name)
         object.__setattr__(self, "_lazy_loader", loader)
+        object.__setattr__(self, "_lazy_materialize_transform", None)
         object.__setattr__(self, "_lazy_module", None)
 
     @property
@@ -70,12 +71,39 @@ class LazyModule:
         module = loader()
         if module is None:
             raise ValueError(f"Deferred loader for module {name} returned None")
+
+        transform = object.__getattribute__(self, "_lazy_materialize_transform")
+        if transform is not None:
+            module = transform(module)
+            if module is None:
+                raise ValueError(f"Materialize transform for module {name} returned None")
         object.__setattr__(self, "_lazy_module", module)
 
         allocated = _cuda_allocated_gib()
         if allocated is not None:
             logger.info("Loaded deferred module %s, cuda allocated now %.2f GiB", name, allocated)
         return module
+
+    def set_materialize_transform(self, transform: Callable[[Any], Any]) -> None:
+        """Apply ``transform`` to this and every future loaded instance.
+
+        Registering a transform does not itself load a deferred component. If
+        something has already materialized the component, transform that
+        instance immediately so current and future instances have the same
+        setup. A transform may return a wrapper, as ``torch.compile`` does.
+        """
+        current_transform = object.__getattribute__(self, "_lazy_materialize_transform")
+        if current_transform is not None:
+            raise RuntimeError(f"Materialize transform for module {self.lazy_name} is already set")
+
+        module = object.__getattribute__(self, "_lazy_module")
+        transformed = transform(module) if module is not None else None
+        if module is not None and transformed is None:
+            raise ValueError(f"Materialize transform for module {self.lazy_name} returned None")
+
+        object.__setattr__(self, "_lazy_materialize_transform", transform)
+        if module is not None:
+            object.__setattr__(self, "_lazy_module", transformed)
 
     def release(self) -> bool:
         """Drop the real component. Returns True if something was released."""

--- a/fastvideo/pipelines/lazy_module.py
+++ b/fastvideo/pipelines/lazy_module.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deferred loading and release of heavy pipeline modules.
+
+A pipeline normally materializes every component before the first stage runs,
+so peak memory is the sum of all components even though no two of them are
+needed at the same moment. On a unified-memory device that sum is charged
+against the same pool the activations come from, and a model whose components
+individually fit can still fail to load.
+
+``LazyModule`` turns that sum into a maximum. It stands in for a component,
+loads it on first use, and drops it once the last stage holding it has run.
+The pipeline decides when to release; this module only owns the proxying and
+the load/free mechanics.
+"""
+
+from __future__ import annotations
+
+import functools
+import gc
+import inspect
+from collections.abc import Callable
+from typing import Any, TypeGuard
+
+import torch
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _cuda_allocated_gib() -> float | None:
+    if not torch.cuda.is_available():
+        return None
+    return torch.cuda.memory_allocated() / 1024**3
+
+
+class LazyModule:
+    """A stand-in for a pipeline component that loads on first use.
+
+    Every attribute access, call, and ``isinstance`` check forwards to the real
+    component, materializing it if needed. ``release`` drops the reference and
+    frees the allocator cache; a later access re-runs the loader, so releasing
+    early is a latency cost, never a correctness one.
+    """
+
+    __slots__ = ("_lazy_name", "_lazy_loader", "_lazy_module")
+
+    def __init__(self, name: str, loader: Callable[[], Any]) -> None:
+        object.__setattr__(self, "_lazy_name", name)
+        object.__setattr__(self, "_lazy_loader", loader)
+        object.__setattr__(self, "_lazy_module", None)
+
+    @property
+    def lazy_name(self) -> str:
+        return object.__getattribute__(self, "_lazy_name")
+
+    @property
+    def is_materialized(self) -> bool:
+        return object.__getattribute__(self, "_lazy_module") is not None
+
+    def materialize(self) -> Any:
+        """Return the real component, loading it if this is the first use."""
+        module = object.__getattribute__(self, "_lazy_module")
+        if module is not None:
+            return module
+
+        name = object.__getattribute__(self, "_lazy_name")
+        loader = object.__getattribute__(self, "_lazy_loader")
+        logger.info("Loading deferred module %s", name)
+        module = loader()
+        if module is None:
+            raise ValueError(f"Deferred loader for module {name} returned None")
+        object.__setattr__(self, "_lazy_module", module)
+
+        allocated = _cuda_allocated_gib()
+        if allocated is not None:
+            logger.info("Loaded deferred module %s, cuda allocated now %.2f GiB", name, allocated)
+        return module
+
+    def release(self) -> bool:
+        """Drop the real component. Returns True if something was released."""
+        module = object.__getattribute__(self, "_lazy_module")
+        if module is None:
+            return False
+
+        name = object.__getattribute__(self, "_lazy_name")
+        before = _cuda_allocated_gib()
+        object.__setattr__(self, "_lazy_module", None)
+        del module
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+        after = _cuda_allocated_gib()
+        if before is not None and after is not None:
+            logger.info("Released deferred module %s, cuda allocated %.2f -> %.2f GiB, freed %.2f GiB", name, before,
+                        after, before - after)
+        else:
+            logger.info("Released deferred module %s", name)
+        return True
+
+    # ------------------------------------------------------------------
+    # Proxying
+    # ------------------------------------------------------------------
+
+    def __getattr__(self, item: str) -> Any:
+        # __slots__ and the methods above are found by normal lookup, so
+        # reaching here means the attribute belongs to the real component.
+        attr = getattr(self.materialize(), item)
+        if inspect.ismethod(attr) or inspect.isbuiltin(attr):
+            return self._preserve_identity(attr)
+        return attr
+
+    def _preserve_identity(self, method: Any) -> Any:
+        """Return the proxy, not the component, from self-returning methods.
+
+        ``nn.Module.to`` and its relatives return ``self``, and callers write
+        ``self.vae = self.vae.to(device)`` all over the stages. Handing back
+        the real component there would quietly replace the proxy with a strong
+        reference the pipeline cannot release, and the run would look normal
+        while freeing nothing.
+        """
+
+        @functools.wraps(method)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            result = method(*args, **kwargs)
+            if result is object.__getattribute__(self, "_lazy_module"):
+                return self
+            return result
+
+        return wrapper
+
+    def __setattr__(self, item: str, value: Any) -> None:
+        setattr(self.materialize(), item, value)
+
+    def __delattr__(self, item: str) -> None:
+        delattr(self.materialize(), item)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.materialize()(*args, **kwargs)
+
+    @property  # type: ignore[misc]
+    def __class__(self) -> type:  # type: ignore[override]
+        # isinstance() consults __class__ when the exact type does not match,
+        # so forwarding it keeps `isinstance(module, FSDPModule)` and friends
+        # honest. The cost is that an isinstance check materializes; a wrong
+        # answer would be worse, because callers branch on it silently.
+        return type(self.materialize())
+
+    def __repr__(self) -> str:
+        # Deliberately does not materialize: logging a pipeline must not
+        # trigger a multi-gigabyte load.
+        name = object.__getattribute__(self, "_lazy_name")
+        state = "materialized" if object.__getattribute__(self, "_lazy_module") is not None else "deferred"
+        return f"<LazyModule {name} ({state})>"
+
+
+def is_lazy_module(obj: Any) -> TypeGuard[LazyModule]:
+    """Type test that does not materialize, unlike ``isinstance``."""
+    return type(obj) is LazyModule

--- a/fastvideo/pipelines/lora_pipeline.py
+++ b/fastvideo/pipelines/lora_pipeline.py
@@ -127,6 +127,7 @@ class LoRAPipeline(ComposedPipelineBase):
         # Adapter tensors and wrapped model layers belong to this pipeline's module
         # instances. Sharing either cache across two generators can apply one model's
         # adapter to another model's layers.
+        self.trainable_transformer_modules = {}
         self.lora_adapters = defaultdict(dict)
         self.lora_adapter_paths = {}
         self.lora_layers = {}
@@ -154,11 +155,6 @@ class LoRAPipeline(ComposedPipelineBase):
             self.trainable_transformer_modules.keys(),
         )
 
-        for (
-                transformer_name,
-                transformer_module,
-        ) in self.trainable_transformer_modules.items():
-            self.exclude_lora_layers[transformer_name] = (transformer_module.config.arch_config.exclude_lora_layers)
         # Only override the pipeline class's own default when the caller actually set
         # one. Assigning unconditionally erases per-model defaults, and a model that
         # declares one usually does so because wrapping every linear breaks its forward.
@@ -265,6 +261,14 @@ class LoRAPipeline(ComposedPipelineBase):
                 transformer_name,
                 transformer_module,
         ) in self.trainable_transformer_modules.items():
+            excluded_lora_layers = self.exclude_lora_layers.get(transformer_name)
+            if excluded_lora_layers is None:
+                # Reading a LazyModule's config materializes it. Defer that read
+                # until LoRA conversion is actually requested so a base inference
+                # pipeline can keep its transformer unloaded through conditioning.
+                excluded_lora_layers = list(transformer_module.config.arch_config.exclude_lora_layers)
+                self.exclude_lora_layers[transformer_name] = excluded_lora_layers
+
             converted_count = 0
             # init bookkeeping structures
             if transformer_name not in self.lora_layers:
@@ -293,7 +297,7 @@ class LoRAPipeline(ComposedPipelineBase):
                             continue
 
                         excluded = False
-                        for exclude_layer in self.exclude_lora_layers[transformer_name]:
+                        for exclude_layer in excluded_lora_layers:
                             if exclude_layer in name:
                                 excluded = True
                                 break

--- a/fastvideo/pipelines/stages/base.py
+++ b/fastvideo/pipelines/stages/base.py
@@ -151,6 +151,34 @@ class PipelineStage(ABC):
                 raise
 
         # Execute the actual stage logic
+        try:
+            result = self._execute(batch, fastvideo_args, stage_key, stage_class_name, stage_name)
+        except BaseException:
+            self._release_deferred_modules(stage_name)
+            raise
+
+        if enable_verification:
+            # Post-execution output verification
+            try:
+                output_result = self.verify_output(result, fastvideo_args)
+                self._run_verification(output_result, stage_name, "output")
+            except Exception as e:
+                logger.error("Output verification failed for %s: %s", stage_name, str(e))
+                self._release_deferred_modules(stage_name)
+                raise
+
+        self._release_deferred_modules(stage_name)
+        return result
+
+    def _execute(
+        self,
+        batch: ForwardBatch,
+        fastvideo_args: FastVideoArgs,
+        stage_key: str,
+        stage_class_name: str,
+        stage_name: str,
+    ) -> ForwardBatch:
+        """Run forward, with the optional timing and logging wrapper."""
         if envs.FASTVIDEO_STAGE_LOGGING:
             logger.info("[%s] Starting execution", stage_name)
             torch.cuda.synchronize()
@@ -176,19 +204,23 @@ class PipelineStage(ABC):
             # Direct execution (current behavior)
             result = self.forward(batch, fastvideo_args)
 
-        if enable_verification:
-            # Post-execution output verification
-            try:
-                output_result = self.verify_output(result, fastvideo_args)
-                self._run_verification(output_result, stage_name, "output")
-            except Exception as e:
-                logger.error("Output verification failed for %s: %s", stage_name, str(e))
-                raise
-
-        for lazy_module in self._lazy_modules_to_release:
-            lazy_module.release()
-
         return result
+
+    def _release_deferred_modules(self, stage_name: str) -> None:
+        """Free the deferred components this stage is the last user of.
+
+        Called on the way out whether or not the stage succeeded. A stage that
+        raises after materializing a multi-gigabyte component would otherwise
+        keep it for the life of the generator, and the retry that a
+        memory-constrained caller is most likely to attempt would start from a
+        worse position than the request that just failed.
+        """
+        for lazy_module in self._lazy_modules_to_release:
+            try:
+                lazy_module.release()
+            except Exception:
+                # Never let cleanup replace the exception being propagated.
+                logger.exception("Failed to release deferred module after %s", stage_name)
 
     @abstractmethod
     def forward(

--- a/fastvideo/pipelines/stages/base.py
+++ b/fastvideo/pipelines/stages/base.py
@@ -15,6 +15,7 @@ import torch
 import fastvideo.envs as envs
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
+from fastvideo.pipelines.lazy_module import LazyModule
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.pipelines.stages.validators import VerificationResult
 
@@ -35,6 +36,12 @@ class PipelineStage(ABC):
     for a specific part of the process, such as prompt encoding, latent preparation, etc.
     """
     performance_component_metric: str | None = None
+    # Deferred modules this stage is the last user of, installed by the
+    # pipeline under ``lazy_module_load``. Released once __call__ returns.
+    # Living here rather than in the pipeline's stage loop means a pipeline
+    # that overrides forward still frees, since __call__ is the one entry
+    # point subclasses are told not to override.
+    _lazy_modules_to_release: tuple[LazyModule, ...] = ()
 
     def verify_input(self, batch: ForwardBatch, fastvideo_args: FastVideoArgs) -> VerificationResult:
         """
@@ -177,6 +184,9 @@ class PipelineStage(ABC):
             except Exception as e:
                 logger.error("Output verification failed for %s: %s", stage_name, str(e))
                 raise
+
+        for lazy_module in self._lazy_modules_to_release:
+            lazy_module.release()
 
         return result
 

--- a/fastvideo/tests/api/test_parser.py
+++ b/fastvideo/tests/api/test_parser.py
@@ -114,6 +114,7 @@ def test_load_run_config_supports_yaml_roundtrip(tmp_path) -> None:
                     "image_encoder": True,
                     "vae": True,
                     "pin_cpu_memory": True,
+                    "lazy_module_load": False,
                 },
                 "compile": {
                     "enabled": False,

--- a/fastvideo/tests/attention/test_vsa_h3_sm100a_route.py
+++ b/fastvideo/tests/attention/test_vsa_h3_sm100a_route.py
@@ -308,6 +308,61 @@ def test_prepared_route_reuses_graph_across_layer_indices_and_preserves_dense_ov
         torch._dynamo.reset()
 
 
+def test_generic_compile_reuses_graph_across_layer_indices_and_stays_on_triton(monkeypatch):
+    """Pipeline compile must share one graph without selecting sm_100a."""
+    fake_sm = _FakeSm100a(supported=True)
+    monkeypatch.setattr(vsa_h3, "_sm100a", fake_sm)
+    monkeypatch.setenv(VSA_SM100A_ENV, "1")
+    monkeypatch.setattr(vsa_h3, "probe_enabled", lambda: None)
+    meta = _build_meta(sparsity=0.5, dense_layers=(0, 17), prefix_segments=(64, 64))
+    q, k, v = _tiled_qkv(meta)
+
+    def fake_triton(q, k, v, block_map, variable_block_sizes):
+        del k, v, variable_block_sizes
+        return q + block_map.all().to(q.dtype), None
+
+    def fail_sm100a(*args, **kwargs):
+        raise AssertionError("generic torch.compile unexpectedly selected sm_100a")
+
+    monkeypatch.setattr(vsa_h3, "block_sparse_attn_64_bhsd", fake_triton)
+    monkeypatch.setattr(fake_sm, "is_supported", fail_sm100a)
+    monkeypatch.setattr(fake_sm, "block_sparse_attn_sm100a", fail_sm100a)
+    monkeypatch.setattr(fake_sm, "block_sparse_attn_sm100a_from_mask", fail_sm100a)
+    monkeypatch.setattr(vsa_h3, "_sm100a_unavailable_reason", fail_sm100a)
+
+    implementations = []
+    for layer_idx in range(20):
+        impl = MiniMaxH3VSAImpl(
+            num_heads=_HEADS,
+            head_size=_DIM,
+            causal=False,
+            softmax_scale=_DIM**-0.5,
+            prefix=f"transformer_blocks.{layer_idx}.attn",
+        )
+        impl.prepare_for_compile(torch.device("cpu"))
+        implementations.append(impl)
+
+    compiled_graphs = []
+
+    def recording_backend(graph_module, _example_inputs):
+        compiled_graphs.append(graph_module)
+        return graph_module.forward
+
+    torch._dynamo.reset()
+    try:
+        compiled = [torch.compile(impl.forward, backend=recording_backend, fullgraph=True)
+                    for impl in implementations]
+        with torch.inference_mode():
+            for layer_idx, run in enumerate(compiled):
+                actual = run(q, k, v, None, meta)
+                expected_delta = 1.0 if layer_idx in meta.dense_layers else 0.0
+                torch.testing.assert_close(actual, q + expected_delta, atol=0, rtol=0)
+    finally:
+        torch._dynamo.reset()
+
+    assert len(compiled_graphs) == 1
+
+
 def test_default_off_routes_triton(routed, monkeypatch):
     fake_sm, fake_triton, run, _ = routed
     monkeypatch.delenv(VSA_SM100A_ENV, raising=False)

--- a/fastvideo/tests/inference/test_inference_regional_compile.py
+++ b/fastvideo/tests/inference/test_inference_regional_compile.py
@@ -106,11 +106,15 @@ def test_h3_vsa_probe_degrades_regional_compile_to_eager(monkeypatch) -> None:
 class _RegionalPrepareProbe:
 
     def __init__(self, unsupported: str | None = None) -> None:
-        self.devices: list[torch.device] = []
+        self.compile_devices: list[torch.device] = []
+        self.regional_devices: list[torch.device] = []
         self.unsupported = unsupported
 
+    def prepare_for_compile(self, device: torch.device) -> None:
+        self.compile_devices.append(device)
+
     def prepare_for_regional_compile(self, device: torch.device) -> str | None:
-        self.devices.append(device)
+        self.regional_devices.append(device)
         return self.unsupported
 
 
@@ -157,7 +161,8 @@ def test_minimax_h3_prepare_for_compile_resolves_loaded_vsa_gates() -> None:
     assert [block.attn._gate_compress_active for block in model.transformer_blocks] == [False, True]
     for block in model.transformer_blocks:
         impl = block.attn.distributed_attention.attn_impl
-        assert impl.devices == []
+        assert impl.compile_devices == [next(block.parameters()).device]
+        assert impl.regional_devices == []
 
 
 def test_training_compile_prepare_does_not_probe_inference_kernel() -> None:
@@ -168,7 +173,9 @@ def test_training_compile_prepare_does_not_probe_inference_kernel() -> None:
     assert reason is None
     attention = model.transformer_blocks[0].attn
     assert attention._gate_compress_active is True
-    assert attention.distributed_attention.attn_impl.devices == []
+    impl = attention.distributed_attention.attn_impl
+    assert impl.compile_devices == [next(model.parameters()).device]
+    assert impl.regional_devices == []
 
 
 def test_regional_compile_prepare_prefers_specialized_hook() -> None:
@@ -179,7 +186,8 @@ def test_regional_compile_prepare_prefers_specialized_hook() -> None:
 
     assert reason is None
     impl = model.transformer_blocks[0].attn.distributed_attention.attn_impl
-    assert impl.devices == [expected_device]
+    assert impl.compile_devices == [expected_device]
+    assert impl.regional_devices == [expected_device]
 
 
 def test_minimax_h3_prepare_for_regional_compile_does_not_require_quantized_q_weight() -> None:
@@ -193,7 +201,8 @@ def test_minimax_h3_prepare_for_regional_compile_does_not_require_quantized_q_we
 
     assert reason is None
     impl = attention.distributed_attention.attn_impl
-    assert impl.devices == [expected_device]
+    assert impl.compile_devices == [expected_device]
+    assert impl.regional_devices == [expected_device]
 
 
 def test_minimax_h3_prepare_for_regional_compile_propagates_backend_rejection() -> None:

--- a/fastvideo/tests/stages/test_lazy_module_load.py
+++ b/fastvideo/tests/stages/test_lazy_module_load.py
@@ -719,3 +719,82 @@ def test_building_the_real_h3_stages_materializes_nothing():
 
     assert loaded == [], f"building stages materialized {loaded}"
     assert len(pipeline._stages) == 6
+
+
+class _LoRAConfigComponent(torch.nn.Module):
+
+    def __init__(self, excluded_layers):
+        super().__init__()
+        self.config = SimpleNamespace(
+            arch_config=SimpleNamespace(exclude_lora_layers=excluded_layers),
+        )
+        self.blocks = torch.nn.ModuleList([torch.nn.Linear(2, 2)])
+
+
+def _build_stub_lora_pipeline(monkeypatch, transformer):
+    from fastvideo.pipelines import lora_pipeline as lora_module
+
+    args = SimpleNamespace(
+        lora_target_modules=None,
+        lora_path=None,
+        lora_nickname="default",
+        lora_strength=1.0,
+        training_mode=False,
+        lora_training=False,
+        dit_layerwise_offload=False,
+    )
+
+    def initialize_base(pipeline, *unused_args, **unused_kwargs):
+        pipeline.fastvideo_args = args
+        pipeline.modules = {"transformer": transformer}
+
+    monkeypatch.setattr(ComposedPipelineBase, "__init__", initialize_base)
+    monkeypatch.setattr(lora_module, "get_local_torch_device", lambda: torch.device("cpu"))
+
+    class _Pipeline(lora_module.LoRAPipeline):
+
+        def create_pipeline_stages(self, fastvideo_args):
+            raise NotImplementedError
+
+    return _Pipeline("unused", args)
+
+
+def test_no_lora_setup_keeps_the_transformer_deferred(monkeypatch):
+    loaded = []
+    transformer = LazyModule(
+        "transformer",
+        lambda: loaded.append("transformer") or _LoRAConfigComponent(["proj_out"]),
+    )
+
+    pipeline = _build_stub_lora_pipeline(monkeypatch, transformer)
+
+    assert loaded == []
+    assert not transformer.is_materialized
+    assert pipeline.exclude_lora_layers == {}
+    assert pipeline.trainable_transformer_modules == {"transformer": transformer}
+
+
+def test_lora_conversion_initializes_exclusions_when_first_requested(monkeypatch):
+    loaded = []
+    transformer = LazyModule(
+        "transformer",
+        lambda: loaded.append("transformer") or _LoRAConfigComponent(["proj_out"]),
+    )
+    pipeline = _build_stub_lora_pipeline(monkeypatch, transformer)
+
+    pipeline.convert_to_lora_layers()
+
+    assert loaded == ["transformer"]
+    assert transformer.is_materialized
+    assert pipeline.exclude_lora_layers == {"transformer": ["proj_out"]}
+
+
+def test_lora_transformer_bookkeeping_is_per_pipeline(monkeypatch):
+    first_transformer = LazyModule("transformer", lambda: _LoRAConfigComponent([]))
+    first = _build_stub_lora_pipeline(monkeypatch, first_transformer)
+    second_transformer = LazyModule("transformer", lambda: _LoRAConfigComponent([]))
+    second = _build_stub_lora_pipeline(monkeypatch, second_transformer)
+
+    assert first.trainable_transformer_modules == {"transformer": first_transformer}
+    assert second.trainable_transformer_modules == {"transformer": second_transformer}
+    assert first.trainable_transformer_modules is not second.trainable_transformer_modules

--- a/fastvideo/tests/stages/test_lazy_module_load.py
+++ b/fastvideo/tests/stages/test_lazy_module_load.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Deferred pipeline-module loading and release.
+
+CPU only. Exercises the proxy contract and the release schedule the pipeline
+derives from what its stages hold; no model weights are touched.
+"""
+
+import dataclasses
+from types import SimpleNamespace
+
+import pytest
+
+from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.pipelines.lazy_module import LazyModule, is_lazy_module
+from fastvideo.pipelines.stages.base import PipelineStage
+
+
+class _Component:
+
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+
+    def __call__(self, value: int) -> int:
+        return value * 2
+
+
+def _counting_loader(tag: str = "c"):
+    calls = []
+
+    def loader():
+        calls.append(tag)
+        return _Component(tag)
+
+    return loader, calls
+
+
+def test_deferred_until_first_use():
+    loader, calls = _counting_loader()
+    module = LazyModule("transformer", loader)
+
+    assert calls == []
+    assert not module.is_materialized
+    assert "deferred" in repr(module)
+
+    assert module.tag == "c"
+    assert calls == ["c"]
+    assert module.is_materialized
+
+
+def test_repr_does_not_materialize():
+    loader, calls = _counting_loader()
+    module = LazyModule("transformer", loader)
+
+    repr(module)
+    f"{module!r}"
+
+    assert calls == []
+
+
+def test_loads_exactly_once_across_many_accesses():
+    loader, calls = _counting_loader()
+    module = LazyModule("vae", loader)
+
+    module.tag
+    module.tag
+    module(3)
+
+    assert calls == ["c"]
+
+
+def test_call_forwards_to_component():
+    loader, _ = _counting_loader()
+    module = LazyModule("vae", loader)
+
+    assert module(21) == 42
+
+
+def test_setattr_and_delattr_forward_to_component():
+    loader, _ = _counting_loader()
+    module = LazyModule("vae", loader)
+
+    module.tag = "changed"
+    assert module.materialize().tag == "changed"
+
+    del module.tag
+    assert not hasattr(module.materialize(), "tag")
+
+
+def test_self_returning_methods_hand_back_the_proxy():
+    # Stages write `self.vae = self.vae.to(device)`. Returning the component
+    # would swap the proxy out and leave nothing releasable, with no error.
+    import torch
+
+    module = LazyModule("vae", lambda: torch.nn.Linear(2, 2))
+
+    assert module.to("cpu") is module
+    assert module.eval() is module
+    assert module.float() is module
+    assert module.requires_grad_(False) is module
+
+
+def test_non_self_returning_methods_pass_their_result_through():
+    import torch
+
+    module = LazyModule("vae", lambda: torch.nn.Linear(2, 2))
+
+    assert isinstance(module.state_dict(), dict)
+    assert module.extra_repr() == "in_features=2, out_features=2, bias=True"
+
+
+def test_callable_submodule_attribute_is_not_wrapped():
+    # Only bound methods get the identity wrapper. A callable submodule must
+    # come back as itself so attribute chains and further calls keep working.
+    import torch
+
+    inner = torch.nn.Linear(2, 2)
+    module = LazyModule("vae", lambda: torch.nn.Sequential(inner))
+
+    assert module.__getattr__("0") is inner
+
+
+def test_isinstance_reports_the_real_class():
+    # Callers branch on isinstance (FSDPModule, nn.Module). A proxy that
+    # answered False would take the wrong branch silently.
+    loader, _ = _counting_loader()
+    module = LazyModule("transformer", loader)
+
+    assert isinstance(module, _Component)
+    assert is_lazy_module(module)
+
+
+def test_is_lazy_module_does_not_materialize():
+    loader, calls = _counting_loader()
+    module = LazyModule("transformer", loader)
+
+    assert is_lazy_module(module)
+    assert calls == []
+    assert not is_lazy_module(_Component("plain"))
+
+
+def test_release_then_reload_is_correct_not_broken():
+    loader, calls = _counting_loader()
+    module = LazyModule("text_encoder", loader)
+
+    first = module.materialize()
+    assert module.release() is True
+    assert not module.is_materialized
+
+    second = module.materialize()
+    assert calls == ["c", "c"]
+    assert second is not first
+    assert second.tag == "c"
+
+
+def test_release_without_materializing_is_a_noop():
+    loader, calls = _counting_loader()
+    module = LazyModule("text_encoder", loader)
+
+    assert module.release() is False
+    assert module.release() is False
+    assert calls == []
+
+
+def test_loader_returning_none_raises_instead_of_proxying_none():
+    module = LazyModule("transformer", lambda: None)
+
+    with pytest.raises(ValueError, match="returned None"):
+        module.materialize()
+
+
+# ----------------------------------------------------------------------
+# Release schedule
+# ----------------------------------------------------------------------
+
+
+class _FakePipeline(ComposedPipelineBase):
+    """Just enough pipeline to exercise the schedule; no weights, no loading."""
+
+    def __init__(self, modules, stages):  # deliberately does not call super()
+        self.modules = modules
+        self._stages = stages
+
+    def create_pipeline_stages(self, fastvideo_args):
+        raise NotImplementedError
+
+
+def _schedule(modules, stages):
+    return _FakePipeline(modules, stages)._build_lazy_release_schedule()
+
+
+def _lazy(name):
+    return LazyModule(name, lambda: _Component(name))
+
+
+def test_schedule_releases_after_the_last_stage_that_holds_a_module():
+    text_encoder = _lazy("text_encoder")
+    transformer = _lazy("transformer")
+    vae = _lazy("vae")
+    modules = {"text_encoder": text_encoder, "transformer": transformer, "vae": vae, "scheduler": object()}
+
+    stages = [
+        SimpleNamespace(vae=vae),  # 0 input prep
+        SimpleNamespace(conditioner=text_encoder),  # 1 conditioning
+        SimpleNamespace(transformer=transformer),  # 2 denoising
+        SimpleNamespace(vae=vae, transformer=transformer),  # 3 decoding
+    ]
+
+    assert _schedule(modules, stages) == {1: ["text_encoder"], 3: ["transformer", "vae"]}
+
+
+def test_building_the_schedule_does_not_materialize_anything():
+    # isinstance() on a proxy forwards __class__, so a careless scan of stage
+    # attributes would load every deferred module before the run starts and
+    # silently undo the whole point of deferring.
+    loaded = []
+
+    def tracked(name):
+        return LazyModule(name, lambda: loaded.append(name) or _Component(name))
+
+    text_encoder, transformer = tracked("text_encoder"), tracked("transformer")
+    stages = [
+        SimpleNamespace(conditioner=text_encoder, flags=[1, 2], opts={"a": 1}, ref2va=False),
+        SimpleNamespace(transformer=transformer),
+    ]
+
+    _schedule({"text_encoder": text_encoder, "transformer": transformer}, stages)
+
+    assert loaded == []
+
+
+def test_schedule_ignores_eager_modules():
+    transformer = _lazy("transformer")
+    scheduler = object()
+    modules = {"transformer": transformer, "scheduler": scheduler}
+    stages = [SimpleNamespace(transformer=transformer, scheduler=scheduler)]
+
+    assert _schedule(modules, stages) == {0: ["transformer"]}
+
+
+def test_schedule_finds_modules_held_inside_containers():
+    text_encoder = _lazy("text_encoder")
+    vae = _lazy("vae")
+    modules = {"text_encoder": text_encoder, "vae": vae}
+    stages = [
+        SimpleNamespace(text_encoders=[text_encoder]),
+        SimpleNamespace(by_name={"vae": vae}),
+    ]
+
+    assert _schedule(modules, stages) == {0: ["text_encoder"], 1: ["vae"]}
+
+
+def test_unreferenced_module_is_never_released():
+    # Safe direction: a module no stage holds stays loaded rather than
+    # disappearing under a caller the schedule cannot see.
+    orphan = _lazy("image_encoder")
+
+    assert _schedule({"image_encoder": orphan}, [SimpleNamespace(other=1)]) == {}
+
+
+def test_schedule_is_empty_without_lazy_modules():
+    assert _schedule({"vae": object()}, [SimpleNamespace(vae=object())]) == {}
+
+
+# ----------------------------------------------------------------------
+# Enablement
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("lazy", "training", "expected"), [
+    (False, False, False),
+    (True, False, True),
+    (True, True, False),
+    (False, True, False),
+])
+def test_training_mode_never_defers(lazy, training, expected):
+    args = SimpleNamespace(lazy_module_load=lazy, training_mode=training)
+
+    assert ComposedPipelineBase._lazy_module_load_enabled(args) is expected
+
+
+def test_flag_defaults_to_off():
+    from fastvideo.fastvideo_args import FastVideoArgs
+
+    fields = {f.name: f for f in dataclasses.fields(FastVideoArgs)}
+    assert fields["lazy_module_load"].default is False
+
+
+# ----------------------------------------------------------------------
+# Release hooks on the stages
+# ----------------------------------------------------------------------
+
+
+class _EchoStage(PipelineStage):
+
+    def __init__(self, **held):
+        for name, value in held.items():
+            setattr(self, name, value)
+
+    def forward(self, batch, fastvideo_args):
+        return batch
+
+
+def test_hooks_land_on_the_last_stage_that_holds_each_module():
+    text_encoder, transformer = _lazy("text_encoder"), _lazy("transformer")
+    stages = [_EchoStage(conditioner=text_encoder), _EchoStage(transformer=transformer, extra=text_encoder)]
+    pipeline = _FakePipeline({"text_encoder": text_encoder, "transformer": transformer}, stages)
+
+    pipeline._install_lazy_release_hooks()
+
+    assert stages[0]._lazy_modules_to_release == ()
+    assert set(stages[1]._lazy_modules_to_release) == {text_encoder, transformer}
+
+
+def test_installing_hooks_twice_does_not_shift_the_schedule():
+    # The installed tuple is itself a container of proxies; a rebuild that
+    # counted it as a use would keep pushing every release to the last stage.
+    text_encoder = _lazy("text_encoder")
+    stages = [_EchoStage(conditioner=text_encoder), _EchoStage(other=1)]
+    pipeline = _FakePipeline({"text_encoder": text_encoder}, stages)
+
+    pipeline._install_lazy_release_hooks()
+    pipeline._install_lazy_release_hooks()
+
+    assert stages[0]._lazy_modules_to_release == (text_encoder, )
+    assert stages[1]._lazy_modules_to_release == ()
+
+
+def test_stage_call_releases_its_modules():
+    loader, calls = _counting_loader()
+    text_encoder = LazyModule("text_encoder", loader)
+    stages = [_EchoStage(conditioner=text_encoder), _EchoStage(other=1)]
+    pipeline = _FakePipeline({"text_encoder": text_encoder}, stages)
+    pipeline._install_lazy_release_hooks()
+
+    text_encoder.tag  # the stage would use it
+    assert text_encoder.is_materialized
+
+    batch = object()
+    args = SimpleNamespace(enable_stage_verification=False)
+    assert stages[0](batch, args) is batch
+
+    assert not text_encoder.is_materialized
+    assert calls == ["c"]
+
+
+def test_stage_without_hooks_releases_nothing():
+    loader, _ = _counting_loader()
+    module = LazyModule("vae", loader)
+    stage = _EchoStage(vae=module)
+    module.tag
+
+    stage(object(), SimpleNamespace(enable_stage_verification=False))
+
+    assert module.is_materialized
+
+
+def test_pipeline_warns_when_no_stage_holds_a_deferred_module(caplog):
+    # A silent no-op here would look exactly like a working run, so the flag
+    # has to say when it cannot do anything.
+    orphan = _lazy("image_encoder")
+    pipeline = _FakePipeline({"image_encoder": orphan}, [_EchoStage(other=1)])
+
+    with caplog.at_level("WARNING"):
+        pipeline._install_lazy_release_hooks()
+
+    assert "nothing will be freed" in caplog.text
+
+
+def test_a_stage_that_rebinds_through_to_can_still_be_released():
+    # The end-to-end shape of the identity rule: a stage does the
+    # `self.vae = self.vae.to(device)` dance, the pipeline still releases.
+    import torch
+
+    vae = LazyModule("vae", lambda: torch.nn.Linear(2, 2))
+    stage = _EchoStage(vae=vae)
+    pipeline = _FakePipeline({"vae": vae}, [stage])
+    pipeline._install_lazy_release_hooks()
+
+    stage.vae = stage.vae.to("cpu")
+    assert stage.vae is vae
+    assert vae.is_materialized
+
+    stage(object(), SimpleNamespace(enable_stage_verification=False))
+
+    assert not vae.is_materialized

--- a/fastvideo/tests/stages/test_lazy_module_load.py
+++ b/fastvideo/tests/stages/test_lazy_module_load.py
@@ -510,3 +510,101 @@ def test_an_aborted_run_releases_everything_already_materialized():
 
     assert not vae.is_materialized
     assert not transformer.is_materialized
+
+
+# ----------------------------------------------------------------------
+# Production wiring
+#
+# The tests above build stages and pipelines by hand. These two run the real
+# code paths where the two defects review found would live: a `load_modules`
+# that never reaches the deferral, and a stage constructor that reads a
+# component's attributes and materializes it before the first request.
+# ----------------------------------------------------------------------
+
+
+class _StubLoader:
+    """Stands in for PipelineComponentLoader and counts what it is asked for."""
+
+    def __init__(self):
+        self.loaded: list[str] = []
+
+    def load_module(self, *, module_name, component_model_path, transformers_or_diffusers, fastvideo_args):
+        self.loaded.append(module_name)
+        return _Component(module_name)
+
+
+def _run_real_load_modules(monkeypatch, lazy_names, manifest_modules):
+    from fastvideo.pipelines import composed_pipeline_base as cpb
+
+    stub = _StubLoader()
+    monkeypatch.setattr(cpb.PipelineComponentLoader, "load_module", stub.load_module)
+
+    class _Pipeline(ComposedPipelineBase):
+        _required_config_modules = list(manifest_modules)
+        _lazy_module_names = lazy_names
+
+        def __init__(self):  # deliberately does not call super()
+            self.model_path = "/nowhere"
+            self.fastvideo_args = None
+
+        def _load_config(self, model_path):
+            index = {"_class_name": "X", "_diffusers_version": "0"}
+            index.update({name: ["diffusers", "Cls", {}] for name in manifest_modules})
+            return index
+
+        def create_pipeline_stages(self, fastvideo_args):
+            raise NotImplementedError
+
+    args = SimpleNamespace(lazy_module_load=True, training_mode=False, revision=None)
+    modules = _Pipeline().load_modules(args)
+    return modules, stub.loaded
+
+
+def test_real_load_modules_defers_only_the_opted_in_components(monkeypatch):
+    modules, loaded = _run_real_load_modules(monkeypatch, ("transformer", "vae"), ["transformer", "vae", "scheduler"])
+
+    assert is_lazy_module(modules["transformer"])
+    assert is_lazy_module(modules["vae"])
+    assert not is_lazy_module(modules["scheduler"])
+    # The loader is asked only for what stays eager.
+    assert loaded == ["scheduler"]
+
+
+def test_real_load_modules_defers_nothing_when_the_pipeline_opts_out(monkeypatch):
+    # The base class ships an empty list, so an unchecked pipeline must load
+    # everything eagerly even with the flag on.
+    modules, loaded = _run_real_load_modules(monkeypatch, (), ["transformer", "vae", "scheduler"])
+
+    assert not any(is_lazy_module(m) for m in modules.values())
+    assert sorted(loaded) == ["scheduler", "transformer", "vae"]
+
+
+def test_building_the_real_h3_stages_materializes_nothing():
+    # `DenoisingStage.__init__` in the shared stage set reads
+    # `transformer.hidden_size` to pick an attention backend, which would pull
+    # the DiT in during post_init. H3's stages must not acquire that habit.
+    from fastvideo.pipelines.basic.minimax_h3.minimax_h3_pipeline import MiniMaxH3Pipeline
+
+    loaded: list[str] = []
+
+    def tracked(name):
+        return LazyModule(name, lambda: loaded.append(name) or _Component(name))
+
+    pipeline = MiniMaxH3Pipeline.__new__(MiniMaxH3Pipeline)
+    pipeline._stages = []
+    pipeline._stage_name_mapping = {}
+    pipeline.modules = {
+        "text_encoder": tracked("text_encoder"),
+        "transformer": tracked("transformer"),
+        "vae": tracked("vae"),
+        "audio_vae": tracked("audio_vae"),
+        "tokenizer": object(),
+        "processor": object(),
+        "scheduler": object(),
+        "audio_scheduler": object(),
+    }
+
+    pipeline._add_stages(ref2va=False)
+
+    assert loaded == [], f"building stages materialized {loaded}"
+    assert len(pipeline._stages) == 6

--- a/fastvideo/tests/stages/test_lazy_module_load.py
+++ b/fastvideo/tests/stages/test_lazy_module_load.py
@@ -154,6 +154,30 @@ def test_release_then_reload_is_correct_not_broken():
     assert second.tag == "c"
 
 
+def test_materialize_transform_applies_to_every_loaded_instance_without_loading_eagerly():
+    loader, calls = _counting_loader()
+    transformed = []
+    module = LazyModule("vae", loader)
+
+    def transform(component):
+        transformed.append(component)
+        component.tag = f"compiled-{component.tag}"
+        return component
+
+    module.set_materialize_transform(transform)
+    assert calls == []
+
+    first = module.materialize()
+    assert first.tag == "compiled-c"
+    assert module.release() is True
+
+    second = module.materialize()
+    assert second.tag == "compiled-c"
+    assert second is not first
+    assert calls == ["c", "c"]
+    assert transformed == [first, second]
+
+
 def test_release_without_materializing_is_a_noop():
     loader, calls = _counting_loader()
     module = LazyModule("text_encoder", loader)
@@ -202,6 +226,93 @@ def _schedule(modules, stages):
 
 def _lazy(name):
     return LazyModule(name, lambda: _Component(name))
+
+
+def test_pipeline_compile_is_reapplied_after_lazy_release(monkeypatch):
+    loads = []
+    compile_calls = []
+
+    class _CompileAwareComponent(torch.nn.Module):
+        _compile_conditions = (lambda name, module: name == "block", )
+
+        def __init__(self):
+            super().__init__()
+            self.block = torch.nn.Linear(2, 2)
+            self.prepare_calls = 0
+
+        def prepare_for_compile(self):
+            self.prepare_calls += 1
+
+    def load_component():
+        component = _CompileAwareComponent()
+        loads.append(component)
+        return component
+
+    def fake_compile(target, **kwargs):
+        compile_calls.append((target, kwargs))
+        return target
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+    lazy = LazyModule("vae", load_component)
+    pipeline = _FakePipeline({"vae": lazy}, [])
+
+    pipeline._maybe_compile_pipeline_module("vae", None, {"mode": "reduce-overhead"})
+    assert loads == []
+
+    first = lazy.materialize()
+    assert first.prepare_calls == 1
+    assert lazy.release() is True
+
+    second = lazy.materialize()
+    assert second is not first
+    assert second.prepare_calls == 1
+    assert loads == [first, second]
+    assert len(compile_calls) == 2
+    assert [kwargs for _, kwargs in compile_calls] == [
+        {"mode": "reduce-overhead"},
+        {"mode": "reduce-overhead"},
+    ]
+
+
+def test_whole_module_compile_keeps_lazy_proxy_and_recompiles_after_release(monkeypatch):
+    loads = []
+    compile_calls = []
+
+    class _WholeComponent(torch.nn.Module):
+
+        def forward(self, value):
+            return value
+
+    class _Compiled:
+
+        def __init__(self, original):
+            self.original = original
+
+    def load_component():
+        component = _WholeComponent()
+        loads.append(component)
+        return component
+
+    def fake_compile(target, **kwargs):
+        compile_calls.append((target, kwargs))
+        return _Compiled(target)
+
+    monkeypatch.setattr(torch, "compile", fake_compile)
+    lazy = LazyModule("text_encoder", load_component)
+    pipeline = _FakePipeline({"text_encoder": lazy}, [])
+
+    pipeline._maybe_compile_pipeline_module("text_encoder", None, {"dynamic": True})
+    assert pipeline.modules["text_encoder"] is lazy
+    assert loads == []
+
+    first = lazy.materialize()
+    assert first.original is loads[0]
+    assert lazy.release() is True
+
+    second = lazy.materialize()
+    assert second.original is loads[1]
+    assert second is not first
+    assert len(compile_calls) == 2
 
 
 def test_schedule_releases_after_the_last_stage_that_holds_a_module():

--- a/fastvideo/tests/stages/test_lazy_module_load.py
+++ b/fastvideo/tests/stages/test_lazy_module_load.py
@@ -383,3 +383,25 @@ def test_a_stage_that_rebinds_through_to_can_still_be_released():
     stage(object(), SimpleNamespace(enable_stage_verification=False))
 
     assert not vae.is_materialized
+
+
+def test_a_stage_added_after_the_schedule_rebuilds_it(caplog):
+    # The schedule is derived from the stage list. A stage appended afterwards
+    # could hold a module an earlier stage was already told to free, which
+    # would hand it a released component mid-run.
+    vae = _lazy("vae")
+    first = _EchoStage(vae=vae)
+    pipeline = _FakePipeline({"vae": vae}, [])
+    pipeline._stage_name_mapping = {}
+    pipeline.add_stage("first", first)
+    pipeline._install_lazy_release_hooks()
+
+    assert first._lazy_modules_to_release == (vae, )
+
+    later = _EchoStage(vae=vae)
+    with caplog.at_level("WARNING"):
+        pipeline.add_stage("later", later)
+
+    assert "rebuilding the schedule" in caplog.text
+    assert first._lazy_modules_to_release == ()
+    assert later._lazy_modules_to_release == (vae, )

--- a/fastvideo/tests/stages/test_lazy_module_load.py
+++ b/fastvideo/tests/stages/test_lazy_module_load.py
@@ -6,6 +6,8 @@ derives from what its stages hold; no model weights are touched.
 """
 
 import dataclasses
+
+import torch
 from types import SimpleNamespace
 
 import pytest
@@ -173,6 +175,16 @@ def test_loader_returning_none_raises_instead_of_proxying_none():
 # ----------------------------------------------------------------------
 
 
+class _EchoStage(PipelineStage):
+
+    def __init__(self, **held):
+        for name, value in held.items():
+            setattr(self, name, value)
+
+    def forward(self, batch, fastvideo_args):
+        return batch
+
+
 class _FakePipeline(ComposedPipelineBase):
     """Just enough pipeline to exercise the schedule; no weights, no loading."""
 
@@ -199,10 +211,10 @@ def test_schedule_releases_after_the_last_stage_that_holds_a_module():
     modules = {"text_encoder": text_encoder, "transformer": transformer, "vae": vae, "scheduler": object()}
 
     stages = [
-        SimpleNamespace(vae=vae),  # 0 input prep
-        SimpleNamespace(conditioner=text_encoder),  # 1 conditioning
-        SimpleNamespace(transformer=transformer),  # 2 denoising
-        SimpleNamespace(vae=vae, transformer=transformer),  # 3 decoding
+        _EchoStage(vae=vae),  # 0 input prep
+        _EchoStage(conditioner=text_encoder),  # 1 conditioning
+        _EchoStage(transformer=transformer),  # 2 denoising
+        _EchoStage(vae=vae, transformer=transformer),  # 3 decoding
     ]
 
     assert _schedule(modules, stages) == {1: ["text_encoder"], 3: ["transformer", "vae"]}
@@ -219,8 +231,8 @@ def test_building_the_schedule_does_not_materialize_anything():
 
     text_encoder, transformer = tracked("text_encoder"), tracked("transformer")
     stages = [
-        SimpleNamespace(conditioner=text_encoder, flags=[1, 2], opts={"a": 1}, ref2va=False),
-        SimpleNamespace(transformer=transformer),
+        _EchoStage(conditioner=text_encoder, flags=[1, 2], opts={"a": 1}, ref2va=False),
+        _EchoStage(transformer=transformer),
     ]
 
     _schedule({"text_encoder": text_encoder, "transformer": transformer}, stages)
@@ -232,7 +244,7 @@ def test_schedule_ignores_eager_modules():
     transformer = _lazy("transformer")
     scheduler = object()
     modules = {"transformer": transformer, "scheduler": scheduler}
-    stages = [SimpleNamespace(transformer=transformer, scheduler=scheduler)]
+    stages = [_EchoStage(transformer=transformer, scheduler=scheduler)]
 
     assert _schedule(modules, stages) == {0: ["transformer"]}
 
@@ -242,8 +254,8 @@ def test_schedule_finds_modules_held_inside_containers():
     vae = _lazy("vae")
     modules = {"text_encoder": text_encoder, "vae": vae}
     stages = [
-        SimpleNamespace(text_encoders=[text_encoder]),
-        SimpleNamespace(by_name={"vae": vae}),
+        _EchoStage(text_encoders=[text_encoder]),
+        _EchoStage(by_name={"vae": vae}),
     ]
 
     assert _schedule(modules, stages) == {0: ["text_encoder"], 1: ["vae"]}
@@ -254,11 +266,11 @@ def test_unreferenced_module_is_never_released():
     # disappearing under a caller the schedule cannot see.
     orphan = _lazy("image_encoder")
 
-    assert _schedule({"image_encoder": orphan}, [SimpleNamespace(other=1)]) == {}
+    assert _schedule({"image_encoder": orphan}, [_EchoStage(other=1)]) == {}
 
 
 def test_schedule_is_empty_without_lazy_modules():
-    assert _schedule({"vae": object()}, [SimpleNamespace(vae=object())]) == {}
+    assert _schedule({"vae": object()}, [_EchoStage(vae=object())]) == {}
 
 
 # ----------------------------------------------------------------------
@@ -288,16 +300,6 @@ def test_flag_defaults_to_off():
 # ----------------------------------------------------------------------
 # Release hooks on the stages
 # ----------------------------------------------------------------------
-
-
-class _EchoStage(PipelineStage):
-
-    def __init__(self, **held):
-        for name, value in held.items():
-            setattr(self, name, value)
-
-    def forward(self, batch, fastvideo_args):
-        return batch
 
 
 def test_hooks_land_on_the_last_stage_that_holds_each_module():
@@ -405,3 +407,106 @@ def test_a_stage_added_after_the_schedule_rebuilds_it(caplog):
     assert "rebuilding the schedule" in caplog.text
     assert first._lazy_modules_to_release == ()
     assert later._lazy_modules_to_release == (vae, )
+
+
+class _CompositeStage(PipelineStage):
+    """Mirrors Cosmos25AutoDenoisingStage: the component lives in a child."""
+
+    def __init__(self, **held):
+        self._child = _EchoStage(**held)
+
+    def forward(self, batch, fastvideo_args):
+        return self._child.forward(batch, fastvideo_args)
+
+
+def test_schedule_walks_into_nested_stages():
+    # A stage can compose others rather than hold the component itself. Left
+    # unwalked, the component reads as unreferenced and is never freed.
+    transformer = _lazy("transformer")
+    stages = [_EchoStage(other=1), _CompositeStage(transformer=transformer)]
+
+    assert _schedule({"transformer": transformer}, stages) == {1: ["transformer"]}
+
+
+def test_nested_walk_survives_a_cycle():
+    vae = _lazy("vae")
+    outer = _EchoStage(vae=vae)
+    inner = _EchoStage(back=outer)
+    outer.inner = inner
+
+    assert _schedule({"vae": vae}, [outer]) == {0: ["vae"]}
+
+
+def test_a_raising_stage_still_releases_its_modules():
+    # The retry a memory-constrained caller attempts must not start from a
+    # worse position than the request that just failed.
+    class _Boom(_EchoStage):
+
+        def forward(self, batch, fastvideo_args):
+            raise RuntimeError("out of activation memory")
+
+    vae = LazyModule("vae", lambda: torch.nn.Linear(2, 2))
+    stage = _Boom(vae=vae)
+    pipeline = _FakePipeline({"vae": vae}, [stage])
+    pipeline._install_lazy_release_hooks()
+    vae.materialize()
+
+    with pytest.raises(RuntimeError, match="out of activation memory"):
+        stage(object(), SimpleNamespace(enable_stage_verification=False))
+
+    assert not vae.is_materialized
+
+
+def test_a_failing_release_does_not_mask_the_original_error():
+    class _Boom(_EchoStage):
+
+        def forward(self, batch, fastvideo_args):
+            raise RuntimeError("original")
+
+    class _BadRelease(LazyModule):
+
+        def release(self):
+            raise ValueError("cleanup blew up")
+
+    stage = _Boom(vae=None)
+    stage._lazy_modules_to_release = (_BadRelease("vae", lambda: object()), )
+
+    with pytest.raises(RuntimeError, match="original"):
+        stage(object(), SimpleNamespace(enable_stage_verification=False))
+
+
+def test_deferral_is_opt_in_per_pipeline():
+    # A pipeline that has not been checked must get no deferral at all,
+    # because releasing and reloading is only safe when nothing outside the
+    # loader mutates the component or reads it while stages are built.
+    from fastvideo.pipelines.basic.minimax_h3.minimax_h3_pipeline import MiniMaxH3BasePipeline
+
+    assert ComposedPipelineBase._lazy_module_names == ()
+    assert set(MiniMaxH3BasePipeline._lazy_module_names) == {"text_encoder", "transformer", "vae", "audio_vae"}
+
+
+def test_an_aborted_run_releases_everything_already_materialized():
+    # A stage frees only what it is the last user of. When the run aborts
+    # earlier, the rest would stay for the life of the generator.
+    vae = LazyModule("vae", lambda: torch.nn.Linear(2, 2))
+    transformer = LazyModule("transformer", lambda: torch.nn.Linear(2, 2))
+
+    class _Boom(_EchoStage):
+
+        def forward(self, batch, fastvideo_args):
+            raise RuntimeError("out of activation memory")
+
+    early = _EchoStage(vae=vae)
+    boom = _Boom(transformer=transformer)
+    late = _EchoStage(vae=vae)
+    pipeline = _FakePipeline({"vae": vae, "transformer": transformer}, [early, boom, late])
+    pipeline._install_lazy_release_hooks()
+    vae.materialize()
+    transformer.materialize()
+
+    assert vae.is_materialized and transformer.is_materialized
+
+    pipeline._release_all_lazy_modules()
+
+    assert not vae.is_materialized
+    assert not transformer.is_materialized


### PR DESCRIPTION
## Problem

A pipeline materializes every component before the first stage runs, so peak memory is the sum of all components even though no two of them are needed at the same moment. For MiniMax-H3 r16 that sum is 96.3 GiB: text encoder 48.0, DiT 37.8, video VAE 9.7, audio VAE 0.6. For FastH3 it is 124.0 GiB.

The existing CPU offload flags cannot help, for two reasons. They act after loading has already finished, so they do nothing about the load-time peak. And on a unified-memory device such as GB10 there is no second pool to offload into, so moving weights to the host frees nothing.

A GB10 has 121 GiB. FastH3's components do not fit on it at all.

## What this changes

Adds `lazy_module_load`, off by default. Heavy components become a `LazyModule` proxy that loads on first use. The pipeline derives, from what its stages actually hold, which stage is the last user of each component, and installs a release hook there. Peak becomes the largest overlapping set rather than the sum.

## Measured

One GB10, 1 GPU, single prompt, 124 frames. Every number below is
`torch.cuda.memory_allocated()` sampled where a component is loaded or
released, so it measures component residency rather than the run's true peak,
which also includes activations.

### MiniMax-H3 r16, 192x320, 4 steps

| moment | cuda allocated |
|---|---|
| after load, before stage 0 | ~0 |
| video VAE materialized | 9.7 GiB |
| text encoder materialized | 57.7 GiB, peak |
| text encoder released | 9.7 GiB, freed 48.0 |
| DiT materialized | 47.5 GiB |
| audio VAE materialized | 48.1 GiB |
| DiT and video VAE released | 0.6 GiB |
| audio VAE released | 0.03 GiB |

Peak 57.7 GiB against 96.3 GiB resident without the flag. The same command without the flag was killed by the machine's out-of-memory daemon during the DiT load an hour earlier, at `fsdp_load.py:584`.

The decisive moment is two adjacent log lines, 4 ms apart:

```
Released deferred module text_encoder, cuda allocated 57.72 -> 9.74 GiB, freed 47.98 GiB
Loading deferred module transformer
```

The DiT starts loading from 9.7 GiB rather than from 58.3 GiB.

### FastH3 Preview v0.2, VSA-H3 attention on the Triton kernel

| resolution | packed tokens | resident components | result |
|---|---|---|---|
| 192x320 | 29,760 | 75.81 GiB | completed, 525 s, video and audio written |
| 384x672 | 124,992 | 75.81 GiB | completed, 745 s, video and audio written |
| 512x896 | 222,208 | 75.82 GiB | completed, 930 s, video and audio written |
| 640x1120 | 347,200 | 75.83 GiB | killed during the first DiT forward |
| 768x1344 | 499,968 | 75.83 GiB | killed during the first DiT forward |

Component residency does not move with resolution, because it is set by the
weights. What moves is activation memory, which this change does not touch.
The last two rows load every component and then die in
`minimax_h3_denoising.py:190`, so the ceiling on one GB10 sits between 222,208
and 347,200 packed tokens. That ceiling also reflects whatever else the shared
machine was running, since the out-of-memory daemon watches the host rather
than this process, so treat it as a lower bound.

DiT 35.05B parameters, 65.5 GiB. The four components sum to 124.0 GiB against the device's 121 GiB, so without the flag this model cannot load at all and there is no eager baseline to compare against.

### Still applies to FastH3 Preview v1

FastVideo has since released [FastH3 Preview v1](https://huggingface.co/FastVideo/FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree). The tables above were measured on v0.2 and are left as recorded, but nothing this change depends on moved: the two checkpoints ship a byte-identical `transformer/config.json`, the same 35.05B parameters, and the same 688 student tensors, so the component sum that overflows a 121 GiB device is unchanged.

Measured with this flag on v1, using [KyleNeverGivesUp/FastH3-4-step-Preview-v1-r16](https://huggingface.co/KyleNeverGivesUp/FastH3-4-step-Preview-v1-r16), which is v1 with the rank-reduced AdaLN converter from #1699 applied:

| frames | resolution | packed tokens | FP8 | resident weights | peak allocated | time |
|---|---|---|---|---|---|---|
| 124 | 768x1344 | 499,968 | no | 51.70 GiB | 69.2 GiB | 902 s |
| 345 | 768x1344 | 1,403,136 | yes | 33.06 GiB | 83.7 GiB | 3096 s |

Both peaks match the same conversion applied to v0.2 to the byte, which is what you would expect if peak is set by the architecture and the packed token count rather than by which training run produced the weights.

The 345-frame row is the longest MiniMax-H3 generates, 14.38 s of synchronized video and audio in one pass on a single GB10. It needs FP8 to fit, and FP8 only reaches the feed-forward stack after #1780.

## Cost

A released component is read from disk again on the next generation. Within one generation nothing reloads, since the release point is the last stage that holds the component, not the last stage that uses it. Across generations the whole set reloads, which for this model is several minutes. That is why the flag is off by default and documented as something to enable only when the model does not otherwise fit.

## Design notes

Four things here would fail silently if done the obvious way.

**The release hook lives on `PipelineStage.__call__`, not in the pipeline's stage loop.** Several pipelines override `forward`, and a loop-based hook would leave those pipelines deferring but never freeing, with no error.

**The proxy forwards `__class__`.** Callers branch on `isinstance(module, FSDPModule)` and similar. A proxy answering `False` would take the wrong branch and produce a wrong result rather than a crash. The cost is that an isinstance check materializes, which is the correct trade.

**Self-returning methods hand back the proxy, not the component.** Stages write `self.vae = self.vae.to(device)` in a dozen places. Returning the component there would replace the proxy with a strong reference the pipeline cannot release, and the run would look completely normal while freeing nothing.

**`add_stage` rebuilds the schedule if it runs after the schedule was built.** Every pipeline in the tree builds its stages inside `create_pipeline_stages`, but nothing enforced it. A stage appended later could hold a component an earlier stage had already been told to free.

Building the schedule also has to avoid `isinstance` on proxy values, since that would materialize every deferred component before the run starts. There is a test for exactly that.

Training keeps every component resident and warns if the flag is set. If no stage holds a deferred component the pipeline warns rather than silently doing nothing.

## Scope

Deferral is opt-in per pipeline. `_lazy_module_names` is empty in the base class and MiniMax-H3 lists the four components measured above. Every other pipeline is unchanged, and setting the flag there logs a warning and does nothing.

The reason is that releasing a component and loading it again is only correct when nothing outside the loader has changed it, and two habits in this tree break that without raising:

- Mutating a component after load. `LongCatPipeline.initialize_pipeline` turns on block-sparse attention and writes parameters into every transformer block. It runs once, so a re-materialized component silently comes back with the feature off.
- Reading a component's attributes while stages are built. The shared `DenoisingStage.__init__` derives the attention backend from `transformer.hidden_size`, which materializes the DiT during `post_init` and defeats the deferral it was meant to gain.

A pipeline opts in once someone has checked it against both. `LTX2Pipeline`, `MagiHumanPipeline`, and `LingbotVideoPipeline` additionally override `load_modules` without delegating to the base implementation, so they would need that too.

The flag lowers weight residency only. It does not change activation memory, so a resolution whose activations do not fit still does not fit. On one GB10, FastH3 runs at 512x896 and is killed at 640x1120, where q, k, v, and the VSA gate alone account for 18.5 GiB against roughly 30 GiB left after the weights. The repository's reference configuration is 768x1344 on four GPUs with `sp_size=4`, which splits those activations across ranks.

## Relationship to the existing MPS special cases

`denoising.py:653`, `decoding.py:343`, and `sr_denoising.py:279` already do a hard-coded version of this behind `if torch.backends.mps.is_available()`, with matching reload paths keyed on `fastvideo_args.model_loaded`. Apple Silicon is unified memory too, so that is the same problem found on a different device.

Those three differ from this change in two ways. They still load everything eagerly first, so they lower the steady-state footprint but not the load-time peak, which is where H3 on GB10 dies. And they never release the text encoder, which for H3 is the largest component at 48 GiB.

This change could subsume all three later. It does not touch them here.

## Tests

31 cases in `fastvideo/tests/stages/test_lazy_module_load.py`, CPU only, covering the proxy contract, the release schedule, the identity rule for self-returning methods, the late-stage rebuild, and the enablement rules. Placed under `stages/` because `fastvideo/tests/loader/` is not collected by any CI lane on this branch's base.

`lazy_module_load` is registered in `docs/design/inference_schema_parity_inventory.yaml` and mapped in `api/compat.py`, so `test_fastvideo_args_fields_are_classified` stays green.
