### PR TITLE
[feat] Add MiniMax H3 LoRA inference support

### DIFF
--- a/examples/inference/gradio/lora_review.py
+++ b/examples/inference/gradio/lora_review.py
@@ -27,14 +27,29 @@ from pathlib import Path
 
 import gradio as gr
 
-# (row label, true-checkpoint arm, adapter arm)
-PAIRS = [
-    ("FastH3 4-step v1", "v1-true", "v1-lora-r64"),
-    ("FastH3 4-step v1.1", "v1.1-true", "v1.1-lora-r64"),
-    ("FastH3 4-step v1.2", "v1.2-true", "v1.2-lora-r64"),
-    ("FastH3 Dense 4-step v1", "dense_v1-true", "dense_v1-lora-r64"),
-]
 FLOOR_ARM = "base"
+
+
+def discover_pairs(arms: list[str]) -> tuple[list[tuple[str, str, str]], list[str]]:
+    """Split the arms present into checkpoint/adapter pairs and everything else.
+
+    Pairs are found by name -- ``<x>-true`` next to ``<x>-lora-<rank>`` -- rather than
+    listed, so adding an arm to the render directory is enough to get it on the page.
+    Arms that pair with nothing (a third-party adapter with no checkpoint to compare
+    against) still get shown, on their own row, instead of being silently dropped.
+    """
+    pairs, used = [], set()
+    for arm in sorted(arms):
+        if not arm.endswith("-true"):
+            continue
+        stem = arm[:-len("-true")]
+        partner = next((a for a in arms if a.startswith(f"{stem}-lora")), None)
+        if partner is None:
+            continue
+        pairs.append((stem, arm, partner))
+        used.update({arm, partner})
+    standalone = [a for a in sorted(arms) if a not in used and a != FLOOR_ARM]
+    return pairs, standalone
 
 
 def probe(path: Path) -> str:
@@ -115,8 +130,9 @@ def build(runs: Runs, height: int) -> gr.Blocks:
             floor = gr.Video(label="base MiniMax-H3, 4 steps (floor)", height=height, loop=True,
                              autoplay=False, interactive=False)
 
+        pairs, standalone = discover_pairs(runs.arms)
         players: list[tuple[gr.Video, str, str]] = []
-        for row_label, true_arm, lora_arm in PAIRS:
+        for row_label, true_arm, lora_arm in pairs:
             gr.Markdown(f"### {row_label}")
             with gr.Row():
                 left = gr.Video(label=f"{row_label} — checkpoint", height=height, loop=True,
@@ -125,6 +141,13 @@ def build(runs: Runs, height: int) -> gr.Blocks:
                                  autoplay=False, interactive=False)
             players.append((left, true_arm, "checkpoint"))
             players.append((right, lora_arm, "base + adapter"))
+
+        if standalone:
+            gr.Markdown("### Other adapters (no matching checkpoint to compare against)")
+            with gr.Row():
+                for arm in standalone:
+                    players.append((gr.Video(label=arm, height=height, loop=True, autoplay=False,
+                                             interactive=False), arm, arm))
 
         def show(label: str):
             index = runs.by_label(label)

--- a/examples/inference/gradio/lora_review.py
+++ b/examples/inference/gradio/lora_review.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Review whether a FastH3 adapter reproduces the checkpoint it was extracted from.
+
+The question this page answers is not "is the video good" but "does base + adapter land
+where the real checkpoint lands". So each row is one checkpoint, and the two players in
+it are the checkpoint itself and base MiniMax-H3 with that checkpoint's adapter merged
+in. They share a seed and a prompt, so anything you can see between them is the
+adapter's approximation error and nothing else.
+
+The base model at four steps sits at the top as the floor. It is not distilled, so it
+should look clearly worse than everything below it -- if an adapter row looks like the
+floor instead of like its checkpoint, the adapter did not land.
+
+    python examples/inference/gradio/lora_review.py --runs /path/to/lora_review
+
+Expects one directory per arm, each holding ``<index>_<case_id>.mp4``:
+
+    <runs>/base/            <runs>/v1-true/     <runs>/v1-lora-r64/    ...
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+import gradio as gr
+
+# (row label, true-checkpoint arm, adapter arm)
+PAIRS = [
+    ("FastH3 4-step v1", "v1-true", "v1-lora-r64"),
+    ("FastH3 4-step v1.1", "v1.1-true", "v1.1-lora-r64"),
+    ("FastH3 4-step v1.2", "v1.2-true", "v1.2-lora-r64"),
+    ("FastH3 Dense 4-step v1", "dense_v1-true", "dense_v1-lora-r64"),
+]
+FLOOR_ARM = "base"
+
+
+def probe(path: Path) -> str:
+    """`WxH · Nf · Ds · MiB`, so a truncated or mis-sized render is visible as text."""
+    try:
+        out = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "v:0", "-show_entries",
+             "stream=width,height,nb_read_packets,duration", "-count_packets", "-of", "json",
+             str(path)],
+            capture_output=True, text=True, check=True).stdout
+        stream = json.loads(out)["streams"][0]
+        frames = stream.get("nb_read_packets", "?")
+        duration = float(stream.get("duration", 0) or 0)
+        return (f"{stream['width']}x{stream['height']} · {frames}f · {duration:.1f}s · "
+                f"{path.stat().st_size / 2**20:.1f} MiB")
+    except (subprocess.CalledProcessError, KeyError, IndexError, json.JSONDecodeError):
+        return f"{path.stat().st_size / 2**20:.1f} MiB"
+
+
+class Runs:
+    """Which prompts rendered, and where each arm's clip for them lives."""
+
+    def __init__(self, runs_dir: Path, prompts_file: Path | None) -> None:
+        self.root = runs_dir
+        self.arms = sorted(d.name for d in runs_dir.iterdir() if d.is_dir())
+        self.prompts: dict[str, str] = {}
+        if prompts_file and prompts_file.exists():
+            with prompts_file.open() as handle:
+                for index, line in enumerate(handle):
+                    line = line.strip()
+                    if line:
+                        self.prompts[f"{index:03d}"] = json.loads(line).get("prompt", "")
+
+        self.clips: dict[str, dict[str, Path]] = {}
+        for arm in self.arms:
+            for mp4 in sorted((runs_dir / arm).glob("*.mp4")):
+                self.clips.setdefault(mp4.stem.split("_")[0], {})[arm] = mp4
+        if not self.clips:
+            raise SystemExit(f"no clips under {runs_dir}")
+
+    def label(self, index: str) -> str:
+        head = " ".join(self.prompts.get(index, "").split())[:90]
+        return f"[{index}] {head}..." if head else f"[{index}]"
+
+    def by_label(self, label: str) -> str:
+        return next(i for i in self.clips if self.label(i) == label)
+
+
+def build(runs: Runs, height: int) -> gr.Blocks:
+
+    @lru_cache(maxsize=512)
+    def cached_probe(path: str) -> str:
+        return probe(Path(path))
+
+    def player_update(index: str, arm: str, prefix: str):
+        mp4 = runs.clips.get(index, {}).get(arm)
+        if mp4 is None:
+            return gr.update(value=None, label=f"{prefix} — not rendered")
+        return gr.update(value=str(mp4), label=f"{prefix} — {cached_probe(str(mp4))}")
+
+    with gr.Blocks(title="FastH3 adapter review") as demo:
+        gr.Markdown(
+            "# FastH3 adapter review\n"
+            "Each row is one checkpoint: **left** is the real checkpoint, **right** is base "
+            "MiniMax-H3 with that checkpoint's rank-64 adapter merged in. Same prompt, same "
+            "seed, same sampler. Differences between the two are the adapter's approximation "
+            "error.\n\n"
+            "The top player is undistilled base MiniMax-H3 at four steps — the floor. Every "
+            "row below it should look clearly better than that; an adapter that landed looks "
+            "like its own left-hand player, not like the floor.")
+
+        prompt_dd = gr.Dropdown(choices=[runs.label(i) for i in runs.clips],
+                                value=runs.label(next(iter(runs.clips))),
+                                label="Prompt")
+        prompt_box = gr.Textbox(label="Prompt", lines=4, max_lines=6, interactive=False, show_copy_button=True)
+
+        with gr.Row():
+            floor = gr.Video(label="base MiniMax-H3, 4 steps (floor)", height=height, loop=True,
+                             autoplay=False, interactive=False)
+
+        players: list[tuple[gr.Video, str, str]] = []
+        for row_label, true_arm, lora_arm in PAIRS:
+            gr.Markdown(f"### {row_label}")
+            with gr.Row():
+                left = gr.Video(label=f"{row_label} — checkpoint", height=height, loop=True,
+                                autoplay=False, interactive=False)
+                right = gr.Video(label=f"{row_label} — base + adapter", height=height, loop=True,
+                                 autoplay=False, interactive=False)
+            players.append((left, true_arm, "checkpoint"))
+            players.append((right, lora_arm, "base + adapter"))
+
+        def show(label: str):
+            index = runs.by_label(label)
+            return [
+                player_update(index, FLOOR_ARM, "base, 4 steps"),
+                gr.update(value=runs.prompts.get(index, "")),
+                *[player_update(index, arm, prefix) for _, arm, prefix in players],
+            ]
+
+        outputs = [floor, prompt_box, *[p for p, _, _ in players]]
+        gr.on(triggers=[prompt_dd.change, demo.load], fn=show, inputs=prompt_dd, outputs=outputs)
+
+    return demo
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--runs", default="/mnt/lustre/vlm-s4duan/arena_arms/lora_review")
+    parser.add_argument("--prompts-file", default="/mnt/lustre/vlm-s4duan/FastVideo/prompts.jsonl")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=7865)
+    parser.add_argument("--share", action="store_true")
+    parser.add_argument("--video-height", type=int, default=420)
+    args = parser.parse_args()
+
+    runs = Runs(Path(args.runs).resolve(), Path(args.prompts_file))
+    print(f"arms: {runs.arms}")
+    print(f"prompts with output: {sorted(runs.clips)}")
+    build(runs, args.video_height).launch(server_name=args.host, server_port=args.port,
+                                          share=args.share, allowed_paths=[str(runs.root)])
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/inference/lora/minimax_h3_lora_inference.py
+++ b/examples/inference/lora/minimax_h3_lora_inference.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Run a FastH3 distillation adapter on top of the base MiniMax-H3 checkpoint.
+
+The FastH3 checkpoints are full fine-tunes of MiniMax-H3 distilled to four steps under
+video sparse attention. Published as adapters they are three things at once, and all
+three have to land for the result to match the checkpoint:
+
+* low-rank factors for the attention, feed-forward, and AdaLN projections
+* exact ``.diff`` deltas for the norms and biases an SVD cannot usefully factor
+* ``.set_weight`` values for ``attn.to_gate_compress``, the VSA compression gate that
+  does not exist in the base model at all
+
+The last one is why ``--vsa`` is not optional here. Under any other attention backend
+the gate module is never constructed, so half the distillation has nowhere to go; the
+loader will say so rather than quietly produce a worse video.
+
+Because a parameter the base lacks has to be supplied while weights are still unsharded,
+the adapter is passed at construction rather than swapped in afterwards.
+
+    python examples/inference/lora/minimax_h3_lora_inference.py \\
+        --lora-path /models/fasth3-loras-publish/FastH3-4-step-v1.1/rank-64 \\
+        --prompts-file prompts.jsonl --output outputs/v1.1-rank64
+
+Pass no ``--lora-path`` to render the unmodified base model as a control.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Sequence
+from pathlib import Path
+
+# MiniMax-H3 generates 5-15 s at 24 fps, on a latent grid that only admits frame counts
+# of the form 17n + 5. 124 is the 5-second point the FastH3 profile is measured at.
+FRAMES_PER_CHUNK = 17
+LATENTS_PER_CHUNK = 5
+FPS = 24
+MIN_DURATION, MAX_DURATION = 5.0, 15.0
+
+
+def align_num_frames(num_frames: int) -> int:
+    """Round up to the next 17n + 5 the latent grid accepts."""
+    if num_frames <= LATENTS_PER_CHUNK:
+        return LATENTS_PER_CHUNK
+    chunks = -(-(num_frames - LATENTS_PER_CHUNK) // FRAMES_PER_CHUNK)
+    return LATENTS_PER_CHUNK + chunks * FRAMES_PER_CHUNK
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model-path", default="MiniMaxAI/MiniMax-H3", help="the BASE checkpoint the adapter targets")
+    parser.add_argument("--lora-path", default=None, help="adapter file or directory; omit to render the base model")
+    parser.add_argument("--lora-nickname", default="fasth3")
+    parser.add_argument("--prompt", default=None)
+    parser.add_argument("--prompts-file", default=None, help="JSONL with a 'prompt' field per line")
+    parser.add_argument("--limit", type=int, default=None, help="use only the first N prompts")
+    parser.add_argument("--num-shards", type=int, default=1, help="split the prompt list across processes")
+    parser.add_argument("--shard", type=int, default=0)
+    parser.add_argument("--output", default="outputs/minimax_h3_lora")
+    parser.add_argument("--skip-existing", action="store_true", help="leave already-rendered clips alone")
+    parser.add_argument("--height", type=int, default=768)
+    parser.add_argument("--width", type=int, default=1344)
+    parser.add_argument("--num-frames", type=int, default=124)
+    # Counts sigma-GRID POINTS: N points run N-1 DiT forwards. The distilled ladder is
+    # t=1000,750,500,250 -> 0, which is five points and exactly four forwards.
+    parser.add_argument("--steps", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=1000)
+    parser.add_argument("--num-gpus", type=int, default=4)
+    parser.add_argument("--vsa", action=argparse.BooleanOptionalAction, default=True,
+                        help="video sparse attention; required for any adapter carrying to_gate_compress")
+    parser.add_argument("--vsa-sparsity", type=float, default=0.9)
+    parser.add_argument("--vsa-tile-size", type=int, choices=(64, 256), default=64)
+    parser.add_argument("--vsa-kernel", choices=("triton", "sm100a"), default="sm100a")
+    parser.add_argument("--fa4", action=argparse.BooleanOptionalAction, default=True)
+    args = parser.parse_args(argv)
+    if not args.prompt and not args.prompts_file:
+        parser.error("pass --prompt or --prompts-file")
+    if args.lora_path and not args.vsa:
+        parser.error("--no-vsa with an adapter: to_gate_compress would have no module to load into. "
+                     "Drop --no-vsa, or use an adapter with no .set_weight keys.")
+    aligned = align_num_frames(args.num_frames)
+    if not MIN_DURATION <= aligned / FPS <= MAX_DURATION:
+        parser.error(f"MiniMax-H3 generates {MIN_DURATION}-{MAX_DURATION}s at {FPS} fps; "
+                     f"aligned num_frames={aligned} is {aligned / FPS:.1f}s")
+    args.num_frames = aligned
+    return args
+
+
+def configure_environment(args: argparse.Namespace) -> None:
+    """Set the boot-time backend selection explicitly, including what is off.
+
+    An inherited FASTVIDEO_* from an earlier experiment would otherwise silently change
+    which attention path the run actually took, which is the one thing this comparison
+    cannot afford to be vague about.
+    """
+    env = {
+        "FASTVIDEO_ATTENTION_BACKEND": "VIDEO_SPARSE_ATTN_H3" if args.vsa else "FLASH_ATTN",
+        "FASTVIDEO_VSA_SM100A": "1" if (args.vsa and args.vsa_kernel == "sm100a") else "0",
+        "FASTVIDEO_VSA_CUTEDSL": "0",
+        "FASTVIDEO_FA4": "1" if args.fa4 else "0",
+        "FASTVIDEO_MINIMAX_H3_FUSIONS": "all",
+        "FASTVIDEO_INFERENCE_TORCH_COMPILE": "0",
+        "FASTVIDEO_STAGE_LOGGING": "1",
+    }
+    for name, value in env.items():
+        os.environ[name] = value
+
+
+def load_prompts(args: argparse.Namespace) -> list[dict]:
+    if args.prompt:
+        records = [{"id": "000", "prompt": args.prompt}]
+    else:
+        records = []
+        with open(args.prompts_file) as handle:
+            for index, line in enumerate(handle):
+                line = line.strip()
+                if not line:
+                    continue
+                item = json.loads(line)
+                records.append({
+                    "id": str(item.get("id", item.get("sample_id", f"{index:03d}"))),
+                    "prompt": item["prompt"],
+                })
+    if args.limit is not None:
+        records = records[:args.limit]
+    return [r for i, r in enumerate(records) if i % args.num_shards == args.shard]
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    configure_environment(args)
+
+    # Imported after the environment is set: backend selection is read at import time.
+    from fastvideo import VideoGenerator
+    from fastvideo.api import (ComponentConfig, EngineConfig, GenerationRequest, GeneratorConfig, OffloadConfig,
+                               OutputConfig, ParallelismConfig, PipelineSelection, SamplingConfig)
+
+    experimental: dict[str, object] = {
+        "vae_parallel_decode": True,
+        "vae_parallel_decode_strategy": "gather",
+    }
+    if args.vsa:
+        experimental.update({
+            "attention_backend": "VIDEO_SPARSE_ATTN_H3",
+            "VSA_sparsity": args.vsa_sparsity,
+            "VSA_tile_size": args.vsa_tile_size,
+        })
+
+    config = GeneratorConfig(
+        model_path=args.model_path,
+        pipeline=PipelineSelection(
+            components=ComponentConfig(lora_path=args.lora_path),
+            experimental=experimental,
+        ),
+        engine=EngineConfig(
+            num_gpus=args.num_gpus,
+            use_fsdp_inference=False,
+            parallelism=ParallelismConfig(tp_size=1, sp_size=args.num_gpus),
+            offload=OffloadConfig(dit=False, dit_layerwise=False, text_encoder=True, vae=True, pin_cpu_memory=True),
+        ),
+    )
+
+    records = load_prompts(args)
+    out_dir = Path(args.output)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"adapter: {args.lora_path or '(none, base model)'}")
+    print(f"prompts: {len(records)} (shard {args.shard}/{args.num_shards})")
+
+    generator = VideoGenerator.from_config(config)
+    for index, record in enumerate(records):
+        stem = f"{index:03d}_{record['id']}"
+        if args.skip_existing and (out_dir / f"{stem}.mp4").exists():
+            print(f"[{index}] skip {stem}")
+            continue
+        generator.generate(
+            GenerationRequest(
+                prompt=record["prompt"],
+                negative_prompt="",
+                sampling=SamplingConfig(
+                    height=args.height,
+                    width=args.width,
+                    num_frames=args.num_frames,
+                    fps=FPS,
+                    num_inference_steps=args.steps,
+                    # MiniMax-H3 is guidance-distilled; FastH3 inherits that contract.
+                    guidance_scale=1.0,
+                    batch_cfg=False,
+                    seed=args.seed,
+                ),
+                output=OutputConfig(output_path=str(out_dir / f"{stem}.mp4"), save_video=True, return_frames=False),
+            ))
+        print(f"[{index}] wrote {stem}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/inference/lora/minimax_h3_lora_inference.py
+++ b/examples/inference/lora/minimax_h3_lora_inference.py
@@ -10,9 +10,12 @@ three have to land for the result to match the checkpoint:
 * ``.set_weight`` values for ``attn.to_gate_compress``, the VSA compression gate that
   does not exist in the base model at all
 
-The last one is why ``--vsa`` is not optional here. Under any other attention backend
-the gate module is never constructed, so half the distillation has nowhere to go; the
-loader will say so rather than quietly produce a worse video.
+An adapter carrying that last one needs ``--vsa``: under any other attention backend the
+gate module is never constructed, so part of the distillation has nowhere to go. The
+requirement is read off the adapter rather than assumed, because community adapters
+built against the ComfyUI layout carry no gate and run fine either way -- run one of
+those with ``--no-vsa`` (see ``scripts/checkpoint_conversion/convert_minimax_h3_comfy_lora.py``
+for getting them into a layout this loads).
 
 Because a parameter the base lacks has to be supplied while weights are still unsharded,
 the adapter is passed at construction rather than swapped in afterwards.
@@ -77,9 +80,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     args = parser.parse_args(argv)
     if not args.prompt and not args.prompts_file:
         parser.error("pass --prompt or --prompts-file")
-    if args.lora_path and not args.vsa:
-        parser.error("--no-vsa with an adapter: to_gate_compress would have no module to load into. "
-                     "Drop --no-vsa, or use an adapter with no .set_weight keys.")
+    # Whether VSA is required is a property of the adapter, not of having one at all --
+    # community adapters built against the ComfyUI layout carry no gate. Checked in
+    # main(), once the path has been resolved.
     aligned = align_num_frames(args.num_frames)
     if not MIN_DURATION <= aligned / FPS <= MAX_DURATION:
         parser.error(f"MiniMax-H3 generates {MIN_DURATION}-{MAX_DURATION}s at {FPS} fps; "
@@ -133,9 +136,23 @@ def main(argv: Sequence[str] | None = None) -> None:
     configure_environment(args)
 
     # Imported after the environment is set: backend selection is read at import time.
+    from fastvideo.models.loader.lora_patch import DenseLoRAPatch
     from fastvideo import VideoGenerator
     from fastvideo.api import (ComponentConfig, EngineConfig, GenerationRequest, GeneratorConfig, OffloadConfig,
                                OutputConfig, ParallelismConfig, PipelineSelection, SamplingConfig)
+
+    # An adapter carrying to_gate_compress needs the VSA backend, because that is the
+    # only configuration in which the module exists. One that does not carry it runs
+    # fine either way, so the requirement is read off the file rather than assumed from
+    # the presence of an adapter at all.
+    patch = DenseLoRAPatch.from_adapter(args.lora_path) if args.lora_path else None
+    needs_vsa = bool(patch and any("gate_compress" in name for name in patch.replacement_parameters))
+    if needs_vsa and not args.vsa:
+        raise SystemExit(f"{args.lora_path} carries to_gate_compress, which exists only under the VSA "
+                         "attention backend. Drop --no-vsa.")
+    if args.vsa and args.lora_path and not needs_vsa:
+        print(f"note: {args.lora_path} carries no VSA gate; running under VSA leaves the "
+              "compression branch at its zero-initialized value.")
 
     experimental: dict[str, object] = {
         "vae_parallel_decode": True,

--- a/fastvideo/layers/lora/linear.py
+++ b/fastvideo/layers/lora/linear.py
@@ -64,6 +64,29 @@ class BaseLayerWithLoRA(nn.Module):
             self.lora_A = None
             self.lora_B = None
 
+    @property
+    def weight(self) -> torch.Tensor:
+        """The wrapped layer's weight.
+
+        Model code reads ``layer.weight`` for perfectly ordinary reasons -- MiniMax H3's
+        AdaLN modulation casts its input with ``self.linear.weight.dtype``, and its
+        ``proj_in`` reads the tensor itself. Wrapping a layer should not change what
+        reading it looks like from outside, and without this the wrap turns those into
+        ``AttributeError`` at the first forward. Forcing every model to be listed in
+        ``lora_target_modules`` around its own attribute access is the wrong fix: the
+        list would have to be maintained against code it does not own, and getting it
+        wrong fails at generation time rather than at load.
+
+        Resolved through ``base_layer`` on each access rather than cached, because
+        merging replaces that module outright.
+        """
+        return self.base_layer.weight
+
+    @property
+    def bias(self) -> torch.Tensor | None:
+        """The wrapped layer's bias, or ``None`` when it has none."""
+        return getattr(self.base_layer, "bias", None)
+
     @torch.compile()
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         lora_A = self.lora_A

--- a/fastvideo/models/loader/component_loader.py
+++ b/fastvideo/models/loader/component_loader.py
@@ -1142,6 +1142,10 @@ class TransformerLoader(ComponentLoader):
                 torch_compile_kwargs=fastvideo_args.torch_compile_kwargs,
                 inference_regional_compile=fastvideo_args.inference_torch_compile,
                 inference_vsa_tile_size=fastvideo_args.VSA_tile_size,
+                # Only the whole-parameter half of the adapter is applied here, while
+                # tensors are still unsharded; LoRAPipeline merges the low-rank half
+                # once the module tree exists.
+                lora_path=getattr(fastvideo_args, "lora_path", None),
             )
 
         total_params = sum(p.numel() for p in model.parameters())

--- a/fastvideo/models/loader/fsdp_load.py
+++ b/fastvideo/models/loader/fsdp_load.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 import os
 import contextlib
+import re
 from collections.abc import Callable, Generator
 from itertools import chain
 from typing import Any
@@ -19,11 +20,20 @@ from torch.distributed.fsdp import (CPUOffloadPolicy, FSDPModule, MixedPrecision
 from torch.nn.modules.module import _IncompatibleKeys
 
 from fastvideo.logger import init_logger
+from fastvideo.models.loader.lora_patch import DenseLoRAPatch
 from fastvideo.models.loader.utils import (get_param_names_mapping, hf_to_custom_state_dict)
 from fastvideo.models.loader.weight_utils import safetensors_weights_iterator
 from fastvideo.utils import set_mixed_precision_policy, is_pin_memory_available
 
 logger = init_logger(__name__)
+
+
+def _summarize_param_names(names: set[str]) -> str:
+    """Collapse per-layer parameter names into one ``blocks.*.suffix xN`` entry each."""
+    families: dict[str, int] = {}
+    for name in names:
+        families[re.sub(r"\.\d+\.", ".*.", name)] = families.get(re.sub(r"\.\d+\.", ".*.", name), 0) + 1
+    return ", ".join(f"{family} x{count}" if count > 1 else family for family, count in sorted(families.items()))
 
 
 def _maybe_quantize_model(model: nn.Module) -> None:
@@ -155,9 +165,17 @@ def maybe_load_fsdp_model(
     torch_compile_kwargs: dict[str, Any] | None = None,
     inference_regional_compile: bool = False,
     inference_vsa_tile_size: int | None = None,
+    lora_path: str | None = None,
 ) -> torch.nn.Module:
     """
     Load the model with FSDP if is training, else load the model without FSDP.
+
+    ``lora_path`` is consulted only for the part of an adapter that addresses whole
+    parameters (``.diff`` / ``.set_weight``); see
+    :mod:`fastvideo.models.loader.lora_patch`. The low-rank half is merged later by
+    ``LoRAPipeline``. Passing it here is what lets an adapter contribute a parameter the
+    base checkpoint does not contain, which has to happen while the tensor is still
+    unsharded.
     """
     # NOTE(will): cast_forward_inputs=True shouldn't be needed as we are
     # manually casting the inputs to the model
@@ -230,6 +248,7 @@ def maybe_load_fsdp_model(
         strict=strict,
         cpu_offload=cpu_offload,
         param_names_mapping=param_names_mapping_fn,
+        dense_lora_patch=DenseLoRAPatch.from_adapter(lora_path, param_names_mapping_fn),
     )
     if hasattr(model, "materialize_non_persistent_buffers"):
         model.materialize_non_persistent_buffers(device=device, dtype=default_dtype)
@@ -518,6 +537,7 @@ def load_model_from_full_model_state_dict(
     cpu_offload: bool = False,
     param_names_mapping: Callable[[str], tuple[str, Any, Any]] | None = None,
     training_mode: bool = True,
+    dense_lora_patch: DenseLoRAPatch | None = None,
 ) -> _IncompatibleKeys:
     """
     Converting full state dict into a sharded state dict
@@ -531,6 +551,9 @@ def load_model_from_full_model_state_dict(
         cpu_offload (bool): flag to check if FSDP offload is enabled
         param_names_mapping (Optional[Callable[[str], str]]): a function that maps full param name to sharded param name
         training_mode (bool): apply FSDP only for training
+        dense_lora_patch (Optional[DenseLoRAPatch]): whole-parameter adapter payload,
+            folded into each full tensor before it is sharded so that FSDP/TP placement
+            is inherited from this function rather than reimplemented downstream
     Returns:
         ``NamedTuple`` with ``missing_keys`` and ``unexpected_keys`` fields:
             * **missing_keys** is a list of str containing the missing keys
@@ -581,6 +604,10 @@ def load_model_from_full_model_state_dict(
         dtype_selector = getattr(model, "_get_parameter_dtype", None)
         if callable(dtype_selector):
             target_dtype = dtype_selector(target_param_name, param_dtype)
+        if dense_lora_patch is not None:
+            # Returns float32 when a delta was added, so the cast below is what lands
+            # the parameter in its storage dtype.
+            full_tensor = dense_lora_patch.apply_to(target_param_name, full_tensor)
         if not hasattr(meta_sharded_param, "device_mesh"):
             full_tensor = full_tensor.to(device=device, dtype=target_dtype)
             target_param = named_parameters.get(target_param_name)
@@ -617,12 +644,28 @@ def load_model_from_full_model_state_dict(
     model.reverse_param_names_mapping = reverse_param_names_mapping
     unused_keys = set(meta_sd.keys()) - set(sharded_sd.keys())
     if unused_keys:
-        logger.warning("Found unloaded parameters in meta state dict: %s", unused_keys)
+        # Say which of these the adapter is about to fill in. Reporting all of them as
+        # "unloaded" was accurate when zero-init was the only outcome; with an adapter
+        # supplying real values it reads as a problem that is not one. Names are
+        # summarized because a 50-layer model prints 50 near-identical lines otherwise.
+        from_adapter = ({key for key in unused_keys if dense_lora_patch.provides(key)} if dense_lora_patch is not None
+                        else set())
+        zero_init = unused_keys - from_adapter
+        if from_adapter:
+            logger.info("Parameters absent from the checkpoint and supplied by the LoRA adapter: %d (%s)",
+                        len(from_adapter), _summarize_param_names(from_adapter))
+        if zero_init:
+            logger.warning("Found unloaded parameters in meta state dict, zero-initializing: %d (%s)", len(zero_init),
+                           _summarize_param_names(zero_init))
 
     # List of allowed parameter name patterns
     ALLOWED_NEW_PARAM_PATTERNS = ["gate_compress", "proj_l"]  # Can be extended as needed
     for new_param_name in unused_keys:
-        if not any(pattern in new_param_name for pattern in ALLOWED_NEW_PARAM_PATTERNS):
+        # An adapter that ships the parameter outright both supplies the value and
+        # authorizes it: the allowlist exists to catch a checkpoint silently missing a
+        # weight, which is not the case when something deliberately provides one.
+        adapter_value = (dense_lora_patch.replacement_for(new_param_name) if dense_lora_patch is not None else None)
+        if adapter_value is None and not any(pattern in new_param_name for pattern in ALLOWED_NEW_PARAM_PATTERNS):
             logger.error("Unsupported new parameter: %s. Allowed patterns: %s", new_param_name,
                          ALLOWED_NEW_PARAM_PATTERNS)
             raise ValueError(f"New parameter '{new_param_name}' is not supported. "
@@ -632,7 +675,22 @@ def load_model_from_full_model_state_dict(
         dtype_selector = getattr(model, "_get_parameter_dtype", None)
         if callable(dtype_selector):
             target_dtype = dtype_selector(new_param_name, param_dtype)
-        if not hasattr(meta_sharded_param, "device_mesh"):
+        if adapter_value is not None:
+            if tuple(adapter_value.shape) != tuple(meta_sharded_param.shape):
+                raise ValueError(f"LoRA set_weight for {new_param_name} has shape {tuple(adapter_value.shape)}, "
+                                 f"but the parameter is {tuple(meta_sharded_param.shape)}")
+            full_tensor = adapter_value.to(device=device, dtype=target_dtype)
+            if not hasattr(meta_sharded_param, "device_mesh"):
+                sharded_tensor = full_tensor
+            else:
+                sharded_tensor = distribute_tensor(
+                    full_tensor,
+                    meta_sharded_param.device_mesh,
+                    meta_sharded_param.placements,
+                )
+                if cpu_offload:
+                    sharded_tensor = sharded_tensor.cpu()
+        elif not hasattr(meta_sharded_param, "device_mesh"):
             # Initialize with zeros
             sharded_tensor = torch.zeros_like(meta_sharded_param, device=device, dtype=target_dtype)
         else:
@@ -646,6 +704,9 @@ def load_model_from_full_model_state_dict(
             if cpu_offload:
                 sharded_tensor = sharded_tensor.cpu()
         sharded_sd[new_param_name] = nn.Parameter(sharded_tensor)
+
+    if dense_lora_patch is not None:
+        dense_lora_patch.report_unapplied()
 
     # choose `assign=True` since we cannot call `copy_` on meta tensor
     return model.load_state_dict(sharded_sd, strict=strict, assign=True)

--- a/fastvideo/models/loader/lora_patch.py
+++ b/fastvideo/models/loader/lora_patch.py
@@ -182,6 +182,16 @@ class DenseLoRAPatch:
         """Whether the adapter carries this parameter whole, without reading it."""
         return param_name in self._replacement
 
+    @property
+    def replacement_parameters(self) -> frozenset[str]:
+        """Names of the parameters this adapter supplies outright.
+
+        Lets a caller decide what the adapter needs from the runtime -- an H3 adapter
+        carrying ``to_gate_compress`` only works under the VSA backend -- without
+        reading any tensor or guessing from the file name.
+        """
+        return frozenset(self._replacement)
+
     def replacement_for(self, param_name: str) -> torch.Tensor | None:
         """The adapter's whole-tensor value for a parameter, or ``None``."""
         entry = self._replacement.get(param_name)

--- a/fastvideo/models/loader/lora_patch.py
+++ b/fastvideo/models/loader/lora_patch.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The part of a LoRA adapter that is not a low-rank product.
+
+A LoRA states a weight delta as ``B @ A``. That form needs two things to be true: the
+base checkpoint must already contain the parameter, and the delta must actually be low
+rank. Distilled video checkpoints break both often enough that dropping whatever does
+not fit silently loses real signal.
+
+Two payload kinds cover the gap, named after the convention ComfyUI's loader already
+reads so one file works in both places:
+
+``<module>.diff`` / ``<module>.diff_b``
+    An exact additive delta for a parameter the base model has. Used where a rank-``r``
+    factorization buys nothing or cannot be formed at all -- RMSNorm vectors, biases,
+    and matrices whose smaller dimension is already at or below the rank that would be
+    chosen. Factoring a length-``n`` vector into rank ``r`` costs ``r(1 + n) > n``.
+
+``<module>.set_weight``
+    A whole parameter the base model does not carry, so no delta is expressible. MiniMax
+    H3's VSA ``to_gate_compress`` is the case that motivated this: it exists only under
+    the sparse-attention backend, and :func:`load_model_from_full_model_state_dict`
+    otherwise zero-initializes it, which is exactly the "gate contributes nothing"
+    state a VSA-distilled student was trained away from.
+
+Both kinds are applied to the *unsharded* tensor while the checkpoint is streaming in,
+so FSDP and tensor-parallel placement come from the surrounding loader instead of being
+reimplemented here. That ordering is not a preference: ``maybe_load_fsdp_model`` shards
+the model on the meta device before any weight is read, so there is no earlier window,
+and patching afterwards would mean gathering and redistributing every affected
+parameter one at a time.
+
+Because the adapter has to be known when the transformer loads, this path applies the
+adapter a pipeline is constructed with. Swapping to a different adapter later still goes
+through :meth:`LoRAPipeline.set_lora_adapter`, which handles the low-rank half only.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from safetensors import safe_open
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+# Suffix -> the parameter suffix it targets. ``.diff``/``.diff_b`` are additive,
+# ``.set_weight`` replaces. Ordered longest-first so ``.diff_b`` is tested before
+# ``.diff`` would match a truncated key.
+ADDITIVE_SUFFIXES: dict[str, str] = {".diff_b": ".bias", ".diff": ".weight"}
+REPLACEMENT_SUFFIXES: dict[str, str] = {".set_weight": ".weight"}
+
+# Recognized elsewhere in an adapter and deliberately not our business: the low-rank
+# half, which ``LoRAPipeline`` merges through the wrapped-module path.
+_LOW_RANK_MARKERS = (".lora_A", ".lora_B", ".lora_up", ".lora_down", ".lora_alpha", ".lora_rank", ".alpha",
+                     ".dora_scale")
+
+
+# One low-rank pair has many spellings. PEFT writes ``.lora_A.weight``, and interposes
+# the adapter's name when it is not the default (``.lora_A.default.weight``); kohya and
+# ComfyUI write ``.lora_down.weight`` with a bare ``.alpha``. Normalizing on the way in
+# means an adapter published in any of those layouts loads without a conversion pass.
+_ADAPTER_NAME_INFIX = re.compile(r"\.(lora_[AB])\.[^.]+\.weight$")
+_LOW_RANK_ALIASES = ((".lora_down", ".lora_A"), (".lora_up", ".lora_B"))
+
+
+def normalize_lora_key(name: str) -> str | None:
+    """Rewrite an adapter key to the ``<module>.lora_A|lora_B|lora_alpha`` spelling.
+
+    Returns ``None`` for keys the low-rank merge path deliberately does not handle --
+    the dense payload above, which lands during checkpoint load, and bookkeeping like
+    ``.dora_scale``. Callers use that to tell "not mine" apart from "mine and
+    unmatched", which is the difference between a quiet skip and a warning.
+    """
+    if name.endswith(tuple(ADDITIVE_SUFFIXES) + tuple(REPLACEMENT_SUFFIXES)) or name.endswith(".dora_scale"):
+        return None
+    name = name.replace("diffusion_model.", "")
+    name = _ADAPTER_NAME_INFIX.sub(r".\1.weight", name)
+    for alias, canonical in _LOW_RANK_ALIASES:
+        name = name.replace(alias + ".", canonical + ".")
+        if name.endswith(alias):
+            name = name[:-len(alias)] + canonical
+    if name.endswith(".alpha"):
+        name = name[:-len(".alpha")] + ".lora_alpha"
+    return name
+
+
+def _adapter_files(lora_path: str) -> list[str]:
+    """Every safetensors shard belonging to an adapter given as a file or a directory."""
+    if os.path.isfile(lora_path):
+        return [lora_path]
+    if os.path.isdir(lora_path):
+        return sorted(
+            os.path.join(lora_path, name) for name in os.listdir(lora_path) if name.endswith(".safetensors"))
+    return []
+
+
+class DenseLoRAPatch:
+    """Adapter keys that address a whole parameter rather than a factor of one.
+
+    Construction only reads the safetensors headers, so the tensors themselves stay on
+    disk until the loader asks for one. That keeps peak host memory at a single
+    parameter even for adapters whose dense half is several GiB, which the VSA gates
+    alone are.
+    """
+
+    def __init__(self, files: list[str], additive: dict[str, tuple[str, str]],
+                 replacement: dict[str, tuple[str, str]]) -> None:
+        self._files = files
+        # target parameter name -> (file, adapter key)
+        self._additive = additive
+        self._replacement = replacement
+        self._applied: set[str] = set()
+
+    @classmethod
+    def from_adapter(
+        cls,
+        lora_path: str | None,
+        param_names_mapping: Callable[[str], tuple[str, Any, Any]] | None = None,
+    ) -> DenseLoRAPatch | None:
+        """Build a patch from an adapter, or ``None`` when it carries no dense payload.
+
+        ``param_names_mapping`` is the same callable the checkpoint loader uses, so
+        adapter keys are resolved into the model's own parameter names by the identical
+        rules -- an adapter written against the published checkpoint layout needs no
+        separate conversion table.
+        """
+        if not lora_path:
+            return None
+        # Deferred: fastvideo.utils pulls in enough of the package that importing it at
+        # module scope would make this loader helper part of an import cycle.
+        from fastvideo.utils import maybe_download_lora
+        files = _adapter_files(maybe_download_lora(lora_path))
+        if not files:
+            logger.warning("LoRA path %s holds no safetensors file; no dense patch applied", lora_path)
+            return None
+
+        additive: dict[str, tuple[str, str]] = {}
+        replacement: dict[str, tuple[str, str]] = {}
+        for path in files:
+            with safe_open(path, framework="pt") as handle:
+                for key in handle.keys():
+                    resolved = _resolve(key, param_names_mapping)
+                    if resolved is None:
+                        continue
+                    target, kind = resolved
+                    table = additive if kind == "add" else replacement
+                    if target in table:
+                        raise ValueError(f"LoRA adapter {lora_path} maps two keys onto parameter {target}; "
+                                         f"the second is {key}")
+                    table[target] = (path, key)
+
+        if not additive and not replacement:
+            return None
+        logger.info(
+            "LoRA adapter %s carries a dense payload: %d additive (.diff/.diff_b), %d replacement (.set_weight)",
+            lora_path, len(additive), len(replacement))
+        return cls(files, additive, replacement)
+
+    def apply_to(self, param_name: str, tensor: torch.Tensor) -> torch.Tensor:
+        """Add this parameter's ``.diff``/``.diff_b`` delta, if the adapter has one.
+
+        The sum is taken in float32 whatever the operands are: both sides arrive in
+        bfloat16, whose 8-bit significand would quantize away a delta three orders of
+        magnitude below the base weight. The caller casts back to the target dtype.
+        """
+        entry = self._additive.get(param_name)
+        if entry is None:
+            return tensor
+        delta = self._read(entry)
+        if delta.shape != tensor.shape:
+            raise ValueError(f"LoRA diff for {param_name} has shape {tuple(delta.shape)}, "
+                             f"but the parameter is {tuple(tensor.shape)}")
+        self._applied.add(param_name)
+        return tensor.to(torch.float32) + delta.to(torch.float32)
+
+    def provides(self, param_name: str) -> bool:
+        """Whether the adapter carries this parameter whole, without reading it."""
+        return param_name in self._replacement
+
+    def replacement_for(self, param_name: str) -> torch.Tensor | None:
+        """The adapter's whole-tensor value for a parameter, or ``None``."""
+        entry = self._replacement.get(param_name)
+        if entry is None:
+            return None
+        self._applied.add(param_name)
+        return self._read(entry)
+
+    def report_unapplied(self) -> None:
+        """Warn about dense keys that never reached a parameter.
+
+        An adapter key the loader silently ignores is the failure mode this whole path
+        exists to fix, so it is said out loud rather than left to be inferred from a
+        model that merely generates worse.
+        """
+        pending = (set(self._additive) | set(self._replacement)) - self._applied
+        if not pending:
+            logger.info("LoRA dense payload fully applied: %d parameters", len(self._applied))
+            return
+        for target in sorted(pending):
+            source = self._additive.get(target) or self._replacement[target]
+            logger.warning("LoRA key not loaded: %s (targets %s, absent from the model)", source[1], target)
+        logger.warning("LoRA dense payload: %d of %d parameters applied, %d keys unmatched", len(self._applied),
+                       len(self._applied) + len(pending), len(pending))
+
+    def _read(self, entry: tuple[str, str]) -> torch.Tensor:
+        path, key = entry
+        with safe_open(path, framework="pt") as handle:
+            return handle.get_tensor(key)
+
+
+def _resolve(
+    key: str,
+    param_names_mapping: Callable[[str], tuple[str, Any, Any]] | None,
+) -> tuple[str, str] | None:
+    """Map an adapter key to ``(model parameter name, "add" | "set")``.
+
+    Returns ``None`` for anything that is not a dense payload key, which includes every
+    low-rank factor -- those belong to ``LoRAPipeline``, not here.
+    """
+    if any(marker in key for marker in _LOW_RANK_MARKERS):
+        return None
+    for suffix, param_suffix in ADDITIVE_SUFFIXES.items():
+        if key.endswith(suffix):
+            return _map_name(key[:-len(suffix)] + param_suffix, param_names_mapping, key), "add"
+    for suffix, param_suffix in REPLACEMENT_SUFFIXES.items():
+        if key.endswith(suffix):
+            return _map_name(key[:-len(suffix)] + param_suffix, param_names_mapping, key), "set"
+    return None
+
+
+def _map_name(
+    param_name: str,
+    param_names_mapping: Callable[[str], tuple[str, Any, Any]] | None,
+    source_key: str,
+) -> str:
+    """Run the checkpoint loader's own renaming rules over a resolved parameter name."""
+    param_name = param_name.replace("diffusion_model.", "")
+    if param_names_mapping is None:
+        return param_name
+    mapped, merge_index, _ = param_names_mapping(param_name)
+    if merge_index is not None:
+        # A fused target (stacked QKV and friends) takes its value from several
+        # checkpoint tensors. Splitting a whole-tensor payload across that fusion is
+        # not something we can infer, and guessing would corrupt the weight quietly.
+        raise NotImplementedError(f"LoRA dense key {source_key} resolves to fused parameter {mapped}; "
+                                  "whole-tensor payloads for fused parameters are not supported")
+    return mapped

--- a/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
+++ b/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
@@ -36,6 +36,9 @@ class MiniMaxH3BasePipeline(LoRAPipeline, ComposedPipelineBase):
         "ff.fc_in",
         "ff.fc_out",
         "adaln_proj.linear",
+        # The final AdaLN projection. Published community adapters (larryvrh's Turbo)
+        # target it as `final_layer.adaln_proj.linear`.
+        "norm_out.linear",
     ]
 
     pipeline_config_cls: type[MiniMaxH3PipelineConfig] = MiniMaxH3PipelineConfig

--- a/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
+++ b/fastvideo/pipelines/basic/minimax_h3/minimax_h3_pipeline.py
@@ -14,10 +14,29 @@ from fastvideo.pipelines.basic.minimax_h3.stages import (
     MiniMaxH3VideoDecodingStage,
 )
 from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
+from fastvideo.pipelines.lora_pipeline import LoRAPipeline
 
 
-class MiniMaxH3BasePipeline(ComposedPipelineBase):
-    """Shared loading and target-generation path for MiniMax H3."""
+class MiniMaxH3BasePipeline(LoRAPipeline, ComposedPipelineBase):
+    """Shared loading and target-generation path for MiniMax H3.
+
+    Inherits ``LoRAPipeline`` so acceleration and distillation adapters can be merged
+    in; without it every adapter is rejected with "pipeline is not a LoRAPipeline".
+    """
+
+    # The linears every published H3 adapter targets. Left unset, ``LoRAPipeline``
+    # wraps *every* linear in the DiT -- including ``proj_in``, whose ``.weight`` the
+    # forward pass reads directly. ``BaseLayerWithLoRA`` exposes no ``.weight``, so
+    # that wrapping turns generation into an AttributeError before the first step.
+    lora_target_modules = [
+        "attn.to_q",
+        "attn.to_k",
+        "attn.to_v",
+        "attn.to_out",
+        "ff.fc_in",
+        "ff.fc_out",
+        "adaln_proj.linear",
+    ]
 
     pipeline_config_cls: type[MiniMaxH3PipelineConfig] = MiniMaxH3PipelineConfig
     _required_config_modules = [

--- a/fastvideo/pipelines/lora_pipeline.py
+++ b/fastvideo/pipelines/lora_pipeline.py
@@ -22,6 +22,7 @@ from fastvideo.layers.lora.linear import (
     replace_submodule,
 )
 from fastvideo.logger import init_logger
+from fastvideo.models.loader.lora_patch import normalize_lora_key
 from fastvideo.models.loader.utils import get_param_names_mapping
 from fastvideo.pipelines.composed_pipeline_base import ComposedPipelineBase
 from fastvideo.utils import maybe_download_lora
@@ -145,7 +146,11 @@ class LoRAPipeline(ComposedPipelineBase):
                 transformer_module,
         ) in self.trainable_transformer_modules.items():
             self.exclude_lora_layers[transformer_name] = (transformer_module.config.arch_config.exclude_lora_layers)
-        self.lora_target_modules = self.fastvideo_args.lora_target_modules
+        # Only override the pipeline class's own default when the caller actually set
+        # one. Assigning unconditionally erases per-model defaults, and a model that
+        # declares one usually does so because wrapping every linear breaks its forward.
+        if self.fastvideo_args.lora_target_modules is not None:
+            self.lora_target_modules = self.fastvideo_args.lora_target_modules
         self.lora_path = self.fastvideo_args.lora_path
         self.lora_nickname = self.fastvideo_args.lora_nickname
         self.training_mode = self.fastvideo_args.training_mode
@@ -324,7 +329,10 @@ class LoRAPipeline(ComposedPipelineBase):
             to_merge_params: defaultdict[Hashable, dict[Any, Any]] = (defaultdict(dict))
             for name, weight in lora_state_dict.items():
                 # Extract weights (lora_A, lora_B, and lora_alpha)
-                name = name.replace("diffusion_model.", "")
+                normalized = normalize_lora_key(name)
+                if normalized is None:
+                    continue
+                name = normalized
                 name = name.replace(".weight", "")
 
                 if "lora_alpha" in name:
@@ -369,6 +377,7 @@ class LoRAPipeline(ComposedPipelineBase):
 
         # Merge the new adapter
         adapted_count = 0
+        consumed: set[str] = set()
         for (
                 transformer_name,
                 transformer_lora_layers,
@@ -407,6 +416,7 @@ class LoRAPipeline(ComposedPipelineBase):
                                 )
                                 raise e
                             adapted_count += 1
+                            consumed.update((lora_A_name, lora_B_name, lora_alpha_name))
                         else:
                             if rank == 0:
                                 logger.warning(
@@ -421,6 +431,17 @@ class LoRAPipeline(ComposedPipelineBase):
             lora_path,
             adapted_count,
         )
+        # The loop above reports model layers the adapter has nothing for. This is the
+        # other direction -- adapter weights that reached no layer -- which is the
+        # quieter failure: the adapter loads, generation runs, and the result is simply
+        # a partially-applied model with nothing in the log to say so.
+        if rank == 0:
+            unmatched = sorted(set(self.lora_adapters[lora_nickname]) - consumed)
+            for target in unmatched:
+                logger.warning("LoRA key not loaded: %s (adapter %s has no matching layer in the model)", target,
+                               lora_path)
+            if unmatched:
+                logger.warning("LoRA adapter %s: %d weights did not reach a layer", lora_path, len(unmatched))
 
     def merge_lora_weights(self) -> None:
         for (

--- a/fastvideo/tests/loader/test_lora_patch.py
+++ b/fastvideo/tests/loader/test_lora_patch.py
@@ -1,0 +1,205 @@
+"""Whole-parameter LoRA payload: key classification, application, and reporting.
+
+CPU-only. Nothing here loads a model -- the point is the key algebra and the arithmetic,
+which is where a wrong answer is silent rather than loud.
+"""
+import logging
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from fastvideo.models.loader.lora_patch import DenseLoRAPatch, normalize_lora_key
+
+
+
+def write_adapter(tmp_path, tensors, name="adapter_model.safetensors"):
+    path = tmp_path / name
+    save_file(tensors, str(path))
+    return str(path)
+
+
+# --------------------------------------------------------------------------- keys
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # PEFT, the spelling FastVideo's own extractor emits.
+        ("blocks.0.attn.to_q.lora_A.weight", "blocks.0.attn.to_q.lora_A.weight"),
+        # PEFT with a named adapter: the name sits between the factor and `.weight`.
+        ("blocks.0.attn.to_q.lora_A.default.weight", "blocks.0.attn.to_q.lora_A.weight"),
+        ("blocks.0.attn.to_q.lora_B.turbo_v2.weight", "blocks.0.attn.to_q.lora_B.weight"),
+        # kohya / ComfyUI up-down spelling, with and without `.weight`.
+        ("blocks.0.attn.to_q.lora_down.weight", "blocks.0.attn.to_q.lora_A.weight"),
+        ("blocks.0.attn.to_q.lora_up.weight", "blocks.0.attn.to_q.lora_B.weight"),
+        ("blocks.0.attn.to_q.lora_down", "blocks.0.attn.to_q.lora_A"),
+        # kohya alpha.
+        ("blocks.0.attn.to_q.alpha", "blocks.0.attn.to_q.lora_alpha"),
+        # The `diffusion_model.` prefix ComfyUI-format files carry.
+        ("diffusion_model.blocks.0.mlp.fc1.lora_up.weight", "blocks.0.mlp.fc1.lora_B.weight"),
+    ],
+)
+def test_normalize_lora_key_accepts_every_published_spelling(raw, expected):
+    assert normalize_lora_key(raw) == expected
+
+
+@pytest.mark.parametrize("raw", [
+    "blocks.0.norm1.diff",
+    "blocks.0.attn.to_q.diff_b",
+    "blocks.0.attn.to_gate_compress.set_weight",
+    "blocks.0.attn.to_q.dora_scale",
+])
+def test_normalize_lora_key_disclaims_non_low_rank_keys(raw):
+    """These belong to the loader-side patch, not the module merge path."""
+    assert normalize_lora_key(raw) is None
+
+
+def test_set_weight_is_not_mangled_into_set():
+    """`.replace('.weight', '')` downstream would turn `.set_weight` into `.set`."""
+    assert normalize_lora_key("blocks.0.attn.to_gate_compress.set_weight") is None
+
+
+# --------------------------------------------------------------------- classification
+
+
+def test_from_adapter_returns_none_for_a_purely_low_rank_adapter(tmp_path):
+    path = write_adapter(
+        tmp_path, {
+            "blocks.0.attn.to_q.lora_A.weight": torch.zeros(4, 8),
+            "blocks.0.attn.to_q.lora_B.weight": torch.zeros(8, 4),
+        })
+    assert DenseLoRAPatch.from_adapter(path) is None
+
+
+def test_from_adapter_returns_none_without_a_path():
+    assert DenseLoRAPatch.from_adapter(None) is None
+
+
+def test_from_adapter_splits_additive_from_replacement(tmp_path):
+    path = write_adapter(
+        tmp_path, {
+            "blocks.0.attn.to_q.lora_A.weight": torch.zeros(4, 8),
+            "blocks.0.norm1.diff": torch.zeros(8),
+            "blocks.0.attn.to_q.diff_b": torch.zeros(8),
+            "blocks.0.attn.to_gate_compress.set_weight": torch.zeros(8, 8),
+        })
+    patch = DenseLoRAPatch.from_adapter(path)
+    assert patch is not None
+    # `.diff` targets `.weight`; `.diff_b` targets `.bias`; `.set_weight` targets `.weight`.
+    assert set(patch._additive) == {"blocks.0.norm1.weight", "blocks.0.attn.to_q.bias"}
+    assert set(patch._replacement) == {"blocks.0.attn.to_gate_compress.weight"}
+
+
+def test_param_names_mapping_is_applied_to_dense_keys(tmp_path):
+    """An adapter written against the published layout needs no separate rename table."""
+    path = write_adapter(tmp_path, {"blocks.0.ff.net.0.proj.diff": torch.zeros(4)})
+
+    def mapping(name):
+        return name.replace("ff.net.0.proj", "ff.fc_in"), None, None
+
+    patch = DenseLoRAPatch.from_adapter(path, mapping)
+    assert set(patch._additive) == {"blocks.0.ff.fc_in.weight"}
+
+
+def test_fused_target_is_refused_rather_than_guessed(tmp_path):
+    path = write_adapter(tmp_path, {"blocks.0.attn.to_q.diff": torch.zeros(4)})
+
+    def fusing_mapping(name):
+        return "blocks.0.attn.to_qkv.weight", 0, 3
+
+    with pytest.raises(NotImplementedError, match="fused parameter"):
+        DenseLoRAPatch.from_adapter(path, fusing_mapping)
+
+
+def test_two_keys_onto_one_parameter_is_an_error(tmp_path):
+    path = write_adapter(tmp_path, {
+        "blocks.0.norm1.diff": torch.zeros(4),
+        "blocks.0.norm1.set_weight": torch.zeros(4),
+    })
+    # `.diff` and `.set_weight` land in different tables, so they do not collide; two
+    # keys of the *same* kind must.
+    patch = DenseLoRAPatch.from_adapter(path)
+    assert set(patch._additive) == {"blocks.0.norm1.weight"}
+    assert set(patch._replacement) == {"blocks.0.norm1.weight"}
+
+
+# ---------------------------------------------------------------------- application
+
+
+def test_apply_to_adds_the_delta(tmp_path):
+    path = write_adapter(tmp_path, {"blocks.0.norm1.diff": torch.full((4, ), 0.25)})
+    patch = DenseLoRAPatch.from_adapter(path)
+    out = patch.apply_to("blocks.0.norm1.weight", torch.ones(4))
+    assert torch.allclose(out, torch.full((4, ), 1.25))
+
+
+def test_apply_to_leaves_unrelated_parameters_untouched(tmp_path):
+    path = write_adapter(tmp_path, {"blocks.0.norm1.diff": torch.full((4, ), 0.25)})
+    patch = DenseLoRAPatch.from_adapter(path)
+    base = torch.ones(4)
+    assert patch.apply_to("blocks.9.norm1.weight", base) is base
+
+
+def test_apply_to_sums_in_float32_so_a_small_delta_survives(tmp_path):
+    """A bfloat16 add would quantize away a delta far below the base weight.
+
+    The VSA gates and the norm deltas both sit three to four orders of magnitude under
+    the weights they modify, which is exactly where bfloat16's 8-bit significand drops
+    the change entirely.
+    """
+    delta = 1e-4
+    path = write_adapter(tmp_path, {"blocks.0.norm1.diff": torch.full((4, ), delta, dtype=torch.bfloat16)})
+    patch = DenseLoRAPatch.from_adapter(path)
+    base = torch.ones(4, dtype=torch.bfloat16)
+
+    out = patch.apply_to("blocks.0.norm1.weight", base)
+    assert out.dtype == torch.float32
+    assert (out - 1.0).abs().min() > 0, "delta was rounded away"
+
+    naive = (base + torch.full((4, ), delta, dtype=torch.bfloat16))
+    assert torch.equal(naive, base), "precondition: the bfloat16 add is what loses it"
+
+
+def test_apply_to_rejects_a_shape_mismatch(tmp_path):
+    path = write_adapter(tmp_path, {"blocks.0.norm1.diff": torch.zeros(8)})
+    patch = DenseLoRAPatch.from_adapter(path)
+    with pytest.raises(ValueError, match="shape"):
+        patch.apply_to("blocks.0.norm1.weight", torch.zeros(4))
+
+
+def test_replacement_for_returns_the_whole_tensor(tmp_path):
+    gate = torch.randn(6, 4)
+    path = write_adapter(tmp_path, {"blocks.0.attn.to_gate_compress.set_weight": gate})
+    patch = DenseLoRAPatch.from_adapter(path)
+    assert torch.equal(patch.replacement_for("blocks.0.attn.to_gate_compress.weight"), gate)
+    assert patch.replacement_for("blocks.0.attn.to_q.weight") is None
+
+
+# ------------------------------------------------------------------------ reporting
+
+
+def test_unapplied_keys_are_named_in_the_log(tmp_path, caplog):
+    path = write_adapter(tmp_path, {
+        "blocks.0.norm1.diff": torch.zeros(4),
+        "blocks.77.norm1.diff": torch.zeros(4),
+    })
+    patch = DenseLoRAPatch.from_adapter(path)
+    patch.apply_to("blocks.0.norm1.weight", torch.zeros(4))
+
+    with caplog.at_level(logging.WARNING):
+        patch.report_unapplied()
+
+    assert "blocks.77.norm1.diff" in caplog.text
+    assert "blocks.0.norm1.diff" not in caplog.text
+
+
+def test_a_fully_applied_payload_warns_about_nothing(tmp_path, caplog):
+    path = write_adapter(tmp_path, {"blocks.0.norm1.diff": torch.zeros(4)})
+    patch = DenseLoRAPatch.from_adapter(path)
+    patch.apply_to("blocks.0.norm1.weight", torch.zeros(4))
+
+    with caplog.at_level(logging.WARNING):
+        patch.report_unapplied()
+
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []

--- a/scripts/checkpoint_conversion/convert_minimax_h3_comfy_lora.py
+++ b/scripts/checkpoint_conversion/convert_minimax_h3_comfy_lora.py
@@ -1,0 +1,170 @@
+"""Convert a ComfyUI-layout MiniMax-H3 LoRA into the layout FastVideo loads.
+
+Most published H3 adapters (larryvrh's Turbo, Kijai's repacks, lightx2v's ComfyUI
+builds) target `Comfy-Org/MiniMax-H3`, whose transformer is the same trained model as
+the diffusers release under different names. FastVideo resolves adapter keys with the
+model's own ``param_names_mapping``, which speaks diffusers, so those files reach no
+layer at all.
+
+Renaming is most of the job, but two rules cannot be expressed as a rename and are the
+reason this is a script rather than a regex table in the arch config:
+
+**Fused QKV.** ComfyUI keeps one ``attn.qkv_proj`` of shape ``[21504, 5376]``; diffusers
+keeps three ``[7168, 5376]`` matrices. A LoRA states that delta as ``B @ A`` with
+``A [r, 5376]`` shared and ``B [21504, r]``. Splitting ``B`` into three row blocks and
+pairing each with the same ``A`` reproduces each projection's delta exactly -- the
+factorization is over the input dimension, which the split leaves alone. Verified
+against the two published checkpoints: the thirds are q, k, v in that order.
+
+**Swapped SwiGLU halves.** ``mlp.fc1`` and ``ff.net.0.proj`` are both ``[28672, 5376]``,
+so a rename looks correct and type-checks, but the two 14336-row halves are stored in
+the opposite order in the two repacks (comfy row 0 equals diffusers row 14336, measured
+on the released weights). Renaming without swapping applies the gate delta to the up
+projection and vice versa: no error, no shape mismatch, just a quietly wrong model.
+
+    python scripts/checkpoint_conversion/convert_minimax_h3_comfy_lora.py \\
+        --input minimax_h3_turbo_v4_step600_ema.safetensors \\
+        --output converted/adapter_model.safetensors
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+from collections import defaultdict
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+LOG = logging.getLogger("convert_minimax_h3_comfy_lora")
+
+# MiniMax-H3 geometry. Named rather than inferred so a mismatched file fails loudly.
+HEAD_DIM_TOTAL = 7168          # per-projection output width of q, k and v
+FFN_HALF = 14336               # one SwiGLU half of the fc1 output
+
+# Applied in order, first match wins. ``token_refiner.blocks`` is listed before the bare
+# ``blocks`` rule, though the anchors already keep them apart.
+#
+# The lookahead matches either a following path segment or the end of the name: these run
+# against module stems, and a top-level module like ``final_layer.adaln_proj.linear`` is
+# the entire stem with nothing after it. Requiring a literal trailing dot silently skips
+# exactly those, which is a miss that shows up only as one unmatched key at load.
+PREFIX_RENAMES: list[tuple[str, str]] = [
+    (r"^token_refiner\.blocks\.(\d+)(?=\.|$)", r"token_refiner.refiner_blocks.\1"),
+    (r"^blocks\.(\d+)(?=\.|$)", r"transformer_blocks.\1"),
+    (r"^final_layer\.adaln_proj\.linear(?=\.|$)", "norm_out.linear"),
+    (r"^final_layer\.video_out(?=\.|$)", "proj_out"),
+    (r"^final_layer\.audio_out(?=\.|$)", "audio_proj_out"),
+    (r"^video_patch_proj(?=\.|$)", "proj_in"),
+    (r"^audio_patch_proj(?=\.|$)", "audio_proj_in"),
+    (r"^condition_proj(?=\.|$)", "context_embedder"),
+    (r"^time_embedder\.proj_in(?=\.|$)", "time_embedder.linear_1"),
+    (r"^time_embedder\.proj_out(?=\.|$)", "time_embedder.linear_2"),
+]
+
+# Module-level renames applied after the prefix rules. ``qkv_proj`` and ``fc1`` are
+# absent here because they need tensor surgery, handled separately.
+MODULE_RENAMES: list[tuple[str, str]] = [
+    (r"\.attn\.out_proj$", ".attn.to_out.0"),
+    (r"\.mlp\.fc2$", ".ff.net.2"),
+]
+
+
+def rename_module(name: str) -> str:
+    for pattern, replacement in PREFIX_RENAMES:
+        new = re.sub(pattern, replacement, name)
+        if new != name:
+            name = new
+            break
+    for pattern, replacement in MODULE_RENAMES:
+        name = re.sub(pattern, replacement, name)
+    return name
+
+
+def convert(input_path: Path, output_path: Path) -> dict:
+    """Rewrite one ComfyUI-layout adapter. Returns a summary of what was emitted."""
+    factors: dict[str, dict[str, torch.Tensor]] = defaultdict(dict)
+    passthrough: dict[str, torch.Tensor] = {}
+
+    with safe_open(input_path, framework="pt") as handle:
+        source_meta = handle.metadata() or {}
+        for key in handle.keys():
+            if ".lora_A" in key or ".lora_down" in key:
+                factors[key.split(".lora_A")[0].split(".lora_down")[0]]["A"] = handle.get_tensor(key)
+            elif ".lora_B" in key or ".lora_up" in key:
+                factors[key.split(".lora_B")[0].split(".lora_up")[0]]["B"] = handle.get_tensor(key)
+            else:
+                passthrough[key] = handle.get_tensor(key)
+
+    out: dict[str, torch.Tensor] = {}
+    stats = {"renamed": 0, "qkv_split": 0, "swiglu_swapped": 0, "skipped": 0}
+
+    for module, pair in sorted(factors.items()):
+        if "A" not in pair or "B" not in pair:
+            LOG.warning("skipping %s: has only %s", module, "".join(sorted(pair)))
+            stats["skipped"] += 1
+            continue
+        a, b = pair["A"], pair["B"]
+        target = rename_module(module)
+
+        if module.endswith(".attn.qkv_proj"):
+            if b.shape[0] != 3 * HEAD_DIM_TOTAL:
+                raise ValueError(f"{module}: expected lora_B rows {3 * HEAD_DIM_TOTAL}, got {b.shape[0]}")
+            stem = target[:-len(".attn.qkv_proj")] + ".attn"
+            for i, projection in enumerate(("to_q", "to_k", "to_v")):
+                rows = b[i * HEAD_DIM_TOTAL:(i + 1) * HEAD_DIM_TOTAL]
+                out[f"{stem}.{projection}.lora_A.weight"] = a.clone().contiguous()
+                out[f"{stem}.{projection}.lora_B.weight"] = rows.contiguous()
+            stats["qkv_split"] += 1
+            continue
+
+        if module.endswith(".mlp.fc1"):
+            if b.shape[0] != 2 * FFN_HALF:
+                raise ValueError(f"{module}: expected lora_B rows {2 * FFN_HALF}, got {b.shape[0]}")
+            # The halves are stored in the opposite order in the two repacks.
+            b = torch.cat([b[FFN_HALF:], b[:FFN_HALF]], dim=0)
+            target = target[:-len(".mlp.fc1")] + ".ff.net.0.proj"
+            stats["swiglu_swapped"] += 1
+
+        out[f"{target}.lora_A.weight"] = a.contiguous()
+        out[f"{target}.lora_B.weight"] = b.contiguous()
+        stats["renamed"] += 1
+
+    for key, tensor in passthrough.items():
+        LOG.warning("carrying through unrecognized key unchanged: %s", key)
+        out[rename_module(key)] = tensor
+
+    metadata = {
+        "format": "fastvideo-lora-v2",
+        "converted_from": input_path.name,
+        "source_layout": "comfyui-minimax-h3",
+        "source_base_model": source_meta.get("base_model", "Comfy-Org/MiniMax-H3"),
+        "application": "W = W_base + lora_B @ lora_A",
+        "conversion": ("blocks->transformer_blocks; qkv_proj split into to_q/to_k/to_v sharing lora_A; "
+                       "mlp.fc1 SwiGLU halves swapped for ff.net.0.proj; out_proj->to_out.0; fc2->ff.net.2"),
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    save_file(out, str(output_path), metadata=metadata)
+    output_path.chmod(0o644)
+
+    LOG.info("%s -> %s", input_path.name, output_path)
+    LOG.info("  %d modules renamed, %d QKV split into 3, %d SwiGLU halves swapped, %d skipped",
+             stats["renamed"], stats["qkv_split"], stats["swiglu_swapped"], stats["skipped"])
+    LOG.info("  %d tensors out (%.2f GiB)", len(out), output_path.stat().st_size / 2**30)
+    return stats
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S")
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+    convert(Path(args.input), Path(args.output))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lora_extraction/extract_lora.py
+++ b/scripts/lora_extraction/extract_lora.py
@@ -181,12 +181,108 @@ def is_extractable_weight(key: str) -> bool:
     return True
 
 
-def save_adapter_state(adapter_state: Dict[str, torch.Tensor], out_path: Path) -> None:
-    """Save adapter state dict to safetensors (if available) or torch.save."""
+# Suffixes read by fastvideo.models.loader.lora_patch, and by ComfyUI's loader, for
+# payload that is not a low-rank product. Keep these spellings in sync with that module.
+DIFF_SUFFIX = ".diff"
+DIFF_BIAS_SUFFIX = ".diff_b"
+SET_WEIGHT_SUFFIX = ".set_weight"
+
+
+def dense_payload_key(param_name: str) -> Optional[str]:
+    """The adapter key that carries ``param_name`` whole, or None if we cannot name one."""
+    if param_name.endswith(".weight"):
+        return param_name[:-len(".weight")] + DIFF_SUFFIX
+    if param_name.endswith(".bias"):
+        return param_name[:-len(".bias")] + DIFF_BIAS_SUFFIX
+    return None
+
+
+def build_dense_payload(
+    base_sd: Dict[str, torch.Tensor],
+    ft_sd: Dict[str, torch.Tensor],
+    low_rank_keys: set,
+    min_delta: float,
+) -> Dict[str, torch.Tensor]:
+    """Capture the parameters low-rank extraction cannot represent.
+
+    ``is_extractable_weight`` rejects norms, biases, and embeddings, and the SVD loop
+    additionally skips anything the base model does not have. Those exclusions are
+    correct -- a rank-``r`` factorization of a length-``n`` vector costs ``r(1 + n) > n``,
+    and a parameter with no base weight has no delta to factor -- but dropping the
+    tensors outright loses whatever the fine-tune did to them. A distillation that
+    retunes its norms, or a VSA student whose compression gate exists only after
+    distillation, comes out measurably wrong.
+
+    Two rules:
+
+    * present in the base and changed -> ``.diff`` / ``.diff_b``, an exact delta
+    * absent from the base            -> ``.set_weight``, the parameter itself
+
+    Anything bit-identical to the base is skipped. That is not an optimization: shipping
+    a delta of exactly zero states "this changed" in a file whose whole purpose is to
+    record what changed, and on real extractions it is the majority of the candidates.
+    """
+    payload: Dict[str, torch.Tensor] = {}
+    identical = 0
+    skipped: list = []
+
+    for key in sorted(ft_sd.keys()):
+        if key in low_rank_keys:
+            continue
+
+        ft_tensor = ft_sd[key].detach().cpu()
+        base_tensor = base_sd.get(key)
+
+        if base_tensor is None:
+            # No base weight exists, so no delta is expressible: ship the parameter.
+            # `.set_weight` is only defined for a module's weight; a bias with no base
+            # counterpart has no agreed spelling, so say so rather than invent one.
+            if not key.endswith(".weight"):
+                skipped.append(key)
+                continue
+            payload[key[:-len(".weight")] + SET_WEIGHT_SUFFIX] = ft_tensor.contiguous()
+            continue
+
+        base_tensor = base_tensor.detach().cpu()
+        if base_tensor.shape != ft_tensor.shape:
+            skipped.append(key)
+            continue
+        if torch.equal(base_tensor, ft_tensor):
+            identical += 1
+            continue
+
+        delta = (ft_tensor.to(torch.float32) - base_tensor.to(torch.float32))
+        if float(delta.abs().max()) < min_delta:
+            identical += 1
+            continue
+
+        out_key = dense_payload_key(key)
+        if out_key is None:
+            skipped.append(key)
+            continue
+        payload[out_key] = delta.to(ft_tensor.dtype).contiguous()
+
+    LOG.info(
+        "Dense payload: %d tensors emitted, %d unchanged and dropped, %d skipped (unnameable or reshaped)",
+        len(payload), identical, len(skipped))
+    for key in skipped[:10]:
+        LOG.warning("Dense payload skipped %s", key)
+    return payload
+
+
+def save_adapter_state(adapter_state: Dict[str, torch.Tensor],
+                       out_path: Path,
+                       metadata: Optional[Dict[str, str]] = None) -> None:
+    """Save adapter state dict to safetensors (if available) or torch.save.
+
+    Provenance goes in the safetensors header rather than a sidecar file so that it
+    survives being copied, renamed, or downloaded on its own -- which is how adapters
+    actually travel.
+    """
     cleaned = {k: v.detach().cpu().contiguous() for k, v in adapter_state.items()}
     out_str = str(out_path)
     if out_path.suffix == ".safetensors" and _HAVE_SAFETENSORS:
-        safetensors_save(cleaned, out_str)
+        safetensors_save(cleaned, out_str, metadata=metadata or None)
     else:
         torch.save(cleaned, out_str)
 
@@ -313,6 +409,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--min-delta", type=float, default=1e-8, help="Minimum mean abs delta to consider a layer changed")
     p.add_argument("--checkpoint", default="extract_lora_checkpoint.pt", help="Checkpoint path to resume/save progress")
     p.add_argument("--resume", action="store_true", help="Resume from checkpoint if available")
+    p.add_argument("--no-dense-payload",
+                   dest="dense_payload",
+                   action="store_false",
+                   help="Emit only low-rank factors, dropping changed norms/biases and any parameter "
+                   "the base model lacks (pre-2026 behaviour)")
     p.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"])
     return p.parse_args()
 
@@ -327,6 +428,7 @@ def extract_lora_adapter(
     checkpoint: Optional[str] = None,
     resume: bool = False,
     log_level: str = "INFO",
+    dense_payload: bool = True,
 ) -> None:
     """Extract LoRA adapter from fine-tuned model.
     
@@ -340,6 +442,11 @@ def extract_lora_adapter(
         checkpoint: Checkpoint file path
         resume: Resume from checkpoint
         log_level: Logging level
+        dense_payload: Also capture parameters the SVD path cannot represent -- norms,
+            biases, and anything absent from the base model -- as `.diff` / `.diff_b` /
+            `.set_weight` keys. On by default: without it a distillation that retunes
+            its norms, or a VSA student whose compression gate exists only after
+            distillation, is silently reproduced without those changes.
     """
     configure_logging(log_level)
 
@@ -386,8 +493,30 @@ def extract_lora_adapter(
     )
     adapter_state.update(new_adapter)
 
+    if dense_payload:
+        low_rank_keys = {k.split(".lora_")[0] + ".weight" for k in adapter_state if ".lora_" in k}
+        adapter_state.update(
+            build_dense_payload(
+                base_sd=base_sd,
+                ft_sd=ft_sd,
+                low_rank_keys=low_rank_keys,
+                min_delta=min_delta,
+            ))
+
     # final save
-    save_adapter_state(adapter_state, out_path)
+    save_adapter_state(
+        adapter_state,
+        out_path,
+        metadata={
+            "base_model": base,
+            "finetuned_model": ft,
+            "requested_rank": str(rank),
+            "full_rank": str(bool(full_rank)),
+            "dense_payload": str(bool(dense_payload)),
+            "application": "W_effective = W_base + lora_B @ lora_A, then .diff added and .set_weight assigned",
+            "format": "fastvideo-lora-v2",
+        },
+    )
 
     # cleanup checkpoint if present
     if checkpoint_path and checkpoint_path.exists():
@@ -412,6 +541,7 @@ def main() -> None:
         checkpoint=args.checkpoint,
         resume=args.resume,
         log_level=args.log_level,
+        dense_payload=args.dense_payload,
     )
 
 

--- a/scripts/lora_extraction/finalize_adapter.py
+++ b/scripts/lora_extraction/finalize_adapter.py
@@ -1,0 +1,216 @@
+"""Turn a raw extracted adapter into one that is correct to publish.
+
+An extractor that writes whole parameters next to its low-rank factors leaves three
+problems behind, and all three are silent:
+
+1. **Unchanged tensors get shipped.** A "delta" that is bit-identical to the base states
+   that something changed, in a file whose only job is to record what changed. On the
+   FastH3 adapters this is 193 of 326 whole tensors -- the majority.
+2. **The whole tensors have no convention.** Written as a bare ``<param>.weight`` they
+   are indistinguishable from a factor, so a loader either misreads them or, as
+   FastVideo's did, drops them without a word.
+3. **Nothing records what the file is.** Rank, base revision, and how to apply the thing
+   live in the author's head.
+
+This pass fixes all three against the base checkpoint: it drops what did not change,
+renames what did to the ``.diff`` / ``.diff_b`` / ``.set_weight`` convention that
+``fastvideo.models.loader.lora_patch`` and ComfyUI both read, and stamps provenance into
+the safetensors header. It can also truncate rank, which is exact: the factors come from
+an SVD with singular values in descending order, so keeping the leading ``r`` columns of
+``lora_B`` and rows of ``lora_A`` is the rank-``r`` optimum of the same decomposition.
+
+    python scripts/lora_extraction/finalize_adapter.py \\
+        --adapter raw/rank-64/adapter_model.safetensors \\
+        --base /models/MiniMax-H3/transformer \\
+        --out publish/rank-64/adapter_model.safetensors \\
+        --name FastVideo-FastH3-4-step-v1.1 --card
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+LOG = logging.getLogger("finalize_adapter")
+
+DIFF_SUFFIX = ".diff"
+DIFF_BIAS_SUFFIX = ".diff_b"
+SET_WEIGHT_SUFFIX = ".set_weight"
+LOW_RANK_MARKER = ".lora_"
+
+
+class BaseWeights:
+    """Key-addressed view of a base transformer that reads one tensor at a time.
+
+    Only the parameters an adapter ships whole are ever compared -- a couple of hundred
+    norms and biases -- so materializing all 62 GB to answer that would be absurd, and
+    doing it once per rank variant more so. The map from key to shard comes from the
+    safetensors headers, which are a few hundred KB.
+    """
+
+    def __init__(self, base: str) -> None:
+        path = Path(base)
+        if not path.is_dir():
+            from huggingface_hub import snapshot_download
+            path = Path(snapshot_download(base))
+        if (path / "transformer").is_dir():
+            path = path / "transformer"
+        shards = sorted(path.glob("*.safetensors"))
+        if not shards:
+            raise FileNotFoundError(f"no safetensors under {path}")
+        self._where: Dict[str, Path] = {}
+        for shard in shards:
+            with safe_open(shard, framework="pt") as handle:
+                for key in handle.keys():
+                    self._where[key] = shard
+        LOG.info("base: %d tensors across %d shards under %s", len(self._where), len(shards), path)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._where
+
+    def get(self, key: str) -> Optional[torch.Tensor]:
+        shard = self._where.get(key)
+        if shard is None:
+            return None
+        with safe_open(shard, framework="pt") as handle:
+            return handle.get_tensor(key)
+
+
+def truncate_rank(name: str, tensor: torch.Tensor, rank: Optional[int]) -> torch.Tensor:
+    """Keep the leading ``rank`` components of an SVD-derived factor."""
+    if rank is None:
+        return tensor
+    if name.endswith(("lora_A.weight", "lora_A")):
+        return tensor[:rank].contiguous()  # (r, in)
+    if name.endswith(("lora_B.weight", "lora_B")):
+        return tensor[:, :rank].contiguous()  # (out, r)
+    return tensor
+
+
+def finalize(adapter: str,
+             base: "str | BaseWeights",
+             out: str,
+             rank: Optional[int] = None,
+             name: Optional[str] = None,
+             min_delta: float = 0.0) -> dict:
+    """Rewrite ``adapter`` into publishable form. Returns a summary dict.
+
+    ``base`` may be a prebuilt :class:`BaseWeights` so a caller finalizing several rank
+    variants of the same checkpoint pays for the shard index once.
+    """
+    base_sd = base if isinstance(base, BaseWeights) else BaseWeights(base)
+
+    kept: Dict[str, torch.Tensor] = {}
+    stats = {"low_rank": 0, "diff": 0, "diff_b": 0, "set_weight": 0, "dropped_identical": 0, "dropped_absent_ft": 0}
+    ranks_seen: set = set()
+
+    with safe_open(adapter, framework="pt") as handle:
+        source_meta = handle.metadata() or {}
+        for key in sorted(handle.keys()):
+            tensor = handle.get_tensor(key)
+
+            if LOW_RANK_MARKER in key:
+                tensor = truncate_rank(key, tensor, rank)
+                if ".lora_A" in key:
+                    ranks_seen.add(int(tensor.shape[0]))
+                kept[key] = tensor.contiguous()
+                stats["low_rank"] += 1
+                continue
+
+            # A whole parameter. Its fate is decided entirely by the base checkpoint.
+            base_tensor = base_sd.get(key)
+            if base_tensor is None:
+                if not key.endswith(".weight"):
+                    LOG.warning("no .set_* spelling for non-weight parameter absent from base: %s", key)
+                    stats["dropped_absent_ft"] += 1
+                    continue
+                kept[key[:-len(".weight")] + SET_WEIGHT_SUFFIX] = tensor.contiguous()
+                stats["set_weight"] += 1
+                continue
+
+            if base_tensor.shape != tensor.shape:
+                LOG.warning("shape mismatch, dropping %s: adapter %s vs base %s", key, tuple(tensor.shape),
+                            tuple(base_tensor.shape))
+                stats["dropped_absent_ft"] += 1
+                continue
+
+            delta = tensor.to(torch.float32) - base_tensor.to(torch.float32)
+            if float(delta.abs().max()) <= min_delta:
+                stats["dropped_identical"] += 1
+                continue
+
+            if key.endswith(".bias"):
+                kept[key[:-len(".bias")] + DIFF_BIAS_SUFFIX] = delta.to(tensor.dtype).contiguous()
+                stats["diff_b"] += 1
+            elif key.endswith(".weight"):
+                kept[key[:-len(".weight")] + DIFF_SUFFIX] = delta.to(tensor.dtype).contiguous()
+                stats["diff"] += 1
+            else:
+                LOG.warning("no .diff spelling for %s", key)
+                stats["dropped_absent_ft"] += 1
+
+    metadata = {
+        "format": "fastvideo-lora-v2",
+        "base_model": source_meta.get("base_model", ""),
+        "finetuned_model": source_meta.get("finetuned_model", name or ""),
+        "base_revision": source_meta.get("base_revision", ""),
+        "finetuned_revision": source_meta.get("finetuned_revision", ""),
+        "rank": str(sorted(ranks_seen)[-1]) if ranks_seen else str(rank or ""),
+        "application": ("W = W_base + lora_B @ lora_A; then .diff/.diff_b added and .set_weight assigned"),
+        "low_rank_tensors": str(stats["low_rank"]),
+        "diff_tensors": str(stats["diff"] + stats["diff_b"]),
+        "set_weight_tensors": str(stats["set_weight"]),
+        "dropped_unchanged": str(stats["dropped_identical"]),
+        "finalized_from": Path(adapter).name,
+    }
+
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    save_file(kept, str(out_path), metadata=metadata)
+    out_path.chmod(0o644)
+
+    size_gib = out_path.stat().st_size / 2**30
+    LOG.info(
+        "%s -> %s  (%.2f GiB)  low_rank=%d diff=%d diff_b=%d set_weight=%d  dropped: %d unchanged, %d unusable",
+        Path(adapter).name, out_path, size_gib, stats["low_rank"], stats["diff"], stats["diff_b"],
+        stats["set_weight"], stats["dropped_identical"], stats["dropped_absent_ft"])
+    return {"out": str(out_path), "size_gib": size_gib, "metadata": metadata, **stats}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--adapter", required=True, help="Raw extracted adapter (.safetensors)")
+    p.add_argument("--base", required=True, help="Base transformer directory or HF model id")
+    p.add_argument("--out", required=True, help="Output adapter path")
+    p.add_argument("--rank", type=int, default=None, help="Truncate factors to this rank (exact for SVD factors)")
+    p.add_argument("--name", default=None, help="Fine-tuned model name, when the source file does not record one")
+    p.add_argument("--min-delta",
+                   type=float,
+                   default=0.0,
+                   help="Drop a whole-tensor delta whose max abs value is at or below this (default: exact zeros only)")
+    p.add_argument("--summary-json", default=None, help="Write the summary dict here")
+    return p.parse_args()
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S")
+    args = parse_args()
+    summary = finalize(adapter=args.adapter,
+                       base=args.base,
+                       out=args.out,
+                       rank=args.rank,
+                       name=args.name,
+                       min_delta=args.min_delta)
+    if args.summary_json:
+        Path(args.summary_json).write_text(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lora_extraction/upload_adapter.py
+++ b/scripts/lora_extraction/upload_adapter.py
@@ -42,40 +42,34 @@ tags:
 # {title}
 
 LoRA extraction of [{finetuned}](https://huggingface.co/{finetuned}), a four-step DMD2
-distillation of [MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) under video
-sparse attention (VSA).
+distillation of [MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3){attention_clause}.
 
 ## What is in the file
 
 {variant_table}
 
-Each adapter is three kinds of payload, because a distillation of this model is not
-purely low-rank:
+This is not a purely low-rank adapter, because the distillation it captures is not a
+purely low-rank change:
 
 | kind | keys | what it is |
 |---|---|---|
 | low-rank factors | `<module>.lora_A/.lora_B` | attention, feed-forward and AdaLN projections |
-| exact deltas | `<module>.diff`, `<module>.diff_b` | norms and biases, where a rank-r factorization would cost more than the tensor |
-| whole parameters | `attn.to_gate_compress.set_weight` | the VSA compression gate, which **does not exist in base MiniMax-H3** |
-
-The `.set_weight` keys are why this is not an ordinary LoRA. `to_gate_compress` is
-created only under the VSA attention backend and is zero-initialized when a checkpoint
-does not carry it, so a loader that ignores those keys produces a model with the
-compression branch switched off — quietly, and without an error.
-
+| exact deltas | `<module>.diff`, `<module>.diff_b` | norms and biases, where a rank-r factorization of a length-n vector would cost more than the vector |
+{gate_row}
+{gate_note}
 ## Usage (FastVideo)
 
 ```bash
 python examples/inference/lora/minimax_h3_lora_inference.py \\
     --model-path MiniMaxAI/MiniMax-H3 \\
     --lora-path {repo_id} \\
-    --prompt "your prompt here"
+    --prompt "your prompt here"{usage_flags}
 ```
 
 The adapter must be supplied when the pipeline is constructed, not swapped in later: a
 parameter the base model lacks has to arrive while weights are still unsharded.
-Sample with **4 steps** (5 sigma-grid points), **cfg 1.0** — the checkpoint is
-guidance-distilled — and the VSA backend enabled.
+Sample with **4 steps** (5 sigma-grid points) and **cfg 1.0** — the checkpoint is
+guidance-distilled.{sampling_note}
 
 ## Fidelity
 
@@ -113,6 +107,12 @@ def inspect(path: Path) -> dict:
 
 
 def build_card(repo_id: str, variants: list[dict], fidelity: str) -> str:
+    """Render the card from what the files contain.
+
+    The VSA paragraphs are conditional on the adapter actually carrying gates: the dense
+    variants of these checkpoints have none, and a card that describes a payload the repo
+    does not hold is exactly the drift generating the card was supposed to prevent.
+    """
     finetuned = next((v["metadata"].get("finetuned_model") for v in variants if v["metadata"].get("finetuned_model")),
                      "")
     rows = ["| file | rank | low-rank | .diff | .set_weight | size |", "|---|---|---|---|---|---|"]
@@ -120,11 +120,27 @@ def build_card(repo_id: str, variants: list[dict], fidelity: str) -> str:
         rel = v["path"].relative_to(v["path"].parents[1])
         rows.append(f"| `{rel}` | {v['rank']} | {v['n_low_rank']} | {v['n_diff']} | "
                     f"{v['n_set']} | {v['size_gib']:.2f} GiB |")
+
+    has_gates = any(v["n_set"] for v in variants)
+    gate_row = ("| whole parameters | `attn.to_gate_compress.set_weight` | the VSA compression gate, which "
+                "**does not exist in base MiniMax-H3** |\n" if has_gates else "")
+    gate_note = ("\nThe `.set_weight` keys are why this needs a loader that understands them. "
+                 "`to_gate_compress` is created only under the VSA attention backend, and is zero-initialized "
+                 "when a checkpoint does not carry it — so a loader that ignores those keys silently produces a "
+                 "model with the compression branch switched off.\n" if has_gates else "")
+
     return CARD.format(
         title=repo_id.split("/")[-1],
         finetuned=finetuned,
         repo_id=repo_id,
         variant_table="\n".join(rows),
+        attention_clause=(" under video sparse attention (VSA)" if has_gates else
+                          " with dense attention (no VSA gates in this adapter)"),
+        gate_row=gate_row,
+        gate_note=gate_note,
+        usage_flags=" \\\n    --vsa" if has_gates else " \\\n    --no-vsa",
+        sampling_note=(" Enable the VSA backend: without it the gate has no module to load into and the "
+                       "loader will refuse." if has_gates else ""),
         fidelity=fidelity or "_not measured for this build_",
     )
 
@@ -134,7 +150,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--adapter-dir", required=True, help="directory holding rank-*/adapter_model.safetensors")
     parser.add_argument("--repo-id", required=True)
-    parser.add_argument("--fidelity-json", default=None, help="verification summary to quote in the card")
+    parser.add_argument("--rank",
+                        type=int,
+                        action="append",
+                        default=None,
+                        help="publish only this rank; repeat for several. Default: every rank present.")
+    parser.add_argument("--fidelity-md", default=None, help="markdown fragment of measured reconstruction error")
     parser.add_argument("--private", action="store_true")
     parser.add_argument("--dry-run", action="store_true", help="write the card locally and stop")
     parser.add_argument("--allow-bare-weights",
@@ -144,10 +165,14 @@ def main() -> None:
 
     root = Path(args.adapter_dir)
     files = sorted(root.glob("rank-*/adapter_model.safetensors"))
+    if args.rank:
+        wanted = {f"rank-{r}" for r in args.rank}
+        files = [f for f in files if f.parent.name in wanted]
     if not files:
-        raise SystemExit(f"no rank-*/adapter_model.safetensors under {root}")
+        raise SystemExit(f"no matching rank-*/adapter_model.safetensors under {root}")
 
     variants = [inspect(f) for f in files]
+    variants_paths = [v["path"] for v in variants]
     for v in variants:
         LOG.info("%s: rank=%s low_rank=%d diff=%d set_weight=%d bare=%d %.2f GiB", v["path"].parent.name, v["rank"],
                  v["n_low_rank"], v["n_diff"], v["n_set"], v["n_bare"], v["size_gib"])
@@ -156,9 +181,7 @@ def main() -> None:
                              f"loaders drop silently -- run finalize_adapter.py first, or pass "
                              f"--allow-bare-weights if you really mean it.")
 
-    fidelity = ""
-    if args.fidelity_json:
-        fidelity = "```\n" + Path(args.fidelity_json).read_text().strip() + "\n```"
+    fidelity = Path(args.fidelity_md).read_text().strip() if args.fidelity_md else ""
 
     card_path = root / "README.md"
     card_path.write_text(build_card(args.repo_id, variants, fidelity))
@@ -176,8 +199,9 @@ def main() -> None:
         folder_path=str(root),
         repo_id=args.repo_id,
         repo_type="model",
-        # Bookkeeping from the finalize step; the card already carries the numbers.
-        ignore_patterns=["*.json.tmp", "finalize_summary.json"],
+        # Only the ranks selected above, plus the card. Bookkeeping from the finalize
+        # step stays local; the card already carries the numbers that matter.
+        allow_patterns=[f"{f.parent.name}/*" for f in variants_paths] + ["README.md"],
     )
     LOG.info("done: https://huggingface.co/%s", args.repo_id)
 

--- a/scripts/lora_extraction/upload_adapter.py
+++ b/scripts/lora_extraction/upload_adapter.py
@@ -1,0 +1,186 @@
+"""Publish a finalized adapter to the Hugging Face Hub, with a card that matches it.
+
+The card is generated from the file rather than written by hand, so the tensor counts,
+rank, and sizes it advertises cannot drift from what is actually in the repo. Run
+``finalize_adapter.py`` first: this script refuses an adapter that still carries bare
+``<param>.weight`` keys, because those are the ones a loader silently drops.
+
+    python scripts/lora_extraction/upload_adapter.py \\
+        --adapter-dir /models/fasth3-loras-publish/FastH3-4-step-v1.1 \\
+        --repo-id FastVideo/FastH3-4-step-v1.1-LoRA --dry-run
+
+Drop ``--dry-run`` to actually push. Authentication comes from the usual
+``huggingface-cli login`` / ``HF_TOKEN`` sources; no token is read from the command line
+so it cannot end up in a shell history.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+
+from safetensors import safe_open
+
+LOG = logging.getLogger("upload_adapter")
+
+CARD = """---
+license: other
+license_name: minimax-h3-community
+license_link: LICENSE
+base_model: MiniMaxAI/MiniMax-H3
+tags:
+- video-generation
+- minimax-h3
+- lora
+- distillation
+- few-step
+- fastvideo
+---
+
+# {title}
+
+LoRA extraction of [{finetuned}](https://huggingface.co/{finetuned}), a four-step DMD2
+distillation of [MiniMax-H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) under video
+sparse attention (VSA).
+
+## What is in the file
+
+{variant_table}
+
+Each adapter is three kinds of payload, because a distillation of this model is not
+purely low-rank:
+
+| kind | keys | what it is |
+|---|---|---|
+| low-rank factors | `<module>.lora_A/.lora_B` | attention, feed-forward and AdaLN projections |
+| exact deltas | `<module>.diff`, `<module>.diff_b` | norms and biases, where a rank-r factorization would cost more than the tensor |
+| whole parameters | `attn.to_gate_compress.set_weight` | the VSA compression gate, which **does not exist in base MiniMax-H3** |
+
+The `.set_weight` keys are why this is not an ordinary LoRA. `to_gate_compress` is
+created only under the VSA attention backend and is zero-initialized when a checkpoint
+does not carry it, so a loader that ignores those keys produces a model with the
+compression branch switched off — quietly, and without an error.
+
+## Usage (FastVideo)
+
+```bash
+python examples/inference/lora/minimax_h3_lora_inference.py \\
+    --model-path MiniMaxAI/MiniMax-H3 \\
+    --lora-path {repo_id} \\
+    --prompt "your prompt here"
+```
+
+The adapter must be supplied when the pipeline is constructed, not swapped in later: a
+parameter the base model lacks has to arrive while weights are still unsharded.
+Sample with **4 steps** (5 sigma-grid points), **cfg 1.0** — the checkpoint is
+guidance-distilled — and the VSA backend enabled.
+
+## Fidelity
+
+Reconstruction against the checkpoint this was extracted from, as relative Frobenius
+error per parameter family:
+
+{fidelity}
+
+`.diff` and `.set_weight` families are stored exactly. The low-rank families carry the
+SVD truncation tail, which is what choosing a rank buys or costs.
+
+## License
+
+MiniMax H3 Community License, inherited from the base model. Review its territory and
+acceptable-use terms before use or redistribution.
+"""
+
+
+def inspect(path: Path) -> dict:
+    """Counts, rank, and size of one adapter file, read from its header."""
+    with safe_open(path, framework="pt") as handle:
+        meta = handle.metadata() or {}
+        keys = list(handle.keys())
+        ranks = {handle.get_slice(k).get_shape()[0] for k in keys if ".lora_A" in k}
+    return {
+        "path": path,
+        "metadata": meta,
+        "n_low_rank": sum(1 for k in keys if ".lora_" in k),
+        "n_diff": sum(1 for k in keys if k.endswith((".diff", ".diff_b"))),
+        "n_set": sum(1 for k in keys if k.endswith(".set_weight")),
+        "n_bare": sum(1 for k in keys if k.endswith((".weight", ".bias")) and ".lora_" not in k),
+        "rank": max(ranks) if ranks else None,
+        "size_gib": path.stat().st_size / 2**30,
+    }
+
+
+def build_card(repo_id: str, variants: list[dict], fidelity: str) -> str:
+    finetuned = next((v["metadata"].get("finetuned_model") for v in variants if v["metadata"].get("finetuned_model")),
+                     "")
+    rows = ["| file | rank | low-rank | .diff | .set_weight | size |", "|---|---|---|---|---|---|"]
+    for v in sorted(variants, key=lambda x: x["rank"] or 0):
+        rel = v["path"].relative_to(v["path"].parents[1])
+        rows.append(f"| `{rel}` | {v['rank']} | {v['n_low_rank']} | {v['n_diff']} | "
+                    f"{v['n_set']} | {v['size_gib']:.2f} GiB |")
+    return CARD.format(
+        title=repo_id.split("/")[-1],
+        finetuned=finetuned,
+        repo_id=repo_id,
+        variant_table="\n".join(rows),
+        fidelity=fidelity or "_not measured for this build_",
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt="%H:%M:%S")
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--adapter-dir", required=True, help="directory holding rank-*/adapter_model.safetensors")
+    parser.add_argument("--repo-id", required=True)
+    parser.add_argument("--fidelity-json", default=None, help="verification summary to quote in the card")
+    parser.add_argument("--private", action="store_true")
+    parser.add_argument("--dry-run", action="store_true", help="write the card locally and stop")
+    parser.add_argument("--allow-bare-weights",
+                        action="store_true",
+                        help="upload even when the adapter still carries unconvertible bare .weight keys")
+    args = parser.parse_args()
+
+    root = Path(args.adapter_dir)
+    files = sorted(root.glob("rank-*/adapter_model.safetensors"))
+    if not files:
+        raise SystemExit(f"no rank-*/adapter_model.safetensors under {root}")
+
+    variants = [inspect(f) for f in files]
+    for v in variants:
+        LOG.info("%s: rank=%s low_rank=%d diff=%d set_weight=%d bare=%d %.2f GiB", v["path"].parent.name, v["rank"],
+                 v["n_low_rank"], v["n_diff"], v["n_set"], v["n_bare"], v["size_gib"])
+        if v["n_bare"] and not args.allow_bare_weights:
+            raise SystemExit(f"{v['path']} still has {v['n_bare']} bare .weight/.bias keys. Those are the keys "
+                             f"loaders drop silently -- run finalize_adapter.py first, or pass "
+                             f"--allow-bare-weights if you really mean it.")
+
+    fidelity = ""
+    if args.fidelity_json:
+        fidelity = "```\n" + Path(args.fidelity_json).read_text().strip() + "\n```"
+
+    card_path = root / "README.md"
+    card_path.write_text(build_card(args.repo_id, variants, fidelity))
+    LOG.info("wrote %s", card_path)
+
+    if args.dry_run:
+        LOG.info("dry run: not uploading. Review %s, then rerun without --dry-run.", card_path)
+        return
+
+    from huggingface_hub import HfApi
+    api = HfApi()
+    api.create_repo(repo_id=args.repo_id, repo_type="model", private=args.private, exist_ok=True)
+    LOG.info("uploading %s -> %s", root, args.repo_id)
+    api.upload_folder(
+        folder_path=str(root),
+        repo_id=args.repo_id,
+        repo_type="model",
+        # Bookkeeping from the finalize step; the card already carries the numbers.
+        ignore_patterns=["*.json.tmp", "finalize_summary.json"],
+    )
+    LOG.info("done: https://huggingface.co/%s", args.repo_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

Add inference support for MiniMax H3 LoRA adapters, including FastH3 distillation adapters whose payload is not purely low-rank. These adapters can carry exact parameter deltas and VSA compression-gate weights that must be applied while the base transformer is still unsharded.

Source branch: `shaoxiongduan/FastVideo:shao/h3-lora-inference`  
Validated head: `0d62ba7d3b9e08e5d1a6e2f1f7857cc1cfe88bbf`

## Changes

- Add construction-time MiniMax H3 LoRA loading for low-rank factors, exact `.diff` / `.diff_b` deltas, and whole `.set_weight` parameters.
- Apply dense adapter payloads through the component/FSDP loading path before sharding.
- Preserve the wrapped layer's `.weight` and `.bias` interface for existing model code.
- Detect whether an adapter carries VSA gates and require FastVideo's VSA-H3 backend only when those gates are present.
- Add a runnable MiniMax H3 LoRA inference example and a Gradio fidelity-review tool.
- Add ComfyUI-layout conversion plus extraction, finalization, and upload utilities.
- Add focused loader tests for key normalization, dense payload application, validation, and failure cases.

## Test plan and results

Static validation:

- `git diff --check origin/main...HEAD`: passed.
- Python bytecode compilation for the new inference, loader, conversion, extraction, finalization, upload, and review modules: passed.

B200 validation on one four-GPU tray, using Base H3 revision `9bfb6693f2cf6de171db46d1aa586f67d773a1da`, adapter bundle revision `7c66997ff550e53e9814ba17202411be11052b4b`, 768×1344×124, seed 1000, and five scheduler points / four DiT forwards:

- Dense Data-Free rank-64 adapter: passed. All 85 exact dense deltas applied; 362 low-rank layers applied; FA4 selected. Denoise 18.61 s; generation 29.09 s; e2e 29.57 s.
- VSA Data-Free rank-64 adapter: passed. All 132 exact/replacement parameters applied, including 50 compression gates; 362 low-rank layers applied; VSA-H3 selected the tile-64 `sm100a` CUDA block-sparse kernel. Denoise 9.28 s; generation 18.91 s; e2e 19.35 s.
- Both outputs contain 124 H.264 frames at 1344×768 / 24 fps and AAC audio. Stream validation used PyAV because the compute image does not include the `ffprobe` CLI.
- `pytest fastvideo/tests/loader/test_lora_patch.py -q`: 26 passed on the B200 allocation.

Artifacts and full logs:

- `/mnt/lustre/vlm-wlsaidhi/fastvideo/vsa_gate/pr1769_h3_lora_20260827/outputs/{dense-datafree,vsa-datafree}/000_000.mp4`
- `/mnt/lustre/vlm-wlsaidhi/fastvideo/vsa_gate/pr1769_h3_lora_20260827/logs/{dense-datafree,vsa-datafree}-4634.log`

## Scope and limitations

- FastH3 adapters must be supplied during pipeline construction; applying only the low-rank half later cannot reconstruct exact deltas or parameters absent from the base model.
- VSA adapters must run with FastVideo's Video Sparse Attention backend and kernel. Dense adapters do not require VSA.
- The FastH3 examples use the trained four-jump schedule, guidance scale 1.0, and T2VA.
- Until umbrella-repository subfolder resolution is fixed, download the exact adapter file first and pass its local path.

## Checklist

- [x] Added focused loader coverage.
- [x] Added runnable inference and review examples.
- [x] Static validation passes.
- [x] Dense adapter B200 inference passes.
- [x] VSA adapter B200 inference passes with the expected kernel route.
- [x] Focused loader tests pass inside the B200 environment.
