### PR TITLE
[feat] Add MiniMax H3 MLX T2VA inference

### DIFF
--- a/docs/getting_started/installation/mps.md
+++ b/docs/getting_started/installation/mps.md
@@ -1,8 +1,9 @@
 # MPS (Apple Silicon)
 
-Install FastVideo on Apple Silicon and run FastMetal-QAD.
+Install FastVideo on Apple Silicon and run FastMetal-QAD or FastH3 Preview.
 
-Apple Silicon uses the MLX runtime and the FastMetal-QAD INT8 checkpoints.
+Apple Silicon uses the MLX runtime. FastMetal-QAD ships ready-to-run MLX
+checkpoints; FastH3 Preview currently requires a local MLX DiT conversion.
 See the [FastMetal-QAD blog](https://haoailab.com/blogs/fastmetal/) and the
 [FastMetal collection](https://huggingface.co/collections/FastVideo/fastmetal).
 
@@ -132,6 +133,57 @@ CUDA FastWan-QAD (`FastVideo/FastWan-QAD-1.3B`, `FastVideo/FastWan-QAD-FP8-1.3B`
 
 `basic_mps.py` is a generic PyTorch MPS demo. For local video on Mac, use the FastMetal commands above.
 
+## Run FastH3 Preview
+
+FastH3 Preview uses the existing MLX runtime for text-to-video-with-audio
+(T2VA). The runtime streams the Qwen3-VL text conditioner, loads one
+heavyweight component at a time, denoises synchronized video and audio
+latents with a converted INT8, INT6, or INT4 DiT, and decodes both modalities
+with native MLX VAEs.
+
+Download the FastH3 snapshot, then convert one or more DiT formats:
+
+```bash
+hf download FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2 \
+  --local-dir ./FastH3-Preview-v0.2
+
+python scripts/checkpoint_conversion/convert_minimax_h3_mlx.py \
+  --model-root ./FastH3-Preview-v0.2/transformer \
+  --out ./FastH3-MLX \
+  --formats "int6"
+```
+
+Run the baseline path:
+
+```bash
+python examples/inference/basic/mlx_fasth3.py \
+  --model-root ./FastH3-Preview-v0.2 \
+  --mlx-checkpoint ./FastH3-MLX/int6 \
+  --prompt "(S1) A presenter says <d>[English] Fast H3 is amazing.</d>" \
+  --height 480 --width 832 --num-frames 124 --seed 2026 \
+  --output-path ./outputs/fasth3_int6.mp4
+```
+
+Add `--fast` for temporal fast mode. It denoises a shorter video sequence,
+uses MLX RIFE to restore the requested frame count, and keeps the audio
+sequence at full duration:
+
+```bash
+python examples/inference/basic/mlx_fasth3.py \
+  --model-root ./FastH3-Preview-v0.2 \
+  --mlx-checkpoint ./FastH3-MLX/int6 \
+  --prompt "(S1) A presenter says <d>[English] Fast H3 is even faster.</d>" \
+  --height 720 --width 1280 --num-frames 124 --seed 2027 \
+  --fast \
+  --output-path ./outputs/fasth3_int6_fast_720p.mp4
+```
+
+!!! note "Current MLX scope"
+    This source runtime supports T2VA and temporal `--fast`. FL2VA, Ref2VA,
+    spatial fast mode, two-pass refinement, VSA, and `VideoGenerator`
+    registry dispatch are not wired yet. The checkpoint uses the MiniMax H3
+    Community License; review the model card before use or redistribution.
+
 ## Development Environment Setup
 
 If you're planning to contribute to FastVideo please see the following page:
@@ -141,6 +193,9 @@ If you're planning to contribute to FastVideo please see the following page:
 
 - **1.3B / 5B:** 16 GB unified memory and up (M1 and later)
 - **14B:** 36 GB unified memory and up
+- **FastH3 Preview:** validated on an M4 Max with 36 GB unified memory; use one
+  converted DiT format at a time and leave substantial free disk space for the
+  source snapshot plus the converted checkpoint
 - Fanless 13-inch MacBook Air can run 1.3B and 5B at the same resolutions
 
 ## Troubleshooting

--- a/docs/inference/support_matrix.md
+++ b/docs/inference/support_matrix.md
@@ -185,8 +185,11 @@ optimizations: absence means **untested**, not incompatible.
 | MLX FastMetal T2V 1.3B | [`FastVideo/FastMetal-1.3B-QAD`](https://huggingface.co/FastVideo/FastMetal-1.3B-QAD) | 480x832, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 16 GB+ unified memory | Released |
 | MLX FastMetal TI2V 5B | [`FastVideo/FastMetal-5B-QAD`](https://huggingface.co/FastVideo/FastMetal-5B-QAD) | 480p / 720p, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 16 GB+ unified memory | Released |
 | MLX FastMetal T2V 14B | [`FastVideo/FastMetal-14B-QAD`](https://huggingface.co/FastVideo/FastMetal-14B-QAD) | 480p / 720p, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 36 GB+ unified memory | Released |
+| MLX FastH3 Preview T2VA | [`FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2`](https://huggingface.co/FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2) + locally converted DiT | 480p / 720p, 124 frames, 4-step DMD2, INT8/INT6/INT4 DiT, native video + audio VAE; optional temporal RIFE fast mode | Apple M4 Max, 36 GB unified memory | Source runtime; T2VA only |
 
-Apple Silicon uses FastMetal-QAD. CUDA FastWan-QAD (`FastVideo/FastWan-QAD-1.3B`,
+Apple Silicon uses the native MLX runtime. FastMetal-QAD is the packaged Wan
+release, while FastH3 Preview currently uses a source checkout and local DiT
+conversion. CUDA FastWan-QAD (`FastVideo/FastWan-QAD-1.3B`,
 `FastVideo/FastWan-QAD-FP8-1.3B`) is the NVIDIA release. See the
 [Apple Silicon guide](../getting_started/installation/mps.md) and the
 [FastMetal-QAD blog](https://haoailab.com/blogs/fastmetal/).

--- a/examples/inference/basic/README.md
+++ b/examples/inference/basic/README.md
@@ -39,6 +39,23 @@ with
 
 `examples/inference/basic/basic_mps.py` is the older PyTorch MPS demo.
 
+FastH3 Preview T2VA also runs through the native MLX runtime. Convert the DiT
+to INT8, INT6, or INT4 first, then run:
+
+~~~bash
+python examples/inference/basic/mlx_fasth3.py \
+  --model-root ./FastH3-Preview-v0.2 \
+  --mlx-checkpoint ./FastH3-MLX/int6 \
+  --prompt "(S1) A presenter says <d>[English] Fast H3 is amazing.</d>" \
+  --height 480 --width 832 --num-frames 124 \
+  --output-path ./outputs/fasth3_int6.mp4
+~~~
+
+Pass `--fast` for temporal RIFE fast mode. This MLX entrypoint currently
+supports T2VA only; FL2VA, Ref2VA, spatial fast mode, and two-pass refinement
+remain follow-up work. The complete setup and conversion commands are in the
+[Apple Silicon guide](https://hao-ai-lab.github.io/FastVideo/getting_started/installation/mps/).
+
 For an example running DMD+VSA inference:
 ```
 python examples/inference/basic/basic_dmd.py

--- a/examples/inference/basic/README.md
+++ b/examples/inference/basic/README.md
@@ -42,14 +42,14 @@ with
 FastH3 Preview T2VA also runs through the native MLX runtime. Convert the DiT
 to INT8, INT6, or INT4 first, then run:
 
-~~~bash
+```bash
 python examples/inference/basic/mlx_fasth3.py \
   --model-root ./FastH3-Preview-v0.2 \
   --mlx-checkpoint ./FastH3-MLX/int6 \
   --prompt "(S1) A presenter says <d>[English] Fast H3 is amazing.</d>" \
   --height 480 --width 832 --num-frames 124 \
   --output-path ./outputs/fasth3_int6.mp4
-~~~
+```
 
 Pass `--fast` for temporal RIFE fast mode. This MLX entrypoint currently
 supports T2VA only; FL2VA, Ref2VA, spatial fast mode, and two-pass refinement

--- a/examples/inference/basic/mlx_fasth3.py
+++ b/examples/inference/basic/mlx_fasth3.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end MiniMax-H3 (FastH3) generation with the Apple Silicon MLX runtime.
+
+Accepts a text prompt and produces an MP4 with H.264 video at 24 fps and
+stereo AAC audio at 32 kHz. One heavyweight model phase is resident at a time.
+
+    python examples/inference/basic/mlx_fasth3.py \
+      --model-root ~/models/FastH3-Preview-v0.2 \
+      --mlx-checkpoint ~/models/FastH3-MLX/int8 \
+      --prompt '(S1) A red panda says <d>[English] Fast H3 is amazing.</d>' \
+      --height 480 --width 832 --num-frames 124 --seed 2026 \
+      --output-path ~/fasth3_outputs/int8.mp4
+
+Conditioning uses the streamed Qwen3-VL text encoder on first use and caches
+the resulting embeddings under --prompt-cache-dir for instant reuse.
+
+``--fast`` is temporal fast mode. It keeps full-duration audio while
+denoising fewer video frames, then uses MLX RIFE 4.25 to reconstruct the
+requested frame count. A 1280x720 request runs on H3's 1280x736 grid and is
+center-cropped after decode.
+
+This entrypoint currently supports text-to-video-with-audio only. It does not
+yet wire FL2VA, Ref2VA, spatial fast mode, or two-pass refinement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model-root", type=Path, default=Path.home() / "models/FastH3-Preview-v0.2",
+                        help="H3 snapshot root (vae/, audio_vae/, text_encoder/, tokenizer/)")
+    parser.add_argument("--mlx-checkpoint", type=Path, required=True,
+                        help="pre-quantized MLX DiT directory (int8/int6/int4 mlx_h3_dit format)")
+    parser.add_argument(
+        "--prompt",
+        required=True,
+        help="H3 text prompt; use (S1) and <d>[Language] words</d> for explicit dialogue",
+    )
+    parser.add_argument("--output-path", type=Path, required=True)
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--width", type=int, default=832)
+    parser.add_argument("--num-frames", type=int, default=124)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--steps", type=int, default=4, help="denoise steps (trained ladder = 4)")
+    parser.add_argument(
+        "--fast",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="denoise fewer video frames, then use MLX RIFE to restore the target frame count; audio stays full length",
+    )
+    parser.add_argument("--fast-factor", type=int, default=2,
+                        help="temporal reduction target for --fast (default: 2)")
+    parser.add_argument("--fast-sharpen", type=float, default=0.6,
+                        help="unsharp strength after RIFE interpolation (0 disables)")
+    parser.add_argument("--rife-weights-dir", type=Path, default=None,
+                        help="optional local mlx-community/RIFE-4.25 snapshot")
+    parser.add_argument("--vae-dtype", choices=("fp32", "fp16", "bf16"), default="fp32")
+    parser.add_argument("--prompt-cache-dir", type=Path, default=None,
+                        help="directory for reusable prompt embedding caches")
+    parser.add_argument(
+        "--tiled-video-decode",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="decode with the reference 256px overlapping VAE tiles (disable only for diagnostics)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    from fastvideo.mlx_runtime.minimax_h3_pipeline import MiniMaxH3MLXPipeline
+
+    pipeline = MiniMaxH3MLXPipeline(
+        model_root=args.model_root,
+        mlx_dit_checkpoint=args.mlx_checkpoint,
+        vae_dtype=args.vae_dtype,
+        prompt_cache_dir=args.prompt_cache_dir,
+    )
+    result = pipeline.generate(
+        args.prompt,
+        output_path=args.output_path,
+        height=args.height,
+        width=args.width,
+        num_frames=args.num_frames,
+        seed=args.seed,
+        num_steps=args.steps,
+        tiled_video_decode=args.tiled_video_decode,
+        fast=args.fast,
+        fast_factor=args.fast_factor,
+        fast_sharpen=args.fast_sharpen,
+        rife_weights_dir=args.rife_weights_dir,
+    )
+    print(json.dumps({
+        "video_path": result.video_path,
+        "timings_s": {k: round(v, 2) for k, v in result.timings.items()},
+        "peak_memory_gib": {k: round(v, 2) for k, v in result.peak_memory_gib.items()},
+        "audio_samples": int(result.waveform.shape[-1]),
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/fastvideo/mlx_runtime/__init__.py
+++ b/fastvideo/mlx_runtime/__init__.py
@@ -1,10 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Experimental Apple MLX runtime helpers.
-
-This package is intentionally small for now. It exists to grow the Apple-native
-FastWan path in measurable steps: shape planning, primitive benchmarks, then
-Wan block parity, then full DiT/runtime support.
-"""
+"""Apple Silicon MLX inference helpers."""
 
 from fastvideo.mlx_runtime.fastwan import (
     FastWanShape,
@@ -71,6 +66,12 @@ from fastvideo.mlx_runtime.prompt_enhance import (
     enhance_result_as_metrics,
     load_or_enhance_prompt,
 )
+from fastvideo.mlx_runtime.minimax_h3_pipeline import (
+    FastTemporalPlan,
+    GenerationResult,
+    MiniMaxH3MLXPipeline,
+    plan_fast_temporal,
+)
 
 __all__ = [
     "AppliedMemoryLimits",
@@ -81,10 +82,13 @@ __all__ = [
     "DEFAULT_REFINE_SIGMA",
     "EnhanceResult",
     "FastSpatialPlan",
+    "FastTemporalPlan",
     "FastWanShape",
+    "GenerationResult",
     "MLXQuantizationSpec",
     "MLXWanDiT",
     "MLXWanTransformerBlock",
+    "MiniMaxH3MLXPipeline",
     "RefinePlan",
     "TwoPassResult",
     "UnsupportedMLXCheckpointError",
@@ -110,6 +114,7 @@ __all__ = [
     "PIXEL_UPSAMPLE_MODES",
     "default_refine_timesteps",
     "plan_fast_spatial",
+    "plan_fast_temporal",
     "plan_refine_resolutions",
     "prepare_refine_latents",
     "quantization_support_error",

--- a/fastvideo/mlx_runtime/fastwan.py
+++ b/fastvideo/mlx_runtime/fastwan.py
@@ -64,6 +64,8 @@ class MLXQuantizationSpec:
             return None
         if name == "int8":
             return cls(mode="affine", bits=8, group_size=64)
+        if name == "int6":
+            return cls(mode="affine", bits=6, group_size=64)
         if name == "int4":
             return cls(mode="affine", bits=4, group_size=64)
         if name == "mxfp8":

--- a/fastvideo/mlx_runtime/minimax_h3.py
+++ b/fastvideo/mlx_runtime/minimax_h3.py
@@ -75,11 +75,6 @@ MINIMAX_H3_AUDIO_TAG = 2
 MINIMAX_H3_MODALITY_NUM = 3
 
 MINIMAX_H3_FPS = 24
-MINIMAX_H3_SHORT_EDGE = 768
-MINIMAX_H3_MAX_PIXELS = 768 * 1344
-MINIMAX_H3_CANVAS_MULTIPLE = 32
-MINIMAX_H3_MIN_ASPECT_RATIO = 1 / 4
-MINIMAX_H3_MAX_ASPECT_RATIO = 4
 MINIMAX_H3_FRAMES_PER_CHUNK = 17
 MINIMAX_H3_LATENTS_PER_CHUNK = 5
 MINIMAX_H3_AUDIO_LATENTS_PER_SECOND = 40
@@ -130,24 +125,6 @@ def _is_ignored_dense_key(key: str) -> bool:
 # ---------------------------------------------------------------------------
 # Geometry (numpy, float64 — the reference RoPE coordinate arithmetic)
 # ---------------------------------------------------------------------------
-
-
-def resolve_canvas_size(aspect_width: float, aspect_height: float) -> tuple[int, int]:
-    if aspect_width <= 0 or aspect_height <= 0:
-        raise ValueError(f"The aspect ratio must be positive, got {aspect_width}:{aspect_height}.")
-    ratio = aspect_width / aspect_height
-    if not MINIMAX_H3_MIN_ASPECT_RATIO <= ratio <= MINIMAX_H3_MAX_ASPECT_RATIO:
-        raise ValueError(f"MiniMax-H3 supports aspect ratios from 1:4 to 4:1, got {aspect_width}:{aspect_height}.")
-    if ratio >= 1:
-        width, height = MINIMAX_H3_SHORT_EDGE * ratio, float(MINIMAX_H3_SHORT_EDGE)
-    else:
-        width, height = float(MINIMAX_H3_SHORT_EDGE), MINIMAX_H3_SHORT_EDGE / ratio
-    area = width * height
-    if area > MINIMAX_H3_MAX_PIXELS:
-        scale = (MINIMAX_H3_MAX_PIXELS / area)**0.5
-        width, height = width * scale, height * scale
-    multiple = MINIMAX_H3_CANVAS_MULTIPLE
-    return max(multiple, round(height / multiple) * multiple), max(multiple, round(width / multiple) * multiple)
 
 
 def align_num_frames(num_frames: int) -> int:
@@ -644,11 +621,7 @@ class MLXMiniMaxH3DiT:
         blocks: list[dict[str, Any]],
         refiner: list[dict[str, Any]],
         config: dict[str, Any],
-        *,
-        compile: bool = False,
     ) -> None:
-        import os
-
         self.weights = weights
         self.blocks = blocks
         self.refiner = refiner
@@ -669,8 +642,6 @@ class MLXMiniMaxH3DiT:
         self.qk_norm_eps = float(config["qk_norm_eps"])
         self.final_norm_eps = float(config["final_norm_eps"])
         self.patch_dim = self.in_channels * math.prod(self.patch_size)
-        self._enable_compile = compile or os.environ.get("FASTVIDEO_MLX_COMPILE", "0") == "1"
-        self._compiled_forward = None
         self._adaln_cache: MiniMaxH3StepCache | None = None
 
     # -- conditioning ------------------------------------------------------
@@ -877,7 +848,7 @@ class MLXMiniMaxH3DiT:
         # Sync per block: without this, MLX enqueues the entire 50-block graph
         # while the GPU lags behind, allocating every intermediate at once
         # (observed as an OOM kill on 36 GiB Macs at 480x832).
-        for block, tables in zip(self.blocks, cache.block_tables, strict=False):
+        for block, tables in zip(self.blocks, cache.block_tables, strict=True):
             packed = _transformer_block(
                 block,
                 packed,
@@ -1124,158 +1095,6 @@ def mlx_h3_dit_from_diffusers_safetensors(
     )
     dit._adaln_cache = cache
     return dit
-
-
-def mlx_h3_bf16_forward_streamed_from_diffusers_safetensors(
-    transformer_path: str | Path,
-    video_rows,
-    audio_rows,
-    text_rows,
-    *,
-    position_ids,
-    token_tags,
-    timestep_indices,
-    timesteps,
-    video_indices,
-    audio_indices,
-    text_indices,
-):
-    """Run one bf16 H3 reference forward with one main block resident at a time.
-
-    The released dense reference remains about 37 GiB after excluding VSA
-    gates and cannot be resident on a 36 GiB Mac. Safetensors arrays stay
-    memory-mapped; global/refiner weights remain resident and each of the 50
-    main blocks is cast, evaluated, used, and released in sequence.
-    """
-    import gc
-
-    import mlx.core as mx
-
-    transformer_path = Path(transformer_path)
-    config_path = transformer_path / "config.json" if transformer_path.is_dir() else transformer_path.with_name(
-        "config.json")
-    config = json.loads(Path(config_path).read_text())
-    num_blocks = int(config["num_layers"])
-    num_refiner = int(config["num_refiner_layers"])
-
-    shards = _safetensors_shards(transformer_path)
-    shard_by_name = {shard.name: shard for shard in shards}
-    index_path = transformer_path / "diffusion_pytorch_model.safetensors.index.json"
-    keys_by_shard: dict[str, list[str]] = {name: [] for name in shard_by_name}
-    if index_path.exists():
-        weight_map = json.loads(index_path.read_text())["weight_map"]
-        for key, shard_name in weight_map.items():
-            keys_by_shard[shard_name].append(key)
-    else:
-        for shard in shards:
-            shard_arrays = mx.load(str(shard))
-            keys_by_shard[shard.name] = list(shard_arrays)
-            del shard_arrays
-
-    weights: dict[str, Any] = {}
-    refiner: list[dict[str, Any] | None] = [None] * num_refiner
-    for shard_name, shard_keys in keys_by_shard.items():
-        selected_keys = [
-            key for key in shard_keys if not key.startswith("transformer_blocks.") and not key.startswith("rope.")
-            and not _is_ignored_dense_key(key)
-        ]
-        if not selected_keys:
-            continue
-        shard_arrays = mx.load(str(shard_by_name[shard_name]))
-        for key in selected_keys:
-            keep_fp32 = key.split(".", 1)[0] in FP32_MODULE_PREFIXES
-            value = _load_array(shard_arrays[key], mx.float32 if keep_fp32 else mx.bfloat16)
-            if key.startswith("token_refiner.refiner_blocks."):
-                _, _, index_str, sub = key.split(".", 3)
-                index = int(index_str)
-                refiner_block = refiner[index]
-                if refiner_block is None:
-                    refiner_block = {}
-                    refiner[index] = refiner_block
-                refiner_block[sub] = value
-            else:
-                weights[key] = value
-        del shard_arrays
-        gc.collect()
-        mx.clear_cache()
-    if any(block is None for block in refiner):
-        raise KeyError("Missing token refiner weights for streamed BF16 forward.")
-
-    dit = MLXMiniMaxH3DiT(weights, [], [block for block in refiner if block is not None], config)
-    sequence_length = position_ids.shape[0]
-    cos, sin = rope_cos_sin(position_ids, dit.rope_freq_dim, dit.rope_theta)
-    video_embeds = linear(
-        video_rows.astype(weight_dtype(weights["proj_in.weight"])),
-        weights["proj_in.weight"],
-        weights["proj_in.bias"],
-    )
-    audio_embeds = linear(
-        audio_rows.astype(weight_dtype(weights["audio_proj_in.weight"])),
-        weights["audio_proj_in.weight"],
-        weights["audio_proj_in.bias"],
-    )
-    text_embeds = dit.refine_text(text_rows)
-    packed = mx.zeros((sequence_length, dit.hidden_size), dtype=text_embeds.dtype)
-    packed[_as_mx_indices(text_indices)] = text_embeds
-    packed[_as_mx_indices(video_indices)] = video_embeds.astype(text_embeds.dtype)
-    packed[_as_mx_indices(audio_indices)] = audio_embeds.astype(text_embeds.dtype)
-    temb = dit.compute_temb(timesteps)
-    adaln_indices = (timestep_indices * MINIMAX_H3_MODALITY_NUM + token_tags).astype(mx.int32)
-    mx.eval(packed, temb, cos, sin)
-    if not bool(mx.all(mx.isfinite(packed))) or not bool(mx.all(mx.isfinite(temb))):
-        raise FloatingPointError("Non-finite H3 activations before the first streamed bf16 transformer block.")
-
-    for block_index in range(num_blocks):
-        prefix = f"transformer_blocks.{block_index}."
-        block: dict[str, Any] = {}
-        for shard_name, shard_keys in keys_by_shard.items():
-            selected_keys = [key for key in shard_keys if key.startswith(prefix) and not _is_ignored_dense_key(key)]
-            if not selected_keys:
-                continue
-            shard_arrays = mx.load(str(shard_by_name[shard_name]))
-            for key in selected_keys:
-                block[key[len(prefix):]] = _load_array(shard_arrays[key], mx.bfloat16)
-            del shard_arrays
-        tables = _adaln_tables(block, temb)
-        packed = _transformer_block(
-            block,
-            packed,
-            tables,
-            adaln_indices,
-            cos,
-            sin,
-            num_heads=dit.num_heads,
-            head_dim=dit.head_dim,
-            norm_eps=dit.norm_eps,
-            qk_norm_eps=dit.qk_norm_eps,
-        )
-        mx.eval(packed)
-        if not bool(mx.all(mx.isfinite(packed))):
-            raise FloatingPointError(f"Non-finite H3 activations after streamed bf16 transformer block {block_index}.")
-        del tables, block
-        gc.collect()
-        mx.clear_cache()
-
-    shift_scale = linear(
-        silu(temb).astype(weight_dtype(weights["norm_out.linear.weight"])),
-        weights["norm_out.linear.weight"],
-        weights["norm_out.linear.bias"],
-    )
-    shift_rows, scale_rows = mx.split(shift_scale, 2, axis=-1)
-    normed = rms_norm(packed, weights["norm_out.norm.weight"], eps=dit.final_norm_eps)
-    normed = normed * (1.0 + scale_rows[timestep_indices]) + shift_rows[timestep_indices]
-    video_output = linear(
-        normed[_as_mx_indices(video_indices)].astype(weight_dtype(weights["proj_out.weight"])),
-        weights["proj_out.weight"],
-        weights["proj_out.bias"],
-    )
-    audio_output = linear(
-        normed[_as_mx_indices(audio_indices)].astype(weight_dtype(weights["audio_proj_out.weight"])),
-        weights["audio_proj_out.weight"],
-        weights["audio_proj_out.bias"],
-    )
-    mx.eval(video_output, audio_output)
-    return video_output, audio_output
 
 
 H3_FORMAT_VERSION = 1

--- a/fastvideo/mlx_runtime/minimax_h3.py
+++ b/fastvideo/mlx_runtime/minimax_h3.py
@@ -624,7 +624,8 @@ class MiniMaxH3StepCache:
     def positions(self, step_timesteps: np.ndarray) -> np.ndarray:
         """Map a step's unique timesteps to rows in the cached union."""
         positions = np.searchsorted(self.timesteps, step_timesteps)
-        if positions.size and not np.allclose(self.timesteps[positions], step_timesteps, atol=1e-6):
+        if (positions.size and (np.any(positions >= len(self.timesteps))
+                                or not np.allclose(self.timesteps[positions], step_timesteps, atol=1e-6))):
             raise ValueError(f"Step timesteps {step_timesteps} are not in the cached schedule union.")
         return positions.astype(np.int64)
 

--- a/fastvideo/mlx_runtime/minimax_h3.py
+++ b/fastvideo/mlx_runtime/minimax_h3.py
@@ -1,0 +1,1466 @@
+# SPDX-License-Identifier: Apache-2.0
+# mypy: disable-error-code=no-untyped-call
+"""MiniMax H3 joint audio-video DiT for the Apple Silicon MLX runtime.
+
+A faithful MLX port of the upstream CUDA reference:
+
+- DiT: ``fastvideo/models/dits/minimax_h3.py`` (merged upstream in #1674).
+  Single-stream packed transformer, per-head qk RMSNorm, 3-axis MM-RoPE
+  (96 of 128 head dims rotated), row-indexed AdaLN keyed by
+  ``(timestep, modality)``, dual video/audio output heads, 2-block text
+  token refiner.
+- Scheduler: ``fastvideo/models/schedulers/scheduling_minimax_h3.py``.
+  Rectified-flow Euler with H3's clean-time convention: ``t = 1 - sigma``,
+  data-ward velocity (``x0 = x_t + sigma * v``), exponential-shift sigma
+  grid (video shift 12.0, audio shift 3.0), fp32 Euler blend.
+- Packing: ``fastvideo/pipelines/basic/minimax_h3/packing.py``.
+  ``[text | condition | audio | video]`` rows, float64 position grids.
+
+Apple Silicon memory controls:
+
+- **AdaLN precompute cache.** ~40% of H3's parameters live in per-block
+  AdaLN projections whose output depends only on ``(timestep, modality)``.
+  For a fixed step schedule the full set of timesteps is known at load time,
+  so :meth:`MLXMiniMaxH3DiT.precompute_adaln` evaluates every modulation
+  table once and (optionally) drops the projection weights. This also removes
+  the repeated AdaLN projection work from each denoising step.
+- **Affine INT8, INT6, or INT4 quantization** of attention/FFN matrices
+  (group size 64). Modulation, embeddings, norms, and input/output projections
+  remain in higher precision.
+
+Checkpoint layout: the released H3 checkpoint uses the diffusers reference
+module names 1:1 (``transformer_blocks.{i}.attn.to_out.0.weight``,
+``ff.net.0.proj.weight``, ``time_embedder.linear_1.weight``, ...). This
+module keeps those names as the MLX weight keys — no renaming contract.
+``proj_in`` / ``audio_proj_in`` / ``time_embedder`` / ``proj_out`` /
+``audio_proj_out`` are fp32 in the release and are kept fp32 here.
+
+Nothing in this file requires the CUDA stack; it imports ``fastvideo.logger``
+only. Parity tests against the torch reference live in
+``fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from fastvideo.logger import init_logger
+from fastvideo.mlx_runtime.fastwan import (
+    MLXQuantizationSpec,
+    QuantizedMatrix,
+    ensure_quantization_supported,
+    linear,
+    quantize_matrix,
+    rms_norm,
+    silu,
+    timestep_embedding,
+    weight_dtype,
+)
+
+logger = init_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants (mirrors fastvideo/pipelines/basic/minimax_h3/packing.py)
+# ---------------------------------------------------------------------------
+
+MINIMAX_H3_VIDEO_TAG = 0
+MINIMAX_H3_TEXT_TAG = 1
+MINIMAX_H3_AUDIO_TAG = 2
+MINIMAX_H3_MODALITY_NUM = 3
+
+MINIMAX_H3_FPS = 24
+MINIMAX_H3_SHORT_EDGE = 768
+MINIMAX_H3_MAX_PIXELS = 768 * 1344
+MINIMAX_H3_CANVAS_MULTIPLE = 32
+MINIMAX_H3_MIN_ASPECT_RATIO = 1 / 4
+MINIMAX_H3_MAX_ASPECT_RATIO = 4
+MINIMAX_H3_FRAMES_PER_CHUNK = 17
+MINIMAX_H3_LATENTS_PER_CHUNK = 5
+MINIMAX_H3_AUDIO_LATENTS_PER_SECOND = 40
+MINIMAX_H3_AUDIO_CHANNELS = 2
+MINIMAX_H3_KEYFRAME_NOISE_AUG = 0.999
+
+MINIMAX_H3_VIDEO_SHIFT = 12.0
+MINIMAX_H3_AUDIO_SHIFT = 3.0
+
+MINIMAX_H3_ROPE_FRAME_RESCALE = 5.0 / 3.0
+MINIMAX_H3_ROPE_FRAMES_PER_LATENT = (1, 4, 4, 4, 4)
+_ROPE_SPATIAL_SCALE = 32.0
+
+# Modules the release checkpoint stores in fp32 (and this runtime keeps fp32).
+FP32_MODULE_PREFIXES = (
+    "proj_in",
+    "audio_proj_in",
+    "time_embedder",
+    "proj_out",
+    "audio_proj_out",
+)
+
+# Linear weights that go on the int8 deploy grid. Everything else — norms,
+# AdaLN/modulation, embeddings, input/output projections — stays unquantized.
+_QUANTIZABLE_SUFFIXES = (
+    "attn.to_q.weight",
+    "attn.to_k.weight",
+    "attn.to_v.weight",
+    "attn.to_out.0.weight",
+    "ff.net.0.proj.weight",
+    "ff.net.2.weight",
+)
+
+# The released FastH3 student carries VSA routing projections. The MLX path is
+# dense, so retaining these weights wastes about 3.6 GiB without affecting a
+# single output value.
+_IGNORED_DENSE_KEY_PARTS = ("attn.to_gate_compress", )
+
+
+def _is_quantizable(key: str) -> bool:
+    return key.endswith(_QUANTIZABLE_SUFFIXES)
+
+
+def _is_ignored_dense_key(key: str) -> bool:
+    return any(part in key for part in _IGNORED_DENSE_KEY_PARTS)
+
+
+# ---------------------------------------------------------------------------
+# Geometry (numpy, float64 — the reference RoPE coordinate arithmetic)
+# ---------------------------------------------------------------------------
+
+
+def resolve_canvas_size(aspect_width: float, aspect_height: float) -> tuple[int, int]:
+    if aspect_width <= 0 or aspect_height <= 0:
+        raise ValueError(f"The aspect ratio must be positive, got {aspect_width}:{aspect_height}.")
+    ratio = aspect_width / aspect_height
+    if not MINIMAX_H3_MIN_ASPECT_RATIO <= ratio <= MINIMAX_H3_MAX_ASPECT_RATIO:
+        raise ValueError(f"MiniMax-H3 supports aspect ratios from 1:4 to 4:1, got {aspect_width}:{aspect_height}.")
+    if ratio >= 1:
+        width, height = MINIMAX_H3_SHORT_EDGE * ratio, float(MINIMAX_H3_SHORT_EDGE)
+    else:
+        width, height = float(MINIMAX_H3_SHORT_EDGE), MINIMAX_H3_SHORT_EDGE / ratio
+    area = width * height
+    if area > MINIMAX_H3_MAX_PIXELS:
+        scale = (MINIMAX_H3_MAX_PIXELS / area)**0.5
+        width, height = width * scale, height * scale
+    multiple = MINIMAX_H3_CANVAS_MULTIPLE
+    return max(multiple, round(height / multiple) * multiple), max(multiple, round(width / multiple) * multiple)
+
+
+def align_num_frames(num_frames: int) -> int:
+    if num_frames < 1:
+        raise ValueError(f"`num_frames` must be positive, got {num_frames}.")
+    while num_frames % MINIMAX_H3_FRAMES_PER_CHUNK != MINIMAX_H3_LATENTS_PER_CHUNK:
+        num_frames += 1
+    return num_frames
+
+
+def video_latent_num_frames(num_frames: int) -> int:
+    if num_frames % MINIMAX_H3_FRAMES_PER_CHUNK != MINIMAX_H3_LATENTS_PER_CHUNK:
+        raise ValueError(f"`num_frames` must be of the form 17 * n + 5, got {num_frames}.")
+    return (num_frames - MINIMAX_H3_LATENTS_PER_CHUNK) // MINIMAX_H3_FRAMES_PER_CHUNK * MINIMAX_H3_LATENTS_PER_CHUNK + 2
+
+
+def audio_latent_num_frames(num_frames: int) -> int:
+    return int(round(num_frames / MINIMAX_H3_FPS * MINIMAX_H3_AUDIO_LATENTS_PER_SECOND))
+
+
+def spatial_position_grid(dim: int, patch: int, sqrt_area: float) -> np.ndarray:
+    ratio = dim / sqrt_area
+    left = (1.0 - ratio) / 2.0
+    # NumPy endpoint=False float64 arithmetic is the reference contract.
+    return np.linspace(left, left + ratio, dim // patch, endpoint=False) * _ROPE_SPATIAL_SCALE
+
+
+def temporal_position_grid(num_latent_frames: int, origin: float) -> np.ndarray:
+    spans = np.array(
+        [
+            MINIMAX_H3_ROPE_FRAME_RESCALE *
+            MINIMAX_H3_ROPE_FRAMES_PER_LATENT[index % len(MINIMAX_H3_ROPE_FRAMES_PER_LATENT)]
+            for index in range(num_latent_frames)
+        ],
+        dtype=np.float64,
+    )
+    return origin + np.concatenate([np.zeros(1, dtype=np.float64), spans[:-1].cumsum()])
+
+
+def _temporal_position_span(num_latent_frames: int) -> float:
+    # Preserve NumPy's pairwise summation order (reference parity note).
+    spans = np.ones(num_latent_frames, dtype=np.float64) * MINIMAX_H3_ROPE_FRAME_RESCALE
+    for index, frames in enumerate(MINIMAX_H3_ROPE_FRAMES_PER_LATENT):
+        spans[index::len(MINIMAX_H3_ROPE_FRAMES_PER_LATENT)] *= frames
+    return float(spans.sum())
+
+
+def patchify_video_latents(latents: np.ndarray, patch_size: tuple[int, int, int]) -> np.ndarray:
+    """(B, C, T, H, W) -> (B*T'*H'*W', C*pt*ph*pw), channel-major patch features."""
+    patch_t, patch_h, patch_w = patch_size
+    batch_size, channels, num_frames, height, width = latents.shape
+    if num_frames % patch_t or height % patch_h or width % patch_w:
+        raise ValueError(f"Latents of shape {latents.shape} are not divisible by the patch {patch_size}.")
+    latents = latents.reshape(
+        batch_size,
+        channels,
+        num_frames // patch_t,
+        patch_t,
+        height // patch_h,
+        patch_h,
+        width // patch_w,
+        patch_w,
+    )
+    latents = latents.transpose(0, 2, 4, 6, 1, 3, 5, 7)
+    return np.ascontiguousarray(latents.reshape(-1, channels * patch_t * patch_h * patch_w))
+
+
+def unpatchify_video_tokens(
+    rows: np.ndarray,
+    num_latent_frames: int,
+    latent_height: int,
+    latent_width: int,
+    channels: int,
+    patch_size: tuple[int, int, int],
+) -> np.ndarray:
+    patch_t, patch_h, patch_w = patch_size
+    rows = rows.reshape(
+        -1,
+        num_latent_frames // patch_t,
+        latent_height // patch_h,
+        latent_width // patch_w,
+        channels,
+        patch_t,
+        patch_h,
+        patch_w,
+    )
+    rows = rows.transpose(0, 4, 1, 5, 2, 6, 3, 7)
+    return np.ascontiguousarray(rows.reshape(-1, channels, num_latent_frames, latent_height, latent_width))
+
+
+def unpack_audio_tokens(rows: np.ndarray, num_audio_latents: int) -> np.ndarray:
+    """(2*num_audio_latents, feat) channel-major rows -> (2, feat, num_audio_latents)."""
+    rows = rows.reshape(MINIMAX_H3_AUDIO_CHANNELS, num_audio_latents, rows.shape[-1])
+    return np.ascontiguousarray(rows.transpose(0, 2, 1))
+
+
+@dataclass(frozen=True)
+class MiniMaxH3PackedLayout:
+    """One packed joint sequence and the geometry needed to interpret it.
+
+    Arrays are NumPy (position_ids in float64, indices int64) and converted
+    to MLX at the model boundary.
+    """
+
+    sequence_length: int
+    position_ids: np.ndarray
+    token_tags: np.ndarray
+    video_indices: np.ndarray
+    audio_indices: np.ndarray
+    text_indices: np.ndarray
+    num_condition_video_rows: int
+    num_condition_audio_rows: int
+    num_video_latent_frames: int
+    latent_height: int
+    latent_width: int
+    num_audio_latents: int
+
+
+def build_packed_layout(
+    num_text_tokens: int,
+    num_latent_frames: int,
+    latent_height: int,
+    latent_width: int,
+    num_audio_latents: int,
+    patch_size: tuple[int, int, int] = (1, 2, 2),
+    keyframe_anchors: tuple[str, ...] = (),
+    text_token_tags: np.ndarray | None = None,
+    video_temporal_scale: float = 1.0,
+) -> MiniMaxH3PackedLayout:
+    """Build the ``[text | condition | audio | video]`` layout (T2VA / FL2VA)."""
+    _, patch_h, patch_w = patch_size
+    if text_token_tags is None:
+        text_token_tags = np.full(num_text_tokens, MINIMAX_H3_TEXT_TAG, dtype=np.int64)
+    if text_token_tags.shape != (num_text_tokens, ):
+        raise ValueError(f"text_token_tags must have shape ({num_text_tokens},), got {text_token_tags.shape}.")
+    if not np.isin(text_token_tags, (MINIMAX_H3_TEXT_TAG, MINIMAX_H3_VIDEO_TAG)).all():
+        raise ValueError("text_token_tags may contain only text and vision tags.")
+    if not np.isfinite(video_temporal_scale) or video_temporal_scale <= 0:
+        raise ValueError(f"video_temporal_scale must be positive and finite, got {video_temporal_scale}.")
+    if keyframe_anchors and video_temporal_scale != 1.0:
+        raise ValueError("video_temporal_scale is currently supported only for T2VA without keyframe anchors.")
+
+    rows_per_frame = (latent_height // patch_h) * (latent_width // patch_w)
+    num_condition_rows = len(keyframe_anchors) * rows_per_frame
+    num_audio_rows = num_audio_latents * MINIMAX_H3_AUDIO_CHANNELS
+    num_video_rows = num_latent_frames * rows_per_frame
+    sequence_length = num_text_tokens + num_condition_rows + num_audio_rows + num_video_rows
+
+    condition_start = num_text_tokens
+    audio_start = condition_start + num_condition_rows
+    video_start = audio_start + num_audio_rows
+
+    position_ids = np.zeros((sequence_length, 3), dtype=np.float64)
+    position_ids[:num_text_tokens, 0] = np.arange(num_text_tokens, dtype=np.float64)
+
+    sqrt_area = float(np.sqrt(latent_height * latent_width))
+    height_grid = spatial_position_grid(latent_height, patch_h, sqrt_area)
+    width_grid = spatial_position_grid(latent_width, patch_w, sqrt_area)
+    mesh_h, mesh_w = np.meshgrid(height_grid, width_grid, indexing="ij")
+    frame_grid = np.stack([mesh_h.reshape(-1), mesh_w.reshape(-1)], axis=-1)
+
+    for index, anchor in enumerate(keyframe_anchors):
+        if anchor == "first":
+            anchor_time = float(num_text_tokens)
+        elif anchor == "last":
+            anchor_time = (float(num_text_tokens) + _temporal_position_span(num_latent_frames) -
+                           MINIMAX_H3_ROPE_FRAME_RESCALE)
+        else:
+            raise ValueError(f"A keyframe anchor must be 'first' or 'last', got {anchor!r}.")
+        rows = slice(condition_start + index * rows_per_frame, condition_start + (index + 1) * rows_per_frame)
+        position_ids[rows, 0] = anchor_time
+        position_ids[rows, 1:] = frame_grid
+
+    audio_time = float(num_text_tokens) + np.arange(num_audio_latents, dtype=np.float64)
+    position_ids[audio_start:video_start, 0] = np.tile(audio_time, MINIMAX_H3_AUDIO_CHANNELS)
+    position_ids[audio_start:video_start, 2] = np.concatenate([
+        np.full(num_audio_latents, float(width_grid[0]), dtype=np.float64),
+        np.full(num_audio_rows - num_audio_latents, float(width_grid[-1]), dtype=np.float64),
+    ])
+
+    frame_time = temporal_position_grid(num_latent_frames, 0.0) * video_temporal_scale + float(num_text_tokens)
+    position_ids[video_start:, 0] = np.repeat(frame_time, rows_per_frame)
+    position_ids[video_start:, 1:] = np.tile(frame_grid, (num_latent_frames, 1))
+
+    video_indices = np.concatenate([
+        np.arange(condition_start, audio_start),
+        np.arange(video_start, sequence_length),
+    ])
+    audio_indices = np.arange(audio_start, video_start)
+    text_indices = np.arange(num_text_tokens)
+    token_tags = np.empty(sequence_length, dtype=np.int64)
+    token_tags[text_indices] = text_token_tags
+    token_tags[audio_indices] = MINIMAX_H3_AUDIO_TAG
+    token_tags[video_indices] = MINIMAX_H3_VIDEO_TAG
+
+    return MiniMaxH3PackedLayout(
+        sequence_length=sequence_length,
+        position_ids=position_ids,
+        token_tags=token_tags,
+        video_indices=video_indices,
+        audio_indices=audio_indices,
+        text_indices=text_indices,
+        num_condition_video_rows=num_condition_rows,
+        num_condition_audio_rows=0,
+        num_video_latent_frames=num_latent_frames,
+        latent_height=latent_height,
+        latent_width=latent_width,
+        num_audio_latents=num_audio_latents,
+    )
+
+
+def build_row_timesteps(
+    layout: MiniMaxH3PackedLayout,
+    video_timestep: float,
+    audio_timestep: float,
+    condition_video_timestep: float = 1.0,
+    condition_audio_timestep: float = 1.0,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per-row timesteps -> (unique timesteps sorted ascending, per-row indices).
+
+    Matches ``torch.unique(..., sorted=True, return_inverse=True)``.
+    """
+    row_timesteps = np.full(layout.sequence_length, video_timestep, dtype=np.float64)
+    if layout.num_condition_video_rows:
+        row_timesteps[layout.video_indices[:layout.num_condition_video_rows]] = condition_video_timestep
+    row_timesteps[layout.audio_indices[layout.num_condition_audio_rows:]] = audio_timestep
+    if layout.num_condition_audio_rows:
+        row_timesteps[layout.audio_indices[:layout.num_condition_audio_rows]] = condition_audio_timestep
+    unique, inverse = np.unique(row_timesteps, return_inverse=True)
+    return unique.astype(np.float32), inverse.astype(np.int64)
+
+
+# ---------------------------------------------------------------------------
+# Scheduler (rectified flow, clean-time convention, data-ward velocity)
+# ---------------------------------------------------------------------------
+
+
+def _unique_consecutive(values: np.ndarray) -> np.ndarray:
+    if values.size == 0:
+        return values
+    keep = np.concatenate(([True], values[1:] != values[:-1]))
+    return values[keep]
+
+
+def minimax_h3_sigmas(shift: float, num_denoise_steps: int) -> np.ndarray:
+    """Sigma grid of length ``num_denoise_steps + 1`` (descending, ending at 0).
+
+    The reference ``set_timesteps(num_inference_steps=N)`` builds N sigmas and
+    N-1 timesteps; this wrapper takes the *denoise step count* directly, which
+    is what a sampler actually schedules.
+    """
+    if num_denoise_steps < 1:
+        raise ValueError(f"num_denoise_steps must be >= 1, got {num_denoise_steps}.")
+    base = np.linspace(1.0, 0.0, num_denoise_steps + 1, dtype=np.float64)
+    sigmas = shift * base / (1.0 + (shift - 1.0) * base)
+    return _unique_consecutive(sigmas).astype(np.float32)
+
+
+@dataclass
+class MiniMaxH3SchedulerState:
+    """One rectified-flow scheduler (use two: video shift 12, audio shift 3)."""
+
+    shift: float
+    sigmas: np.ndarray
+    timesteps: np.ndarray  # 1 - sigmas[:-1], fp32
+
+    @classmethod
+    def create(cls, shift: float, num_denoise_steps: int) -> MiniMaxH3SchedulerState:
+        if shift <= 0:
+            raise ValueError(f"`shift` must be positive, got {shift}.")
+        sigmas = minimax_h3_sigmas(shift, num_denoise_steps)
+        return cls(shift=shift, sigmas=sigmas, timesteps=(1.0 - sigmas[:-1]).astype(np.float32))
+
+    @property
+    def num_steps(self) -> int:
+        return int(self.timesteps.shape[0])
+
+    def step(self, model_output, step_index: int, sample):
+        """Data-ward Euler: x0 = x_t + sigma*v; blend toward x0 by sigma ratio.
+
+        fp32 blend for fp16/bf16 samples, matching the reference.
+        """
+        import mlx.core as mx
+
+        sigma_from_timestep = float(1.0 - self.timesteps[step_index])
+        denoised = sample + sigma_from_timestep * model_output
+        sigma = float(self.sigmas[step_index])
+        sigma_next = float(self.sigmas[step_index + 1])
+        ratio = sigma_next / sigma
+        prev = ratio * sample.astype(mx.float32) + (1.0 - ratio) * denoised.astype(mx.float32)
+        return prev.astype(sample.dtype)
+
+    def scale_noise(self, sample, timestep: float, noise):
+        """Conditioning noise-aug: t*sample + (1-t)*noise (t=0.999 for keyframes)."""
+        return timestep * sample + (1.0 - timestep) * noise
+
+
+# ---------------------------------------------------------------------------
+# DiT
+# ---------------------------------------------------------------------------
+
+
+def _as_mx_indices(indices):
+    """NumPy/python index arrays are not accepted by MLX indexing; convert."""
+    import mlx.core as mx
+
+    if isinstance(indices, mx.array):
+        return indices
+    return mx.array(np.asarray(indices, dtype=np.int64))
+
+
+def rope_cos_sin(position_ids, rope_freq_dim: int, rope_theta: float):
+    """(S, 3) positions -> (cos, sin) each (S, 6*rope_freq_dim), fp32.
+
+    Shared 16-freq inv_freq across the three axes; the (t, h, w) blocks are
+    concatenated and doubled, so the rotary width is 6 * rope_freq_dim (96 of
+    the 128 head dims at full size).
+    """
+    import mlx.core as mx
+
+    positions = position_ids.astype(mx.float32)
+    inv_freq = 1.0 / (rope_theta**(mx.arange(0, 2 * rope_freq_dim, 2, dtype=mx.float32) / (2 * rope_freq_dim)))
+    freqs = positions[:, :, None] * inv_freq[None, None, :]  # (S, 3, F)
+    freqs_t, freqs_h, freqs_w = freqs[:, 0], freqs[:, 1], freqs[:, 2]
+    freqs = mx.concatenate([freqs_t, freqs_h, freqs_w], axis=-1)
+    freqs = mx.concatenate([freqs, freqs], axis=-1)
+    return mx.cos(freqs), mx.sin(freqs)
+
+
+def apply_h3_rotary(x, cos, sin):
+    """Rotate the RoPE prefix of each head, preserving the rest.
+
+    x: (S, H, D); cos/sin: (S, R) with R <= D. Half-split (GPT-NeoX style)
+    rotation inside the rotary prefix, computed in fp32.
+    """
+    import mlx.core as mx
+
+    rotary_dim = cos.shape[-1]
+    x_rotary = x[..., :rotary_dim].astype(mx.float32)
+    x_pass = x[..., rotary_dim:]
+    cos_b = cos[:, None, :].astype(mx.float32)
+    sin_b = sin[:, None, :].astype(mx.float32)
+    first_half, second_half = mx.split(x_rotary, 2, axis=-1)
+    rotated = mx.concatenate([-second_half, first_half], axis=-1)
+    out = x_rotary * cos_b + rotated * sin_b
+    return mx.concatenate([out.astype(x.dtype), x_pass], axis=-1)
+
+
+def _attention(weights: dict[str, Any], x, cos, sin, *, num_heads: int, head_dim: int, eps: float, use_rope: bool):
+    """H3 attention: bias-free qkv, per-head qk RMSNorm, partial RoPE."""
+    import mlx.core as mx
+
+    seq_len = x.shape[0]
+    q = linear(x, weights["attn.to_q.weight"]).reshape(seq_len, num_heads, head_dim)
+    k = linear(x, weights["attn.to_k.weight"]).reshape(seq_len, num_heads, head_dim)
+    v = linear(x, weights["attn.to_v.weight"]).reshape(seq_len, num_heads, head_dim)
+    q = rms_norm(q, weights["attn.norm_q.weight"], eps=eps)
+    k = rms_norm(k, weights["attn.norm_k.weight"], eps=eps)
+    if use_rope:
+        q = apply_h3_rotary(q, cos, sin)
+        k = apply_h3_rotary(k, cos, sin)
+    # contiguous() guards against MLX fused-SDPA mis-computation on strided views.
+    attended = mx.fast.scaled_dot_product_attention(
+        mx.contiguous(q.transpose(1, 0, 2))[None],
+        mx.contiguous(k.transpose(1, 0, 2))[None],
+        mx.contiguous(v.transpose(1, 0, 2))[None],
+        scale=head_dim**-0.5,
+    )[0].transpose(1, 0, 2)
+    attended = mx.contiguous(attended.reshape(seq_len, num_heads * head_dim))
+    return linear(attended, weights["attn.to_out.0.weight"])
+
+
+def _feed_forward(weights: dict[str, Any], x):
+    """Bias-free SwiGLU with value-first packed halves: h * silu(gate)."""
+    import mlx.core as mx
+
+    hidden = linear(x, weights["ff.net.0.proj.weight"])
+    value, gate = mx.split(hidden, 2, axis=-1)
+    return linear(value * silu(gate), weights["ff.net.2.weight"])
+
+
+def _adaln_tables(weights: dict[str, Any], temb):
+    """Six (n_t * 3, hidden) modulation tables from (n_t, time_embed_dim)."""
+    import mlx.core as mx
+
+    projected = linear(
+        silu(temb).astype(weight_dtype(weights["adaln_proj.linear.weight"])),
+        weights["adaln_proj.linear.weight"],
+        weights["adaln_proj.linear.bias"],
+    )
+    hidden = weights["adaln_proj.linear.bias"].shape[0] // (6 * MINIMAX_H3_MODALITY_NUM)
+    tables = projected.reshape(-1, 6 * hidden)
+    return mx.split(tables, 6, axis=-1)
+
+
+def _transformer_block(
+    weights: dict[str, Any],
+    hidden_states,
+    tables,
+    adaln_indices,
+    cos,
+    sin,
+    *,
+    num_heads: int,
+    head_dim: int,
+    norm_eps: float,
+    qk_norm_eps: float,
+):
+    shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = tables
+
+    residual = hidden_states
+    normed = rms_norm(hidden_states, weights["norm1.weight"], eps=norm_eps)
+    normed = normed * (1.0 + scale_msa[adaln_indices]) + shift_msa[adaln_indices]
+    attn_output = _attention(
+        weights,
+        normed.astype(weight_dtype(weights["attn.to_q.weight"])),
+        cos,
+        sin,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        eps=qk_norm_eps,
+        use_rope=True,
+    )
+    hidden_states = residual + gate_msa[adaln_indices] * attn_output
+
+    residual = hidden_states
+    normed = rms_norm(hidden_states, weights["norm2.weight"], eps=norm_eps)
+    normed = normed * (1.0 + scale_mlp[adaln_indices]) + shift_mlp[adaln_indices]
+    ff_output = _feed_forward(weights, normed.astype(weight_dtype(weights["ff.net.0.proj.weight"])))
+    return residual + gate_mlp[adaln_indices] * ff_output
+
+
+def _refiner_block(
+    weights: dict[str, Any],
+    hidden_states,
+    *,
+    num_heads: int,
+    head_dim: int,
+    norm_eps: float,
+    qk_norm_eps: float,
+):
+    residual = hidden_states
+    normed = rms_norm(hidden_states, weights["norm1.weight"], eps=norm_eps)
+    attn_output = _attention(
+        weights,
+        normed.astype(weight_dtype(weights["attn.to_q.weight"])),
+        None,
+        None,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        eps=qk_norm_eps,
+        use_rope=False,
+    )
+    hidden_states = residual + attn_output
+    normed = rms_norm(hidden_states, weights["norm2.weight"], eps=norm_eps)
+    return hidden_states + _feed_forward(weights, normed.astype(weight_dtype(weights["ff.net.0.proj.weight"])))
+
+
+@dataclass
+class MiniMaxH3StepCache:
+    """Precomputed AdaLN tables + norm_out modulation for a fixed schedule.
+
+    Holds one row set per distinct timestep in ``timesteps`` (the union of
+    every denoise step's video/audio/condition timesteps). Blocks then index
+    tables directly and the per-block ``adaln_proj`` weights can be freed —
+    ~40% of H3's parameters never need to be resident during denoise.
+    """
+
+    timesteps: np.ndarray  # (n,) fp32, sorted
+    block_tables: list[tuple[Any, ...]]  # per block: 6 tables of (n*3, hidden)
+    norm_out_shift: Any  # (n, hidden)
+    norm_out_scale: Any  # (n, hidden)
+
+    def positions(self, step_timesteps: np.ndarray) -> np.ndarray:
+        """Map a step's unique timesteps to rows in the cached union."""
+        positions = np.searchsorted(self.timesteps, step_timesteps)
+        if positions.size and not np.allclose(self.timesteps[positions], step_timesteps, atol=1e-6):
+            raise ValueError(f"Step timesteps {step_timesteps} are not in the cached schedule union.")
+        return positions.astype(np.int64)
+
+
+class MLXMiniMaxH3DiT:
+    """MiniMax H3 joint audio-video DiT in MLX (batch-1 packed forward).
+
+    Weight dicts keep the released checkpoint's key names. ``blocks`` holds
+    the main transformer blocks, ``refiner`` the text refiner blocks; each is
+    a dict of arrays / :class:`QuantizedMatrix`.
+    """
+
+    def __init__(
+        self,
+        weights: dict[str, Any],
+        blocks: list[dict[str, Any]],
+        refiner: list[dict[str, Any]],
+        config: dict[str, Any],
+        *,
+        compile: bool = False,
+    ) -> None:
+        import os
+
+        self.weights = weights
+        self.blocks = blocks
+        self.refiner = refiner
+        self.config = config
+        self.hidden_size = int(config["hidden_size"])
+        self.num_heads = int(config["num_attention_heads"])
+        self.head_dim = int(config["attention_head_dim"])
+        self.ffn_dim = int(config["ffn_dim"])
+        self.in_channels = int(config["in_channels"])
+        self.audio_in_channels = int(config["audio_in_channels"])
+        self.patch_size = tuple(config["patch_size"])
+        self.text_dim = int(config["text_dim"])
+        self.freq_dim = int(config["freq_dim"])
+        self.time_embed_dim = int(config["time_embed_dim"])
+        self.rope_freq_dim = int(config["rope_freq_dim"])
+        self.rope_theta = float(config["rope_theta"])
+        self.norm_eps = float(config["norm_eps"])
+        self.qk_norm_eps = float(config["qk_norm_eps"])
+        self.final_norm_eps = float(config["final_norm_eps"])
+        self.patch_dim = self.in_channels * math.prod(self.patch_size)
+        self._enable_compile = compile or os.environ.get("FASTVIDEO_MLX_COMPILE", "0") == "1"
+        self._compiled_forward = None
+        self._adaln_cache: MiniMaxH3StepCache | None = None
+
+    # -- conditioning ------------------------------------------------------
+
+    def compute_temb(self, timesteps):
+        """(n,) timesteps -> (n, time_embed_dim) through time_proj + MLP."""
+        t_freq = timestep_embedding(timesteps,
+                                    self.freq_dim).astype(weight_dtype(self.weights["time_embedder.linear_1.weight"]))
+        temb = linear(
+            t_freq,
+            self.weights["time_embedder.linear_1.weight"],
+            self.weights["time_embedder.linear_1.bias"],
+        )
+        return linear(
+            silu(temb),
+            self.weights["time_embedder.linear_2.weight"],
+            self.weights["time_embedder.linear_2.bias"],
+        )
+
+    def refine_text(self, text_rows):
+        hidden = linear(
+            text_rows.astype(weight_dtype(self.weights["context_embedder.weight"])),
+            self.weights["context_embedder.weight"],
+            self.weights["context_embedder.bias"],
+        )
+        for block in self.refiner:
+            hidden = _refiner_block(
+                block,
+                hidden,
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
+                norm_eps=self.norm_eps,
+                qk_norm_eps=self.qk_norm_eps,
+            )
+        return rms_norm(hidden, self.weights["token_refiner.final_norm.weight"], eps=self.final_norm_eps)
+
+    # -- AdaLN cache --------------------------------------------------------
+
+    def precompute_adaln(self, timesteps: np.ndarray, *, drop_weights: bool = True) -> MiniMaxH3StepCache:
+        """Evaluate every modulation table for a fixed schedule, once.
+
+        ``timesteps`` is the union (sorted, unique) of all per-step
+        video/audio/condition timesteps the sampler will use. With
+        ``drop_weights=True`` the per-block ``adaln_proj.linear`` weights are
+        released afterwards — the memory win this runtime exists for.
+        """
+        import mlx.core as mx
+
+        timesteps = np.unique(np.asarray(timesteps, dtype=np.float32))
+        temb = self.compute_temb(mx.array(timesteps))
+        block_tables = [_adaln_tables(block, temb) for block in self.blocks]
+        shift_scale = linear(
+            silu(temb).astype(weight_dtype(self.weights["norm_out.linear.weight"])),
+            self.weights["norm_out.linear.weight"],
+            self.weights["norm_out.linear.bias"],
+        )
+        norm_out_shift, norm_out_scale = mx.split(shift_scale, 2, axis=-1)
+        mx.eval(block_tables, norm_out_scale, norm_out_shift)
+        self._adaln_cache = MiniMaxH3StepCache(
+            timesteps=timesteps,
+            block_tables=block_tables,
+            norm_out_shift=norm_out_shift,
+            norm_out_scale=norm_out_scale,
+        )
+        if drop_weights:
+            for block in self.blocks:
+                block["adaln_proj.linear.weight"] = None
+                block["adaln_proj.linear.bias"] = None
+        return self._adaln_cache
+
+    # -- forward ------------------------------------------------------------
+
+    def forward(
+        self,
+        video_rows,
+        audio_rows,
+        text_rows,
+        *,
+        position_ids,
+        token_tags,
+        timestep_indices,
+        timesteps,
+        video_indices,
+        audio_indices,
+        text_indices,
+    ):
+        """Faithful port of the torch forward (batch-1, rows already patchified).
+
+        Returns (video_output, audio_output) rows. The torch reference
+        projects *all* packed rows through both heads and then selects; this
+        selects first and projects only the relevant rows — row-wise
+        identical math at a fraction of the cost.
+        """
+        import mlx.core as mx
+
+        sequence_length = position_ids.shape[0]
+        cos, sin = rope_cos_sin(position_ids, self.rope_freq_dim, self.rope_theta)
+
+        video_embeds = linear(
+            video_rows.astype(weight_dtype(self.weights["proj_in.weight"])),
+            self.weights["proj_in.weight"],
+            self.weights["proj_in.bias"],
+        )
+        audio_embeds = linear(
+            audio_rows.astype(weight_dtype(self.weights["audio_proj_in.weight"])),
+            self.weights["audio_proj_in.weight"],
+            self.weights["audio_proj_in.bias"],
+        )
+        text_embeds = self.refine_text(text_rows)
+
+        packed = mx.zeros((sequence_length, self.hidden_size), dtype=text_embeds.dtype)
+        packed[_as_mx_indices(text_indices)] = text_embeds
+        packed[_as_mx_indices(video_indices)] = video_embeds.astype(text_embeds.dtype)
+        packed[_as_mx_indices(audio_indices)] = audio_embeds.astype(text_embeds.dtype)
+
+        temb = self.compute_temb(timesteps)
+        adaln_indices = (timestep_indices * MINIMAX_H3_MODALITY_NUM + token_tags).astype(mx.int32)
+
+        for block in self.blocks:
+            tables = _adaln_tables(block, temb)
+            packed = _transformer_block(
+                block,
+                packed,
+                tables,
+                adaln_indices,
+                cos,
+                sin,
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
+                norm_eps=self.norm_eps,
+                qk_norm_eps=self.qk_norm_eps,
+            )
+            mx.eval(packed)  # per-block sync: see forward_with_cache note
+
+        shift_scale = linear(
+            silu(temb).astype(weight_dtype(self.weights["norm_out.linear.weight"])),
+            self.weights["norm_out.linear.weight"],
+            self.weights["norm_out.linear.bias"],
+        )
+        shift_rows, scale_rows = mx.split(shift_scale, 2, axis=-1)
+        normed = rms_norm(packed, self.weights["norm_out.norm.weight"], eps=self.final_norm_eps)
+        normed = normed * (1.0 + scale_rows[timestep_indices]) + shift_rows[timestep_indices]
+        video_output = linear(
+            normed[_as_mx_indices(video_indices)].astype(weight_dtype(self.weights["proj_out.weight"])),
+            self.weights["proj_out.weight"],
+            self.weights["proj_out.bias"],
+        )
+        audio_output = linear(
+            normed[_as_mx_indices(audio_indices)].astype(weight_dtype(self.weights["audio_proj_out.weight"])),
+            self.weights["audio_proj_out.weight"],
+            self.weights["audio_proj_out.bias"],
+        )
+        return video_output, audio_output
+
+    def forward_with_cache(
+        self,
+        video_rows,
+        audio_rows,
+        text_rows,
+        *,
+        layout: MiniMaxH3PackedLayout,
+        step_timesteps: np.ndarray,
+        row_timestep_inverse: np.ndarray,
+    ):
+        """Denoise-step forward served entirely from the AdaLN cache.
+
+        ``step_timesteps`` are this step's unique timesteps (sorted);
+        ``row_timestep_inverse`` maps each packed row to one of them (the
+        ``build_row_timesteps`` inverse). The cache must cover every value in
+        ``step_timesteps``.
+        """
+        import mlx.core as mx
+
+        if self._adaln_cache is None:
+            raise RuntimeError("precompute_adaln() must run before forward_with_cache().")
+        cache = self._adaln_cache
+        positions = mx.array(cache.positions(step_timesteps))
+
+        sequence_length = layout.sequence_length
+        position_ids = mx.array(layout.position_ids)
+        cos, sin = rope_cos_sin(position_ids, self.rope_freq_dim, self.rope_theta)
+
+        video_embeds = linear(
+            video_rows.astype(weight_dtype(self.weights["proj_in.weight"])),
+            self.weights["proj_in.weight"],
+            self.weights["proj_in.bias"],
+        )
+        audio_embeds = linear(
+            audio_rows.astype(weight_dtype(self.weights["audio_proj_in.weight"])),
+            self.weights["audio_proj_in.weight"],
+            self.weights["audio_proj_in.bias"],
+        )
+        text_embeds = self.refine_text(text_rows)
+
+        packed = mx.zeros((sequence_length, self.hidden_size), dtype=text_embeds.dtype)
+        packed[mx.array(layout.text_indices)] = text_embeds
+        packed[mx.array(layout.video_indices)] = video_embeds.astype(text_embeds.dtype)
+        packed[mx.array(layout.audio_indices)] = audio_embeds.astype(text_embeds.dtype)
+
+        token_tags = mx.array(layout.token_tags)
+        row_inverse = mx.array(row_timestep_inverse)
+        adaln_indices = (positions[row_inverse] * MINIMAX_H3_MODALITY_NUM + token_tags).astype(mx.int32)
+
+        # Sync per block: without this, MLX enqueues the entire 50-block graph
+        # while the GPU lags behind, allocating every intermediate at once
+        # (observed as an OOM kill on 36 GiB Macs at 480x832).
+        for block, tables in zip(self.blocks, cache.block_tables, strict=False):
+            packed = _transformer_block(
+                block,
+                packed,
+                tables,
+                adaln_indices,
+                cos,
+                sin,
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
+                norm_eps=self.norm_eps,
+                qk_norm_eps=self.qk_norm_eps,
+            )
+            mx.eval(packed)
+
+        row_positions = positions[row_inverse]
+        normed = rms_norm(packed, self.weights["norm_out.norm.weight"], eps=self.final_norm_eps)
+        normed = normed * (1.0 + cache.norm_out_scale[row_positions]) + cache.norm_out_shift[row_positions]
+        video_output = linear(
+            normed[mx.array(layout.video_indices)].astype(weight_dtype(self.weights["proj_out.weight"])),
+            self.weights["proj_out.weight"],
+            self.weights["proj_out.bias"],
+        )
+        audio_output = linear(
+            normed[mx.array(layout.audio_indices)].astype(weight_dtype(self.weights["audio_proj_out.weight"])),
+            self.weights["audio_proj_out.weight"],
+            self.weights["audio_proj_out.bias"],
+        )
+        return video_output, audio_output
+
+    __call__ = forward
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint loading (diffusers-layout safetensors) and pre-quantized save/load
+# ---------------------------------------------------------------------------
+
+
+def _load_array(array, dtype):
+    import mlx.core as mx
+
+    if dtype is not None and array.dtype != dtype:
+        array = array.astype(dtype)
+    mx.eval(array)
+    return array
+
+
+def _eval_value(value) -> None:
+    import mlx.core as mx
+
+    if isinstance(value, QuantizedMatrix):
+        args = [value.weight, value.scales]
+        if value.biases is not None:
+            args.append(value.biases)
+        mx.eval(*args)
+    else:
+        mx.eval(value)
+
+
+def _safetensors_shards(transformer_dir: str | Path) -> list[Path]:
+    transformer_dir = Path(transformer_dir)
+    if transformer_dir.is_file():
+        return [transformer_dir]
+    index = transformer_dir / "diffusion_pytorch_model.safetensors.index.json"
+    if index.exists():
+        weight_map = json.loads(index.read_text())["weight_map"]
+        return sorted({transformer_dir / shard for shard in weight_map.values()})
+    single = transformer_dir / "diffusion_pytorch_model.safetensors"
+    if single.exists():
+        return [single]
+    shards = sorted(transformer_dir.glob("*.safetensors"))
+    if shards:
+        return shards
+    raise FileNotFoundError(f"No safetensors found under {transformer_dir}")
+
+
+def mlx_h3_dit_from_diffusers_safetensors(
+    transformer_path: str | Path,
+    config: dict[str, Any] | None = None,
+    *,
+    dtype: str = "fp16",
+    num_blocks: int | None = None,
+    quantization: str | MLXQuantizationSpec | None = None,
+    adaln_cache_timesteps: np.ndarray | None = None,
+) -> MLXMiniMaxH3DiT:
+    """Load the released H3 transformer (diffusers layout) into MLX.
+
+    ``transformer_path`` is the ``transformer/`` directory of the HF repo (or
+    a single safetensors file, e.g. a student checkpoint). ``config`` defaults
+    to ``config.json`` next to the weights. fp32-release modules stay fp32;
+    attention/FFN matrices are quantized when ``quantization`` is set.
+
+    When ``adaln_cache_timesteps`` is provided, AdaLN tables are computed one
+    block at a time while the checkpoint is read. The 13B projection weights
+    are never retained together and are omitted from the returned model. This
+    is the memory-bounded build path for the released 33B student.
+    """
+    import mlx.core as mx
+    transformer_path = Path(transformer_path)
+    if config is None:
+        config_path = transformer_path / "config.json" if transformer_path.is_dir() else transformer_path.with_name(
+            "config.json")
+        config = json.loads(Path(config_path).read_text())
+    total_blocks = int(config["num_layers"])
+    if num_blocks is None:
+        num_blocks = total_blocks
+    num_refiner = int(config["num_refiner_layers"])
+    cast_dtype = {"fp16": mx.float16, "bf16": mx.bfloat16, "fp32": mx.float32}[dtype]
+    spec = MLXQuantizationSpec.from_name(quantization) if (quantization is None
+                                                           or isinstance(quantization, str)) else quantization
+    ensure_quantization_supported(spec)
+
+    weights: dict[str, Any] = {}
+    blocks: list[dict[str, Any] | None] = [None] * num_blocks
+    refiner: list[dict[str, Any] | None] = [None] * num_refiner
+    cache_timesteps = None
+    temb = None
+    cached_block_tables: list[tuple[Any, ...] | None] | None = None
+    pending_adaln: dict[int, dict[str, Any]] = {}
+
+    def assign(key: str, value) -> None:
+        if key.startswith("transformer_blocks."):
+            _, index_str, sub = key.split(".", 2)
+            index = int(index_str)
+            if index < num_blocks:
+                block = blocks[index]
+                if block is None:
+                    block = {}
+                    blocks[index] = block
+                block[sub] = value
+        elif key.startswith("token_refiner.refiner_blocks."):
+            _, _, index_str, sub = key.split(".", 3)
+            index = int(index_str)
+            refiner_block = refiner[index]
+            if refiner_block is None:
+                refiner_block = {}
+                refiner[index] = refiner_block
+            refiner_block[sub] = value
+        else:
+            weights[key] = value
+
+    if adaln_cache_timesteps is not None:
+        cache_timesteps = np.unique(np.asarray(adaln_cache_timesteps, dtype=np.float32))
+        for shard in _safetensors_shards(transformer_path):
+            shard_arrays = mx.load(str(shard))
+            for key, source in shard_arrays.items():
+                if not key.startswith("time_embedder."):
+                    continue
+                keep_fp32 = key.split(".", 1)[0] in FP32_MODULE_PREFIXES
+                target_dtype = mx.float32 if keep_fp32 else cast_dtype
+                assign(key, _load_array(source, target_dtype))
+            del shard_arrays
+        required_time_keys = {
+            "time_embedder.linear_1.weight",
+            "time_embedder.linear_1.bias",
+            "time_embedder.linear_2.weight",
+            "time_embedder.linear_2.bias",
+        }
+        missing_time_keys = sorted(required_time_keys - weights.keys())
+        if missing_time_keys:
+            raise KeyError(f"Missing time-embedder weights needed for the AdaLN cache: {missing_time_keys}")
+        timestep_rows = mx.array(cache_timesteps)
+        t_freq = timestep_embedding(timestep_rows, int(config["freq_dim"])).astype(
+            weight_dtype(weights["time_embedder.linear_1.weight"]))
+        temb = linear(t_freq, weights["time_embedder.linear_1.weight"], weights["time_embedder.linear_1.bias"])
+        temb = linear(silu(temb), weights["time_embedder.linear_2.weight"], weights["time_embedder.linear_2.bias"])
+        mx.eval(temb)
+        cached_block_tables = [None] * num_blocks
+
+    for shard in _safetensors_shards(transformer_path):
+        shard_arrays = mx.load(str(shard))
+        for key, source in shard_arrays.items():
+            if _is_ignored_dense_key(key):
+                continue
+            if temb is not None and key.startswith("time_embedder."):
+                continue
+            if key.startswith("transformer_blocks."):
+                index = int(key.split(".")[1])
+                if index >= num_blocks:
+                    continue
+            if key.startswith("rope."):
+                continue  # non-persistent analytic buffer, rebuilt on the fly
+            keep_fp32 = key.split(".", 1)[0] in FP32_MODULE_PREFIXES
+            target_dtype = mx.float32 if keep_fp32 else cast_dtype
+            array = _load_array(source, target_dtype)
+            if temb is not None and ".adaln_proj.linear." in key:
+                _, index_str, sub = key.split(".", 2)
+                index = int(index_str)
+                block_pending = pending_adaln.setdefault(index, {})
+                block_pending[sub] = array
+                if {"adaln_proj.linear.weight", "adaln_proj.linear.bias"} <= block_pending.keys():
+                    tables = _adaln_tables(block_pending, temb)
+                    mx.eval(tables)
+                    assert cached_block_tables is not None
+                    cached_block_tables[index] = tables
+                    block = blocks[index]
+                    if block is None:
+                        block = {}
+                        blocks[index] = block
+                    block["adaln_proj.linear.weight"] = None
+                    block["adaln_proj.linear.bias"] = None
+                    del pending_adaln[index]
+                continue
+            if spec is not None and _is_quantizable(key) and not keep_fp32:
+                value = quantize_matrix(array, spec)
+                del array
+            else:
+                value = array
+            _eval_value(value)
+            assign(key, value)
+        del shard_arrays
+
+    cache = None
+    if temb is not None:
+        if pending_adaln:
+            raise KeyError(f"Incomplete AdaLN projection pairs for blocks {sorted(pending_adaln)}")
+        assert cache_timesteps is not None and cached_block_tables is not None
+        missing_cache_blocks = [index for index, tables in enumerate(cached_block_tables) if tables is None]
+        if missing_cache_blocks:
+            raise KeyError(f"Missing AdaLN cache tables for blocks {missing_cache_blocks}")
+        shift_scale = linear(
+            silu(temb).astype(weight_dtype(weights["norm_out.linear.weight"])),
+            weights["norm_out.linear.weight"],
+            weights["norm_out.linear.bias"],
+        )
+        norm_out_shift, norm_out_scale = mx.split(shift_scale, 2, axis=-1)
+        mx.eval(norm_out_shift, norm_out_scale)
+        cache = MiniMaxH3StepCache(
+            timesteps=cache_timesteps,
+            block_tables=[tables for tables in cached_block_tables if tables is not None],
+            norm_out_shift=norm_out_shift,
+            norm_out_scale=norm_out_scale,
+        )
+
+    if any(block is None for block in blocks):
+        missing = [i for i, block in enumerate(blocks) if block is None]
+        raise KeyError(f"Missing transformer block weights for indices {missing}.")
+    if any(block is None for block in refiner):
+        raise KeyError("Missing token refiner weights.")
+    dit = MLXMiniMaxH3DiT(
+        weights,
+        [block for block in blocks if block is not None],
+        [block for block in refiner if block is not None],
+        config,
+    )
+    dit._adaln_cache = cache
+    return dit
+
+
+def mlx_h3_bf16_forward_streamed_from_diffusers_safetensors(
+    transformer_path: str | Path,
+    video_rows,
+    audio_rows,
+    text_rows,
+    *,
+    position_ids,
+    token_tags,
+    timestep_indices,
+    timesteps,
+    video_indices,
+    audio_indices,
+    text_indices,
+):
+    """Run one bf16 H3 reference forward with one main block resident at a time.
+
+    The released dense reference remains about 37 GiB after excluding VSA
+    gates and cannot be resident on a 36 GiB Mac. Safetensors arrays stay
+    memory-mapped; global/refiner weights remain resident and each of the 50
+    main blocks is cast, evaluated, used, and released in sequence.
+    """
+    import gc
+
+    import mlx.core as mx
+
+    transformer_path = Path(transformer_path)
+    config_path = transformer_path / "config.json" if transformer_path.is_dir() else transformer_path.with_name(
+        "config.json")
+    config = json.loads(Path(config_path).read_text())
+    num_blocks = int(config["num_layers"])
+    num_refiner = int(config["num_refiner_layers"])
+
+    shards = _safetensors_shards(transformer_path)
+    shard_by_name = {shard.name: shard for shard in shards}
+    index_path = transformer_path / "diffusion_pytorch_model.safetensors.index.json"
+    keys_by_shard: dict[str, list[str]] = {name: [] for name in shard_by_name}
+    if index_path.exists():
+        weight_map = json.loads(index_path.read_text())["weight_map"]
+        for key, shard_name in weight_map.items():
+            keys_by_shard[shard_name].append(key)
+    else:
+        for shard in shards:
+            shard_arrays = mx.load(str(shard))
+            keys_by_shard[shard.name] = list(shard_arrays)
+            del shard_arrays
+
+    weights: dict[str, Any] = {}
+    refiner: list[dict[str, Any] | None] = [None] * num_refiner
+    for shard_name, shard_keys in keys_by_shard.items():
+        selected_keys = [
+            key for key in shard_keys if not key.startswith("transformer_blocks.") and not key.startswith("rope.")
+            and not _is_ignored_dense_key(key)
+        ]
+        if not selected_keys:
+            continue
+        shard_arrays = mx.load(str(shard_by_name[shard_name]))
+        for key in selected_keys:
+            keep_fp32 = key.split(".", 1)[0] in FP32_MODULE_PREFIXES
+            value = _load_array(shard_arrays[key], mx.float32 if keep_fp32 else mx.bfloat16)
+            if key.startswith("token_refiner.refiner_blocks."):
+                _, _, index_str, sub = key.split(".", 3)
+                index = int(index_str)
+                refiner_block = refiner[index]
+                if refiner_block is None:
+                    refiner_block = {}
+                    refiner[index] = refiner_block
+                refiner_block[sub] = value
+            else:
+                weights[key] = value
+        del shard_arrays
+        gc.collect()
+        mx.clear_cache()
+    if any(block is None for block in refiner):
+        raise KeyError("Missing token refiner weights for streamed BF16 forward.")
+
+    dit = MLXMiniMaxH3DiT(weights, [], [block for block in refiner if block is not None], config)
+    sequence_length = position_ids.shape[0]
+    cos, sin = rope_cos_sin(position_ids, dit.rope_freq_dim, dit.rope_theta)
+    video_embeds = linear(
+        video_rows.astype(weight_dtype(weights["proj_in.weight"])),
+        weights["proj_in.weight"],
+        weights["proj_in.bias"],
+    )
+    audio_embeds = linear(
+        audio_rows.astype(weight_dtype(weights["audio_proj_in.weight"])),
+        weights["audio_proj_in.weight"],
+        weights["audio_proj_in.bias"],
+    )
+    text_embeds = dit.refine_text(text_rows)
+    packed = mx.zeros((sequence_length, dit.hidden_size), dtype=text_embeds.dtype)
+    packed[_as_mx_indices(text_indices)] = text_embeds
+    packed[_as_mx_indices(video_indices)] = video_embeds.astype(text_embeds.dtype)
+    packed[_as_mx_indices(audio_indices)] = audio_embeds.astype(text_embeds.dtype)
+    temb = dit.compute_temb(timesteps)
+    adaln_indices = (timestep_indices * MINIMAX_H3_MODALITY_NUM + token_tags).astype(mx.int32)
+    mx.eval(packed, temb, cos, sin)
+    if not bool(mx.all(mx.isfinite(packed))) or not bool(mx.all(mx.isfinite(temb))):
+        raise FloatingPointError("Non-finite H3 activations before the first streamed bf16 transformer block.")
+
+    for block_index in range(num_blocks):
+        prefix = f"transformer_blocks.{block_index}."
+        block: dict[str, Any] = {}
+        for shard_name, shard_keys in keys_by_shard.items():
+            selected_keys = [key for key in shard_keys if key.startswith(prefix) and not _is_ignored_dense_key(key)]
+            if not selected_keys:
+                continue
+            shard_arrays = mx.load(str(shard_by_name[shard_name]))
+            for key in selected_keys:
+                block[key[len(prefix):]] = _load_array(shard_arrays[key], mx.bfloat16)
+            del shard_arrays
+        tables = _adaln_tables(block, temb)
+        packed = _transformer_block(
+            block,
+            packed,
+            tables,
+            adaln_indices,
+            cos,
+            sin,
+            num_heads=dit.num_heads,
+            head_dim=dit.head_dim,
+            norm_eps=dit.norm_eps,
+            qk_norm_eps=dit.qk_norm_eps,
+        )
+        mx.eval(packed)
+        if not bool(mx.all(mx.isfinite(packed))):
+            raise FloatingPointError(f"Non-finite H3 activations after streamed bf16 transformer block {block_index}.")
+        del tables, block
+        gc.collect()
+        mx.clear_cache()
+
+    shift_scale = linear(
+        silu(temb).astype(weight_dtype(weights["norm_out.linear.weight"])),
+        weights["norm_out.linear.weight"],
+        weights["norm_out.linear.bias"],
+    )
+    shift_rows, scale_rows = mx.split(shift_scale, 2, axis=-1)
+    normed = rms_norm(packed, weights["norm_out.norm.weight"], eps=dit.final_norm_eps)
+    normed = normed * (1.0 + scale_rows[timestep_indices]) + shift_rows[timestep_indices]
+    video_output = linear(
+        normed[_as_mx_indices(video_indices)].astype(weight_dtype(weights["proj_out.weight"])),
+        weights["proj_out.weight"],
+        weights["proj_out.bias"],
+    )
+    audio_output = linear(
+        normed[_as_mx_indices(audio_indices)].astype(weight_dtype(weights["audio_proj_out.weight"])),
+        weights["audio_proj_out.weight"],
+        weights["audio_proj_out.bias"],
+    )
+    mx.eval(video_output, audio_output)
+    return video_output, audio_output
+
+
+H3_FORMAT_VERSION = 1
+H3_WEIGHTS_FILENAME = "mlx_h3_dit.safetensors"
+H3_MANIFEST_FILENAME = "mlx_h3_dit.json"
+
+_DTYPE_TO_NAME = {"float16": "fp16", "bfloat16": "bf16", "float32": "fp32"}
+
+
+def _dtype_name(dtype) -> str:
+    import mlx.core as mx
+
+    for raw, name in _DTYPE_TO_NAME.items():
+        if dtype == getattr(mx, raw):
+            return name
+    raise ValueError(f"Unsupported MLX dtype for checkpointing: {dtype}")
+
+
+def _name_to_dtype(name: str):
+    import mlx.core as mx
+
+    return {"fp16": mx.float16, "bf16": mx.bfloat16, "fp32": mx.float32}[name]
+
+
+def _flatten_h3_weights(dit: MLXMiniMaxH3DiT) -> dict[str, Any]:
+    flat: dict[str, Any] = dict(dit.weights)
+    for index, block in enumerate(dit.blocks):
+        for name, value in block.items():
+            if value is not None:
+                flat[f"blocks.{index}.{name}"] = value
+    for index, block in enumerate(dit.refiner):
+        for name, value in block.items():
+            flat[f"refiner.{index}.{name}"] = value
+    return flat
+
+
+def save_mlx_h3_checkpoint(dit: MLXMiniMaxH3DiT, checkpoint_dir: str | Path) -> Path:
+    """Persist a (possibly quantized, possibly AdaLN-dropped) H3 DiT."""
+    import mlx.core as mx
+
+    checkpoint_dir = Path(checkpoint_dir)
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    arrays: dict[str, Any] = {}
+    quantized: dict[str, dict[str, Any]] = {}
+    spec: MLXQuantizationSpec | None = None
+    for key, value in _flatten_h3_weights(dit).items():
+        if isinstance(value, QuantizedMatrix):
+            if spec is not None and value.spec != spec:
+                raise ValueError(f"Mixed quantization specs in one checkpoint ({spec} vs {value.spec} at '{key}').")
+            spec = value.spec
+            arrays[key] = value.weight
+            arrays[f"{key}.scales"] = value.scales
+            if value.biases is not None:
+                arrays[f"{key}.biases"] = value.biases
+            quantized[key] = {
+                "dequantized_dtype": _dtype_name(value.dequantized_dtype),
+                "has_biases": value.biases is not None,
+            }
+        else:
+            arrays[key] = value
+
+    cache_manifest = None
+    if dit._adaln_cache is not None:
+        cache = dit._adaln_cache
+        cache_manifest = {
+            "timesteps": cache.timesteps.tolist(),
+            "num_blocks": len(cache.block_tables),
+            "tables_per_block": 6,
+        }
+        for block_index, tables in enumerate(cache.block_tables):
+            for table_index, table in enumerate(tables):
+                arrays[f"__adaln_cache.block.{block_index}.table.{table_index}"] = table
+        arrays["__adaln_cache.norm_out_shift"] = cache.norm_out_shift
+        arrays["__adaln_cache.norm_out_scale"] = cache.norm_out_scale
+
+    manifest = {
+        "format_version": H3_FORMAT_VERSION,
+        "config": dit.config,
+        "num_blocks": len(dit.blocks),
+        "num_refiner_blocks": len(dit.refiner),
+        "quantization": None if spec is None else {
+            "mode": spec.mode,
+            "bits": spec.bits,
+            "group_size": spec.group_size,
+        },
+        "quantized_keys": quantized,
+        "adaln_cache": cache_manifest,
+    }
+    weights_path = checkpoint_dir / H3_WEIGHTS_FILENAME
+    mx.save_safetensors(str(weights_path), arrays)
+    (checkpoint_dir / H3_MANIFEST_FILENAME).write_text(json.dumps(manifest, indent=2))
+    logger.info("Saved MLX H3 DiT checkpoint (%d arrays, quantization=%s) to %s", len(arrays),
+                spec.label if spec else "none", checkpoint_dir)
+    return checkpoint_dir
+
+
+def load_mlx_h3_checkpoint(checkpoint_dir: str | Path) -> MLXMiniMaxH3DiT:
+    """Rebuild an H3 DiT saved by :func:`save_mlx_h3_checkpoint`.
+
+    Refuses a quantization grid the installed MLX cannot execute, loudly —
+    never silently dequantizes onto a different grid.
+    """
+    import mlx.core as mx
+
+    checkpoint_dir = Path(checkpoint_dir)
+    manifest_path = checkpoint_dir / H3_MANIFEST_FILENAME
+    weights_path = checkpoint_dir / H3_WEIGHTS_FILENAME
+    if not manifest_path.exists() or not weights_path.exists():
+        raise FileNotFoundError(f"Not an MLX H3 checkpoint directory: {checkpoint_dir} "
+                                f"(expected {H3_MANIFEST_FILENAME} and {H3_WEIGHTS_FILENAME}).")
+
+    manifest = json.loads(manifest_path.read_text())
+    version = manifest.get("format_version")
+    if version != H3_FORMAT_VERSION:
+        raise ValueError(f"MLX H3 checkpoint {checkpoint_dir} has format_version={version}; "
+                         f"this build reads version {H3_FORMAT_VERSION}. Re-export the checkpoint.")
+
+    spec = None
+    if manifest["quantization"] is not None:
+        spec = MLXQuantizationSpec(**manifest["quantization"])
+        ensure_quantization_supported(spec)
+
+    arrays = mx.load(str(weights_path))
+    quantized_keys: dict[str, dict[str, Any]] = manifest["quantized_keys"]
+
+    def rebuild(key: str):
+        if key not in quantized_keys:
+            return arrays[key]
+        info = quantized_keys[key]
+        assert spec is not None, f"Quantized key '{key}' in a checkpoint without a quantization spec"
+        return QuantizedMatrix(
+            weight=arrays[key],
+            scales=arrays[f"{key}.scales"],
+            biases=arrays[f"{key}.biases"] if info["has_biases"] else None,
+            spec=spec,
+            dequantized_dtype=_name_to_dtype(info["dequantized_dtype"]),
+        )
+
+    weights: dict[str, Any] = {}
+    blocks: list[dict[str, Any] | None] = [None] * int(manifest["num_blocks"])
+    refiner: list[dict[str, Any] | None] = [None] * int(manifest["num_refiner_blocks"])
+    for key in arrays:
+        if key.startswith("__adaln_cache."):
+            continue
+        if key.endswith(".scales") or key.endswith(".biases"):
+            continue
+        value = rebuild(key)
+        if key.startswith("blocks."):
+            _, index_str, sub = key.split(".", 2)
+            index = int(index_str)
+            block = blocks[index]
+            if block is None:
+                block = {}
+                blocks[index] = block
+            block[sub] = value
+        elif key.startswith("refiner."):
+            _, index_str, sub = key.split(".", 2)
+            index = int(index_str)
+            refiner_block = refiner[index]
+            if refiner_block is None:
+                refiner_block = {}
+                refiner[index] = refiner_block
+            refiner_block[sub] = value
+        else:
+            weights[key] = value
+
+    if any(block is None for block in blocks) or any(block is None for block in refiner):
+        raise ValueError(f"MLX H3 checkpoint {checkpoint_dir} is missing block weights.")
+    dit = MLXMiniMaxH3DiT(
+        weights,
+        [block for block in blocks if block is not None],
+        [block for block in refiner if block is not None],
+        manifest["config"],
+    )
+    cache_info = manifest.get("adaln_cache")
+    if cache_info is not None:
+        block_tables = []
+        for block_index in range(int(cache_info["num_blocks"])):
+            block_tables.append(
+                tuple(arrays[f"__adaln_cache.block.{block_index}.table.{table_index}"]
+                      for table_index in range(int(cache_info["tables_per_block"]))))
+        dit._adaln_cache = MiniMaxH3StepCache(
+            timesteps=np.asarray(cache_info["timesteps"], dtype=np.float32),
+            block_tables=block_tables,
+            norm_out_shift=arrays["__adaln_cache.norm_out_shift"],
+            norm_out_scale=arrays["__adaln_cache.norm_out_scale"],
+        )
+    return dit

--- a/fastvideo/mlx_runtime/minimax_h3_audio_vae.py
+++ b/fastvideo/mlx_runtime/minimax_h3_audio_vae.py
@@ -477,7 +477,8 @@ def mlx_h3_audio_vae_from_dir(component_dir: str | Path,
                               include_encoder: bool = True,
                               storage_dtype: str = "fp32") -> MLXMiniMaxH3AudioVAE:
     """Load from the released component directory (audio_vae/)."""
-    import mlx.core as _mx  # noqa: F401  (already imported at module level)
+    if storage_dtype != "fp32":
+        raise ValueError(f"H3 audio VAE numerics require storage_dtype='fp32', got {storage_dtype!r}.")
 
     component_dir = Path(component_dir)
     single = component_dir / "diffusion_pytorch_model.safetensors"

--- a/fastvideo/mlx_runtime/minimax_h3_audio_vae.py
+++ b/fastvideo/mlx_runtime/minimax_h3_audio_vae.py
@@ -85,12 +85,7 @@ class MiniMaxH3AudioVAEConfigView:
     def hop_length(self) -> int:
         return math.prod(self.encoder_rates)
 
-    @property
-    def activation_ratio(self) -> int:
-        return ACTIVATION_RATIO
 
-
-ACTIVATION_KERNEL_SIZE = 12
 ACTIVATION_RATIO = 2
 
 # ---------------------------------------------------------------------------
@@ -463,13 +458,14 @@ def mlx_h3_audio_vae_from_file(weights_path: str | Path,
     del arrays
     gc.collect()
     mx.clear_cache()
-    vae = MLXMiniMaxH3AudioVAE(weights, config, include_encoder=include_encoder)
+    required = ["dec_in_proj.weight", "decoder.conv_pre.weight_v", "decoder.conv_post.weight_v"]
     if include_encoder:
-        for required in ("mean_proj.weight", "logs_proj.weight", "pre_block.attn.qkv.weight",
-                         "encoder.block.0.weight_v"):
-            if required not in weights:
-                raise KeyError(f"H3 audio VAE is missing required tensor '{required}'.")
-    return vae
+        required.extend(
+            ("mean_proj.weight", "logs_proj.weight", "pre_block.attn.qkv.weight", "encoder.block.0.weight_v"))
+    missing = [key for key in required if key not in weights]
+    if missing:
+        raise KeyError(f"H3 audio VAE is missing required tensors: {missing}")
+    return MLXMiniMaxH3AudioVAE(weights, config, include_encoder=include_encoder)
 
 
 def mlx_h3_audio_vae_from_dir(component_dir: str | Path,

--- a/fastvideo/mlx_runtime/minimax_h3_audio_vae.py
+++ b/fastvideo/mlx_runtime/minimax_h3_audio_vae.py
@@ -183,8 +183,8 @@ def _snake(x, alpha):
 
 def _snake_beta(x, alpha, beta):
     """SnakeBeta: x + sin(exp(alpha)*x)^2 / (exp(beta) + 1e-9)."""
-    a = mx.exp(alpha)[None, :, None]
-    b = mx.exp(beta)[None, :, None]
+    a = mx.exp(mx.reshape(alpha, (-1, )))[None, :, None]
+    b = mx.exp(mx.reshape(beta, (-1, )))[None, :, None]
     return x + mx.sin(a * x)**2 / (b + 1e-9)
 
 

--- a/fastvideo/mlx_runtime/minimax_h3_audio_vae.py
+++ b/fastvideo/mlx_runtime/minimax_h3_audio_vae.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+# mypy: disable-error-code=no-untyped-call
+"""MiniMax-H3 audio VAE (DAC encoder + BigVGAN decoder) for Apple Silicon MLX.
+
+Faithful port of ``fastvideo/models/vaes/minimax_h3_audio.py``:
+
+- **Encoder**: plain-Snake residual units (dilations 1/3/9), strided
+  down-sampling blocks, then the attention projection block — causal
+  multi-head attention over the latent stream with q/v biases and a forced
+  zero k bias, head averaging, average pooling into ``latent_channels``
+  streams, output projection, and a GeGLU MLP.
+- **Decoder**: 1x1 projection back to the trunk width, BigVGAN with
+  weight-normalized ConvTranspose1d upsampling, AMP residual blocks with
+  SnakeBeta behind alias-free Kaiser-window up/down sampling, final SnakeBeta
+  + conv, and the [-1, 1] clamp.
+- Kaiser-window low-pass filters exactly as released; released filter buffers
+  are used when present so numerics do not depend on window construction.
+
+Waveforms are float32 in [-1, 1] at 32 kHz. Stereo latents ``(2, 32, N)``
+decode independently while preserving channel order and duration. Production
+code never imports PyTorch; torch parity references live only in tests.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import numpy as np
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _ct(x, *order):
+    """Contiguous transpose: some MLX builds silently mis-compute ops on
+    strided views, so every layout change materializes."""
+    return mx.contiguous(x.transpose(*order))
+
+
+@dataclass(frozen=True)
+class MiniMaxH3AudioVAEConfigView:
+    """Architecture constants (defaults mirror the released audio_vae/config.json)."""
+
+    encoder_dim: int = 64
+    encoder_rates: tuple[int, ...] = (2, 4, 4, 5, 5)
+    latent_dim: int = 2048
+    latent_channels: int = 32
+    num_attention_heads: int = 8
+    decoder_dim: int = 1024
+    decoder_rates: tuple[int, ...] = (5, 5, 2, 2, 2, 2, 2)
+    decoder_kernel_sizes: tuple[int, ...] = (9, 9, 4, 4, 4, 4, 4)
+    resblock_kernel_sizes: tuple[int, ...] = (3, 7, 11)
+    resblock_dilation_sizes: tuple[tuple[int, ...], ...] = ((1, 3, 5), (1, 3, 5), (1, 3, 5))
+    sampling_rate: int = 32000
+    latents_mean: tuple[float, ...] | None = None
+    latents_std: tuple[float, ...] | None = None
+
+    @classmethod
+    def from_vae_dir(cls, vae_dir: str | Path) -> MiniMaxH3AudioVAEConfigView:
+        config = json.loads((Path(vae_dir) / "config.json").read_text())
+        return cls(
+            encoder_dim=int(config["encoder_dim"]),
+            encoder_rates=tuple(int(v) for v in config["encoder_rates"]),
+            latent_dim=int(config["latent_dim"]),
+            latent_channels=int(config["latent_channels"]),
+            num_attention_heads=int(config["num_attention_heads"]),
+            decoder_dim=int(config["decoder_dim"]),
+            decoder_rates=tuple(int(v) for v in config["decoder_rates"]),
+            decoder_kernel_sizes=tuple(int(v) for v in config["decoder_kernel_sizes"]),
+            resblock_kernel_sizes=tuple(int(v) for v in config["resblock_kernel_sizes"]),
+            resblock_dilation_sizes=tuple(tuple(int(d) for d in group) for group in config["resblock_dilation_sizes"]),
+            sampling_rate=int(config["sampling_rate"]),
+            latents_mean=tuple(float(v) for v in config["latents_mean"]) if "latents_mean" in config else None,
+            latents_std=tuple(float(v) for v in config["latents_std"]) if "latents_std" in config else None,
+        )
+
+    @property
+    def hop_length(self) -> int:
+        return math.prod(self.encoder_rates)
+
+    @property
+    def activation_ratio(self) -> int:
+        return ACTIVATION_RATIO
+
+
+ACTIVATION_KERNEL_SIZE = 12
+ACTIVATION_RATIO = 2
+
+# ---------------------------------------------------------------------------
+# Primitives (torch layout (B, C, L); convs run channels-last internally)
+# ---------------------------------------------------------------------------
+
+
+def _wn_weight(weight_v, weight_g):
+    """torch weight_norm (dim=0): w = v * g / per-out-channel ||v||."""
+    norm = mx.sqrt(mx.sum(weight_v * weight_v, axis=(1, 2), keepdims=True))
+    return weight_v * (weight_g / norm)
+
+
+def _conv1d(x, weight, bias=None, *, stride: int = 1, padding: int = 0, dilation: int = 1, groups: int = 1):
+    """(B, C, L) in/out around channels-last MLX conv1d. weight: (O, I, K)."""
+    # mx.contiguous guards against silent mis-computation on strided views.
+    y = mx.conv1d(_ct(x, 0, 2, 1),
+                  _ct(weight, 0, 2, 1),
+                  stride=stride,
+                  padding=padding,
+                  dilation=dilation,
+                  groups=groups)
+    if bias is not None:
+        y = y + bias
+    return _ct(y, 0, 2, 1)
+
+
+def _conv_transpose1d(x, weight_torch_layout, bias=None, *, stride: int = 1, padding: int = 0):
+    """(B, C, L) in/out. weight in torch layout (I, O, K) -> MLX (O, K, I)."""
+    y = mx.conv_transpose1d(_ct(x, 0, 2, 1), _ct(weight_torch_layout, 1, 2, 0), stride=stride, padding=padding)
+    if bias is not None:
+        y = y + bias
+    return _ct(y, 0, 2, 1)
+
+
+def _replicate_pad(x, left: int, right: int):
+    """Replicate padding on the last axis of (B, C, L)."""
+    if left == 0 and right == 0:
+        return x
+    pieces = []
+    if left > 0:
+        pieces.append(mx.repeat(x[:, :, :1], left, axis=-1))
+    pieces.append(x)
+    if right > 0:
+        pieces.append(mx.repeat(x[:, :, -1:], right, axis=-1))
+    return mx.concatenate(pieces, axis=-1)
+
+
+def _gelu_tanh(x):
+    return 0.5 * x * (1.0 + mx.tanh(0.7978845608028654 * (x + 0.044715 * x * x * x)))
+
+
+def _layer_norm(x, weight, bias, eps: float = 1e-5):
+    mean = x.mean(axis=-1, keepdims=True)
+    var = ((x - mean)**2).mean(axis=-1, keepdims=True)
+    return (x - mean) / mx.sqrt(var + eps) * weight + bias
+
+
+def _linear(x, weight, bias=None):
+    y = x @ weight.T
+    if bias is not None:
+        y = y + bias
+    return y
+
+
+def kaiser_sinc_filter1d(cutoff: float, half_width: float, kernel_size: int) -> np.ndarray:
+    """NumPy replica of the released Kaiser-windowed sinc low-pass."""
+    half_size = kernel_size // 2
+    attenuation = 2.285 * (half_size - 1) * math.pi * (4 * half_width) + 7.95
+    if attenuation > 50.0:
+        beta = 0.1102 * (attenuation - 8.7)
+    elif attenuation >= 21.0:
+        beta = 0.5842 * (attenuation - 21)**0.4 + 0.07886 * (attenuation - 21.0)
+    else:
+        beta = 0.0
+    window = np.kaiser(kernel_size, beta).astype(np.float32)  # periodic=False semantics
+    if kernel_size % 2 == 0:
+        time = np.arange(-half_size, half_size, dtype=np.float32) + 0.5
+    else:
+        time = np.arange(kernel_size, dtype=np.float32) - half_size
+    filter_ = 2 * cutoff * window * np.sinc(2 * cutoff * time)
+    filter_ /= filter_.sum()
+    return filter_.astype(np.float32)
+
+
+def _snake(x, alpha):
+    """MiniMaxH3AudioSnake1d: x + sin(alpha*x)^2 / (alpha + 1e-9)."""
+    return x + mx.sin(alpha * x)**2 / (alpha + 1e-9)
+
+
+def _snake_beta(x, alpha, beta):
+    """SnakeBeta: x + sin(exp(alpha)*x)^2 / (exp(beta) + 1e-9)."""
+    a = mx.exp(alpha)[None, :, None]
+    b = mx.exp(beta)[None, :, None]
+    return x + mx.sin(a * x)**2 / (b + 1e-9)
+
+
+def _low_pass(x, filter_, stride: int):
+    """Grouped low-pass with replicate padding. x: (B, C, L); filter: (K,)."""
+    channels = x.shape[1]
+    kernel_size = filter_.shape[0]
+    even = kernel_size % 2 == 0
+    pad_left = kernel_size // 2 - int(even)
+    pad_right = kernel_size // 2
+    padded = _replicate_pad(x, pad_left, pad_right)
+    weight = mx.repeat(filter_[None, :, None], channels, axis=0)  # depthwise (C, K, 1), MLX layout
+    # Depthwise weights are already in MLX layout; do not route through _conv1d
+    # (it would re-transpose them as torch-layout (O, I, K)).
+    y = mx.conv1d(_ct(padded, 0, 2, 1), weight, stride=stride, groups=channels)
+    return _ct(y, 0, 2, 1)
+
+
+def _up_sample(x, filter_, ratio: int, kernel_size: int):
+    """Kaiser-windowed up-sampling with the official cropping. x: (B, C, L).
+
+    Implemented as zero-stuffing plus depthwise conv1d with the flipped
+    filter: identical to ``F.conv_transpose1d`` for symmetric filters, and it
+    avoids grouped conv_transpose whose weight layout differs across MLX
+    builds.
+    """
+    pad = kernel_size // ratio - 1
+    pad_left = pad * ratio + (kernel_size - ratio) // 2
+    pad_right = pad * ratio + (kernel_size - ratio + 1) // 2
+    batch, channels, length = x.shape
+    padded = _replicate_pad(x, pad, pad)
+    stuffed_len = padded.shape[-1] * ratio
+    parts = [mx.expand_dims(padded, -1)] + [mx.zeros((batch, channels, padded.shape[-1], 1))] * (ratio - 1)
+    stuffed = mx.reshape(mx.concatenate(parts, axis=-1), (batch, channels, stuffed_len))
+    # Correlation alignment: zero-pad by (K-1) on both sides of the stuffed signal.
+    stuffed = _ct(
+        mx.concatenate([
+            mx.zeros((batch, channels, kernel_size - 1)),
+            stuffed,
+            mx.zeros((batch, channels, kernel_size - 1)),
+        ],
+                       axis=-1), 0, 2, 1)
+    weight = mx.repeat(mx.reshape(filter_[::-1], (1, -1, 1)), channels, axis=0)  # depthwise (C, K, 1)
+    y = _ct(mx.conv1d(stuffed, weight, stride=1, groups=channels), 0, 2, 1)
+    out_len = (padded.shape[-1] - 1) * ratio + kernel_size
+    full = ratio * y[..., :out_len]
+    end = full.shape[-1] - pad_right if pad_right > 0 else full.shape[-1]
+    return full[..., pad_left:end]
+
+
+def _activation1d(x, alpha, beta, up_filter, down_filter, ratio: int = ACTIVATION_RATIO):
+    """Alias-free SnakeBeta activation: up-sample -> SnakeBeta -> low-pass."""
+    x = _up_sample(x, up_filter, ratio, up_filter.shape[0])
+    x = _snake_beta(x, alpha, beta)
+    return _low_pass(x, down_filter, ratio)
+
+
+# ---------------------------------------------------------------------------
+# The MLX H3 audio VAE
+# ---------------------------------------------------------------------------
+
+
+class MLXMiniMaxH3AudioVAE:
+    """DAC-style posterior encoder plus BigVGAN waveform decoder."""
+
+    def __init__(self, weights: dict[str, Any], config: MiniMaxH3AudioVAEConfigView, *, include_encoder: bool = True):
+        self.weights = weights
+        self.config = config
+        self.has_encoder = include_encoder
+        self.latent_channels = config.latent_channels
+        mean = config.latents_mean if config.latents_mean is not None else [0.0] * config.latent_channels
+        std = config.latents_std if config.latents_std is not None else [1.0] * config.latent_channels
+        self._latents_mean = np.asarray(mean, dtype=np.float32).reshape(1, -1, 1)
+        self._latents_std = np.asarray(std, dtype=np.float32).reshape(1, -1, 1)
+
+    # -- normalization --------------------------------------------------
+
+    def normalize_latents(self, latents):
+        return (latents - mx.array(self._latents_mean)) / mx.array(self._latents_std)
+
+    def denormalize_latents(self, latents):
+        return latents * mx.array(self._latents_std) + mx.array(self._latents_mean)
+
+    def _filter(self, key: str) -> mx.array:
+        """Released filter buffer flattened to (K,) (they ship as (1, 1, K))."""
+        try:
+            return mx.reshape(self.weights[key], (-1, ))
+        except KeyError as exc:
+            raise KeyError(f"H3 audio VAE is missing released filter buffer '{key}'") from exc
+
+    # -- encoder ----------------------------------------------------------
+
+    def encode(self, waveform):
+        """Mono waveform (1, 1, S) -> posterior mean/logvar each (1, C, N)."""
+        if not self.has_encoder:
+            raise RuntimeError("This MLX H3 audio VAE was loaded without encoder weights.")
+        cfg = self.config
+        w = self.weights
+        samples = waveform.shape[-1]
+        right_pad = math.ceil(samples / cfg.hop_length) * cfg.hop_length - samples
+        if right_pad > 0:
+            waveform = mx.pad(waveform, ((0, 0), (0, 0), (0, right_pad)))
+
+        x = _conv1d(waveform,
+                    _wn_weight(w["encoder.block.0.weight_v"], w["encoder.block.0.weight_g"]),
+                    w["encoder.block.0.bias"],
+                    padding=3)
+        dim = cfg.encoder_dim
+        for index, stride in enumerate(cfg.encoder_rates, start=1):
+            prefix = f"encoder.block.{index}"
+            dim *= 2
+            # Three residual units with dilations 1, 3, 9 at dim//2 channels.
+            for unit, dilation in enumerate((1, 3, 9)):
+                p = f"{prefix}.block.{unit}"
+                residual = _snake(x, w[f"{p}.block.0.alpha"])
+                residual = _conv1d(residual,
+                                   _wn_weight(w[f"{p}.block.1.weight_v"], w[f"{p}.block.1.weight_g"]),
+                                   w[f"{p}.block.1.bias"],
+                                   padding=((7 - 1) * dilation) // 2,
+                                   dilation=dilation)
+                residual = _snake(residual, w[f"{p}.block.2.alpha"])
+                residual = _conv1d(residual, _wn_weight(w[f"{p}.block.3.weight_v"], w[f"{p}.block.3.weight_g"]),
+                                   w[f"{p}.block.3.bias"])
+                pad = (x.shape[-1] - residual.shape[-1]) // 2
+                if pad > 0:
+                    x = x[..., pad:-pad]
+                x = x + residual
+            x = _snake(x, w[f"{prefix}.block.3.alpha"])
+            x = _conv1d(x,
+                        _wn_weight(w[f"{prefix}.block.4.weight_v"], w[f"{prefix}.block.4.weight_g"]),
+                        w[f"{prefix}.block.4.bias"],
+                        stride=stride,
+                        padding=math.ceil(stride / 2))
+        snake_index = len(cfg.encoder_rates) + 1
+        conv_index = len(cfg.encoder_rates) + 2
+        x = _snake(x, w[f"encoder.block.{snake_index}.alpha"])
+        hidden = _conv1d(x,
+                         _wn_weight(w[f"encoder.block.{conv_index}.weight_v"],
+                                    w[f"encoder.block.{conv_index}.weight_g"]),
+                         w[f"encoder.block.{conv_index}.bias"],
+                         padding=1)
+
+        projected = _ct(self._attention_projection(_ct(hidden, 0, 2, 1)), 0, 2, 1)
+        mean = _conv1d(projected, w["mean_proj.weight"], w["mean_proj.bias"])
+        logvar = _conv1d(projected, w["logs_proj.weight"], w["logs_proj.bias"])
+        return mean, logvar
+
+    def _attention_projection(self, hidden):
+        """MiniMaxH3AudioAttnProjection over (B, S, latent_dim)."""
+        cfg = self.config
+        w = self.weights
+        num_heads = cfg.num_attention_heads
+        head_dim = hidden.shape[-1] // num_heads
+        batch, seq_len, _ = hidden.shape
+
+        normed = _layer_norm(hidden, w["pre_block.norm1.weight"], w["pre_block.norm1.bias"])
+        bias = mx.concatenate([w["pre_block.attn.q_bias"], w["pre_block.attn.zero_k_bias"], w["pre_block.attn.v_bias"]])
+        qkv = _linear(normed, w["pre_block.attn.qkv.weight"], bias)
+        qkv = qkv.reshape(batch, seq_len, 3, num_heads, head_dim)
+        query = _ct(qkv[:, :, 0], 0, 2, 1, 3)  # (B, H, S, Dh)
+        key = _ct(qkv[:, :, 1], 0, 2, 1, 3)
+        value = _ct(qkv[:, :, 2], 0, 2, 1, 3)
+
+        scores = (query @ _ct(key, 0, 1, 3, 2)) * head_dim**-0.5
+        causal_mask = mx.triu(mx.ones((seq_len, seq_len), dtype=mx.bool_), k=1)
+        scores = mx.where(causal_mask[None, None], mx.array(-np.inf, dtype=scores.dtype), scores)
+        attn_weights = mx.softmax(scores, axis=-1)
+        attended = attn_weights @ value  # (B, H, S, Dh)
+        attended = _ct(attended, 0, 2, 1, 3).mean(axis=2)  # head mean -> (B, S, Dh)
+
+        out_dim = cfg.latent_channels
+        pool_factor = attended.shape[-1] // out_dim
+        if attended.shape[-1] % out_dim != 0:
+            raise ValueError("Attention head dimension must pool evenly into latent channels.")
+        pooled = attended.reshape(batch, seq_len, out_dim, pool_factor).mean(axis=-1)
+        attn_out = _linear(pooled, w["pre_block.attn.proj.weight"], w["pre_block.attn.proj.bias"])
+
+        projected = _linear(_layer_norm(hidden, w["pre_block.norm3.weight"], w["pre_block.norm3.bias"]),
+                            w["pre_block.proj.weight"], w["pre_block.proj.bias"]) + attn_out
+        mlp_in = _layer_norm(projected, w["pre_block.norm2.weight"], w["pre_block.norm2.bias"])
+        # GeGluMlp carries its own inner LayerNorm before w0/w1.
+        mlp_normed = _layer_norm(mlp_in, w["pre_block.mlp.norm.weight"], w["pre_block.mlp.norm.bias"])
+        gate = _gelu_tanh(_linear(mlp_normed, w["pre_block.mlp.w0.weight"], w["pre_block.mlp.w0.bias"]))
+        value_mlp = _linear(mlp_normed, w["pre_block.mlp.w1.weight"], w["pre_block.mlp.w1.bias"])
+        mlp_out = _linear(gate * value_mlp, w["pre_block.mlp.w2.weight"], w["pre_block.mlp.w2.bias"])
+        return projected + mlp_out
+
+    # -- decoder ----------------------------------------------------------
+
+    def decode(self, latents):
+        """Latents (B, 32, N) -> waveforms (B, 1, S) clamped to [-1, 1]."""
+        cfg = self.config
+        w = self.weights
+        hidden = _conv1d(latents, w["dec_in_proj.weight"], w["dec_in_proj.bias"])
+        hidden = _conv1d(hidden,
+                         _wn_weight(w["decoder.conv_pre.weight_v"], w["decoder.conv_pre.weight_g"]),
+                         w["decoder.conv_pre.bias"],
+                         padding=3)
+        num_resblocks = len(cfg.resblock_kernel_sizes)
+        for index, (rate, kernel) in enumerate(zip(cfg.decoder_rates, cfg.decoder_kernel_sizes, strict=False)):
+            weight = _wn_weight(w[f"decoder.ups.{index}.0.weight_v"], w[f"decoder.ups.{index}.0.weight_g"])
+            hidden = _conv_transpose1d(hidden,
+                                       weight,
+                                       w[f"decoder.ups.{index}.0.bias"],
+                                       stride=rate,
+                                       padding=(kernel - rate) // 2)
+            residual_sum = None
+            for j in range(num_resblocks):
+                out = self._amp_block(hidden, f"decoder.resblocks.{index * num_resblocks + j}",
+                                      cfg.resblock_kernel_sizes[j], cfg.resblock_dilation_sizes[j])
+                residual_sum = out if residual_sum is None else residual_sum + out
+            if residual_sum is None:
+                raise RuntimeError("H3 audio VAE decoder has no residual blocks.")
+            hidden = residual_sum / num_resblocks
+        alpha = w["decoder.activation_post.act.alpha"]
+        beta = w["decoder.activation_post.act.beta"]
+        up_filter = self._filter("decoder.activation_post.upsample.filter")
+        down_filter = self._filter("decoder.activation_post.downsample.lowpass.filter")
+        hidden = _activation1d(hidden, alpha, beta, up_filter, down_filter)
+        hidden = _conv1d(hidden,
+                         _wn_weight(w["decoder.conv_post.weight_v"], w["decoder.conv_post.weight_g"]),
+                         w.get("decoder.conv_post.bias"),
+                         padding=3)
+        return mx.clip(hidden, -1.0, 1.0)
+
+    def _amp_block(self, x, prefix: str, kernel_size: int, dilations: tuple[int, ...]):
+        """MiniMaxH3AudioAMPBlock: per dilation, act -> conv1 -> act -> conv2 + skip."""
+        w = self.weights
+        for j, dilation in enumerate(dilations):
+            pad1 = (kernel_size * dilation - dilation) // 2
+            pad2 = (kernel_size - 1) // 2
+            up1 = self._filter(f"{prefix}.activations.{2 * j}.upsample.filter")
+            down1 = self._filter(f"{prefix}.activations.{2 * j}.downsample.lowpass.filter")
+            residual = _activation1d(x, w[f"{prefix}.activations.{2 * j}.act.alpha"],
+                                     w[f"{prefix}.activations.{2 * j}.act.beta"], up1, down1)
+            residual = _conv1d(residual,
+                               _wn_weight(w[f"{prefix}.convs1.{j}.weight_v"], w[f"{prefix}.convs1.{j}.weight_g"]),
+                               w[f"{prefix}.convs1.{j}.bias"],
+                               padding=pad1,
+                               dilation=dilation)
+            up2 = self._filter(f"{prefix}.activations.{2 * j + 1}.upsample.filter")
+            down2 = self._filter(f"{prefix}.activations.{2 * j + 1}.downsample.lowpass.filter")
+            residual = _activation1d(residual, w[f"{prefix}.activations.{2 * j + 1}.act.alpha"],
+                                     w[f"{prefix}.activations.{2 * j + 1}.act.beta"], up2, down2)
+            residual = _conv1d(residual,
+                               _wn_weight(w[f"{prefix}.convs2.{j}.weight_v"], w[f"{prefix}.convs2.{j}.weight_g"]),
+                               w[f"{prefix}.convs2.{j}.bias"],
+                               padding=pad2)
+            x = residual + x
+        return x
+
+
+def mlx_h3_audio_vae_from_file(weights_path: str | Path,
+                               *,
+                               include_encoder: bool = True,
+                               config: MiniMaxH3AudioVAEConfigView | None = None,
+                               component_dir: str | Path | None = None) -> MLXMiniMaxH3AudioVAE:
+    """Load the released audio VAE from its single safetensors file.
+
+    The released checkpoint is ~605 MB fp32; it is read whole (bounded) and
+    kept at release precision.
+    """
+    weights_path = Path(weights_path)
+    if config is None:
+        if component_dir is None:
+            component_dir = weights_path.parent
+        config = MiniMaxH3AudioVAEConfigView.from_vae_dir(component_dir)
+    arrays = mx.load(str(weights_path))
+    wanted_prefixes: tuple[str, ...] = ("dec_in_proj.", "decoder.", "mean_proj.", "logs_proj.")
+    if include_encoder:
+        wanted_prefixes += ("encoder.", "pre_block.")
+    weights: dict[str, Any] = {}
+    for key in arrays:
+        if key.startswith(wanted_prefixes):
+            weights[key] = arrays[key]
+    del arrays
+    gc.collect()
+    mx.clear_cache()
+    vae = MLXMiniMaxH3AudioVAE(weights, config, include_encoder=include_encoder)
+    if include_encoder:
+        for required in ("mean_proj.weight", "logs_proj.weight", "pre_block.attn.qkv.weight",
+                         "encoder.block.0.weight_v"):
+            if required not in weights:
+                raise KeyError(f"H3 audio VAE is missing required tensor '{required}'.")
+    return vae
+
+
+def mlx_h3_audio_vae_from_dir(component_dir: str | Path,
+                              *,
+                              include_encoder: bool = True,
+                              storage_dtype: str = "fp32") -> MLXMiniMaxH3AudioVAE:
+    """Load from the released component directory (audio_vae/)."""
+    import mlx.core as _mx  # noqa: F401  (already imported at module level)
+
+    component_dir = Path(component_dir)
+    single = component_dir / "diffusion_pytorch_model.safetensors"
+    if not single.exists():
+        raise FileNotFoundError(f"No audio VAE safetensors under {component_dir}")
+    return mlx_h3_audio_vae_from_file(single, include_encoder=include_encoder, component_dir=component_dir)

--- a/fastvideo/mlx_runtime/minimax_h3_conditioner.py
+++ b/fastvideo/mlx_runtime/minimax_h3_conditioner.py
@@ -76,6 +76,7 @@ class _ShardIndex:
         component_dir = Path(component_dir)
         index_path = component_dir / "model.safetensors.index.json"
         self.key_to_shard: dict[str, str] = {}
+        self._header_cache: dict[str, tuple[dict, int]] = {}
         if index_path.exists():
             weight_map = json.loads(index_path.read_text())["weight_map"]
             self.key_to_shard = {k: str(component_dir / s) for k, s in weight_map.items()}
@@ -88,6 +89,20 @@ class _ShardIndex:
                 (header_len, ) = struct.unpack("<Q", handle.read(8))
                 header = json.loads(handle.read(header_len))
             self.key_to_shard = {k: str(single) for k in header if k != "__metadata__"}
+        # Pre-cache all shard headers
+        for shard_path in set(self.key_to_shard.values()):
+            self._cache_header(shard_path)
+
+    def _cache_header(self, path: str) -> tuple[dict, int]:
+        """Parse and cache a shard's header, returning (header_dict, data_start_offset)."""
+        if path not in self._header_cache:
+            import struct
+            with open(path, "rb") as handle:
+                (header_len, ) = struct.unpack("<Q", handle.read(8))
+                header = json.loads(handle.read(header_len))
+            data_start = 8 + header_len
+            self._header_cache[path] = (header, data_start)
+        return self._header_cache[path]
 
     def has(self, prefix: str) -> bool:
         return any(key.startswith(prefix) for key in self.key_to_shard)
@@ -97,11 +112,13 @@ class _ShardIndex:
 
     def get(self, key: str) -> np.ndarray:
         shard = self.key_to_shard[key]
-        return _read_safetensors_bf16(shard, key)
+        header, data_start = self._header_cache[shard]
+        return _read_safetensors_bf16(shard, key, header, data_start)
 
     def get_row(self, key: str, row: int) -> np.ndarray:
         shard = self.key_to_shard[key]
-        return _read_safetensors_row(shard, key, row)
+        header, data_start = self._header_cache[shard]
+        return _read_safetensors_row(shard, key, row, header, data_start)
 
     def close(self) -> None:
         gc.collect()
@@ -110,15 +127,9 @@ class _ShardIndex:
 _DTYPES = {"F32": np.float32, "F16": np.float16, "I64": np.int64, "I32": np.int32}
 
 
-def _read_safetensors_bf16(path: str, key: str) -> np.ndarray:
+def _read_safetensors_bf16(path: str, key: str, header: dict, data_start: int) -> np.ndarray:
     """Read one tensor (any dtype incl. BF16) without loading the shard."""
-    import struct
-
-    with open(path, "rb") as handle:
-        (header_len, ) = struct.unpack("<Q", handle.read(8))
-        header = json.loads(handle.read(header_len))
     meta = header[key]
-    data_start = 8 + header_len
     begin, end = meta["data_offsets"]
     count = end - begin
     dtype = meta["dtype"]
@@ -135,13 +146,8 @@ def _read_safetensors_bf16(path: str, key: str) -> np.ndarray:
                   shape=(count // np.dtype(_DTYPES[dtype]).itemsize, )).reshape(meta["shape"]))
 
 
-def _read_safetensors_row(path: str, key: str, row: int) -> np.ndarray:
+def _read_safetensors_row(path: str, key: str, row: int, header: dict, data_start: int) -> np.ndarray:
     """Read one leading-dimension row without materializing the full tensor."""
-    import struct
-
-    with open(path, "rb") as handle:
-        (header_len, ) = struct.unpack("<Q", handle.read(8))
-        header = json.loads(handle.read(header_len))
     meta = header[key]
     shape = tuple(int(value) for value in meta["shape"])
     if len(shape) < 2:
@@ -154,7 +160,6 @@ def _read_safetensors_row(path: str, key: str, row: int) -> np.ndarray:
         raise ValueError(f"Unsupported safetensors dtype {dtype} in {path}:{key}")
     item_size = 2 if dtype in {"BF16", "F16"} else np.dtype(_DTYPES[dtype]).itemsize
     row_count = int(np.prod(shape[1:], dtype=np.int64))
-    data_start = 8 + header_len
     begin = int(meta["data_offsets"][0]) + row * row_count * item_size
     if dtype == "BF16":
         raw = np.memmap(path, dtype=np.uint16, mode="r", offset=data_start + begin, shape=(row_count, ))

--- a/fastvideo/mlx_runtime/minimax_h3_conditioner.py
+++ b/fastvideo/mlx_runtime/minimax_h3_conditioner.py
@@ -104,12 +104,6 @@ class _ShardIndex:
             self._header_cache[path] = (header, data_start)
         return self._header_cache[path]
 
-    def has(self, prefix: str) -> bool:
-        return any(key.startswith(prefix) for key in self.key_to_shard)
-
-    def keys_with_prefix(self, prefix: str) -> list[str]:
-        return sorted(key for key in self.key_to_shard if key.startswith(prefix))
-
     def get(self, key: str) -> np.ndarray:
         shard = self.key_to_shard[key]
         header, data_start = self._header_cache[shard]

--- a/fastvideo/mlx_runtime/minimax_h3_conditioner.py
+++ b/fastvideo/mlx_runtime/minimax_h3_conditioner.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+# mypy: disable-error-code=no-untyped-call
+"""Streamed Qwen3-VL prompt conditioner for MiniMax-H3 on Apple Silicon MLX.
+
+Produces exactly the conditioning the H3 DiT consumes: the language-model
+hidden states after the first 50 language-model layers plus the per-token
+modality tags for text prompts.
+
+Memory contract for the 36 GiB tier: the released conditioner is ~66 GB of
+BF16 and never becomes resident. Tensors are memory-mapped per-key from the
+safetensors shards and only the pieces a given forward needs are materialized:
+
+- token embedding table row-gathered per batch (full table never copied);
+- one decoder layer (~1 GB BF16) resident at a time, computed in FP32,
+  released before the next layer loads;
+The forward pass uses MLX. Tokenization uses the Transformers tokenizer API.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import mlx.core as mx
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+TEXT_ENCODER_LAYER = 50
+
+
+@dataclass
+class ConditionerConfig:
+    hidden_size: int = 5120
+    num_layers: int = 64
+    num_attention_heads: int = 64
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    intermediate_size: int = 25600
+    rms_norm_eps: float = 1e-6
+    rope_theta: float = 5_000_000.0
+    mrope_section: tuple[int, ...] = (24, 20, 20)
+    vocab_size: int = 151936
+
+    @classmethod
+    def from_config_json(cls, path: str | Path) -> ConditionerConfig:
+        raw = json.loads(Path(path).read_text())
+        text = raw.get("text_config", raw)
+        scaling = text.get("rope_scaling", {}) or {}
+        return cls(
+            hidden_size=int(text["hidden_size"]),
+            num_layers=int(text["num_hidden_layers"]),
+            num_attention_heads=int(text["num_attention_heads"]),
+            num_key_value_heads=int(text["num_key_value_heads"]),
+            head_dim=int(text.get("head_dim", text["hidden_size"] // text["num_attention_heads"])),
+            intermediate_size=int(text["intermediate_size"]),
+            rms_norm_eps=float(text["rms_norm_eps"]),
+            rope_theta=float(text["rope_theta"]),
+            mrope_section=tuple(int(v) for v in scaling.get("mrope_section", (24, 20, 20))),
+            vocab_size=int(text.get("vocab_size", 151936)),
+        )
+
+
+class _ShardIndex:
+    """Per-key memory-mapped access across the diffusers safetensors shards.
+
+    Reads tensors directly through the safetensors header so BF16 weights
+    stream from disk without loading a shard (and without torch).
+    """
+
+    def __init__(self, component_dir: Path):
+        component_dir = Path(component_dir)
+        index_path = component_dir / "model.safetensors.index.json"
+        self.key_to_shard: dict[str, str] = {}
+        if index_path.exists():
+            weight_map = json.loads(index_path.read_text())["weight_map"]
+            self.key_to_shard = {k: str(component_dir / s) for k, s in weight_map.items()}
+        else:
+            single = component_dir / "model.safetensors"
+            if not single.exists():
+                raise FileNotFoundError(f"No conditioner weights under {component_dir}")
+            import struct
+            with open(single, "rb") as handle:
+                (header_len, ) = struct.unpack("<Q", handle.read(8))
+                header = json.loads(handle.read(header_len))
+            self.key_to_shard = {k: str(single) for k in header if k != "__metadata__"}
+
+    def has(self, prefix: str) -> bool:
+        return any(key.startswith(prefix) for key in self.key_to_shard)
+
+    def keys_with_prefix(self, prefix: str) -> list[str]:
+        return sorted(key for key in self.key_to_shard if key.startswith(prefix))
+
+    def get(self, key: str) -> np.ndarray:
+        shard = self.key_to_shard[key]
+        return _read_safetensors_bf16(shard, key)
+
+    def get_row(self, key: str, row: int) -> np.ndarray:
+        shard = self.key_to_shard[key]
+        return _read_safetensors_row(shard, key, row)
+
+    def close(self) -> None:
+        gc.collect()
+
+
+_DTYPES = {"F32": np.float32, "F16": np.float16, "I64": np.int64, "I32": np.int32}
+
+
+def _read_safetensors_bf16(path: str, key: str) -> np.ndarray:
+    """Read one tensor (any dtype incl. BF16) without loading the shard."""
+    import struct
+
+    with open(path, "rb") as handle:
+        (header_len, ) = struct.unpack("<Q", handle.read(8))
+        header = json.loads(handle.read(header_len))
+    meta = header[key]
+    data_start = 8 + header_len
+    begin, end = meta["data_offsets"]
+    count = end - begin
+    dtype = meta["dtype"]
+    if dtype == "BF16":
+        raw = np.memmap(path, dtype=np.uint16, mode="r", offset=data_start + begin, shape=(count // 2, ))
+        return (raw.astype(np.uint32) << 16).view(np.float32).reshape(meta["shape"])
+    if dtype not in _DTYPES:
+        raise ValueError(f"Unsupported safetensors dtype {dtype} in {path}:{key}")
+    return np.asarray(
+        np.memmap(path,
+                  dtype=_DTYPES[dtype],
+                  mode="r",
+                  offset=data_start + begin,
+                  shape=(count // np.dtype(_DTYPES[dtype]).itemsize, )).reshape(meta["shape"]))
+
+
+def _read_safetensors_row(path: str, key: str, row: int) -> np.ndarray:
+    """Read one leading-dimension row without materializing the full tensor."""
+    import struct
+
+    with open(path, "rb") as handle:
+        (header_len, ) = struct.unpack("<Q", handle.read(8))
+        header = json.loads(handle.read(header_len))
+    meta = header[key]
+    shape = tuple(int(value) for value in meta["shape"])
+    if len(shape) < 2:
+        raise ValueError(f"Row access requires a rank >= 2 tensor, got {shape} for {key}")
+    if not 0 <= row < shape[0]:
+        raise IndexError(f"Row {row} is outside leading dimension {shape[0]} for {key}")
+
+    dtype = meta["dtype"]
+    if dtype != "BF16" and dtype not in _DTYPES:
+        raise ValueError(f"Unsupported safetensors dtype {dtype} in {path}:{key}")
+    item_size = 2 if dtype in {"BF16", "F16"} else np.dtype(_DTYPES[dtype]).itemsize
+    row_count = int(np.prod(shape[1:], dtype=np.int64))
+    data_start = 8 + header_len
+    begin = int(meta["data_offsets"][0]) + row * row_count * item_size
+    if dtype == "BF16":
+        raw = np.memmap(path, dtype=np.uint16, mode="r", offset=data_start + begin, shape=(row_count, ))
+        return (raw.astype(np.uint32) << 16).view(np.float32).reshape(shape[1:])
+    return np.array(
+        np.memmap(path, dtype=_DTYPES[dtype], mode="r", offset=data_start + begin, shape=(row_count, )),
+        copy=True,
+    ).reshape(shape[1:])
+
+
+def _rms_norm(x, weight, eps: float):
+    return x / mx.sqrt(mx.mean(x * x, axis=-1, keepdims=True) + eps) * weight
+
+
+def _linear(x, weight, bias=None):
+    y = x @ weight.T
+    if bias is not None:
+        y = y + bias
+    return y
+
+
+def _mrope_cos_sin(positions: np.ndarray, cfg: ConditionerConfig) -> tuple[mx.array, mx.array]:
+    """(3, S) axis positions -> cos/sin each (S, 1, head_dim), fp32.
+
+    Interleaved MRoPE assembled in NumPy exactly like the reference (strided
+    slice overwrite on top of the temporal-axis frequencies); MLX lacks
+    strided slice assignment.
+    """
+    half = cfg.head_dim // 2
+    inv_freq = (1.0 / (cfg.rope_theta**(np.arange(0, half, dtype=np.float32) / half))).astype(np.float32)
+    frequencies = positions.astype(np.float32)[:, :, None] * inv_freq[None, None, :]  # (3, S, half)
+    sections = cfg.mrope_section
+    interleaved = frequencies[0].copy()
+    stop = sections[1] * 3
+    interleaved[:, 1:stop:3] = frequencies[1][:, 1:stop:3]
+    stop = sections[2] * 3
+    interleaved[:, 2:stop:3] = frequencies[2][:, 2:stop:3]
+    embedding = np.concatenate([interleaved, interleaved], axis=-1)[:, None, :]
+    return mx.array(np.cos(embedding)), mx.array(np.sin(embedding))
+
+
+class StreamedMiniMaxH3TextConditioner:
+    """Layer-streaming Qwen3-VL text stack -> H3 conditioning hidden states."""
+
+    def __init__(self, component_dir: str | Path, tokenizer_dir: str | Path | None = None):
+        self.component_dir = Path(component_dir)
+        self.config = ConditionerConfig.from_config_json(self.component_dir / "config.json")
+        self.index = _ShardIndex(self.component_dir)
+        self.tokenizer = self._load_tokenizer(tokenizer_dir)
+
+    def _load_tokenizer(self, tokenizer_dir: str | Path | None):
+        from transformers import AutoTokenizer
+
+        candidates = [Path(tokenizer_dir)] if tokenizer_dir else [
+            self.component_dir.parent / "tokenizer",
+            self.component_dir,
+        ]
+        last_error = None
+        for candidate in candidates:
+            try:
+                return AutoTokenizer.from_pretrained(str(candidate))
+            except Exception as error:  # noqa: BLE001 - fall through to next candidate
+                last_error = error
+        raise RuntimeError(f"Could not load an H3 tokenizer from {candidates}: {last_error}")
+
+    # -- public API ------------------------------------------------------
+
+    def tokenize(self, prompt: str) -> list[int]:
+        encoded = self.tokenizer(prompt, add_special_tokens=False)
+        input_ids = encoded["input_ids"]
+        if input_ids and isinstance(input_ids[0], list):
+            if len(input_ids) != 1:
+                raise ValueError("H3 conditioning expects exactly one sequence.")
+            input_ids = input_ids[0]
+        return [int(t) for t in input_ids]
+
+    def encode_prompt(self, prompt: str) -> tuple[np.ndarray, np.ndarray]:
+        """prompt -> (hidden states (S, hidden), token tags (S,)) both fp32."""
+        token_ids = self.tokenize(prompt)
+        return self.encode_tokens(token_ids)
+
+    def encode_tokens(self, token_ids: list[int]) -> tuple[np.ndarray, np.ndarray]:
+        import mlx.core as mx
+
+        cfg = self.config
+        seq_len = len(token_ids)
+        positions = np.stack([
+            np.arange(seq_len, dtype=np.float64),
+            np.arange(seq_len, dtype=np.float64),
+            np.arange(seq_len, dtype=np.float64),
+        ])
+        cos, sin = _mrope_cos_sin(positions, cfg)
+
+        # Embedding rows gathered individually; the (151936, 5120) table is
+        # never fully materialized.
+        rows = []
+        for token in token_ids:
+            key = "model.language_model.embed_tokens.weight"
+            rows.append(self.index.get_row(key, token))
+        hidden = mx.array(np.stack(rows).astype(np.float32))
+        del rows
+        gc.collect()
+
+        if cfg.num_layers <= TEXT_ENCODER_LAYER:
+            raise ValueError(f"Conditioner needs > {TEXT_ENCODER_LAYER} layers, has {cfg.num_layers}.")
+        for layer in range(TEXT_ENCODER_LAYER):
+            hidden = self._decoder_layer(layer, hidden, cos, sin)
+            # Per-layer sync: without this the whole 50-layer graph accumulates
+            # and the machine runs out of memory (same failure mode as the DiT).
+            mx.eval(hidden)
+            gc.collect()
+
+        tags = np.full((seq_len, ), 1, dtype=np.int64)  # MINIMAX_H3_TEXT_TAG
+        return np.asarray(hidden).astype(np.float32), tags
+
+    # -- layers ----------------------------------------------------------
+
+    def _decoder_layer(self, index: int, hidden, cos, sin):
+        cfg = self.config
+        prefix = f"model.language_model.layers.{index}."
+
+        def w(name):
+            return mx.array(np.asarray(self.index.get(prefix + name)).astype(np.float32))
+
+        # Self-attention block.
+        residual = hidden
+        normed = _rms_norm(hidden, w("input_layernorm.weight"), cfg.rms_norm_eps)
+        query = _linear(normed, w("self_attn.q_proj.weight"))
+        key = _linear(normed, w("self_attn.k_proj.weight"))
+        value = _linear(normed, w("self_attn.v_proj.weight"))
+
+        heads = cfg.num_attention_heads
+        kv_heads = cfg.num_key_value_heads
+        head_dim = cfg.head_dim
+        seq_len = hidden.shape[0]
+
+        def split_heads(t, count):
+            return t.reshape(seq_len, count, head_dim)
+
+        query = split_heads(query, heads)
+        key = split_heads(key, kv_heads)
+        value = split_heads(value, kv_heads)
+        # Per-head QK RMSNorm (Qwen3), weights only.
+        query = _rms_norm(query, w("self_attn.q_norm.weight"), cfg.rms_norm_eps)
+        key = _rms_norm(key, w("self_attn.k_norm.weight"), cfg.rms_norm_eps)
+
+        # Interleaved MRoPE.
+        query = _apply_mrope(query, cos, sin)
+        key = _apply_mrope(key, cos, sin)
+
+        # GQA: repeat KV heads.
+        repeats = heads // kv_heads
+        key = mx.repeat(key, repeats, axis=1)
+        value = mx.repeat(value, repeats, axis=1)
+
+        scores = (query.transpose(1, 0, 2) @ key.transpose(1, 2, 0)) * head_dim**-0.5
+        mask = mx.triu(mx.ones((seq_len, seq_len), dtype=mx.bool_), k=1)
+        scores = mx.where(mask[None], mx.array(-np.inf, dtype=scores.dtype), scores)
+        attended = mx.softmax(scores, axis=-1) @ value.transpose(1, 0, 2)
+        # Attention is head-major here: (heads, sequence, head_dim).  Restore
+        # sequence-major ordering before concatenating heads for o_proj.
+        attended = attended.transpose(1, 0, 2)
+        attn_out = _linear(attended.reshape(seq_len, -1), w("self_attn.o_proj.weight"))
+        hidden = residual + attn_out
+
+        # MLP block (SwiGLU).
+        residual = hidden
+        normed = _rms_norm(hidden, w("post_attention_layernorm.weight"), cfg.rms_norm_eps)
+        gate = _linear(normed, w("mlp.gate_proj.weight"))
+        up = _linear(normed, w("mlp.up_proj.weight"))
+        down = _linear(gate * mx.sigmoid(gate) * up, w("mlp.down_proj.weight"))
+        return residual + down
+
+    def close(self) -> None:
+        self.index.close()
+
+
+def _apply_mrope(q_or_k, cos, sin):
+    """q_or_k: (S, H, D); cos/sin: (S, 1, D)."""
+    half = q_or_k.shape[-1] // 2
+    first, second = q_or_k[..., :half], q_or_k[..., half:]
+    rotated = mx.concatenate([-second, first], axis=-1)
+    return q_or_k * cos + rotated * sin

--- a/fastvideo/mlx_runtime/minimax_h3_pipeline.py
+++ b/fastvideo/mlx_runtime/minimax_h3_pipeline.py
@@ -148,6 +148,20 @@ def _cleanup_mlx() -> None:
         clear()
 
 
+def _default_metal_wired_limit_gib(mx) -> float:
+    """Keep the default below both physical memory and the tested 30 GiB cap."""
+    metal = getattr(mx, "metal", None)
+    if metal is None:
+        return 30.0
+    try:
+        total_bytes = int(metal.device_info().get("memory_size", 0))
+    except (AttributeError, TypeError, ValueError):
+        return 30.0
+    if total_bytes <= 0:
+        return 30.0
+    return min(30.0, 0.84 * total_bytes / 2**30)
+
+
 MINIMAX_H3_PROMPT_CACHE_VERSION = "v2-attention-layout"
 
 
@@ -209,7 +223,7 @@ class MiniMaxH3MLXPipeline:
         prompt_cache_dir: str | Path | None = None,
         conditioner_dir: str | Path | None = None,
         tokenizer_dir: str | Path | None = None,
-        metal_wired_limit_gib: float = 30.0,
+        metal_wired_limit_gib: float | None = None,
     ) -> None:
         import mlx.core as mx
 
@@ -219,6 +233,8 @@ class MiniMaxH3MLXPipeline:
         if set_limit is not None:
             # Keep large resident models inside a predictable wired budget.
             try:
+                if metal_wired_limit_gib is None:
+                    metal_wired_limit_gib = _default_metal_wired_limit_gib(mx)
                 set_limit(int(metal_wired_limit_gib * 2**30))
             except Exception as error:  # noqa: BLE001 - best effort on older MLX
                 logger.info("Could not raise the Metal wired limit: %s", error)
@@ -229,6 +245,13 @@ class MiniMaxH3MLXPipeline:
         self.conditioner_dir = Path(conditioner_dir) if conditioner_dir else self.model_root / "text_encoder"
         self.tokenizer_dir = Path(tokenizer_dir) if tokenizer_dir else self.model_root / "tokenizer"
         self._validate_inputs_before_loading()
+        manifest = json.loads((self.dit_checkpoint / H3_MANIFEST_FILENAME).read_text())
+        dit_config = manifest["config"]
+        patch_size = dit_config["patch_size"]
+        if len(patch_size) != 3:
+            raise ValueError(f"H3 DiT patch_size must have three dimensions, got {patch_size}.")
+        self._dit_patch_size = (int(patch_size[0]), int(patch_size[1]), int(patch_size[2]))
+        self._dit_in_channels = int(dit_config["in_channels"])
 
     # -- input validation (before anything heavy loads) -------------------
 
@@ -238,9 +261,9 @@ class MiniMaxH3MLXPipeline:
             missing.append(str(self.dit_checkpoint))
         vae_dir = self.model_root / "vae"
         audio_dir = self.model_root / "audio_vae"
-        if not any(vae_dir.glob("*.safetensors")) if vae_dir.exists() else True:
+        if not (vae_dir.exists() and any(vae_dir.glob("*.safetensors"))):
             missing.append(str(vae_dir))
-        if not any(audio_dir.glob("*.safetensors")) if audio_dir.exists() else True:
+        if not (audio_dir.exists() and any(audio_dir.glob("*.safetensors"))):
             missing.append(str(audio_dir))
         if missing:
             raise FileNotFoundError(f"Missing required H3 components: {missing}")
@@ -292,7 +315,13 @@ class MiniMaxH3MLXPipeline:
         _cleanup_mlx()
         if cache_key is not None:
             cache_key.parent.mkdir(parents=True, exist_ok=True)
-            np.savez(cache_key, hidden_states=hidden, token_tags=tags)
+            tmp_cache = cache_key.with_name(f".{cache_key.name}.tmp")
+            try:
+                with tmp_cache.open("wb") as handle:
+                    np.savez(handle, hidden_states=hidden, token_tags=tags)
+                tmp_cache.replace(cache_key)
+            finally:
+                tmp_cache.unlink(missing_ok=True)
         return hidden, tags
 
     def load_prompt_cache(self, path: str | Path) -> tuple[np.ndarray, np.ndarray]:
@@ -330,16 +359,6 @@ class MiniMaxH3MLXPipeline:
 
         geometry = self.resolve_geometry(height, width, num_frames, enforce_duration=audio_num_frames is None)
         audio_frames = geometry["num_frames"] if audio_num_frames is None else align_num_frames(audio_num_frames)
-        layout = build_packed_layout(
-            len(token_tags),
-            geometry["latent_frame_count"],
-            geometry["latent_height"],
-            geometry["latent_width"],
-            audio_latent_num_frames(audio_frames),
-            patch_size=(1, 2, 2),
-            text_token_tags=np.asarray(token_tags, dtype=np.int64),
-            video_temporal_scale=video_temporal_scale,
-        )
 
         owned_dit = dit is None
         if owned_dit:
@@ -347,6 +366,17 @@ class MiniMaxH3MLXPipeline:
             t0 = time.perf_counter()
             dit = load_mlx_h3_checkpoint(self.dit_checkpoint)
             logger.info("Loaded MLX H3 DiT from %s in %.1fs", self.dit_checkpoint, time.perf_counter() - t0)
+
+        layout = build_packed_layout(
+            len(token_tags),
+            geometry["latent_frame_count"],
+            geometry["latent_height"],
+            geometry["latent_width"],
+            audio_latent_num_frames(audio_frames),
+            patch_size=dit.patch_size,
+            text_token_tags=np.asarray(token_tags, dtype=np.int64),
+            video_temporal_scale=video_temporal_scale,
+        )
 
         video_scheduler = MiniMaxH3SchedulerState.create(MINIMAX_H3_VIDEO_SHIFT, num_steps)
         audio_scheduler = MiniMaxH3SchedulerState.create(MINIMAX_H3_AUDIO_SHIFT, num_steps)
@@ -366,8 +396,8 @@ class MiniMaxH3MLXPipeline:
         video_key, audio_key = mx.random.split(mx.random.key(seed))
         target_video_rows = int(layout.video_indices.shape[0] - layout.num_condition_video_rows)
         target_audio_rows = int(layout.audio_indices.shape[0] - layout.num_condition_audio_rows)
-        x_v = mx.random.normal((target_video_rows, 96), key=video_key)
-        x_a = mx.random.normal((target_audio_rows, 32), key=audio_key)
+        x_v = mx.random.normal((target_video_rows, dit.patch_dim), key=video_key)
+        x_a = mx.random.normal((target_audio_rows, dit.audio_in_channels), key=audio_key)
         text = mx.array(text_rows.astype(np.float32))
 
         for step_index in range(num_steps):
@@ -417,15 +447,24 @@ class MiniMaxH3MLXPipeline:
         from fastvideo.mlx_runtime.minimax_h3_video_vae import mlx_h3_video_vae_from_dir
 
         geometry = self.resolve_geometry(height, width, num_frames, enforce_duration=False)
+        vae = mlx_h3_video_vae_from_dir(self.model_root / "vae", include_encoder=False, storage_dtype=self.vae_dtype)
+        expected_height = height // vae.spatial_compression_ratio
+        expected_width = width // vae.spatial_compression_ratio
+        if (geometry["latent_height"], geometry["latent_width"]) != (expected_height, expected_width):
+            raise RuntimeError("H3 pipeline/VAE spatial compression mismatch: "
+                               f"pipeline={(geometry['latent_height'], geometry['latent_width'])}, "
+                               f"VAE={(expected_height, expected_width)}.")
+        if vae.latent_channels != self._dit_in_channels:
+            raise RuntimeError(
+                f"H3 DiT/VAE latent-channel mismatch: DiT={self._dit_in_channels}, VAE={vae.latent_channels}.")
         latents = unpatchify_video_tokens(
             video_rows,
             geometry["latent_frame_count"],
             geometry["latent_height"],
             geometry["latent_width"],
-            24,
-            (1, 2, 2),
+            vae.latent_channels,
+            self._dit_patch_size,
         )
-        vae = mlx_h3_video_vae_from_dir(self.model_root / "vae", include_encoder=False, storage_dtype=self.vae_dtype)
         z = mx.array(latents)
         z = vae.denormalize_latents(z)
         decoded = vae.decode(z,
@@ -479,56 +518,59 @@ class MiniMaxH3MLXPipeline:
         pcm = (np.clip(waveform.T, -1.0, 1.0) * 32767.0).astype("<i2")  # (S, 2)
         import wave
 
-        with wave.open(str(tmp_audio), "wb") as handle:
-            handle.setnchannels(2)
-            handle.setsampwidth(2)
-            handle.setframerate(sample_rate)
-            handle.writeframes(pcm.tobytes())
+        try:
+            with wave.open(str(tmp_audio), "wb") as handle:
+                handle.setnchannels(2)
+                handle.setsampwidth(2)
+                handle.setframerate(sample_rate)
+                handle.writeframes(pcm.tobytes())
 
-        height, width = frames.shape[1:3]
-        ffmpeg = shutil.which("ffmpeg")
-        if ffmpeg is None:
-            raise RuntimeError("ffmpeg is required for MP4 muxing.")
-        subprocess.run(
-            [
-                ffmpeg,
-                "-y",
-                "-loglevel",
-                "error",
-                "-f",
-                "rawvideo",
-                "-pix_fmt",
-                "rgb24",
-                "-s",
-                f"{width}x{height}",
-                "-r",
-                str(fps),
-                "-i",
-                "-",
-                "-i",
-                str(tmp_audio),
-                "-c:v",
-                "libx264",
-                "-preset",
-                "medium",
-                "-crf",
-                "18",
-                "-pix_fmt",
-                "yuv420p",
-                "-c:a",
-                "aac",
-                "-b:a",
-                "192k",
-                "-shortest",
-                "-movflags",
-                "+faststart",
-                str(tmp_video),
-            ],
-            input=frames.tobytes(),
-            check=True,
-        )
-        tmp_audio.unlink(missing_ok=True)
-        tmp_video.replace(output_path)
+            height, width = frames.shape[1:3]
+            ffmpeg = shutil.which("ffmpeg")
+            if ffmpeg is None:
+                raise RuntimeError("ffmpeg is required for MP4 muxing.")
+            subprocess.run(
+                [
+                    ffmpeg,
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "rawvideo",
+                    "-pix_fmt",
+                    "rgb24",
+                    "-s",
+                    f"{width}x{height}",
+                    "-r",
+                    str(fps),
+                    "-i",
+                    "-",
+                    "-i",
+                    str(tmp_audio),
+                    "-c:v",
+                    "libx264",
+                    "-preset",
+                    "medium",
+                    "-crf",
+                    "18",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-c:a",
+                    "aac",
+                    "-b:a",
+                    "192k",
+                    "-shortest",
+                    "-movflags",
+                    "+faststart",
+                    str(tmp_video),
+                ],
+                input=frames.tobytes(),
+                check=True,
+            )
+            tmp_video.replace(output_path)
+        finally:
+            tmp_audio.unlink(missing_ok=True)
+            tmp_video.unlink(missing_ok=True)
         return output_path
 
     # -- end-to-end ----------------------------------------------------------

--- a/fastvideo/mlx_runtime/minimax_h3_pipeline.py
+++ b/fastvideo/mlx_runtime/minimax_h3_pipeline.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import gc
 import hashlib
+import importlib.util
+import json
 import math
 import shutil
 import subprocess
@@ -32,6 +34,7 @@ import numpy as np
 
 from fastvideo.logger import init_logger
 from fastvideo.mlx_runtime.minimax_h3 import (
+    H3_MANIFEST_FILENAME,
     MINIMAX_H3_AUDIO_SHIFT,
     MINIMAX_H3_FPS,
     MINIMAX_H3_KEYFRAME_NOISE_AUG,
@@ -156,6 +159,42 @@ def prompt_cache_path(cache_dir: str | Path, model_root: str | Path, prompt: str
 
 def _audio_sample_count(num_frames: int, fps: int = MINIMAX_H3_FPS, sample_rate: int = 32000) -> int:
     return math.ceil(num_frames / fps * sample_rate)
+
+
+def _adaln_schedule_union(num_steps: int) -> np.ndarray:
+    video = MiniMaxH3SchedulerState.create(MINIMAX_H3_VIDEO_SHIFT, num_steps)
+    audio = MiniMaxH3SchedulerState.create(MINIMAX_H3_AUDIO_SHIFT, num_steps)
+    return np.unique(np.concatenate([video.timesteps, audio.timesteps, [1.0]]).astype(np.float32))
+
+
+def _validate_checkpoint_step_ladder(checkpoint_dir: str | Path, num_steps: int) -> None:
+    """Reject a schedule that a fixed, AdaLN-dropped checkpoint cannot serve."""
+    checkpoint_dir = Path(checkpoint_dir)
+    manifest_path = checkpoint_dir / H3_MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Missing MLX H3 checkpoint manifest: {manifest_path}")
+    cache_info = json.loads(manifest_path.read_text()).get("adaln_cache")
+    if cache_info is None:
+        return
+    cached = np.asarray(cache_info["timesteps"], dtype=np.float32)
+    requested = _adaln_schedule_union(num_steps)
+    if not np.array_equal(cached, requested):
+        raise ValueError(
+            f"MLX H3 checkpoint {checkpoint_dir} has a fixed AdaLN ladder that does not support --steps "
+            f"{num_steps}. Use the step count used during conversion (normally 4), or re-export the checkpoint.")
+
+
+def _preflight_media_dependencies(*, fast: bool, fast_sharpen: float, rife_weights_dir: str | Path | None) -> None:
+    """Fail before conditioning when required output dependencies are unavailable."""
+    if shutil.which("ffmpeg") is None:
+        raise RuntimeError("ffmpeg is required for MP4 muxing; install it before generation.")
+    if not fast:
+        return
+    if fast_sharpen > 0 and importlib.util.find_spec("cv2") is None:
+        raise RuntimeError("OpenCV is required when --fast-sharpen is greater than zero.")
+    from fastvideo.mlx_runtime.rife_interp import ensure_weights_available
+
+    ensure_weights_available(weights_dir=str(rife_weights_dir) if rife_weights_dir is not None else None)
 
 
 class MiniMaxH3MLXPipeline:
@@ -304,6 +343,7 @@ class MiniMaxH3MLXPipeline:
 
         owned_dit = dit is None
         if owned_dit:
+            _validate_checkpoint_step_ladder(self.dit_checkpoint, num_steps)
             t0 = time.perf_counter()
             dit = load_mlx_h3_checkpoint(self.dit_checkpoint)
             logger.info("Loaded MLX H3 DiT from %s in %.1fs", self.dit_checkpoint, time.perf_counter() - t0)
@@ -311,12 +351,7 @@ class MiniMaxH3MLXPipeline:
         video_scheduler = MiniMaxH3SchedulerState.create(MINIMAX_H3_VIDEO_SHIFT, num_steps)
         audio_scheduler = MiniMaxH3SchedulerState.create(MINIMAX_H3_AUDIO_SHIFT, num_steps)
         # The released artifacts persist the converter grid: video ∪ audio ∪ {1.0}.
-        union = np.unique(
-            np.concatenate([
-                video_scheduler.timesteps,
-                audio_scheduler.timesteps,
-                [1.0],
-            ]).astype(np.float32))
+        union = _adaln_schedule_union(num_steps)
         # The keyframe-noise timestep (0.999) is only exercised by FL2VA/Ref2VA
         # conditioning rows; those modes recompute the ladder before denoise.
 
@@ -518,11 +553,17 @@ class MiniMaxH3MLXPipeline:
         timings: dict[str, float] = {}
         peaks: dict[str, float] = {}
 
+        if fast_sharpen < 0:
+            raise ValueError(f"fast_sharpen must be non-negative, got {fast_sharpen}.")
+        _validate_checkpoint_step_ladder(self.dit_checkpoint, num_steps)
+        _preflight_media_dependencies(
+            fast=fast,
+            fast_sharpen=fast_sharpen,
+            rife_weights_dir=rife_weights_dir,
+        )
         canvas_height, canvas_width = _model_canvas_size(height, width)
         target_geometry = self.resolve_geometry(canvas_height, canvas_width, num_frames)
         fast_plan = plan_fast_temporal(target_geometry["num_frames"], fast_factor) if fast else None
-        if fast_sharpen < 0:
-            raise ValueError(f"fast_sharpen must be non-negative, got {fast_sharpen}.")
         video_num_frames = fast_plan.source_frames if fast_plan is not None else target_geometry["num_frames"]
         video_temporal_scale = fast_plan.video_temporal_scale if fast_plan is not None else 1.0
         video_geometry = self.resolve_geometry(

--- a/fastvideo/mlx_runtime/minimax_h3_pipeline.py
+++ b/fastvideo/mlx_runtime/minimax_h3_pipeline.py
@@ -1,0 +1,630 @@
+# SPDX-License-Identifier: Apache-2.0
+# mypy: disable-error-code=no-untyped-call
+"""End-to-end MiniMax-H3 joint audio-video generation on Apple Silicon MLX.
+
+Phased runtime that keeps one heavyweight component resident at a time:
+
+1. **Condition** — streamed Qwen3-VL text encoding (or a verified prompt
+   embedding cache);
+2. **Denoise** — pre-quantized H3 DiT (one of int8/int6/int4 resident),
+   dual rectified-flow schedulers (video shift 12 / audio shift 3), served
+   from the persisted AdaLN ladder;
+3. **Decode** — MLX H3 video VAE and audio VAE, sequentially;
+4. **Mux** — H.264 24 fps + AAC 32 kHz stereo MP4 via ffmpeg.
+
+MLX-native memory cleanup (`mx.clear_cache`) runs between every phase.
+The MLX path itself does not call PyTorch.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+import math
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from fastvideo.logger import init_logger
+from fastvideo.mlx_runtime.minimax_h3 import (
+    MINIMAX_H3_AUDIO_SHIFT,
+    MINIMAX_H3_FPS,
+    MINIMAX_H3_KEYFRAME_NOISE_AUG,
+    MINIMAX_H3_VIDEO_SHIFT,
+    MiniMaxH3SchedulerState,
+    align_num_frames,
+    audio_latent_num_frames,
+    build_packed_layout,
+    build_row_timesteps,
+    load_mlx_h3_checkpoint,
+    temporal_position_grid,
+    unpatchify_video_tokens,
+    unpack_audio_tokens,
+    video_latent_num_frames,
+)
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class GenerationResult:
+    video_path: str | None
+    frames: np.ndarray | None
+    waveform: np.ndarray | None
+    sample_rate: int
+    timings: dict[str, float] = field(default_factory=dict)
+    peak_memory_gib: dict[str, float] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class FastTemporalPlan:
+    """Sparse video geometry for RIFE fast mode with full-duration audio."""
+
+    target_frames: int
+    source_frames: int
+    factor: int
+    video_temporal_scale: float
+
+
+def plan_fast_temporal(target_frames: int, factor: int = 2) -> FastTemporalPlan:
+    """Choose the smallest H3-valid source sequence that covers the target timeline."""
+    target_frames = align_num_frames(target_frames)
+    if factor < 2:
+        raise ValueError(f"fast factor must be at least 2, got {factor}.")
+    ideal_source_frames = math.ceil((target_frames - 1) / factor) + 1
+    source_frames = align_num_frames(ideal_source_frames)
+    if source_frames >= target_frames:
+        raise ValueError(f"fast factor {factor} does not reduce the H3-aligned target of {target_frames} frames.")
+
+    source_grid = temporal_position_grid(video_latent_num_frames(source_frames), 0.0)
+    target_grid = temporal_position_grid(video_latent_num_frames(target_frames), 0.0)
+    video_temporal_scale = float(target_grid[-1] / source_grid[-1])
+    return FastTemporalPlan(
+        target_frames=target_frames,
+        source_frames=source_frames,
+        factor=factor,
+        video_temporal_scale=video_temporal_scale,
+    )
+
+
+def _model_canvas_size(height: int, width: int) -> tuple[int, int]:
+    """Round an exact output size up to H3's 32-pixel model grid."""
+    if height <= 0 or width <= 0:
+        raise ValueError(f"H3 output size must be positive, got {height}x{width}.")
+    multiple = 32
+    return math.ceil(height / multiple) * multiple, math.ceil(width / multiple) * multiple
+
+
+def _center_crop_frames(frames: np.ndarray, height: int, width: int) -> np.ndarray:
+    frame_height, frame_width = frames.shape[1:3]
+    if height > frame_height or width > frame_width:
+        raise ValueError(f"cannot crop {frame_width}x{frame_height} frames to {width}x{height}.")
+    top = (frame_height - height) // 2
+    left = (frame_width - width) // 2
+    return np.ascontiguousarray(frames[:, top:top + height, left:left + width])
+
+
+def _sharpen_frames(frames: list[np.ndarray], amount: float) -> list[np.ndarray]:
+    if amount <= 0:
+        return frames
+    import cv2
+
+    sharpened = []
+    for frame in frames:
+        blur = cv2.GaussianBlur(frame, (0, 0), 1.0)
+        sharpened.append(cv2.addWeighted(frame, 1.0 + amount, blur, -amount, 0))
+    return sharpened
+
+
+def _peak_memory_gib() -> float:
+    import mlx.core as mx
+
+    getter = getattr(mx, "get_peak_memory", None)
+    return 0.0 if getter is None else float(getter()) / 2**30
+
+
+def _reset_peak_memory() -> None:
+    import mlx.core as mx
+
+    reset = getattr(mx, "reset_peak_memory", None)
+    if reset is not None:
+        reset()
+
+
+def _cleanup_mlx() -> None:
+    import mlx.core as mx
+
+    gc.collect()
+    clear = getattr(mx, "clear_cache", None)
+    if clear is not None:
+        clear()
+
+
+MINIMAX_H3_PROMPT_CACHE_VERSION = "v2-attention-layout"
+
+
+def prompt_cache_path(cache_dir: str | Path, model_root: str | Path, prompt: str) -> Path:
+    digest = hashlib.sha256(
+        f"{MINIMAX_H3_PROMPT_CACHE_VERSION}::{Path(model_root)}::{prompt}".encode()).hexdigest()[:24]
+    return Path(cache_dir) / f"prompt_embeds_{digest}.npz"
+
+
+def _audio_sample_count(num_frames: int, fps: int = MINIMAX_H3_FPS, sample_rate: int = 32000) -> int:
+    return math.ceil(num_frames / fps * sample_rate)
+
+
+class MiniMaxH3MLXPipeline:
+    """Text-to-video-with-audio generation through the native MLX runtime."""
+
+    def __init__(
+        self,
+        *,
+        model_root: str | Path,
+        mlx_dit_checkpoint: str | Path,
+        vae_dtype: str = "fp32",
+        prompt_cache_dir: str | Path | None = None,
+        conditioner_dir: str | Path | None = None,
+        tokenizer_dir: str | Path | None = None,
+        metal_wired_limit_gib: float = 30.0,
+    ) -> None:
+        import mlx.core as mx
+
+        set_limit = getattr(mx, "set_memory_limit", None)
+        if set_limit is None and hasattr(mx, "metal"):
+            set_limit = getattr(mx.metal, "set_memory_limit", None)
+        if set_limit is not None:
+            # Keep large resident models inside a predictable wired budget.
+            try:
+                set_limit(int(metal_wired_limit_gib * 2**30))
+            except Exception as error:  # noqa: BLE001 - best effort on older MLX
+                logger.info("Could not raise the Metal wired limit: %s", error)
+        self.model_root = Path(model_root)
+        self.dit_checkpoint = Path(mlx_dit_checkpoint)
+        self.vae_dtype = vae_dtype
+        self.prompt_cache_dir = Path(prompt_cache_dir) if prompt_cache_dir else None
+        self.conditioner_dir = Path(conditioner_dir) if conditioner_dir else self.model_root / "text_encoder"
+        self.tokenizer_dir = Path(tokenizer_dir) if tokenizer_dir else self.model_root / "tokenizer"
+        self._validate_inputs_before_loading()
+
+    # -- input validation (before anything heavy loads) -------------------
+
+    def _validate_inputs_before_loading(self) -> bool:
+        missing = []
+        if not self.dit_checkpoint.exists():
+            missing.append(str(self.dit_checkpoint))
+        vae_dir = self.model_root / "vae"
+        audio_dir = self.model_root / "audio_vae"
+        if not any(vae_dir.glob("*.safetensors")) if vae_dir.exists() else True:
+            missing.append(str(vae_dir))
+        if not any(audio_dir.glob("*.safetensors")) if audio_dir.exists() else True:
+            missing.append(str(audio_dir))
+        if missing:
+            raise FileNotFoundError(f"Missing required H3 components: {missing}")
+        return True
+
+    @staticmethod
+    def resolve_geometry(
+        height: int,
+        width: int,
+        num_frames: int,
+        *,
+        enforce_duration: bool = True,
+    ) -> dict[str, int]:
+        """Explicit canvases pass through (positive multiples of 32); the
+        aspect-ratio resolver only applies when dimensions are omitted."""
+        if height <= 0 or width <= 0 or height % 32 or width % 32:
+            raise ValueError(f"H3 canvas must be positive multiples of 32, got {height}x{width}.")
+        aligned_frames = align_num_frames(num_frames)
+        latent_frames = video_latent_num_frames(aligned_frames)
+        duration = aligned_frames / MINIMAX_H3_FPS
+        if enforce_duration and not 5.0 <= duration <= 15.0:
+            raise ValueError(f"H3 generates 5-15 s at {MINIMAX_H3_FPS} fps; {aligned_frames} frames "
+                             f"is {duration:.2f} s.")
+        return {
+            "height": height,
+            "width": width,
+            "num_frames": aligned_frames,
+            "latent_frame_count": latent_frames,
+            "latent_height": height // 16,
+            "latent_width": width // 16,
+        }
+
+    # -- phase 1: conditioning -------------------------------------------
+
+    def encode_prompt(self, prompt: str) -> tuple[np.ndarray, np.ndarray]:
+        """Returns (hidden states (S, hidden), token tags). Uses the cache or
+        the streamed conditioner."""
+        cache_key = None
+        if self.prompt_cache_dir is not None:
+            cache_key = prompt_cache_path(self.prompt_cache_dir, self.model_root, prompt)
+            if cache_key.exists():
+                data = np.load(cache_key)
+                logger.info("Loaded prompt embeddings from cache %s", cache_key)
+                return data["hidden_states"], data["token_tags"]
+
+        conditioner = self._load_conditioner()
+        hidden, tags = conditioner.encode_prompt(prompt)
+        conditioner.close()
+        _cleanup_mlx()
+        if cache_key is not None:
+            cache_key.parent.mkdir(parents=True, exist_ok=True)
+            np.savez(cache_key, hidden_states=hidden, token_tags=tags)
+        return hidden, tags
+
+    def load_prompt_cache(self, path: str | Path) -> tuple[np.ndarray, np.ndarray]:
+        data = np.load(path)
+        return data["hidden_states"], data["token_tags"]
+
+    def has_conditioner_weights(self) -> bool:
+        marker = self.conditioner_dir / "model.safetensors.index.json"
+        single = self.conditioner_dir / "model.safetensors"
+        return marker.exists() or single.exists()
+
+    def _load_conditioner(self):
+        from fastvideo.mlx_runtime.minimax_h3_conditioner import StreamedMiniMaxH3TextConditioner
+
+        return StreamedMiniMaxH3TextConditioner(self.conditioner_dir, self.tokenizer_dir)
+
+    # -- phase 2: denoise --------------------------------------------------
+
+    def denoise(
+        self,
+        text_rows: np.ndarray,
+        token_tags: np.ndarray,
+        *,
+        height: int,
+        width: int,
+        num_frames: int,
+        audio_num_frames: int | None = None,
+        video_temporal_scale: float = 1.0,
+        seed: int,
+        num_steps: int = 4,
+        dit: Any | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Denoise joint latents; returns (normalized video rows, audio rows)."""
+        import mlx.core as mx
+
+        geometry = self.resolve_geometry(height, width, num_frames, enforce_duration=audio_num_frames is None)
+        audio_frames = geometry["num_frames"] if audio_num_frames is None else align_num_frames(audio_num_frames)
+        layout = build_packed_layout(
+            len(token_tags),
+            geometry["latent_frame_count"],
+            geometry["latent_height"],
+            geometry["latent_width"],
+            audio_latent_num_frames(audio_frames),
+            patch_size=(1, 2, 2),
+            text_token_tags=np.asarray(token_tags, dtype=np.int64),
+            video_temporal_scale=video_temporal_scale,
+        )
+
+        owned_dit = dit is None
+        if owned_dit:
+            t0 = time.perf_counter()
+            dit = load_mlx_h3_checkpoint(self.dit_checkpoint)
+            logger.info("Loaded MLX H3 DiT from %s in %.1fs", self.dit_checkpoint, time.perf_counter() - t0)
+
+        video_scheduler = MiniMaxH3SchedulerState.create(MINIMAX_H3_VIDEO_SHIFT, num_steps)
+        audio_scheduler = MiniMaxH3SchedulerState.create(MINIMAX_H3_AUDIO_SHIFT, num_steps)
+        # The released artifacts persist the converter grid: video ∪ audio ∪ {1.0}.
+        union = np.unique(
+            np.concatenate([
+                video_scheduler.timesteps,
+                audio_scheduler.timesteps,
+                [1.0],
+            ]).astype(np.float32))
+        # The keyframe-noise timestep (0.999) is only exercised by FL2VA/Ref2VA
+        # conditioning rows; those modes recompute the ladder before denoise.
+
+        cache = getattr(dit, "_adaln_cache", None)
+        if cache is None:
+            dit.precompute_adaln(union, drop_weights=True)
+        elif not np.array_equal(cache.timesteps.astype(np.float32), union):
+            extra = np.setdiff1d(union, cache.timesteps)
+            logger.info("Recomputing AdaLN cache for %d-step ladder (extra timesteps %s).", num_steps, extra)
+            dit.precompute_adaln(union, drop_weights=True)
+
+        video_key, audio_key = mx.random.split(mx.random.key(seed))
+        target_video_rows = int(layout.video_indices.shape[0] - layout.num_condition_video_rows)
+        target_audio_rows = int(layout.audio_indices.shape[0] - layout.num_condition_audio_rows)
+        x_v = mx.random.normal((target_video_rows, 96), key=video_key)
+        x_a = mx.random.normal((target_audio_rows, 32), key=audio_key)
+        text = mx.array(text_rows.astype(np.float32))
+
+        for step_index in range(num_steps):
+            video_t = float(video_scheduler.timesteps[step_index])
+            audio_t = float(audio_scheduler.timesteps[step_index])
+            unique, inverse = build_row_timesteps(
+                layout,
+                video_timestep=video_t,
+                audio_timestep=audio_t,
+                condition_video_timestep=max(video_t, MINIMAX_H3_KEYFRAME_NOISE_AUG),
+                condition_audio_timestep=1.0,
+            )
+            video_velocity, audio_velocity = dit.forward_with_cache(
+                x_v,
+                x_a,
+                text,
+                layout=layout,
+                step_timesteps=unique,
+                row_timestep_inverse=inverse,
+            )
+            # Only target rows are being denoised (no conditions in T2VA).
+            video_velocity = video_velocity[layout.num_condition_video_rows:]
+            audio_velocity = audio_velocity[layout.num_condition_audio_rows:]
+            x_v = video_scheduler.step(video_velocity, step_index, x_v)
+            x_a = audio_scheduler.step(audio_velocity, step_index, x_a)
+            mx.eval(x_v, x_a)
+
+        video_rows = np.asarray(x_v, dtype=np.float32)
+        audio_rows = np.asarray(x_a, dtype=np.float32)
+        if owned_dit:
+            del dit
+            _cleanup_mlx()
+        return video_rows, audio_rows
+
+    # -- phase 3a: video decode -------------------------------------------
+
+    def decode_video(self,
+                     video_rows: np.ndarray,
+                     *,
+                     height: int,
+                     width: int,
+                     num_frames: int,
+                     tiled: bool = True) -> np.ndarray:
+        """Normalized packed rows -> (T, H, W, 3) uint8 frames."""
+        import mlx.core as mx
+
+        from fastvideo.mlx_runtime.minimax_h3_video_vae import mlx_h3_video_vae_from_dir
+
+        geometry = self.resolve_geometry(height, width, num_frames, enforce_duration=False)
+        latents = unpatchify_video_tokens(
+            video_rows,
+            geometry["latent_frame_count"],
+            geometry["latent_height"],
+            geometry["latent_width"],
+            24,
+            (1, 2, 2),
+        )
+        vae = mlx_h3_video_vae_from_dir(self.model_root / "vae", include_encoder=False, storage_dtype=self.vae_dtype)
+        z = mx.array(latents)
+        z = vae.denormalize_latents(z)
+        decoded = vae.decode(z,
+                             tiled=tiled,
+                             tile_sample_min_height=min(geometry["height"], 256),
+                             tile_sample_min_width=min(geometry["width"], 256))
+        pixels = np.clip(np.asarray(vae.denormalize_pixels(decoded)), 0.0, 1.0)
+        del vae, decoded, z
+        _cleanup_mlx()
+        frames = (pixels[0].transpose(1, 2, 3, 0) * 255.0).astype(np.uint8)  # (T, H, W, C)
+        if frames.shape[0] != geometry["num_frames"]:
+            raise RuntimeError(f"decoded {frames.shape[0]} frames, expected {geometry['num_frames']}")
+        return frames
+
+    # -- phase 3b: audio decode --------------------------------------------
+
+    def decode_audio(self, audio_rows: np.ndarray, *, num_frames: int) -> np.ndarray:
+        """Normalized packed audio rows -> stereo waveform (2, S) fp32 in [-1, 1]."""
+        import mlx.core as mx
+
+        from fastvideo.mlx_runtime.minimax_h3_audio_vae import mlx_h3_audio_vae_from_dir
+
+        num_audio_latents = audio_latent_num_frames(align_num_frames(num_frames))
+        latents = unpack_audio_tokens(audio_rows, num_audio_latents)
+        vae = mlx_h3_audio_vae_from_dir(self.model_root / "audio_vae", include_encoder=False)
+        z = vae.denormalize_latents(mx.array(latents))
+        waveform = np.asarray(vae.decode(z))[:, 0, :]  # (B, 1, S) -> (B, S)
+        del vae, z
+        _cleanup_mlx()
+        # Keep audio at least as long as the final video packet. Rounding down
+        # by a fractional sample makes ffmpeg's ``-shortest`` drop frame 124.
+        expected_samples = _audio_sample_count(align_num_frames(num_frames))
+        if waveform.shape[-1] < expected_samples:
+            waveform = np.pad(waveform, ((0, 0), (0, expected_samples - waveform.shape[-1])))
+        return np.clip(waveform[:, :expected_samples], -1.0, 1.0)
+
+    # -- phase 4: mux --------------------------------------------------------
+
+    def mux(self,
+            frames: np.ndarray,
+            waveform: np.ndarray,
+            output_path: str | Path,
+            fps: int = MINIMAX_H3_FPS,
+            sample_rate: int = 32000) -> Path:
+        """H.264 video + AAC stereo audio, A/V durations within one frame."""
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_video = output_path.with_suffix(".tmp.mp4")
+        tmp_audio = output_path.with_suffix(".tmp.wav")
+
+        pcm = (np.clip(waveform.T, -1.0, 1.0) * 32767.0).astype("<i2")  # (S, 2)
+        import wave
+
+        with wave.open(str(tmp_audio), "wb") as handle:
+            handle.setnchannels(2)
+            handle.setsampwidth(2)
+            handle.setframerate(sample_rate)
+            handle.writeframes(pcm.tobytes())
+
+        height, width = frames.shape[1:3]
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg is None:
+            raise RuntimeError("ffmpeg is required for MP4 muxing.")
+        subprocess.run(
+            [
+                ffmpeg,
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "rawvideo",
+                "-pix_fmt",
+                "rgb24",
+                "-s",
+                f"{width}x{height}",
+                "-r",
+                str(fps),
+                "-i",
+                "-",
+                "-i",
+                str(tmp_audio),
+                "-c:v",
+                "libx264",
+                "-preset",
+                "medium",
+                "-crf",
+                "18",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "192k",
+                "-shortest",
+                "-movflags",
+                "+faststart",
+                str(tmp_video),
+            ],
+            input=frames.tobytes(),
+            check=True,
+        )
+        tmp_audio.unlink(missing_ok=True)
+        tmp_video.replace(output_path)
+        return output_path
+
+    # -- end-to-end ----------------------------------------------------------
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        output_path: str | Path,
+        height: int = 480,
+        width: int = 832,
+        num_frames: int = 124,
+        seed: int = 0,
+        num_steps: int = 4,
+        save_frames: bool = False,
+        tiled_video_decode: bool = True,
+        fast: bool = False,
+        fast_factor: int = 2,
+        fast_sharpen: float = 0.6,
+        rife_weights_dir: str | Path | None = None,
+    ) -> GenerationResult:
+        timings: dict[str, float] = {}
+        peaks: dict[str, float] = {}
+
+        canvas_height, canvas_width = _model_canvas_size(height, width)
+        target_geometry = self.resolve_geometry(canvas_height, canvas_width, num_frames)
+        fast_plan = plan_fast_temporal(target_geometry["num_frames"], fast_factor) if fast else None
+        if fast_sharpen < 0:
+            raise ValueError(f"fast_sharpen must be non-negative, got {fast_sharpen}.")
+        video_num_frames = fast_plan.source_frames if fast_plan is not None else target_geometry["num_frames"]
+        video_temporal_scale = fast_plan.video_temporal_scale if fast_plan is not None else 1.0
+        video_geometry = self.resolve_geometry(
+            canvas_height,
+            canvas_width,
+            video_num_frames,
+            enforce_duration=fast_plan is None,
+        )
+        logger.info(
+            "Geometry: output=%dx%dx%d model=%dx%dx%d audio_frames=%d fast=%s",
+            width,
+            height,
+            target_geometry["num_frames"],
+            canvas_width,
+            canvas_height,
+            video_geometry["num_frames"],
+            target_geometry["num_frames"],
+            fast_plan,
+        )
+
+        _reset_peak_memory()
+        started = time.perf_counter()
+        text_rows, token_tags = self.encode_prompt(prompt)
+        timings["condition_s"] = time.perf_counter() - started
+        peaks["condition_gib"] = _peak_memory_gib()
+        _cleanup_mlx()
+
+        _reset_peak_memory()
+        started = time.perf_counter()
+        video_rows, audio_rows = self.denoise(
+            text_rows,
+            token_tags,
+            height=video_geometry["height"],
+            width=video_geometry["width"],
+            num_frames=video_geometry["num_frames"],
+            audio_num_frames=target_geometry["num_frames"] if fast_plan is not None else None,
+            video_temporal_scale=video_temporal_scale,
+            seed=seed,
+            num_steps=num_steps,
+        )
+        timings["denoise_s"] = time.perf_counter() - started
+        peaks["denoise_gib"] = _peak_memory_gib()
+        del text_rows
+        _cleanup_mlx()
+
+        _reset_peak_memory()
+        started = time.perf_counter()
+        frames = self.decode_video(
+            video_rows,
+            height=video_geometry["height"],
+            width=video_geometry["width"],
+            num_frames=video_geometry["num_frames"],
+            tiled=tiled_video_decode,
+        )
+        frames = _center_crop_frames(frames, height, width)
+        timings["video_decode_s"] = time.perf_counter() - started
+        peaks["video_decode_gib"] = _peak_memory_gib()
+        _cleanup_mlx()
+
+        if fast_plan is not None:
+            from fastvideo.mlx_runtime.rife_interp import interpolate_to_frame_count, load_model
+
+            _reset_peak_memory()
+            started = time.perf_counter()
+            model = load_model(weights_dir=str(rife_weights_dir) if rife_weights_dir is not None else None)
+            try:
+                interpolated = interpolate_to_frame_count(
+                    frames,
+                    target_geometry["num_frames"],
+                    model=model,
+                )
+                interpolated = _sharpen_frames(interpolated, fast_sharpen)
+                frames = np.stack(interpolated)
+                if frames.shape[0] != target_geometry["num_frames"]:
+                    raise RuntimeError(
+                        f"RIFE produced {frames.shape[0]} frames, expected {target_geometry['num_frames']}.")
+                del interpolated
+                timings["rife_s"] = time.perf_counter() - started
+                peaks["rife_gib"] = _peak_memory_gib()
+            finally:
+                load_model.cache_clear()
+                del model
+                _cleanup_mlx()
+
+        _reset_peak_memory()
+        started = time.perf_counter()
+        waveform = self.decode_audio(audio_rows, num_frames=target_geometry["num_frames"])
+        timings["audio_decode_s"] = time.perf_counter() - started
+        peaks["audio_decode_gib"] = _peak_memory_gib()
+        _cleanup_mlx()
+
+        started = time.perf_counter()
+        video_path = self.mux(frames, waveform, output_path)
+        timings["mux_s"] = time.perf_counter() - started
+
+        result = GenerationResult(
+            video_path=str(video_path),
+            frames=frames if save_frames else None,
+            waveform=waveform,
+            sample_rate=32000,
+            timings=timings,
+            peak_memory_gib=peaks,
+        )
+        logger.info("Generation complete: %s | timings=%s peaks=%s", video_path, timings, peaks)
+        return result

--- a/fastvideo/mlx_runtime/minimax_h3_video_vae.py
+++ b/fastvideo/mlx_runtime/minimax_h3_video_vae.py
@@ -1,0 +1,708 @@
+# SPDX-License-Identifier: Apache-2.0
+# mypy: disable-error-code=no-untyped-call
+"""MiniMax-H3 video VAE for the Apple Silicon MLX runtime.
+
+Faithful MLX port of ``fastvideo/models/vaes/minimax_h3_video.py`` (itself
+parity-validated against the official diffusers implementation):
+
+- **Encoder**: causal 3D CNN — causal temporal padding, reflect spatial
+  padding, per-frame GroupNorm, residual blocks, spatial/temporal downsampling,
+  then a 1x1x1 ``quant_conv`` producing mean/logvar channels.
+- **Decoder**: 1x1x1 ``post_quant_conv``, then a 36-layer ViT — per-head Q/K
+  RMSNorm, three-axis rotary embedding (theta 100, rotary width 48 of 64 head
+  dims), register tokens plus a final zero class token, SwiGLU feed-forward,
+  residual scale vectors, FP32 norm accumulation, final LayerNorm, output
+  projection, and channel-major unpatchification (temporal patch 4, spatial
+  patch 16x16) — with the exact clip chunking (``clip_length=17``,
+  ``token_drop=3``), frame pre-padding, overlap blending, tail trimming, and
+  optional spatial tiling of the released model.
+
+Released weights are FP32; the loader streams shards so peak memory stays
+bounded, and can optionally store bf16/fp16 after callers have measured the
+dtype drift against the FP32 acceptance gate.
+
+Production code here never imports PyTorch. Torch parity references live in
+the tests under ``tests/local_tests/minimax_h3/``.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import mlx.core as mx
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _ct(x, *order):
+    """Contiguous transpose: some MLX builds silently mis-compute ops on
+    strided views, so every layout change materializes."""
+    return mx.contiguous(x.transpose(*order))
+
+
+PIXEL_MEAN = (0.485, 0.456, 0.406)
+PIXEL_STD = (0.229, 0.224, 0.225)
+
+
+@dataclass(frozen=True)
+class MiniMaxH3VideoVAEConfigView:
+    """Architecture constants (defaults mirror the released vae/config.json)."""
+
+    in_channels: int = 3
+    out_channels: int = 3
+    latent_channels: int = 24
+    block_out_channels: tuple[int, ...] = (128, 256, 256, 512, 512, 1024)
+    layers_per_block: int = 2
+    spatial_downsample_factors: tuple[int, ...] = (2, 2, 2, 2, 1, 1)
+    temporal_downsample_factors: tuple[int, ...] = (1, 2, 2, 1, 1, 1)
+    norm_num_groups: int = 32
+    norm_eps: float = 1e-6
+    decoder_num_layers: int = 36
+    decoder_num_attention_heads: int = 32
+    decoder_attention_head_dim: int = 64
+    decoder_num_register_tokens: int = 4
+    decoder_ffn_mult: int = 4
+    decoder_rope_theta: float = 100.0
+    decoder_rope_dim_ratio: float = 0.75
+    decoder_norm_eps: float = 1e-5
+    clip_length: int = 17
+    token_drop: int = 3
+    latents_mean: tuple[float, ...] | None = None
+    latents_std: tuple[float, ...] | None = None
+
+    @classmethod
+    def from_vae_dir(cls, vae_dir: str | Path) -> MiniMaxH3VideoVAEConfigView:
+        config = json.loads((Path(vae_dir) / "config.json").read_text())
+        latents_mean = tuple(float(v) for v in config.get("latents_mean", ()))
+        latents_std = tuple(float(v) for v in config.get("latents_std", ()))
+        return cls(
+            in_channels=int(config["in_channels"]),
+            out_channels=int(config["out_channels"]),
+            latent_channels=int(config["latent_channels"]),
+            block_out_channels=tuple(int(v) for v in config["block_out_channels"]),
+            layers_per_block=int(config["layers_per_block"]),
+            spatial_downsample_factors=tuple(int(v) for v in config["spatial_downsample_factors"]),
+            temporal_downsample_factors=tuple(int(v) for v in config["temporal_downsample_factors"]),
+            norm_num_groups=int(config["norm_num_groups"]),
+            norm_eps=float(config["norm_eps"]),
+            decoder_num_layers=int(config["decoder_num_layers"]),
+            decoder_num_attention_heads=int(config["decoder_num_attention_heads"]),
+            decoder_attention_head_dim=int(config["decoder_attention_head_dim"]),
+            decoder_num_register_tokens=int(config["decoder_num_register_tokens"]),
+            decoder_ffn_mult=int(config.get("decoder_ffn_mult", 4)),
+            decoder_rope_theta=float(config["decoder_rope_theta"]),
+            decoder_rope_dim_ratio=float(config["decoder_rope_dim_ratio"]),
+            decoder_norm_eps=float(config["decoder_norm_eps"]),
+            clip_length=int(config["clip_length"]),
+            token_drop=int(config["token_drop"]),
+            latents_mean=latents_mean or None,
+            latents_std=latents_std or None,
+        )
+
+    @property
+    def spatial_compression_ratio(self) -> int:
+        return math.prod(self.spatial_downsample_factors)
+
+    @property
+    def temporal_compression_ratio(self) -> int:
+        return math.prod(self.temporal_downsample_factors)
+
+    @property
+    def tokens_chunk_size(self) -> int:
+        """Latent frames decoded per clip chunk (ceil(clip_length / ratio))."""
+        return math.ceil(self.clip_length / self.temporal_compression_ratio)
+
+    @property
+    def token_overlap(self) -> int:
+        return (-self.token_drop) % self.tokens_chunk_size
+
+    @property
+    def frame_pre_padding(self) -> int:
+        return (-self.clip_length) % self.temporal_compression_ratio
+
+    @property
+    def frame_overlap(self) -> int:
+        return max(self.token_overlap * self.temporal_compression_ratio - self.frame_pre_padding, 0)
+
+
+# ---------------------------------------------------------------------------
+# MLX primitives (channels-last conv3d: input (N,D,H,W,C), weight (O,kT,kH,kW,C))
+# ---------------------------------------------------------------------------
+
+
+def _reflect_pad_axis(x, axis: int, left: int, right: int):
+    """Torch-style reflect padding (edge value excluded), version-portable."""
+    if left == 0 and right == 0:
+        return x
+    size = x.shape[axis]
+    indices = list(range(left, 0, -1)) + list(range(size)) + list(range(size - 2, size - 2 - right, -1))
+    return mx.concatenate([mx.take(x, mx.array([i]), axis=axis) for i in indices], axis=axis)
+
+
+def _causal_conv3d(x, weight, bias=None, *, stride=(1, 1, 1), spatial_padding: int = 0, temporal_padding: int = 0):
+    """Reflect spatial padding + zero causal temporal padding, then conv3d.
+
+    Accepts and returns torch-style (N, C, T, H, W); MLX conv3d runs
+    channels-last internally.
+    """
+    x = _ct(x, 0, 2, 3, 4, 1)
+    if spatial_padding > 0:
+        x = _reflect_pad_axis(x, 2, spatial_padding, spatial_padding)
+        x = _reflect_pad_axis(x, 3, spatial_padding, spatial_padding)
+    if temporal_padding > 0:
+        x = mx.pad(x, ((0, 0), (temporal_padding, 0), (0, 0), (0, 0), (0, 0)))
+    y = mx.conv3d(mx.contiguous(x), weight, stride=stride)
+    if bias is not None:
+        y = y + bias[None, None, None, None, :]
+    return _ct(y, 0, 4, 1, 2, 3)
+
+
+def _group_norm_per_frame(x, weight, bias, *, num_groups: int, eps: float):
+    """GroupNorm over channels for every (batch, frame) independently.
+
+    x: (N, C, T, H, W) -> same layout. Mirrors MiniMaxH3VideoGroupNorm.
+    """
+    n, c, t, h, w = x.shape
+    assert c % num_groups == 0
+    grouped = _ct(x, 0, 2, 1, 3, 4).reshape(n * t, num_groups, c // num_groups, h, w)
+    mean = grouped.mean(axis=(2, 3, 4), keepdims=True)
+    var = ((grouped - mean)**2).mean(axis=(2, 3, 4), keepdims=True)
+    grouped = (grouped - mean) / mx.sqrt(var + eps)
+    grouped = grouped.reshape(n, t, c, h, w)
+    grouped = _ct(grouped, 0, 2, 1, 3, 4)
+    return grouped * weight[None, :, None, None, None] + bias[None, :, None, None, None]
+
+
+def _rms_norm_no_affine(x, eps: float):
+    return x / mx.sqrt(mx.mean(x * x, axis=-1, keepdims=True) + eps)
+
+
+def _silu(x):
+    return x * (mx.sigmoid(x))
+
+
+def _linear(x, weight, bias=None):
+    y = x @ weight.T
+    if bias is not None:
+        y = y + bias
+    return y
+
+
+def _rotary_cos_sin(position_ids, *, rotary_dim: int, theta: float):
+    """(S, 3) positions -> cos/sin each (S, 1, rotary_dim), fp32.
+
+    inv_freq has rotary_dim//6 entries per axis; the three axes are
+    concatenated and doubled (matches MiniMaxH3VideoRotaryPosEmbed). The
+    singleton middle axis broadcasts over attention heads.
+    """
+    freqs_per_axis = rotary_dim // 6
+    inv_freq = 1.0 / (theta**(mx.arange(0, freqs_per_axis, dtype=mx.float32) * (6.0 / rotary_dim)))
+    angles = 2.0 * math.pi * position_ids[:, :, None].astype(mx.float32) * inv_freq[None, None, :]
+    # (S, 3, F) -> (S, 3*F) -> doubled -> (S, 6*F == rotary_dim)
+    angles = angles.reshape(position_ids.shape[0], 3 * freqs_per_axis)
+    angles = mx.concatenate([angles, angles], axis=-1)[:, None, None, :]
+    return mx.cos(angles), mx.sin(angles)
+
+
+def _apply_rotary(query, key, cos, sin):
+    """Half-split rotation on the rotary prefix of each head (fp32)."""
+    rotary_dim = cos.shape[-1]
+    q_rot, q_pass = query[..., :rotary_dim], query[..., rotary_dim:]
+    k_rot, k_pass = key[..., :rotary_dim], key[..., rotary_dim:]
+    q_rot = q_rot.astype(mx.float32)
+    k_rot = k_rot.astype(mx.float32)
+    q_first, q_second = mx.split(q_rot, 2, axis=-1)
+    k_first, k_second = mx.split(k_rot, 2, axis=-1)
+    q_out = q_rot * cos + mx.concatenate([-q_second, q_first], axis=-1) * sin
+    k_out = k_rot * cos + mx.concatenate([-k_second, k_first], axis=-1) * sin
+    return (mx.concatenate([q_out.astype(query.dtype), q_pass],
+                           axis=-1), mx.concatenate([k_out.astype(key.dtype), k_pass], axis=-1))
+
+
+def _attention(block: dict[str, Any], x, cos, sin, *, num_heads: int, head_dim: int, eps: float):
+    """x: (S, B, D) sequence-major. Returns (S, B, D)."""
+    seq_len, batch, hidden = x.shape
+    q = _linear(x, block["attn.to_q.weight"], block["attn.to_q.bias"])
+    k = _linear(x, block["attn.to_k.weight"], block["attn.to_k.bias"])
+    v = _linear(x, block["attn.to_v.weight"], block["attn.to_v.bias"])
+
+    # Per-head Q/K RMSNorm without affine parameters, accumulated in fp32.
+    q = q.reshape(seq_len, batch, num_heads, head_dim)
+    k = k.reshape(seq_len, batch, num_heads, head_dim)
+    v = v.reshape(seq_len, batch, num_heads, head_dim)
+    q = _rms_norm_no_affine(q.astype(mx.float32), eps).astype(x.dtype)
+    k = _rms_norm_no_affine(k.astype(mx.float32), eps).astype(x.dtype)
+    if cos is not None:
+        q, k = _apply_rotary(q, k, cos, sin)
+    # -> (B, H, S, Dh); contiguous() matters: some MLX builds silently
+    # mis-compute fused SDPA on strided views.
+    q = _ct(q, 1, 2, 0, 3)
+    k = _ct(k, 1, 2, 0, 3)
+    v = _ct(v, 1, 2, 0, 3)
+    attended = mx.fast.scaled_dot_product_attention(q, k, v, scale=head_dim**-0.5)
+    attended = _ct(attended, 0, 2, 1, 3).reshape(seq_len, batch, hidden)
+    return _linear(attended, block["attn.to_out.0.weight"], block["attn.to_out.0.bias"])
+
+
+def _feed_forward(block: dict[str, Any], x):
+    hidden = _linear(x, block["ff.net.0.proj.weight"], block["ff.net.0.proj.bias"])
+    value, gate = mx.split(hidden, 2, axis=-1)
+    return _linear(value * _silu(gate), block["ff.net.2.weight"], block["ff.net.2.bias"])
+
+
+def _transformer_block(block: dict[str, Any], x, scale1, scale2, cos, sin, *, num_heads: int, head_dim: int,
+                       norm_eps: float, qk_norm_eps: float):
+    """x: (S, B, D) sequence-major like the torch reference."""
+    normed = _rms_norm_affine(x.astype(mx.float32), block["norm1.weight"], norm_eps).astype(x.dtype)
+    x = x + _attention(block, normed, cos, sin, num_heads=num_heads, head_dim=head_dim, eps=qk_norm_eps) * scale1
+    normed = _rms_norm_affine(x.astype(mx.float32), block["norm2.weight"], norm_eps).astype(x.dtype)
+    return x + _feed_forward(block, normed) * scale2
+
+
+def _rms_norm_affine(x_fp32, weight, eps: float):
+    return x_fp32 / mx.sqrt(mx.mean(x_fp32 * x_fp32, axis=-1, keepdims=True) + eps) * weight
+
+
+def _resnet_block(weights: dict[str, Any], prefix: str, x, *, num_groups: int, eps: float):
+    residual = x
+    h = _silu(
+        _group_norm_per_frame(x,
+                              weights[f"{prefix}.norm1.weight"],
+                              weights[f"{prefix}.norm1.bias"],
+                              num_groups=num_groups,
+                              eps=eps))
+    h = _causal_conv3d(h,
+                       weights[f"{prefix}.conv1.weight"],
+                       weights[f"{prefix}.conv1.bias"],
+                       spatial_padding=1,
+                       temporal_padding=2)
+    h = _silu(
+        _group_norm_per_frame(h,
+                              weights[f"{prefix}.norm2.weight"],
+                              weights[f"{prefix}.norm2.bias"],
+                              num_groups=num_groups,
+                              eps=eps))
+    h = _causal_conv3d(h,
+                       weights[f"{prefix}.conv2.weight"],
+                       weights[f"{prefix}.conv2.bias"],
+                       spatial_padding=1,
+                       temporal_padding=2)
+    shortcut_key = f"{prefix}.conv_shortcut.weight"
+    if shortcut_key in weights:
+        residual = _causal_conv3d(x, weights[shortcut_key], weights[f"{prefix}.conv_shortcut.bias"])
+    return residual + h
+
+
+# ---------------------------------------------------------------------------
+# The MLX H3 video VAE
+# ---------------------------------------------------------------------------
+
+
+class MLXMiniMaxH3VideoVAE:
+    """Encoder + decoder for the released MiniMax-H3 video VAE."""
+
+    def __init__(self, weights: dict[str, Any], config: MiniMaxH3VideoVAEConfigView, *, has_encoder: bool = True):
+        self.weights = weights
+        self.config = config
+        self.has_encoder = has_encoder
+        self.latent_channels = config.latent_channels
+        self.spatial_compression_ratio = config.spatial_compression_ratio
+        self.temporal_compression_ratio = config.temporal_compression_ratio
+        self.num_heads = config.decoder_num_attention_heads
+        self.head_dim = config.decoder_attention_head_dim
+        self.dim = self.num_heads * self.head_dim
+        self.rotary_dim = int(self.head_dim * config.decoder_rope_dim_ratio)
+        self._blocks: list[dict[str, Any]] | None = None
+        arch = config
+        mean = arch.latents_mean if arch.latents_mean is not None else [0.0] * arch.latent_channels
+        std = arch.latents_std if arch.latents_std is not None else [1.0] * arch.latent_channels
+        self._latents_mean = np.asarray(mean, dtype=np.float32).reshape(1, -1, 1, 1, 1)
+        self._latents_std = np.asarray(std, dtype=np.float32).reshape(1, -1, 1, 1, 1)
+        self._pixel_mean = np.asarray(PIXEL_MEAN, dtype=np.float32).reshape(1, -1, 1, 1, 1)
+        self._pixel_std = np.asarray(PIXEL_STD, dtype=np.float32).reshape(1, -1, 1, 1, 1)
+
+    # -- normalization -------------------------------------------------
+
+    def normalize_latents(self, latents):
+        return latents - mx.array(self._latents_mean)
+
+    def denormalize_latents(self, latents):
+        return latents * mx.array(self._latents_std) + mx.array(self._latents_mean)
+
+    def normalize_pixels(self, pixels):
+        return (pixels - mx.array(self._pixel_mean)) / mx.array(self._pixel_std)
+
+    def denormalize_pixels(self, sample):
+        return sample * mx.array(self._pixel_std) + mx.array(self._pixel_mean)
+
+    # -- encoder ---------------------------------------------------------
+
+    def _encode_clip(self, x):
+        """(N, 3, T, H, W) pixels -> (N, 2C, T', H', W') moments."""
+        w = self.weights
+        cfg = self.config
+        x = _causal_conv3d(x,
+                           w["encoder.conv_in.weight"],
+                           w["encoder.conv_in.bias"],
+                           spatial_padding=1,
+                           temporal_padding=2)
+        for index in range(len(cfg.block_out_channels)):
+            td = cfg.temporal_downsample_factors[index]
+            sd = cfg.spatial_downsample_factors[index]
+            for layer in range(cfg.layers_per_block):
+                x = _resnet_block(w,
+                                  f"encoder.down_blocks.{index}.resnets.{layer}",
+                                  x,
+                                  num_groups=cfg.norm_num_groups,
+                                  eps=cfg.norm_eps)
+            if td * sd > 1:
+                if sd == 2:
+                    x = _reflect_pad_axis(x, 3, 0, 1)
+                    x = _reflect_pad_axis(x, 4, 0, 1)
+                x = _causal_conv3d(
+                    x,
+                    w[f"encoder.down_blocks.{index}.downsamplers.0.conv.weight"],
+                    w[f"encoder.down_blocks.{index}.downsamplers.0.conv.bias"],
+                    stride=(td, sd, sd),
+                    temporal_padding=2,
+                )
+        x = _silu(
+            _group_norm_per_frame(x,
+                                  w["encoder.norm_out.weight"],
+                                  w["encoder.norm_out.bias"],
+                                  num_groups=cfg.norm_num_groups,
+                                  eps=cfg.norm_eps))
+        x = _causal_conv3d(x,
+                           w["encoder.conv_out.weight"],
+                           w["encoder.conv_out.bias"],
+                           spatial_padding=1,
+                           temporal_padding=2)
+        x = _causal_conv3d(x, w["quant_conv.weight"], w["quant_conv.bias"])
+        return x
+
+    def encode(self, pixels):
+        """Normalized pixels (1, 3, T, H, W) -> (mean, logvar) each (1, C, T', H', W').
+
+        Pads the clip to ``clip_length`` and drops ``token_drop`` trailing
+        moment frames exactly like the reference ``_encode``.
+        """
+        if not self.has_encoder:
+            raise RuntimeError("This MLX H3 video VAE was loaded without encoder weights.")
+        cfg = self.config
+        num_frames = pixels.shape[2]
+        if num_frames % cfg.clip_length != 0:
+            pad_frames = (-num_frames) % cfg.clip_length
+            tail = mx.repeat(pixels[:, :, -1:], pad_frames, axis=2)
+            pixels = mx.concatenate([pixels, tail], axis=2)
+        moment_chunks: list[Any] = []
+        for index in range(pixels.shape[2] // cfg.clip_length):
+            clip = pixels[:, :, index * cfg.clip_length:(index + 1) * cfg.clip_length]
+            moment_chunks.append(self._encode_clip(clip))
+        moments = mx.concatenate(moment_chunks, axis=2)
+        if cfg.token_drop > 0:
+            moments = moments[:, :, :-cfg.token_drop]
+        mean, logvar = mx.split(moments, 2, axis=1)
+        logvar = mx.clip(logvar, -30.0, 20.0)
+        return mean, logvar
+
+    def encode_keyframe(self, pixels):
+        """Single-frame conditioning encode without chunk padding."""
+        if pixels.shape[2] != 1:
+            raise ValueError(f"encode_keyframe expects exactly one frame, got {pixels.shape}.")
+        moments = self._encode_clip(pixels)
+        mean, logvar = mx.split(moments, 2, axis=1)
+        logvar = mx.clip(logvar, -30.0, 20.0)
+        return mean, logvar
+
+    @staticmethod
+    def sample_posterior(mean, logvar, noise):
+        """Reparameterization with an explicit noise array (deterministic parity)."""
+        return mean + mx.exp(0.5 * logvar) * noise
+
+    # -- decoder ---------------------------------------------------------
+
+    def _decoder_blocks(self) -> list[dict[str, Any]]:
+        """Split the flat weight dict into per-block dicts once."""
+        if self._blocks is None:
+            blocks: list[dict[str, Any]] = [{} for _ in range(self.config.decoder_num_layers)]
+            prefix = "decoder.transformer_blocks."
+            for key, value in self.weights.items():
+                if key.startswith(prefix):
+                    index, sub = key[len(prefix):].split(".", 1)
+                    blocks[int(index)][sub] = value
+            self._blocks = blocks
+        return self._blocks
+
+    def _decode_clip(self, z):
+        """(1, C, T_tokens, H', W') latents -> (1, 3, T_tokens*4, H, W) pixels."""
+        w = self.weights
+        cfg = self.config
+        z = _causal_conv3d(z, w["post_quant_conv.weight"], w["post_quant_conv.bias"])
+        batch, channels, num_frames, height, width = z.shape
+        # (B, C, T, H, W) -> (B*T*H*W, C): sequence-major tokens.
+        tokens = _ct(z, 0, 2, 3, 4, 1).reshape(-1, channels)
+        tokens = _linear(tokens, w["decoder.proj_in.weight"], w["decoder.proj_in.bias"])
+        num_patches = tokens.shape[0]
+
+        num_reg = self.config.decoder_num_register_tokens
+        register = mx.broadcast_to(w["decoder.register_tokens"], (batch, num_reg, self.dim)).reshape(-1, self.dim)
+        cls_token = mx.zeros((batch, self.dim), dtype=tokens.dtype)
+        hidden = mx.concatenate([tokens, register, cls_token], axis=0)[:, None, :]  # (S, B, D)
+
+        grids = [2.0 * (mx.arange(0.5, size, dtype=mx.float32) / size) - 1.0 for size in (num_frames, height, width)]
+        mesh_t, mesh_h, mesh_w = mx.meshgrid(grids[0], grids[1], grids[2], indexing="ij")
+        position_ids = mx.stack([mesh_t.reshape(-1), mesh_h.reshape(-1), mesh_w.reshape(-1)], axis=-1)
+        suffix = mx.zeros((batch * (cfg.decoder_num_register_tokens + 1), 3), dtype=position_ids.dtype)
+        position_ids = mx.concatenate([position_ids, suffix], axis=0)  # (S, 3)
+        cos, sin = _rotary_cos_sin(position_ids, rotary_dim=self.rotary_dim, theta=cfg.decoder_rope_theta)
+
+        for block in self._decoder_blocks():
+            hidden = _transformer_block(
+                block,
+                hidden,
+                block["scale1"],
+                block["scale2"],
+                cos,
+                sin,
+                num_heads=self.num_heads,
+                head_dim=self.head_dim,
+                norm_eps=cfg.decoder_norm_eps,
+                qk_norm_eps=cfg.decoder_norm_eps,
+            )
+            mx.eval(hidden)  # per-block sync (36 blocks build a huge lazy graph)
+        hidden = _layer_norm(hidden, w["decoder.norm_out.weight"], w["decoder.norm_out.bias"], eps=cfg.decoder_norm_eps)
+        output = _linear(hidden, w["decoder.proj_out.weight"], w["decoder.proj_out.bias"])[:num_patches]
+
+        patch_t = cfg.temporal_compression_ratio
+        patch_h = patch_w = cfg.spatial_compression_ratio
+        output = output.reshape(num_patches, cfg.out_channels, patch_t, patch_h, patch_w)
+        output = output.reshape(batch, num_frames, height, width, cfg.out_channels, patch_t, patch_h, patch_w)
+        output = _ct(output, 0, 4, 1, 5, 2, 6, 3, 7)
+        return output.reshape(batch, cfg.out_channels, num_frames * patch_t, height * patch_h, width * patch_w)
+
+    def _split_tiles(self, length: int, tile_size: int, min_overlap: int):
+        if tile_size >= length:
+            return [0], [length], []
+        num_tiles = math.ceil(length / tile_size)
+        while tile_size * num_tiles - min_overlap * (num_tiles - 1) - length < 0:
+            num_tiles += 1
+        overlaps = [min_overlap] * (num_tiles - 1)
+        remaining = tile_size * num_tiles - sum(overlaps) - length
+        for index in range(remaining // self.spatial_compression_ratio):
+            overlaps[index % (num_tiles - 1)] += self.spatial_compression_ratio
+        starts = [0]
+        for index in range(num_tiles - 1):
+            starts.append(starts[-1] + tile_size - overlaps[index])
+        return starts, [tile_size] * num_tiles, overlaps
+
+    @staticmethod
+    def _blend(a, b, blend_extent: int, dim: int):
+        blend_extent = min(a.shape[dim], b.shape[dim], blend_extent)
+        positions = mx.arange(blend_extent, dtype=b.dtype)
+        shape = [1] * a.ndim
+        shape[dim] = blend_extent
+        weight_a = (1 - positions / blend_extent).reshape(shape)
+        weight_b = (positions / blend_extent).reshape(shape)
+        slice_a = [slice(None)] * a.ndim
+        slice_a[dim] = slice(-blend_extent, None)
+        slice_b = [slice(None)] * b.ndim
+        slice_b[dim] = slice(0, blend_extent)
+        blended = a[tuple(slice_a)] * weight_a + b[tuple(slice_b)] * weight_b
+        if blend_extent == b.shape[dim]:
+            return blended
+        rest = [slice(None)] * b.ndim
+        rest[dim] = slice(blend_extent, None)
+        return mx.concatenate([blended, b[tuple(rest)]], axis=dim)
+
+    def _stitch_tiles(self, tiles, height_overlaps, width_overlaps):
+        result_rows = []
+        for row_index, row in enumerate(tiles):
+            result_row = []
+            for column_index, tile in enumerate(row):
+                if row_index > 0:
+                    tile = self._blend(tiles[row_index - 1][column_index], tile, height_overlaps[row_index - 1], -2)
+                if column_index > 0:
+                    tile = self._blend(row[column_index - 1], tile, width_overlaps[column_index - 1], -1)
+                if row_index < len(tiles) - 1:
+                    tile = tile[..., :-height_overlaps[row_index], :]
+                if column_index < len(row) - 1:
+                    tile = tile[..., :, :-width_overlaps[column_index]]
+                result_row.append(tile)
+            result_rows.append(mx.concatenate(result_row, axis=-1))
+        return mx.concatenate(result_rows, axis=-2)
+
+    def decode_clip_tiled(self,
+                          z,
+                          tile_sample_min_height: int,
+                          tile_sample_min_width: int,
+                          tile_sample_min_overlap_height: int = 64,
+                          tile_sample_min_overlap_width: int = 64):
+        """One clip through the decoder with spatial tiling (memory bounded)."""
+        height = z.shape[-2] * self.spatial_compression_ratio
+        width = z.shape[-1] * self.spatial_compression_ratio
+        y_starts, y_lengths, y_overlaps = self._split_tiles(height, tile_sample_min_height,
+                                                            tile_sample_min_overlap_height)
+        x_starts, x_lengths, x_overlaps = self._split_tiles(width, tile_sample_min_width, tile_sample_min_overlap_width)
+        ratio = self.spatial_compression_ratio
+        rows = []
+        for y_start, y_length in zip(y_starts, y_lengths, strict=False):
+            row = []
+            for x_start, x_length in zip(x_starts, x_lengths, strict=False):
+                tile = z[..., y_start // ratio:y_start // ratio + y_length // ratio,
+                         x_start // ratio:x_start // ratio + x_length // ratio]
+                row.append(self._decode_clip(tile))
+            rows.append(row)
+        return self._stitch_tiles(rows, y_overlaps, x_overlaps)
+
+    def decode(self,
+               z,
+               *,
+               tiled: bool = True,
+               tile_sample_min_height: int = 256,
+               tile_sample_min_width: int = 256,
+               tile_sample_min_overlap_height: int = 64,
+               tile_sample_min_overlap_width: int = 64):
+        """Chunked decode of normalized latents (1, C, T_lat, H', W') -> (1, 3, T, H, W)."""
+        cfg = self.config
+        tokens_chunk_size = cfg.tokens_chunk_size
+        token_drop = cfg.token_drop
+        temporal_ratio = self.temporal_compression_ratio
+        chunk_num_frames = tokens_chunk_size * temporal_ratio
+        num_tokens = z.shape[2] + token_drop
+        pad_tokens = (-num_tokens) % tokens_chunk_size
+        num_chunks = (num_tokens + pad_tokens) // tokens_chunk_size - int(token_drop > 0)
+        if pad_tokens > 0:
+            tail = mx.repeat(z[:, :, -1:], pad_tokens, axis=2)
+            z = mx.concatenate([z, tail], axis=2)
+
+        def decode_one(chunk):
+            if tiled:
+                return self.decode_clip_tiled(chunk, tile_sample_min_height, tile_sample_min_width,
+                                              tile_sample_min_overlap_height, tile_sample_min_overlap_width)
+            return self._decode_clip(chunk)
+
+        decoded_chunks = []
+        overlap = None
+        for index in range(num_chunks):
+            start = index * tokens_chunk_size
+            clip = decode_one(z[:, :, start:start + tokens_chunk_size + cfg.token_overlap])
+            for overlap_index in range(int(token_drop > 0) + 1):
+                frame_start = overlap_index * chunk_num_frames
+                chunk = clip[:, :, frame_start:frame_start + chunk_num_frames]
+                chunk = chunk[:, :, cfg.frame_pre_padding:]
+                if overlap_index == 0:
+                    if overlap is not None:
+                        chunk = self._blend(overlap, chunk, cfg.frame_overlap, dim=-3)
+                    mx.eval(chunk)  # materialize per clip; keeps the lazy graph bounded
+                    decoded_chunks.append(chunk)
+                else:
+                    overlap = chunk
+                    mx.eval(overlap)
+        if overlap is not None:
+            decoded_chunks.append(overlap)
+        decoded = mx.concatenate(decoded_chunks, axis=2)
+
+        if pad_tokens > 0:
+            intra_tail = cfg.clip_length % temporal_ratio
+            num_tokens_before_pad = z.shape[2] - pad_tokens
+            pad_frames = sum(intra_tail if intra_tail and (num_tokens_before_pad + offset) %
+                             tokens_chunk_size == 0 else temporal_ratio for offset in range(pad_tokens))
+            decoded = decoded[:, :, :-pad_frames]
+        return decoded
+
+
+def _layer_norm(x, weight, bias, eps: float):
+    mean = x.mean(axis=-1, keepdims=True)
+    var = ((x - mean)**2).mean(axis=-1, keepdims=True)
+    return (x - mean) / mx.sqrt(var + eps) * weight + bias
+
+
+# ---------------------------------------------------------------------------
+# Streaming safetensors loading
+# ---------------------------------------------------------------------------
+
+
+def _shards(component_dir: Path) -> list[Path]:
+    component_dir = Path(component_dir)
+    index = component_dir / "diffusion_pytorch_model.safetensors.index.json"
+    if index.exists():
+        weight_map = json.loads(index.read_text())["weight_map"]
+        return sorted({component_dir / shard for shard in set(weight_map.values())})
+    single = component_dir / "diffusion_pytorch_model.safetensors"
+    if single.exists():
+        return [single]
+    shards = sorted(component_dir.glob("*.safetensors"))
+    if shards:
+        return shards
+    raise FileNotFoundError(f"No safetensors found under {component_dir}")
+
+
+_DTYPE_MAP = {"fp32": mx.float32, "bf16": mx.bfloat16, "fp16": mx.float16}
+
+
+def mlx_h3_video_vae_from_dir(vae_dir: str | Path,
+                              *,
+                              include_encoder: bool = True,
+                              storage_dtype: str = "fp32",
+                              config: MiniMaxH3VideoVAEConfigView | None = None) -> MLXMiniMaxH3VideoVAE:
+    """Load the released H3 video VAE, streaming one shard at a time.
+
+    ``storage_dtype="fp32"`` keeps the released numerics. bf16/fp16 halve
+    residency; measure drift against the FP32 acceptance gate before shipping
+    a reduced-dtype configuration.
+    """
+    import mlx.core as mx
+
+    vae_dir = Path(vae_dir)
+    config = config or MiniMaxH3VideoVAEConfigView.from_vae_dir(vae_dir)
+    cast_dtype = _DTYPE_MAP[storage_dtype]
+
+    wanted_prefixes: tuple[str, ...] = ("post_quant_conv.", "decoder.")
+    if include_encoder:
+        wanted_prefixes = ("quant_conv.", "encoder.", "post_quant_conv.", "decoder.")
+
+    weights: dict[str, Any] = {}
+    for shard in _shards(vae_dir):
+        arrays = mx.load(str(shard))
+        for key, source in arrays.items():
+            if not key.startswith(wanted_prefixes):
+                continue
+            array = source.astype(cast_dtype)
+            if array.ndim == 5:  # conv3d (O, I, kT, kH, kW) -> (O, kT, kH, kW, I)
+                array = _ct(array, 0, 2, 3, 4, 1)
+            mx.eval(array)
+            del source
+            weights[key] = array
+        del arrays
+        gc.collect()
+        mx.clear_cache()
+
+    required = [
+        "post_quant_conv.weight", "post_quant_conv.bias", "decoder.proj_in.weight", "decoder.norm_out.weight",
+        "decoder.proj_out.weight", "decoder.register_tokens"
+    ]
+    missing = [key for key in required if key not in weights]
+    if missing:
+        raise KeyError(f"H3 video VAE at {vae_dir} is missing required tensors: {missing}")
+    if include_encoder:
+        encoder_required = [
+            "quant_conv.weight", "encoder.conv_in.weight", "encoder.conv_out.weight", "encoder.norm_out.weight"
+        ]
+        missing = [key for key in encoder_required if key not in weights]
+        if missing:
+            raise KeyError(f"H3 video VAE encoder at {vae_dir} is missing required tensors: {missing}")
+    vae = MLXMiniMaxH3VideoVAE(weights, config, has_encoder=include_encoder)
+    expected_blocks = config.decoder_num_layers
+    found_blocks = {int(key.split(".")[2]) for key in weights if key.startswith("decoder.transformer_blocks.")}
+    if found_blocks != set(range(expected_blocks)):
+        raise KeyError(f"H3 video VAE decoder blocks incomplete: found {sorted(found_blocks)} "
+                       f"of {expected_blocks}.")
+    return vae

--- a/fastvideo/mlx_runtime/minimax_h3_video_vae.py
+++ b/fastvideo/mlx_runtime/minimax_h3_video_vae.py
@@ -332,7 +332,7 @@ class MLXMiniMaxH3VideoVAE:
     # -- normalization -------------------------------------------------
 
     def normalize_latents(self, latents):
-        return latents - mx.array(self._latents_mean)
+        return (latents - mx.array(self._latents_mean)) / mx.array(self._latents_std)
 
     def denormalize_latents(self, latents):
         return latents * mx.array(self._latents_std) + mx.array(self._latents_mean)

--- a/fastvideo/mlx_runtime/minimax_h3_video_vae.py
+++ b/fastvideo/mlx_runtime/minimax_h3_video_vae.py
@@ -143,8 +143,14 @@ def _reflect_pad_axis(x, axis: int, left: int, right: int):
     if left == 0 and right == 0:
         return x
     size = x.shape[axis]
-    indices = list(range(left, 0, -1)) + list(range(size)) + list(range(size - 2, size - 2 - right, -1))
-    return mx.concatenate([mx.take(x, mx.array([i]), axis=axis) for i in indices], axis=axis)
+    pieces = []
+    if left > 0:
+        pieces.append(mx.take(x, mx.array(list(range(left, 0, -1))), axis=axis))
+    pieces.append(x)
+    if right > 0:
+        indices = list(range(size - 2, size - 2 - right, -1))
+        pieces.append(mx.take(x, mx.array(indices), axis=axis))
+    return mx.contiguous(mx.concatenate(pieces, axis=axis))
 
 
 def _causal_conv3d(x, weight, bias=None, *, stride=(1, 1, 1), spatial_padding: int = 0, temporal_padding: int = 0):

--- a/fastvideo/mlx_runtime/rife_interp.py
+++ b/fastvideo/mlx_runtime/rife_interp.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from functools import lru_cache
+from pathlib import Path
 
 import numpy as np
 from huggingface_hub.utils import LocalEntryNotFoundError
@@ -20,6 +21,28 @@ class RIFEBackendError(RuntimeError):
 
 class RIFEWeightsUnavailableError(RIFEBackendError):
     """Raised when uncached RIFE weights cannot be downloaded."""
+
+
+def ensure_weights_available(version: str = "4.25", weights_dir: str | None = None) -> Path:
+    """Resolve or download RIFE weights without constructing the MLX model."""
+    try:
+        from fastvideo.third_party.rife_mlx.config import VERSIONS
+        from fastvideo.third_party.rife_mlx.utils.weights import _resolve_dir
+    except ImportError as exc:
+        raise RIFEBackendError("MLX RIFE is unavailable; install with `uv pip install -e '.[mlx]'`.") from exc
+
+    try:
+        config = VERSIONS[version]
+        resolved = Path(_resolve_dir(config, weights_dir))
+    except LocalEntryNotFoundError as exc:
+        raise RIFEWeightsUnavailableError(f"MLX RIFE {version} weights are unavailable: {exc}") from exc
+    except (KeyError, OSError) as exc:
+        raise RIFEWeightsUnavailableError(f"MLX RIFE {version} weights are unavailable: {exc}") from exc
+
+    missing = [name for name in ("config.json", "model.safetensors") if not (resolved / name).is_file()]
+    if missing:
+        raise RIFEWeightsUnavailableError(f"MLX RIFE {version} weights under {resolved} are missing {missing}.")
+    return resolved
 
 
 def aligned_keyframe_count(target_frames: int, factor: int, temporal_compression: int = 4) -> int:

--- a/fastvideo/mlx_runtime/rife_interp.py
+++ b/fastvideo/mlx_runtime/rife_interp.py
@@ -135,3 +135,43 @@ def interpolate(
             out.append(interpolate_pair(left, right, step / factor, model=model, scale=scale))
     out.append(frame_list[-1])
     return out
+
+
+def interpolate_to_frame_count(
+    frames: list[np.ndarray] | Iterable[np.ndarray],
+    target_frames: int,
+    *,
+    model=None,
+    scale: float = 1.0,
+) -> list[np.ndarray]:
+    """Interpolate a sparse sequence to an exact frame count.
+
+    Unlike :func:`interpolate`, this accepts targets that are not an integer
+    multiple of the source interval count. The first and last source frames
+    remain the first and last output frames, and every intermediate output is
+    evaluated at its uniformly spaced source-time position.
+    """
+    frame_list = [_require_hwc_rgb(frame, idx) for idx, frame in enumerate(frames)]
+    if target_frames < len(frame_list):
+        raise ValueError(f"target_frames must be at least the source count ({len(frame_list)}), got {target_frames}.")
+    if target_frames == len(frame_list):
+        return [frame.copy() for frame in frame_list]
+    if len(frame_list) < 2:
+        raise ValueError("at least two source frames are required for interpolation")
+
+    if model is None:
+        model = load_model()
+
+    positions = np.linspace(0.0, len(frame_list) - 1, target_frames, dtype=np.float64)
+    out: list[np.ndarray] = []
+    for position in positions:
+        left = int(np.floor(position))
+        if left >= len(frame_list) - 1:
+            out.append(frame_list[-1].copy())
+            continue
+        fraction = float(position - left)
+        if fraction <= 1e-12:
+            out.append(frame_list[left].copy())
+            continue
+        out.append(interpolate_pair(frame_list[left], frame_list[left + 1], fraction, model=model, scale=scale))
+    return out

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_conditioner.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_conditioner.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused correctness gates for the MLX-only MiniMax-H3 conditioner path."""
+
+from __future__ import annotations
+
+import inspect
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core", reason="MLX is required for MiniMax-H3 conditioner tests")
+torch = pytest.importorskip("torch", reason="PyTorch supplies an independent attention reference")
+
+from fastvideo.mlx_runtime.minimax_h3_conditioner import (  # noqa: E402
+    ConditionerConfig,
+    StreamedMiniMaxH3TextConditioner,
+    _ShardIndex,
+)
+from fastvideo.mlx_runtime.minimax_h3_pipeline import (  # noqa: E402
+    MINIMAX_H3_PROMPT_CACHE_VERSION,
+    _audio_sample_count,
+    prompt_cache_path,
+)
+from fastvideo.mlx_runtime.minimax_h3_video_vae import MLXMiniMaxH3VideoVAE  # noqa: E402
+
+
+class _ArrayIndex:
+    def __init__(self, weights: dict[str, np.ndarray]):
+        self.weights = weights
+
+    def get(self, key: str) -> np.ndarray:
+        return self.weights[key]
+
+
+def test_bf16_embedding_row_read_does_not_materialize_full_table(tmp_path, monkeypatch) -> None:
+    from safetensors.torch import save_file
+    import fastvideo.mlx_runtime.minimax_h3_conditioner as conditioner_module
+
+    key = "model.language_model.embed_tokens.weight"
+    table = torch.arange(60, dtype=torch.float32).reshape(10, 6).to(torch.bfloat16)
+    save_file({key: table}, tmp_path / "model.safetensors")
+    index = _ShardIndex(tmp_path)
+
+    def reject_full_read(*_args, **_kwargs):
+        raise AssertionError("embedding lookup materialized the full table")
+
+    monkeypatch.setattr(conditioner_module, "_read_safetensors_bf16", reject_full_read)
+    row = index.get_row(key, 7)
+    np.testing.assert_array_equal(row, table[7].float().numpy())
+    assert row.shape == (6, )
+    assert row.nbytes == 6 * np.dtype(np.float32).itemsize
+
+
+def _rms_norm(value: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    return value * torch.rsqrt(value.square().mean(dim=-1, keepdim=True) + eps) * weight
+
+
+def test_decoder_layer_matches_independent_torch_attention_layout() -> None:
+    """Catch head-major attention output being flattened as sequence-major."""
+    cfg = ConditionerConfig(
+        hidden_size=8,
+        num_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=4,
+        intermediate_size=12,
+        rms_norm_eps=1e-6,
+        mrope_section=(1, 1, 0),
+        vocab_size=16,
+    )
+    rng = np.random.default_rng(4112)
+    prefix = "model.language_model.layers.0."
+
+    def matrix(rows: int, columns: int) -> np.ndarray:
+        return (rng.standard_normal((rows, columns)) * 0.15).astype(np.float32)
+
+    weights = {
+        prefix + "input_layernorm.weight": rng.uniform(0.8, 1.2, 8).astype(np.float32),
+        prefix + "self_attn.q_proj.weight": matrix(8, 8),
+        prefix + "self_attn.k_proj.weight": matrix(4, 8),
+        prefix + "self_attn.v_proj.weight": matrix(4, 8),
+        prefix + "self_attn.q_norm.weight": rng.uniform(0.8, 1.2, 4).astype(np.float32),
+        prefix + "self_attn.k_norm.weight": rng.uniform(0.8, 1.2, 4).astype(np.float32),
+        prefix + "self_attn.o_proj.weight": matrix(8, 8),
+        prefix + "post_attention_layernorm.weight": rng.uniform(0.8, 1.2, 8).astype(np.float32),
+        prefix + "mlp.gate_proj.weight": matrix(12, 8),
+        prefix + "mlp.up_proj.weight": matrix(12, 8),
+        prefix + "mlp.down_proj.weight": matrix(8, 12),
+    }
+    hidden_np = rng.standard_normal((3, 8)).astype(np.float32)
+    cos = mx.ones((3, 1, 4), dtype=mx.float32)
+    sin = mx.zeros((3, 1, 4), dtype=mx.float32)
+
+    conditioner = StreamedMiniMaxH3TextConditioner.__new__(StreamedMiniMaxH3TextConditioner)
+    conditioner.config = cfg
+    conditioner.index = _ArrayIndex(weights)
+    actual = np.asarray(conditioner._decoder_layer(0, mx.array(hidden_np), cos, sin))
+
+    w = {name[len(prefix):]: torch.from_numpy(value) for name, value in weights.items()}
+    hidden = torch.from_numpy(hidden_np)
+    residual = hidden
+    normed = _rms_norm(hidden, w["input_layernorm.weight"], cfg.rms_norm_eps)
+    query = torch.nn.functional.linear(normed, w["self_attn.q_proj.weight"]).reshape(3, 2, 4)
+    key = torch.nn.functional.linear(normed, w["self_attn.k_proj.weight"]).reshape(3, 1, 4)
+    value = torch.nn.functional.linear(normed, w["self_attn.v_proj.weight"]).reshape(3, 1, 4)
+    query = _rms_norm(query, w["self_attn.q_norm.weight"], cfg.rms_norm_eps)
+    key = _rms_norm(key, w["self_attn.k_norm.weight"], cfg.rms_norm_eps)
+    key = key.repeat_interleave(2, dim=1)
+    value = value.repeat_interleave(2, dim=1)
+    scores = torch.matmul(query.transpose(0, 1), key.permute(1, 2, 0)) * cfg.head_dim**-0.5
+    scores = scores.masked_fill(torch.triu(torch.ones(3, 3, dtype=torch.bool), diagonal=1), -torch.inf)
+    attended = torch.matmul(scores.softmax(dim=-1), value.transpose(0, 1))
+    attended = attended.transpose(0, 1).reshape(3, 8)
+    hidden = residual + torch.nn.functional.linear(attended, w["self_attn.o_proj.weight"])
+    residual = hidden
+    normed = _rms_norm(hidden, w["post_attention_layernorm.weight"], cfg.rms_norm_eps)
+    gate = torch.nn.functional.linear(normed, w["mlp.gate_proj.weight"])
+    up = torch.nn.functional.linear(normed, w["mlp.up_proj.weight"])
+    expected = residual + torch.nn.functional.linear(torch.nn.functional.silu(gate) * up,
+                                                     w["mlp.down_proj.weight"])
+
+    np.testing.assert_allclose(actual, expected.numpy(), rtol=2e-5, atol=2e-5)
+
+
+def test_prompt_cache_is_versioned_for_conditioner_layout() -> None:
+    current = prompt_cache_path("/tmp/cache", "/tmp/model", "two people")
+    legacy_digest = __import__("hashlib").sha256(b"/tmp/model::two people").hexdigest()[:24]
+    assert MINIMAX_H3_PROMPT_CACHE_VERSION == "v2-attention-layout"
+    assert current.name != f"prompt_embeds_{legacy_digest}.npz"
+
+
+def test_video_vae_decode_defaults_to_reference_spatial_tiles() -> None:
+    parameters = inspect.signature(MLXMiniMaxH3VideoVAE.decode).parameters
+    assert parameters["tiled"].default is True
+    assert parameters["tile_sample_min_height"].default == 256
+    assert parameters["tile_sample_min_width"].default == 256
+
+    vae = MLXMiniMaxH3VideoVAE.__new__(MLXMiniMaxH3VideoVAE)
+    vae.spatial_compression_ratio = 16
+    assert len(vae._split_tiles(480, 256, 64)[0]) > 1
+    assert len(vae._split_tiles(832, 256, 64)[0]) > 1
+
+
+def test_h3_audio_duration_rounds_up_to_cover_last_video_packet() -> None:
+    assert _audio_sample_count(124) == 165334

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_conditioner.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_conditioner.py
@@ -18,6 +18,7 @@ from fastvideo.mlx_runtime.minimax_h3_conditioner import (  # noqa: E402
 )
 from fastvideo.mlx_runtime.minimax_h3_pipeline import (  # noqa: E402
     MINIMAX_H3_PROMPT_CACHE_VERSION,
+    MiniMaxH3MLXPipeline,
     _audio_sample_count,
     prompt_cache_path,
 )
@@ -127,6 +128,32 @@ def test_prompt_cache_is_versioned_for_conditioner_layout() -> None:
     legacy_digest = __import__("hashlib").sha256(b"/tmp/model::two people").hexdigest()[:24]
     assert MINIMAX_H3_PROMPT_CACHE_VERSION == "v2-attention-layout"
     assert current.name != f"prompt_embeds_{legacy_digest}.npz"
+
+
+def test_prompt_cache_write_is_atomic(tmp_path, monkeypatch) -> None:
+    class FakeConditioner:
+        def encode_prompt(self, _prompt):
+            return np.ones((2, 3), dtype=np.float32), np.ones((2, ), dtype=np.int64)
+
+        def close(self):
+            return None
+
+    pipeline = MiniMaxH3MLXPipeline.__new__(MiniMaxH3MLXPipeline)
+    pipeline.prompt_cache_dir = tmp_path
+    pipeline.model_root = tmp_path / "model"
+    monkeypatch.setattr(MiniMaxH3MLXPipeline, "_load_conditioner", lambda _self: FakeConditioner())
+
+    def interrupted_save(handle, **_arrays):
+        handle.write(b"partial")
+        raise RuntimeError("interrupted")
+
+    monkeypatch.setattr(np, "savez", interrupted_save)
+    cache_path = prompt_cache_path(tmp_path, pipeline.model_root, "prompt")
+    with pytest.raises(RuntimeError, match="interrupted"):
+        pipeline.encode_prompt("prompt")
+
+    assert not cache_path.exists()
+    assert not cache_path.with_name(f".{cache_path.name}.tmp").exists()
 
 
 def test_video_vae_decode_defaults_to_reference_spatial_tiles() -> None:

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_fast_mode.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_fast_mode.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -16,8 +18,10 @@ from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
     video_latent_num_frames,
 )
 from fastvideo.mlx_runtime.minimax_h3_pipeline import (  # noqa: E402
+    MiniMaxH3MLXPipeline,
     _adaln_schedule_union,
     _center_crop_frames,
+    _default_metal_wired_limit_gib,
     _preflight_media_dependencies,
     _validate_checkpoint_step_ladder,
     plan_fast_temporal,
@@ -103,3 +107,29 @@ def test_fast_media_preflight_resolves_rife_weights(monkeypatch: pytest.MonkeyPa
     _preflight_media_dependencies(fast=True, fast_sharpen=0.6, rife_weights_dir="/tmp/rife")
 
     assert calls == [{"weights_dir": "/tmp/rife"}]
+
+
+def test_default_wired_limit_scales_down_and_keeps_tested_cap() -> None:
+    small = SimpleNamespace(metal=SimpleNamespace(device_info=lambda: {"memory_size": 24 * 2**30}))
+    large = SimpleNamespace(metal=SimpleNamespace(device_info=lambda: {"memory_size": 64 * 2**30}))
+
+    assert _default_metal_wired_limit_gib(small) == pytest.approx(20.16)
+    assert _default_metal_wired_limit_gib(large) == 30.0
+
+
+def test_mux_cleans_temporary_files_after_ffmpeg_failure(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pipeline = MiniMaxH3MLXPipeline.__new__(MiniMaxH3MLXPipeline)
+    output = tmp_path / "output.mp4"
+    frames = np.zeros((1, 2, 2, 3), dtype=np.uint8)
+    waveform = np.zeros((2, 32), dtype=np.float32)
+    monkeypatch.setattr("fastvideo.mlx_runtime.minimax_h3_pipeline.shutil.which", lambda _name: "/opt/ffmpeg")
+
+    def fail(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(1, "ffmpeg")
+
+    monkeypatch.setattr("fastvideo.mlx_runtime.minimax_h3_pipeline.subprocess.run", fail)
+    with pytest.raises(subprocess.CalledProcessError):
+        pipeline.mux(frames, waveform, output)
+
+    assert not output.with_suffix(".tmp.mp4").exists()
+    assert not output.with_suffix(".tmp.wav").exists()

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_fast_mode.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_fast_mode.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Contracts for MiniMax-H3 temporal fast mode on Apple Silicon."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mlx.core", reason="MLX is required for MiniMax H3 fast-mode tests")
+
+from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
+    audio_latent_num_frames,
+    build_packed_layout,
+    video_latent_num_frames,
+)
+from fastvideo.mlx_runtime.minimax_h3_pipeline import (  # noqa: E402
+    _center_crop_frames,
+    plan_fast_temporal,
+)
+from fastvideo.mlx_runtime import rife_interp  # noqa: E402
+
+
+def test_fast_plan_keeps_full_audio_and_reduces_only_video() -> None:
+    plan = plan_fast_temporal(124, factor=2)
+
+    assert plan.target_frames == 124
+    assert plan.source_frames == 73
+    assert plan.source_frames % 17 == 5
+    assert video_latent_num_frames(plan.source_frames) == 22
+    assert video_latent_num_frames(plan.target_frames) == 37
+    assert audio_latent_num_frames(plan.target_frames) == 207
+    assert plan.video_temporal_scale > 1.0
+
+
+def test_fast_layout_stretches_video_positions_without_changing_audio() -> None:
+    baseline = build_packed_layout(8, 22, 46, 80, 207)
+    fast = build_packed_layout(8, 22, 46, 80, 207, video_temporal_scale=1.7)
+
+    np.testing.assert_array_equal(fast.audio_indices, baseline.audio_indices)
+    np.testing.assert_array_equal(
+        fast.position_ids[fast.audio_indices],
+        baseline.position_ids[baseline.audio_indices],
+    )
+    baseline_video_time = baseline.position_ids[baseline.video_indices, 0] - 8.0
+    fast_video_time = fast.position_ids[fast.video_indices, 0] - 8.0
+    np.testing.assert_allclose(fast_video_time, baseline_video_time * 1.7)
+
+
+def test_rife_interpolates_to_exact_non_multiple_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = [np.full((4, 6, 3), value, dtype=np.uint8) for value in (0, 100, 200)]
+    sentinel_model = object()
+
+    def fake_pair(left, right, timestep, *, model, scale=1.0):
+        assert model is sentinel_model
+        return np.rint(left * (1.0 - timestep) + right * timestep).astype(np.uint8)
+
+    monkeypatch.setattr(rife_interp, "interpolate_pair", fake_pair)
+    result = rife_interp.interpolate_to_frame_count(source, 6, model=sentinel_model)
+
+    assert len(result) == 6
+    np.testing.assert_array_equal(result[0], source[0])
+    np.testing.assert_array_equal(result[-1], source[-1])
+    assert [int(frame[0, 0, 0]) for frame in result] == [0, 40, 80, 120, 160, 200]
+
+
+def test_fast_mode_center_crops_internal_736p_canvas_to_720p() -> None:
+    frames = np.arange(2 * 736 * 1280 * 3, dtype=np.uint8).reshape(2, 736, 1280, 3)
+    cropped = _center_crop_frames(frames, 720, 1280)
+
+    assert cropped.shape == (2, 720, 1280, 3)
+    np.testing.assert_array_equal(cropped[:, 0], frames[:, 8])
+    np.testing.assert_array_equal(cropped[:, -1], frames[:, 727])

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_fast_mode.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_fast_mode.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
 
@@ -14,7 +16,10 @@ from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
     video_latent_num_frames,
 )
 from fastvideo.mlx_runtime.minimax_h3_pipeline import (  # noqa: E402
+    _adaln_schedule_union,
     _center_crop_frames,
+    _preflight_media_dependencies,
+    _validate_checkpoint_step_ladder,
     plan_fast_temporal,
 )
 from fastvideo.mlx_runtime import rife_interp  # noqa: E402
@@ -70,3 +75,31 @@ def test_fast_mode_center_crops_internal_736p_canvas_to_720p() -> None:
     assert cropped.shape == (2, 720, 1280, 3)
     np.testing.assert_array_equal(cropped[:, 0], frames[:, 8])
     np.testing.assert_array_equal(cropped[:, -1], frames[:, 727])
+
+
+def test_fixed_adaln_checkpoint_rejects_different_step_count(tmp_path) -> None:
+    manifest = {"adaln_cache": {"timesteps": _adaln_schedule_union(4).tolist()}}
+    (tmp_path / "mlx_h3_dit.json").write_text(json.dumps(manifest))
+
+    _validate_checkpoint_step_ladder(tmp_path, 4)
+    with pytest.raises(ValueError, match=r"does not support --steps 6"):
+        _validate_checkpoint_step_ladder(tmp_path, 6)
+
+
+def test_media_preflight_checks_ffmpeg_before_generation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("fastvideo.mlx_runtime.minimax_h3_pipeline.shutil.which", lambda _name: None)
+
+    with pytest.raises(RuntimeError, match="ffmpeg is required"):
+        _preflight_media_dependencies(fast=False, fast_sharpen=0.0, rife_weights_dir=None)
+
+
+def test_fast_media_preflight_resolves_rife_weights(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+    monkeypatch.setattr("fastvideo.mlx_runtime.minimax_h3_pipeline.shutil.which", lambda _name: "/opt/ffmpeg")
+    monkeypatch.setattr("fastvideo.mlx_runtime.minimax_h3_pipeline.importlib.util.find_spec",
+                        lambda _name: object())
+    monkeypatch.setattr(rife_interp, "ensure_weights_available", lambda **kwargs: calls.append(kwargs))
+
+    _preflight_media_dependencies(fast=True, fast_sharpen=0.6, rife_weights_dir="/tmp/rife")
+
+    assert calls == [{"weights_dir": "/tmp/rife"}]

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py
@@ -22,6 +22,7 @@ import numpy as np
 import pytest
 
 pytest.importorskip("mlx.core", reason="MLX is required for MiniMax H3 parity tests")
+torch = pytest.importorskip("torch", reason="PyTorch supplies the independent H3 reference")
 
 from fastvideo.mlx_runtime.fastwan import MLXQuantizationSpec  # noqa: E402
 from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
@@ -35,17 +36,14 @@ from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
     save_mlx_h3_checkpoint,
 )
 from fastvideo.tests.mlx.tiny_h3 import (  # noqa: E402
-    AUDIO_TIMESTEP,
     LATENT_HEIGHT,
     LATENT_WIDTH,
     NUM_AUDIO_LATENTS,
     NUM_LATENT_FRAMES,
     NUM_TEXT_TOKENS,
     TINY_ARCH,
-    VIDEO_TIMESTEP,
     build_hf_config,
     build_inputs,
-    build_schedulers,
     build_tiny_h3_config,
     build_torch_model,
     mlx_cache_output,
@@ -85,7 +83,7 @@ def test_packed_layout_matches_upstream_builder(distributed_setup) -> None:
         patch_size=tuple(TINY_ARCH["patch_size"]),
     )
     reference = build_packed_sequence(
-        __import__("torch").full((NUM_TEXT_TOKENS, ), 1, dtype=__import__("torch").long),
+        torch.full((NUM_TEXT_TOKENS, ), 1, dtype=torch.long),
         NUM_LATENT_FRAMES,
         LATENT_HEIGHT,
         LATENT_WIDTH,
@@ -103,8 +101,6 @@ def test_packed_layout_matches_upstream_builder(distributed_setup) -> None:
 def test_packed_layout_with_keyframes(distributed_setup) -> None:
     """FL2VA anchors: 'first' pins time at n_text; 'last' at span - 5/3."""
     from fastvideo.pipelines.basic.minimax_h3.packing import build_packed_sequence
-    import torch
-
     layout = build_packed_layout(
         NUM_TEXT_TOKENS,
         NUM_LATENT_FRAMES,

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py
@@ -28,8 +28,11 @@ from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
     MINIMAX_H3_AUDIO_SHIFT,
     MINIMAX_H3_VIDEO_SHIFT,
     MiniMaxH3SchedulerState,
+    MiniMaxH3StepCache,
     build_packed_layout,
+    load_mlx_h3_checkpoint,
     minimax_h3_sigmas,
+    save_mlx_h3_checkpoint,
 )
 from fastvideo.tests.mlx.tiny_h3 import (  # noqa: E402
     AUDIO_TIMESTEP,
@@ -188,6 +191,50 @@ def test_adaln_cache_matches_faithful_forward(distributed_setup) -> None:
     for block in dit.blocks:
         assert block["adaln_proj.linear.weight"] is None
         assert block["adaln_proj.linear.bias"] is None
+
+
+def test_quantized_checkpoint_with_adaln_cache_round_trips(tmp_path, distributed_setup) -> None:
+    """The converted checkpoint format must preserve quantization and cached inference."""
+    import mlx.core as mx
+
+    model = build_torch_model()
+    hf_config = build_hf_config(build_tiny_h3_config())
+    layout, _, mlx_inputs = build_inputs()
+    dit = mlx_dit_from_torch_model(
+        model,
+        hf_config,
+        quantization=MLXQuantizationSpec.from_name("int8"),
+    )
+    expected_video, expected_audio = mlx_cache_output(dit, layout, mlx_inputs)
+    save_mlx_h3_checkpoint(dit, tmp_path)
+
+    restored = load_mlx_h3_checkpoint(tmp_path)
+    video, audio = restored.forward_with_cache(
+        mx.array(mlx_inputs["video_rows"]),
+        mx.array(mlx_inputs["audio_rows"]),
+        mx.array(mlx_inputs["text_rows"]),
+        layout=layout,
+        step_timesteps=mlx_inputs["timesteps"],
+        row_timestep_inverse=mlx_inputs["timestep_indices"],
+    )
+    mx.eval(video, audio)
+
+    np.testing.assert_allclose(np.asarray(video), expected_video, atol=CACHE_ATOL, rtol=CACHE_ATOL)
+    np.testing.assert_allclose(np.asarray(audio), expected_audio, atol=CACHE_ATOL, rtol=CACHE_ATOL)
+    assert restored._adaln_cache is not None
+    assert all("adaln_proj.linear.weight" not in block for block in restored.blocks)
+
+
+def test_step_cache_reports_out_of_range_timestep() -> None:
+    cache = MiniMaxH3StepCache(
+        timesteps=np.asarray([0.25, 0.5], dtype=np.float32),
+        block_tables=[],
+        norm_out_shift=None,
+        norm_out_scale=None,
+    )
+
+    with pytest.raises(ValueError, match="not in the cached schedule union"):
+        cache.positions(np.asarray([0.75], dtype=np.float32))
 
 
 def test_full_dit_forward_int8_stays_close_to_fp32(distributed_setup) -> None:

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiniMax H3 parity: the MLX runtime vs the upstream PyTorch reference (#1674).
+
+The H3 analogue of ``test_mlx_dit_parity.py`` — the trust gate for the Apple
+Silicon H3 track. A tiny random-weight ``MiniMaxH3Transformer3DModel`` runs
+end to end (packing -> token refiner -> AdaLN blocks -> dual heads) in
+PyTorch and in ``fastvideo.mlx_runtime.minimax_h3.MLXMiniMaxH3DiT`` with
+identical weights, and outputs must match within pinned fp32 tolerances.
+
+Also gated: the packed-layout geometry vs the upstream packing builder, the
+dual rectified-flow scheduler vs the upstream scheduler, the AdaLN precompute
+cache vs the faithful forward, and int8 quantization SNR.
+
+Runs anywhere MLX is installed (Metal on Apple Silicon, CPU elsewhere):
+
+    pytest fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py -v
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mlx.core", reason="MLX is required for MiniMax H3 parity tests")
+
+from fastvideo.mlx_runtime.fastwan import MLXQuantizationSpec  # noqa: E402
+from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
+    MINIMAX_H3_AUDIO_SHIFT,
+    MINIMAX_H3_VIDEO_SHIFT,
+    MiniMaxH3SchedulerState,
+    build_packed_layout,
+    minimax_h3_sigmas,
+)
+from fastvideo.tests.mlx.tiny_h3 import (  # noqa: E402
+    AUDIO_TIMESTEP,
+    LATENT_HEIGHT,
+    LATENT_WIDTH,
+    NUM_AUDIO_LATENTS,
+    NUM_LATENT_FRAMES,
+    NUM_TEXT_TOKENS,
+    TINY_ARCH,
+    VIDEO_TIMESTEP,
+    build_hf_config,
+    build_inputs,
+    build_schedulers,
+    build_tiny_h3_config,
+    build_torch_model,
+    mlx_cache_output,
+    mlx_dit_from_torch_model,
+    mlx_output,
+    torch_reference_output,
+)
+
+# fp32 full-forward tolerances, matching the Wan parity gate's headroom logic.
+FP32_ATOL = 2e-4
+FP32_RTOL = 2e-4
+
+# int8 (group 64) on tiny random weights lands far above this; a broken dequant
+# path lands near 0 dB.
+INT8_MIN_SNR_DB = 20.0
+
+# The AdaLN cache reorders the same math, so it should be nearly exact.
+CACHE_ATOL = 1e-4
+
+
+def _snr_db(reference: np.ndarray, actual: np.ndarray) -> float:
+    signal = float(np.mean(np.square(reference)))
+    noise = float(np.mean(np.square(reference - actual)))
+    return 10.0 * np.log10(signal / max(noise, 1e-20))
+
+
+def test_packed_layout_matches_upstream_builder(distributed_setup) -> None:
+    """The numpy packing geometry must equal the upstream torch builder's."""
+    from fastvideo.pipelines.basic.minimax_h3.packing import build_packed_sequence
+
+    layout = build_packed_layout(
+        NUM_TEXT_TOKENS,
+        NUM_LATENT_FRAMES,
+        LATENT_HEIGHT,
+        LATENT_WIDTH,
+        NUM_AUDIO_LATENTS,
+        patch_size=tuple(TINY_ARCH["patch_size"]),
+    )
+    reference = build_packed_sequence(
+        __import__("torch").full((NUM_TEXT_TOKENS, ), 1, dtype=__import__("torch").long),
+        NUM_LATENT_FRAMES,
+        LATENT_HEIGHT,
+        LATENT_WIDTH,
+        NUM_AUDIO_LATENTS,
+        tuple(TINY_ARCH["patch_size"]),
+    )
+    assert layout.sequence_length == reference.sequence_length
+    np.testing.assert_array_equal(layout.position_ids, reference.position_ids.numpy())
+    np.testing.assert_array_equal(layout.token_tags, reference.token_tags.numpy())
+    np.testing.assert_array_equal(layout.video_indices, reference.video_indices.numpy())
+    np.testing.assert_array_equal(layout.audio_indices, reference.audio_indices.numpy())
+    np.testing.assert_array_equal(layout.text_indices, reference.text_indices.numpy())
+
+
+def test_packed_layout_with_keyframes(distributed_setup) -> None:
+    """FL2VA anchors: 'first' pins time at n_text; 'last' at span - 5/3."""
+    from fastvideo.pipelines.basic.minimax_h3.packing import build_packed_sequence
+    import torch
+
+    layout = build_packed_layout(
+        NUM_TEXT_TOKENS,
+        NUM_LATENT_FRAMES,
+        LATENT_HEIGHT,
+        LATENT_WIDTH,
+        NUM_AUDIO_LATENTS,
+        patch_size=tuple(TINY_ARCH["patch_size"]),
+        keyframe_anchors=("first", "last"),
+    )
+    reference = build_packed_sequence(
+        torch.full((NUM_TEXT_TOKENS, ), 1, dtype=torch.long),
+        NUM_LATENT_FRAMES,
+        LATENT_HEIGHT,
+        LATENT_WIDTH,
+        NUM_AUDIO_LATENTS,
+        tuple(TINY_ARCH["patch_size"]),
+        keyframe_anchors=("first", "last"),
+    )
+    assert layout.sequence_length == reference.sequence_length
+    np.testing.assert_array_equal(layout.position_ids, reference.position_ids.numpy())
+    np.testing.assert_array_equal(layout.token_tags, reference.token_tags.numpy())
+    np.testing.assert_array_equal(layout.video_indices, reference.video_indices.numpy())
+
+
+def test_scheduler_matches_upstream(distributed_setup) -> None:
+    """Sigma grids and data-ward Euler steps match the upstream scheduler."""
+    import torch
+    from fastvideo.models.schedulers.scheduling_minimax_h3 import MiniMaxH3Scheduler
+
+    num_steps = 6
+    for shift in (MINIMAX_H3_VIDEO_SHIFT, MINIMAX_H3_AUDIO_SHIFT):
+        reference = MiniMaxH3Scheduler(shift=shift)
+        reference.set_timesteps(num_steps + 1)  # reference counts sigmas, not steps
+        ours = MiniMaxH3SchedulerState.create(shift, num_steps)
+        np.testing.assert_allclose(ours.sigmas, reference.sigmas.numpy(), rtol=1e-6, atol=1e-7)
+        np.testing.assert_allclose(ours.timesteps, reference.timesteps.numpy(), rtol=1e-6, atol=1e-7)
+
+        generator = torch.Generator(device="cpu").manual_seed(7)
+        sample = torch.randn(2, 8, generator=generator, dtype=torch.float32)
+        model_output = torch.randn(2, 8, generator=generator, dtype=torch.float32)
+        import mlx.core as mx
+
+        mlx_sample = mx.array(sample.numpy())
+        mlx_output_step = mx.array(model_output.numpy())
+        for step_index in range(num_steps):
+            sample = reference.step(model_output, reference.timesteps[step_index], sample).prev_sample
+            mlx_sample = ours.step(mlx_output_step, step_index, mlx_sample)
+            np.testing.assert_allclose(
+                np.asarray(mlx_sample),
+                sample.numpy(),
+                rtol=1e-5,
+                atol=1e-6,
+                err_msg=f"scheduler step {step_index} diverged (shift={shift})",
+            )
+
+
+def test_full_dit_forward_matches_torch_reference(distributed_setup) -> None:
+    model = build_torch_model()
+    hf_config = build_hf_config(build_tiny_h3_config())
+    layout, torch_inputs, mlx_inputs = build_inputs()
+    reference_video, reference_audio = torch_reference_output(model, torch_inputs)
+
+    dit = mlx_dit_from_torch_model(model, hf_config)
+    video, audio = mlx_output(dit, layout, mlx_inputs)
+
+    np.testing.assert_allclose(video, reference_video, atol=FP32_ATOL, rtol=FP32_RTOL)
+    np.testing.assert_allclose(audio, reference_audio, atol=FP32_ATOL, rtol=FP32_RTOL)
+
+
+def test_adaln_cache_matches_faithful_forward(distributed_setup) -> None:
+    """The precompute-cache path (the 24 GB Mac enabler) must match the
+    faithful temb path — it is the same math, served from precomputed rows."""
+    model = build_torch_model()
+    hf_config = build_hf_config(build_tiny_h3_config())
+    layout, _, mlx_inputs = build_inputs()
+
+    dit = mlx_dit_from_torch_model(model, hf_config)
+    video_ref, audio_ref = mlx_output(dit, layout, mlx_inputs)
+    video_cache, audio_cache = mlx_cache_output(dit, layout, mlx_inputs)
+
+    np.testing.assert_allclose(video_cache, video_ref, atol=CACHE_ATOL, rtol=CACHE_ATOL)
+    np.testing.assert_allclose(audio_cache, audio_ref, atol=CACHE_ATOL, rtol=CACHE_ATOL)
+    # The cache must actually free the modulation projections.
+    for block in dit.blocks:
+        assert block["adaln_proj.linear.weight"] is None
+        assert block["adaln_proj.linear.bias"] is None
+
+
+def test_full_dit_forward_int8_stays_close_to_fp32(distributed_setup) -> None:
+    model = build_torch_model()
+    hf_config = build_hf_config(build_tiny_h3_config())
+    layout, _, mlx_inputs = build_inputs()
+
+    fp32_dit = mlx_dit_from_torch_model(model, hf_config)
+    reference_video, reference_audio = mlx_output(fp32_dit, layout, mlx_inputs)
+
+    int8_spec = MLXQuantizationSpec.from_name("int8")
+    int8_dit = mlx_dit_from_torch_model(model, hf_config, quantization=int8_spec)
+    video, audio = mlx_output(int8_dit, layout, mlx_inputs)
+
+    assert _snr_db(reference_video, video) >= INT8_MIN_SNR_DB
+    assert _snr_db(reference_audio, audio) >= INT8_MIN_SNR_DB
+
+
+def test_h3_int6_uses_affine_group_64() -> None:
+    spec = MLXQuantizationSpec.from_name("int6")
+
+    assert spec is not None
+    assert spec.mode == "affine"
+    assert spec.bits == 6
+    assert spec.group_size == 64
+
+
+def test_sigma_grid_shape_and_monotonicity() -> None:
+    for shift in (MINIMAX_H3_VIDEO_SHIFT, MINIMAX_H3_AUDIO_SHIFT, 1.0):
+        sigmas = minimax_h3_sigmas(shift, 3)
+        assert sigmas.shape == (4, )
+        assert sigmas[0] == pytest.approx(1.0)
+        assert sigmas[-1] == 0.0
+        assert np.all(np.diff(sigmas) < 0)

--- a/fastvideo/tests/mlx/tiny_h3.py
+++ b/fastvideo/tests/mlx/tiny_h3.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tiny random-weight MiniMax H3 fixtures shared by the MLX runtime tests.
+
+Builds a miniature ``MiniMaxH3Transformer3DModel`` (upstream torch reference,
+merged in #1674) plus the conversion into
+``fastvideo.mlx_runtime.minimax_h3.MLXMiniMaxH3DiT``. All matmul dims are
+multiples of the int8 group size (64) so the quantized variants of the tests
+reuse the same model; ``rope_freq_dim`` keeps the rotary width (6 * dim)
+inside the head dim, as in the real config (96 <= 128).
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import torch
+
+os.environ.setdefault("FASTVIDEO_ATTENTION_BACKEND", "TORCH_SDPA")
+os.environ.setdefault("MASTER_ADDR", "localhost")
+os.environ.setdefault("MASTER_PORT", "29513")
+
+from fastvideo.configs.models.dits.minimax_h3 import (  # noqa: E402
+    MiniMaxH3ArchConfig,
+    MiniMaxH3Config,
+)
+from fastvideo.forward_context import set_forward_context  # noqa: E402
+from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
+    MLXMiniMaxH3DiT,
+    MiniMaxH3SchedulerState,
+    MINIMAX_H3_AUDIO_SHIFT,
+    MINIMAX_H3_VIDEO_SHIFT,
+    build_packed_layout,
+    build_row_timesteps,
+    patchify_video_latents,
+)
+from fastvideo.models.dits.minimax_h3 import MiniMaxH3Transformer3DModel  # noqa: E402
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch  # noqa: E402
+
+SEED = 2027
+
+TINY_ARCH = dict(
+    num_attention_heads=8,
+    attention_head_dim=64,  # inner 512 > hidden 256, like the real 7168 > 5376
+    hidden_size=256,
+    num_layers=2,
+    num_refiner_layers=1,
+    ffn_dim=384,
+    in_channels=8,
+    audio_in_channels=4,
+    patch_size=(1, 2, 2),
+    text_dim=128,
+    freq_dim=64,
+    time_embed_hidden_dim=256,
+    time_embed_dim=192,
+    rope_freq_dim=8,  # rotary width 48 <= 64 head dim
+    rope_theta=10000.0,
+    norm_eps=1e-5,
+    qk_norm_eps=1e-5,
+    final_norm_eps=1e-5,
+)
+
+# Geometry: 2 latent frames of 4x4, patch (1,2,2) -> 4 rows/frame -> 8 video
+# rows; 6 text rows; 3 audio latents -> 6 audio rows. Sequence length 20.
+NUM_TEXT_TOKENS = 6
+NUM_LATENT_FRAMES = 2
+LATENT_HEIGHT = 4
+LATENT_WIDTH = 4
+NUM_AUDIO_LATENTS = 3
+VIDEO_TIMESTEP = 0.7
+AUDIO_TIMESTEP = 0.4
+
+
+def build_tiny_h3_config() -> MiniMaxH3Config:
+    return MiniMaxH3Config(arch_config=MiniMaxH3ArchConfig(**TINY_ARCH))
+
+
+def build_hf_config(config: MiniMaxH3Config) -> dict[str, object]:
+    arch = config.arch_config
+    return {
+        "num_attention_heads": arch.num_attention_heads,
+        "attention_head_dim": arch.attention_head_dim,
+        "hidden_size": arch.hidden_size,
+        "num_layers": arch.num_layers,
+        "num_refiner_layers": arch.num_refiner_layers,
+        "ffn_dim": arch.ffn_dim,
+        "in_channels": arch.in_channels,
+        "audio_in_channels": arch.audio_in_channels,
+        "patch_size": list(arch.patch_size),
+        "text_dim": arch.text_dim,
+        "freq_dim": arch.freq_dim,
+        "time_embed_hidden_dim": arch.time_embed_hidden_dim,
+        "time_embed_dim": arch.time_embed_dim,
+        "rope_freq_dim": arch.rope_freq_dim,
+        "rope_theta": arch.rope_theta,
+        "norm_eps": arch.norm_eps,
+        "qk_norm_eps": arch.qk_norm_eps,
+        "final_norm_eps": arch.final_norm_eps,
+    }
+
+
+def initialize_model_parameters(model: torch.nn.Module) -> None:
+    # ReplicatedLinear parameters are allocated with torch.empty and need an
+    # explicit initialization in tests to avoid undefined values.
+    torch.manual_seed(SEED + 3)
+    with torch.no_grad():
+        for name, param in model.named_parameters():
+            if param.ndim <= 1:
+                if name.endswith("weight") and "norm" in name:
+                    param.fill_(1.0)
+                else:
+                    param.normal_(mean=0.0, std=0.02)
+                continue
+            torch.nn.init.xavier_uniform_(param)
+
+
+def build_torch_model() -> MiniMaxH3Transformer3DModel:
+    config = build_tiny_h3_config()
+    model = MiniMaxH3Transformer3DModel(config=config, hf_config=build_hf_config(config))
+    model = model.to(device="cpu", dtype=torch.float32)
+    initialize_model_parameters(model)
+    model.eval()
+    return model
+
+
+def build_layout():
+    return build_packed_layout(
+        NUM_TEXT_TOKENS,
+        NUM_LATENT_FRAMES,
+        LATENT_HEIGHT,
+        LATENT_WIDTH,
+        NUM_AUDIO_LATENTS,
+        patch_size=tuple(TINY_ARCH["patch_size"]),
+    )
+
+
+def build_inputs():
+    """Random rows + the packed layout, in both torch and numpy form."""
+    layout = build_layout()
+    generator = torch.Generator(device="cpu").manual_seed(SEED + 1)
+    channels = TINY_ARCH["in_channels"]
+    latents = torch.randn(
+        1,
+        channels,
+        NUM_LATENT_FRAMES,
+        LATENT_HEIGHT,
+        LATENT_WIDTH,
+        generator=generator,
+        dtype=torch.float32,
+    )
+    video_rows_np = patchify_video_latents(latents.numpy(), tuple(TINY_ARCH["patch_size"]))
+    patch_dim = video_rows_np.shape[-1]
+    audio_rows_np = np.random.default_rng(SEED + 2).standard_normal(
+        (NUM_AUDIO_LATENTS * 2, TINY_ARCH["audio_in_channels"])).astype(np.float32)
+    text_rows_np = np.random.default_rng(SEED + 5).standard_normal(
+        (NUM_TEXT_TOKENS, TINY_ARCH["text_dim"])).astype(np.float32)
+
+    unique, inverse = build_row_timesteps(layout, VIDEO_TIMESTEP, AUDIO_TIMESTEP)
+
+    torch_inputs = dict(
+        hidden_states=torch.from_numpy(video_rows_np)[None],
+        audio_hidden_states=torch.from_numpy(audio_rows_np)[None],
+        encoder_hidden_states=torch.from_numpy(text_rows_np)[None],
+        timestep=torch.from_numpy(unique),
+        timestep_indices=torch.from_numpy(inverse),
+        token_tags=torch.from_numpy(layout.token_tags),
+        position_ids=torch.from_numpy(layout.position_ids),
+        video_indices=torch.from_numpy(layout.video_indices),
+        audio_indices=torch.from_numpy(layout.audio_indices),
+        text_indices=torch.from_numpy(layout.text_indices),
+    )
+    mlx_inputs = dict(
+        video_rows=video_rows_np,
+        audio_rows=audio_rows_np,
+        text_rows=text_rows_np,
+        timesteps=unique,
+        timestep_indices=inverse,
+    )
+    return layout, torch_inputs, mlx_inputs
+
+
+# torch (FastVideo module names) -> MLX (released checkpoint / diffusers names,
+# per MiniMaxH3ArchConfig.param_names_mapping read in reverse).
+def torch_key_to_mlx(name: str) -> str:
+    if name.startswith("time_embedder.fc_in."):
+        return name.replace("time_embedder.fc_in.", "time_embedder.linear_1.", 1)
+    if name.startswith("time_embedder.fc_out."):
+        return name.replace("time_embedder.fc_out.", "time_embedder.linear_2.", 1)
+    name = name.replace(".attn.to_out.", ".attn.to_out.0.")
+    name = name.replace(".ff.fc_in.", ".ff.net.0.proj.")
+    name = name.replace(".ff.fc_out.", ".ff.net.2.")
+    return name
+
+
+def mlx_dit_from_torch_model(
+    model: MiniMaxH3Transformer3DModel,
+    hf_config: dict[str, object],
+    *,
+    quantization=None,
+) -> MLXMiniMaxH3DiT:
+    import mlx.core as mx
+
+    from fastvideo.mlx_runtime.minimax_h3 import _is_quantizable, quantize_matrix
+
+    weights: dict[str, object] = {}
+    blocks: list[dict[str, object]] = [{} for _ in range(TINY_ARCH["num_layers"])]
+    refiner: list[dict[str, object]] = [{} for _ in range(TINY_ARCH["num_refiner_layers"])]
+
+    for torch_name, param in model.state_dict().items():
+        name = torch_key_to_mlx(torch_name)
+        if name.startswith("rope."):
+            continue  # non-persistent analytic buffer, rebuilt on the fly
+        array = mx.array(param.detach().float().numpy())
+        if quantization is not None and _is_quantizable(name):
+            value = quantize_matrix(array, quantization)
+        else:
+            value = array
+        if name.startswith("transformer_blocks."):
+            _, index_str, sub = name.split(".", 2)
+            blocks[int(index_str)][sub] = value
+        elif name.startswith("token_refiner.refiner_blocks."):
+            _, _, index_str, sub = name.split(".", 3)
+            refiner[int(index_str)][sub] = value
+        else:
+            weights[name] = value
+    return MLXMiniMaxH3DiT(weights, blocks, refiner, dict(hf_config))
+
+
+def torch_reference_output(model, torch_inputs) -> tuple[np.ndarray, np.ndarray]:
+    with torch.no_grad(), set_forward_context(
+            current_timestep=0,
+            attn_metadata=None,
+            forward_batch=ForwardBatch(data_type="dummy"),
+    ):
+        video_output, audio_output = model(**torch_inputs)
+    return video_output[0].float().numpy(), audio_output[0].float().numpy()
+
+
+def mlx_output(dit: MLXMiniMaxH3DiT, layout, mlx_inputs) -> tuple[np.ndarray, np.ndarray]:
+    import mlx.core as mx
+
+    video_output, audio_output = dit.forward(
+        mx.array(mlx_inputs["video_rows"]),
+        mx.array(mlx_inputs["audio_rows"]),
+        mx.array(mlx_inputs["text_rows"]),
+        position_ids=mx.array(layout.position_ids.astype(np.float32)),
+        token_tags=mx.array(layout.token_tags),
+        timestep_indices=mx.array(mlx_inputs["timestep_indices"]),
+        timesteps=mx.array(mlx_inputs["timesteps"]),
+        video_indices=mx.array(layout.video_indices),
+        audio_indices=mx.array(layout.audio_indices),
+        text_indices=mx.array(layout.text_indices),
+    )
+    mx.eval(video_output, audio_output)
+    return np.asarray(video_output), np.asarray(audio_output)
+
+
+def mlx_cache_output(dit: MLXMiniMaxH3DiT, layout, mlx_inputs) -> tuple[np.ndarray, np.ndarray]:
+    import mlx.core as mx
+
+    union = np.unique(
+        np.concatenate([
+            mlx_inputs["timesteps"],
+            np.array([1.0], dtype=np.float32),  # condition rows, if any
+        ]))
+    dit.precompute_adaln(union, drop_weights=True)
+    video_output, audio_output = dit.forward_with_cache(
+        mx.array(mlx_inputs["video_rows"]),
+        mx.array(mlx_inputs["audio_rows"]),
+        mx.array(mlx_inputs["text_rows"]),
+        layout=layout,
+        step_timesteps=mlx_inputs["timesteps"],
+        row_timestep_inverse=mlx_inputs["timestep_indices"],
+    )
+    mx.eval(video_output, audio_output)
+    return np.asarray(video_output), np.asarray(audio_output)
+
+
+def build_schedulers(num_denoise_steps: int = 6) -> tuple[MiniMaxH3SchedulerState, MiniMaxH3SchedulerState]:
+    return (
+        MiniMaxH3SchedulerState.create(MINIMAX_H3_VIDEO_SHIFT, num_denoise_steps),
+        MiniMaxH3SchedulerState.create(MINIMAX_H3_AUDIO_SHIFT, num_denoise_steps),
+    )

--- a/scripts/checkpoint_conversion/convert_minimax_h3_mlx.py
+++ b/scripts/checkpoint_conversion/convert_minimax_h3_mlx.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Convert the FastH3 Preview DiT into pre-quantized MLX checkpoints.
+
+Each output dir is a self-contained, shippable artifact in the
+`mlx_h3_dit.safetensors` format: weights already cast/quantized, optional
+AdaLN tables dropped at load time by the runtime. Conversion streams source
+weights so the full BF16 DiT is not resident at once.
+
+Usage (on the target Mac):
+
+    python scripts/checkpoint_conversion/convert_minimax_h3_mlx.py \\
+        --model-root ~/models/FastH3-Preview-v0.2/transformer \\
+        --out ~/models/FastH3-MLX \\
+        --formats "int8 int6 int4"
+
+Output layout: `~/models/FastH3-MLX/<format>/mlx_h3_dit.safetensors` + manifest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import time
+from pathlib import Path
+
+import numpy as np
+
+from fastvideo.logger import init_logger
+from fastvideo.mlx_runtime.fastwan import MLXQuantizationSpec, ensure_quantization_supported
+from fastvideo.mlx_runtime.minimax_h3 import (
+    MINIMAX_H3_AUDIO_SHIFT,
+    MINIMAX_H3_VIDEO_SHIFT,
+    mlx_h3_dit_from_diffusers_safetensors,
+    minimax_h3_sigmas,
+    save_mlx_h3_checkpoint,
+)
+
+logger = init_logger(__name__)
+
+SUPPORTED_FORMATS = ("int8", "int6", "int4")
+DEFAULT_FORMATS = " ".join(SUPPORTED_FORMATS)
+
+
+def _adaln_cache_timesteps() -> np.ndarray:
+    video = 1.0 - minimax_h3_sigmas(MINIMAX_H3_VIDEO_SHIFT, 4)[:-1]
+    audio = 1.0 - minimax_h3_sigmas(MINIMAX_H3_AUDIO_SHIFT, 4)[:-1]
+    return np.unique(np.concatenate([video, audio, [1.0]])).astype(np.float32)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-root", required=True, help="transformer/ dir of the diffusers snapshot")
+    parser.add_argument("--out", required=True, help="base dir for the per-format MLX checkpoints")
+    parser.add_argument("--formats", default=DEFAULT_FORMATS)
+    return parser.parse_args()
+
+
+def main() -> None:
+    import mlx.core as mx
+
+    args = parse_args()
+    formats = args.formats.split()
+    unsupported = sorted(set(formats) - set(SUPPORTED_FORMATS))
+    if unsupported:
+        raise ValueError(f"Unsupported H3 MLX formats: {unsupported}. Choose from {SUPPORTED_FORMATS}.")
+    out_base = Path(args.out)
+    out_base.mkdir(parents=True, exist_ok=True)
+    cache_timesteps = _adaln_cache_timesteps()
+
+    for fmt in formats:
+        spec = MLXQuantizationSpec.from_name(fmt)
+        if spec is None:
+            raise ValueError(f"Expected a quantized H3 format, got {fmt}.")
+        ensure_quantization_supported(spec)
+        dtype = "bf16"
+        out_dir = out_base / fmt
+        if (out_dir / "mlx_h3_dit.json").exists() and (out_dir / "mlx_h3_dit.safetensors").exists():
+            print(f"[skip] {fmt} already converted at {out_dir}", flush=True)
+            continue
+        print(f"[convert] {fmt} (dtype={dtype}, spec={spec})", flush=True)
+        if hasattr(mx, "reset_peak_memory"):
+            mx.reset_peak_memory()
+        t0 = time.perf_counter()
+        dit = mlx_h3_dit_from_diffusers_safetensors(
+            args.model_root,
+            quantization=spec,
+            dtype=dtype,
+            adaln_cache_timesteps=cache_timesteps,
+        )
+        mx.eval()
+        save_mlx_h3_checkpoint(dit, out_dir)
+        peak_gib = float(getattr(mx, "get_peak_memory", lambda: 0)()) / 2**30
+        print(f"[done] {fmt} in {time.perf_counter() - t0:.1f}s | peak {peak_gib:.1f} GiB -> {out_dir}", flush=True)
+        del dit
+        gc.collect()
+        if hasattr(mx, "clear_cache"):
+            mx.clear_cache()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/checkpoint_conversion/convert_minimax_h3_mlx.py
+++ b/scripts/checkpoint_conversion/convert_minimax_h3_mlx.py
@@ -28,6 +28,8 @@ import numpy as np
 from fastvideo.logger import init_logger
 from fastvideo.mlx_runtime.fastwan import MLXQuantizationSpec, ensure_quantization_supported
 from fastvideo.mlx_runtime.minimax_h3 import (
+    H3_MANIFEST_FILENAME,
+    H3_WEIGHTS_FILENAME,
     MINIMAX_H3_AUDIO_SHIFT,
     MINIMAX_H3_VIDEO_SHIFT,
     mlx_h3_dit_from_diffusers_safetensors,
@@ -74,7 +76,7 @@ def main() -> None:
         ensure_quantization_supported(spec)
         dtype = "bf16"
         out_dir = out_base / fmt
-        if (out_dir / "mlx_h3_dit.json").exists() and (out_dir / "mlx_h3_dit.safetensors").exists():
+        if (out_dir / H3_MANIFEST_FILENAME).exists() and (out_dir / H3_WEIGHTS_FILENAME).exists():
             print(f"[skip] {fmt} already converted at {out_dir}", flush=True)
             continue
         print(f"[convert] {fmt} (dtype={dtype}, spec={spec})", flush=True)

--- a/tests/local_tests/minimax_h3/test_mlx_audio_vae_parity.py
+++ b/tests/local_tests/minimax_h3/test_mlx_audio_vae_parity.py
@@ -236,6 +236,13 @@ def test_latent_normalization_roundtrip() -> None:
     _stats("denormalize", denorm, latents, atol=1e-5, rtol=1e-5)
 
 
+def test_directory_loader_rejects_non_fp32_storage(tmp_path) -> None:
+    from fastvideo.mlx_runtime.minimax_h3_audio_vae import mlx_h3_audio_vae_from_dir
+
+    with pytest.raises(ValueError, match="storage_dtype='fp32'"):
+        mlx_h3_audio_vae_from_dir(tmp_path, storage_dtype="bf16")
+
+
 # ---------------------------------------------------------------------------
 # Real released weights (bounded segment)
 # ---------------------------------------------------------------------------

--- a/tests/local_tests/minimax_h3/test_mlx_audio_vae_parity.py
+++ b/tests/local_tests/minimax_h3/test_mlx_audio_vae_parity.py
@@ -146,12 +146,12 @@ def test_activation1d_matches_torch() -> None:
     from fastvideo.models.vaes.minimax_h3_audio import (
         MiniMaxH3AudioActivation1d,
         MiniMaxH3AudioDownSample1d,
+        MiniMaxH3AudioSnakeBeta,
         MiniMaxH3AudioUpSample1d,
     )
 
     torch.manual_seed(SEED + 1)
-    act = MiniMaxH3AudioActivation1d(activation=__import__("fastvideo.models.vaes.minimax_h3_audio",
-                                                            fromlist=["MiniMaxH3AudioSnakeBeta"]).MiniMaxH3AudioSnakeBeta(4))
+    act = MiniMaxH3AudioActivation1d(activation=MiniMaxH3AudioSnakeBeta(4))
     with torch.no_grad():
         act.act.alpha.normal_(0.0, 0.1)
         act.act.beta.normal_(0.0, 0.1)
@@ -241,6 +241,15 @@ def test_directory_loader_rejects_non_fp32_storage(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="storage_dtype='fp32'"):
         mlx_h3_audio_vae_from_dir(tmp_path, storage_dtype="bf16")
+
+
+def test_audio_loader_validates_decoder_weights_before_construction(tmp_path) -> None:
+    from fastvideo.mlx_runtime.minimax_h3_audio_vae import mlx_h3_audio_vae_from_file
+
+    weights_path = tmp_path / "audio.safetensors"
+    mx.save_safetensors(str(weights_path), {"unrelated": mx.zeros((1, ))})
+    with pytest.raises(KeyError, match="dec_in_proj.weight"):
+        mlx_h3_audio_vae_from_file(weights_path, include_encoder=False, config=build_mlx_model().config)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/local_tests/minimax_h3/test_mlx_audio_vae_parity.py
+++ b/tests/local_tests/minimax_h3/test_mlx_audio_vae_parity.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiniMax-H3 audio VAE parity: FastVideo-native PyTorch reference vs MLX.
+
+Tiny random-weight models exercise every primitive (Snake/SnakeBeta,
+Kaiser-window up/down sampling, DAC encoder blocks, causal attention
+projection, GeGLU MLP, BigVGAN AMP blocks); a real-weight bounded-segment
+case validates the released FP32 checkpoint end to end.
+
+    pytest tests/local_tests/minimax_h3/test_mlx_audio_vae_parity.py -v
+
+The real-weight case activates automatically when the released snapshot is
+present; point MINIMAX_H3_MODEL_ROOT at another checkout otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch", reason="PyTorch reference needed for audio VAE parity")
+mx = pytest.importorskip("mlx.core", reason="MLX needed for audio VAE parity")
+
+from fastvideo.configs.models.vaes.minimax_h3_audio import (  # noqa: E402
+    MiniMaxH3AudioVAEArchConfig,
+    MiniMaxH3AudioVAEConfig,
+)
+from fastvideo.models.vaes.minimax_h3_audio import MiniMaxH3AudioVAE  # noqa: E402
+from fastvideo.mlx_runtime.minimax_h3_audio_vae import (  # noqa: E402
+    MLXMiniMaxH3AudioVAE,
+    MiniMaxH3AudioVAEConfigView,
+    kaiser_sinc_filter1d,
+)
+
+SEED = 9112
+
+# decoder_rates product must equal the encoder hop length (config invariant).
+TINY_ARCH = dict(
+    encoder_dim=8,
+    encoder_rates=(2, 2),
+    latent_dim=32,
+    latent_channels=4,
+    num_attention_heads=2,
+    decoder_dim=16,
+    decoder_rates=(2, 2),
+    decoder_kernel_sizes=(5, 4),
+    resblock_kernel_sizes=(3,),
+    resblock_dilation_sizes=((1, 2),),
+    sampling_rate=32000,
+    latents_mean=[0.05 * i for i in range(4)],
+    latents_std=[1.0 + 0.1 * i for i in range(4)],
+)
+
+
+def initialize_model_parameters(model: torch.nn.Module) -> None:
+    """ReplicatedLinear parameters are allocated with torch.empty and need
+    explicit initialization to avoid undefined (often zero) values."""
+    torch.manual_seed(SEED + 3)
+    with torch.no_grad():
+        for name, param in model.named_parameters():
+            if param.ndim <= 1:
+                if name.endswith("weight") and "norm" in name:
+                    param.fill_(1.0)
+                else:
+                    param.normal_(mean=0.0, std=0.02)
+                continue
+            if "weight_v" in name or param.ndim >= 2:
+                torch.nn.init.xavier_uniform_(param)
+
+
+def build_torch_model() -> MiniMaxH3AudioVAE:
+    arch = MiniMaxH3AudioVAEArchConfig(**TINY_ARCH)
+    config = MiniMaxH3AudioVAEConfig(arch_config=arch)
+    config.use_tiling = False
+    torch.manual_seed(SEED)
+    model = MiniMaxH3AudioVAE(config)
+    initialize_model_parameters(model)
+    return model.float().eval()
+
+
+def build_mlx_model(model=None) -> MLXMiniMaxH3AudioVAE:
+    model = model or build_torch_model()
+    weights = {}
+    for name, tensor in model.state_dict().items():
+        weights[name] = mx.array(np.ascontiguousarray(tensor.detach().float().numpy()))
+    view = MiniMaxH3AudioVAEConfigView(
+        encoder_dim=TINY_ARCH["encoder_dim"],
+        encoder_rates=TINY_ARCH["encoder_rates"],
+        latent_dim=TINY_ARCH["latent_dim"],
+        latent_channels=TINY_ARCH["latent_channels"],
+        num_attention_heads=TINY_ARCH["num_attention_heads"],
+        decoder_dim=TINY_ARCH["decoder_dim"],
+        decoder_rates=TINY_ARCH["decoder_rates"],
+        decoder_kernel_sizes=TINY_ARCH["decoder_kernel_sizes"],
+        resblock_kernel_sizes=TINY_ARCH["resblock_kernel_sizes"],
+        resblock_dilation_sizes=tuple(tuple(d) for d in TINY_ARCH["resblock_dilation_sizes"]),
+        sampling_rate=TINY_ARCH["sampling_rate"],
+        latents_mean=tuple(TINY_ARCH["latents_mean"]),
+        latents_std=tuple(TINY_ARCH["latents_std"]),
+    )
+    return MLXMiniMaxH3AudioVAE(weights, view)
+
+
+def _stats(name: str, actual: np.ndarray, expected: np.ndarray, atol: float, rtol: float) -> None:
+    diff = np.abs(actual.astype(np.float64) - expected.astype(np.float64))
+    denom = np.linalg.norm(expected.astype(np.float64)) + 1e-12
+    print(f"[{name}] max_abs={diff.max():.3e} mean_abs={diff.mean():.3e} "
+          f"rel_l2={float(np.linalg.norm(diff)/denom):.3e} shape={actual.shape}")
+    assert diff.max() <= atol + rtol * np.abs(expected).max(), f"{name} drifted beyond tolerance"
+
+
+def test_kaiser_filter_matches_torch() -> None:
+    from fastvideo.models.vaes.minimax_h3_audio import kaiser_sinc_filter1d as torch_filter
+
+    for cutoff, half_width, size in ((0.25, 0.6, 12), (0.125, 0.15, 12), (0.5, 0.6, 13)):
+        ref = torch_filter(cutoff, half_width, size).detach().numpy().reshape(-1)
+        out = kaiser_sinc_filter1d(cutoff, half_width, size)
+        np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-7)
+
+
+def test_snake_activations_match_torch() -> None:
+    import mlx.core as mx_
+    from fastvideo.models.vaes.minimax_h3_audio import MiniMaxH3AudioSnakeBeta
+    from fastvideo.mlx_runtime.minimax_h3_audio_vae import _snake_beta
+
+    rng = np.random.default_rng(SEED)
+    x = (rng.standard_normal((1, 6, 20)) * 0.5).astype(np.float32)
+
+    mod = MiniMaxH3AudioSnakeBeta(6)
+    with torch.no_grad():
+        mod.alpha.fill_(0.1)
+        mod.beta.fill_(-0.2)
+        ref = mod(torch.from_numpy(x)).numpy()
+
+    alpha = np.full((6, ), 0.1, dtype=np.float32)
+    beta = np.full((6, ), -0.2, dtype=np.float32)
+    got = np.asarray(_snake_beta(mx_.array(x), mx_.array(alpha), mx_.array(beta)))
+    _stats("snake_beta", got, ref, atol=1e-5, rtol=1e-5)
+
+
+def test_activation1d_matches_torch() -> None:
+    """Alias-free SnakeBeta block with released-style filters."""
+    from fastvideo.models.vaes.minimax_h3_audio import (
+        MiniMaxH3AudioActivation1d,
+        MiniMaxH3AudioDownSample1d,
+        MiniMaxH3AudioUpSample1d,
+    )
+
+    torch.manual_seed(SEED + 1)
+    act = MiniMaxH3AudioActivation1d(activation=__import__("fastvideo.models.vaes.minimax_h3_audio",
+                                                            fromlist=["MiniMaxH3AudioSnakeBeta"]).MiniMaxH3AudioSnakeBeta(4))
+    with torch.no_grad():
+        act.act.alpha.normal_(0.0, 0.1)
+        act.act.beta.normal_(0.0, 0.1)
+    rng = np.random.default_rng(SEED + 2)
+    x = rng.standard_normal((1, 4, 50)).astype(np.float32)
+    with torch.no_grad():
+        ref = act(torch.from_numpy(x)).numpy()
+
+    up_f = act.upsample.filter.detach().numpy().reshape(-1)
+    down_f = act.downsample.lowpass.filter.detach().numpy().reshape(-1)
+    alpha = act.act.alpha.detach().numpy().reshape(-1)
+    beta = act.act.beta.detach().numpy().reshape(-1)
+
+    from fastvideo.mlx_runtime.minimax_h3_audio_vae import _activation1d
+
+    got = np.asarray(_activation1d(mx.array(x), mx.array(alpha), mx.array(beta),
+                                   mx.array(up_f), mx.array(down_f)))
+    _stats("activation1d", got, ref, atol=1e-4, rtol=1e-4)
+
+
+def test_encode_moments_match_torch() -> None:
+    model = build_torch_model()
+    vae = build_mlx_model(model)
+    rng = np.random.default_rng(SEED + 3)
+    samples = 400  # exact multiple of hop 4
+    wave = rng.standard_normal((1, 1, samples)).astype(np.float32) * 0.1
+    mean_m, logvar_m = vae.encode(mx.array(wave))
+    with torch.no_grad():
+        post = model.encode(torch.from_numpy(wave)).latent_dist
+    _stats("encode.mean", np.asarray(mean_m), post.mean.numpy(), atol=2e-4, rtol=2e-4)
+    _stats("encode.logvar", np.asarray(logvar_m), post.logs.numpy(), atol=2e-4, rtol=2e-4)
+
+
+def test_encode_right_pads_like_reference() -> None:
+    model = build_torch_model()
+    vae = build_mlx_model(model)
+    rng = np.random.default_rng(SEED + 4)
+    samples = 401  # forces right padding to 404
+    wave = rng.standard_normal((1, 1, samples)).astype(np.float32) * 0.1
+    mean_m, logvar_m = vae.encode(mx.array(wave))
+    padded = torch.from_numpy(np.concatenate([wave, np.zeros((1, 1, 3), np.float32)], -1))
+    with torch.no_grad():
+        post = model.encode(padded).latent_dist
+    _stats("encode.pad.mean", np.asarray(mean_m), post.mean.numpy(), atol=2e-4, rtol=2e-4)
+    _stats("encode.pad.logvar", np.asarray(logvar_m), post.logs.numpy(), atol=2e-4, rtol=2e-4)
+
+
+def test_decode_waveform_matches_torch() -> None:
+    model = build_torch_model()
+    vae = build_mlx_model(model)
+    rng = np.random.default_rng(SEED + 5)
+    z_np = rng.standard_normal((1, TINY_ARCH["latent_channels"], 12)).astype(np.float32) * 0.5
+    with torch.no_grad():
+        ref = model.decode(torch.from_numpy(z_np)).sample.numpy()
+    out = vae.decode(mx.array(z_np))
+    assert out.shape[-1] == ref.shape[-1]
+    _stats("decode.wave", np.asarray(out), ref, atol=5e-4, rtol=5e-4)
+
+
+def test_stereo_decode_is_independent_and_ordered() -> None:
+    vae = build_mlx_model()
+    rng = np.random.default_rng(SEED + 6)
+    left = rng.standard_normal((1, TINY_ARCH["latent_channels"], 10)).astype(np.float32) * 0.5
+    right = rng.standard_normal((1, TINY_ARCH["latent_channels"], 10)).astype(np.float32) * 0.5
+    stereo = np.concatenate([left, right], 0)
+    both = np.asarray(vae.decode(mx.array(stereo)))
+    single_l = np.asarray(vae.decode(mx.array(left)))
+    single_r = np.asarray(vae.decode(mx.array(right)))
+    np.testing.assert_allclose(both[0], single_l[0], rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(both[1], single_r[0], rtol=1e-5, atol=1e-6)
+
+
+def test_latent_normalization_roundtrip() -> None:
+    model = build_torch_model()
+    vae = build_mlx_model(model)
+    rng = np.random.default_rng(SEED + 7)
+    latents = rng.standard_normal((1, TINY_ARCH["latent_channels"], 5)).astype(np.float32)
+    normalized = np.asarray(vae.normalize_latents(mx.array(latents)))
+    ref = ((torch.from_numpy(latents) - model.latents_mean) / model.latents_std).numpy()
+    _stats("normalize", normalized, ref, atol=1e-5, rtol=1e-5)
+    denorm = np.asarray(vae.denormalize_latents(mx.array(normalized)))
+    _stats("denormalize", denorm, latents, atol=1e-5, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Real released weights (bounded segment)
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL_ROOT = Path(os.environ.get("MINIMAX_H3_MODEL_ROOT", Path.home() / "models/FastH3-Preview-v0.2"))
+REAL_WEIGHTS_PRESENT = (DEFAULT_MODEL_ROOT / "audio_vae").is_dir() and any(
+    (DEFAULT_MODEL_ROOT / "audio_vae").glob("*.safetensors"))
+
+
+@pytest.mark.skipif(not REAL_WEIGHTS_PRESENT, reason="released H3 audio VAE snapshot not found")
+def test_real_weights_bounded_segment_decode() -> None:
+    from fastvideo.mlx_runtime.minimax_h3_audio_vae import mlx_h3_audio_vae_from_dir
+
+    torch_vae = MiniMaxH3AudioVAE(MiniMaxH3AudioVAEConfig(arch_config=MiniMaxH3AudioVAEArchConfig())).float().eval()
+    state = load_released_state(DEFAULT_MODEL_ROOT / "audio_vae")
+    missing, unexpected = torch_vae.load_state_dict(state, strict=False)
+    assert not [k for k in unexpected]
+
+    mlx_vae = mlx_h3_audio_vae_from_dir(DEFAULT_MODEL_ROOT / "audio_vae")
+
+    rng = np.random.default_rng(SEED + 8)
+    z_np = rng.standard_normal((1, 32, 10)).astype(np.float32) * 0.5
+    with torch.no_grad():
+        ref = torch_vae.decode(torch.from_numpy(z_np)).sample.numpy()
+    out = np.asarray(mlx_vae.decode(mx.array(z_np)))
+    _stats("real.audio.segment(fp32)", out, ref, atol=2e-4, rtol=2e-4)
+
+
+def load_released_state(component_dir: Path) -> dict:
+    from safetensors.torch import safe_open
+
+    state = {}
+    index_path = component_dir / "diffusion_pytorch_model.safetensors.index.json"
+    if index_path.exists():
+        weight_map = json.loads(index_path.read_text())["weight_map"]
+        shards = {}
+        for key, shard in weight_map.items():
+            if shard not in shards:
+                shards[shard] = safe_open(str(component_dir / shard), framework="pt", device="cpu")
+            state[key] = shards[shard].get_tensor(key)
+    else:
+        with safe_open(str(component_dir / "diffusion_pytorch_model.safetensors"), framework="pt",
+                       device="cpu") as handle:
+            for key in handle.keys():
+                state[key] = handle.get_tensor(key)
+    return state

--- a/tests/local_tests/minimax_h3/test_mlx_video_vae_parity.py
+++ b/tests/local_tests/minimax_h3/test_mlx_video_vae_parity.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MiniMax-H3 video VAE parity: FastVideo-native PyTorch reference vs MLX.
+
+Tiny random-weight models exercise every primitive (causal conv3d, per-frame
+GroupNorm, ViT attention with QK-RMSNorm + partial RoPE, SwiGLU, chunked
+clip decoding, spatial tiling); a real-weight bounded-tile case validates the
+released FP32 checkpoint end to end.
+
+Runs in any environment with torch + mlx (CPU is fine):
+
+    pytest tests/local_tests/minimax_h3/test_mlx_video_vae_parity.py -v
+
+The real-weight case activates automatically when the released snapshot is
+present; point MINIMAX_H3_MODEL_ROOT at another checkout otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch", reason="PyTorch reference needed for video VAE parity")
+mx = pytest.importorskip("mlx.core", reason="MLX needed for video VAE parity")
+
+from fastvideo.configs.models.vaes.minimax_h3_video import (  # noqa: E402
+    MiniMaxH3VideoVAEArchConfig,
+    MiniMaxH3VideoVAEConfig,
+)
+from fastvideo.models.vaes.minimax_h3_video import AutoencoderKLMiniMaxH3  # noqa: E402
+from fastvideo.mlx_runtime.minimax_h3_video_vae import (  # noqa: E402
+    MLXMiniMaxH3VideoVAE,
+    MiniMaxH3VideoVAEConfigView,
+    _rotary_cos_sin,
+)
+
+SEED = 4112
+
+TINY_ARCH = dict(
+    in_channels=3,
+    out_channels=3,
+    latent_channels=4,
+    block_out_channels=(8, 16),
+    layers_per_block=1,
+    spatial_downsample_factors=(2, 2),
+    temporal_downsample_factors=(1, 2),
+    norm_num_groups=4,
+    norm_eps=1e-6,
+    decoder_num_layers=2,
+    decoder_num_attention_heads=4,
+    decoder_attention_head_dim=16,
+    decoder_num_register_tokens=2,
+    decoder_ffn_mult=2,
+    decoder_rope_theta=100.0,
+    decoder_rope_dim_ratio=0.75,
+    decoder_norm_eps=1e-5,
+    clip_length=5,
+    token_drop=1,
+    latents_mean=(0.0, 0.1, -0.1, 0.2),
+    latents_std=(1.0, 0.9, 1.1, 0.8),
+)
+
+
+def build_torch_model() -> AutoencoderKLMiniMaxH3:
+    arch = MiniMaxH3VideoVAEArchConfig(**TINY_ARCH)
+    config = MiniMaxH3VideoVAEConfig(arch_config=arch)
+    config.use_tiling = False
+    torch.manual_seed(SEED)
+    model = AutoencoderKLMiniMaxH3(config)
+    return model.float().eval()
+
+
+def transfer_weights(model: AutoencoderKLMiniMaxH3) -> dict:
+    """state_dict -> MLX weight dict (conv3d kernels transpose to channels-last)."""
+    weights = {}
+    for name, tensor in model.state_dict().items():
+        array = tensor.detach().float().numpy()
+        if array.ndim == 5:  # conv3d (O, I, kT, kH, kW) -> (O, kT, kH, kW, I)
+            array = np.ascontiguousarray(array.transpose(0, 2, 3, 4, 1))
+        weights[name] = mx.array(np.ascontiguousarray(array))
+        # The torch encoder keeps conv_shortcut absent when channels match.
+    return weights
+
+
+def build_mlx_model(model=None) -> MLXMiniMaxH3VideoVAE:
+    model = model or build_torch_model()
+    view = MiniMaxH3VideoVAEConfigView(
+        in_channels=TINY_ARCH["in_channels"],
+        out_channels=TINY_ARCH["out_channels"],
+        latent_channels=TINY_ARCH["latent_channels"],
+        block_out_channels=TINY_ARCH["block_out_channels"],
+        layers_per_block=TINY_ARCH["layers_per_block"],
+        spatial_downsample_factors=TINY_ARCH["spatial_downsample_factors"],
+        temporal_downsample_factors=TINY_ARCH["temporal_downsample_factors"],
+        norm_num_groups=TINY_ARCH["norm_num_groups"],
+        norm_eps=TINY_ARCH["norm_eps"],
+        decoder_num_layers=TINY_ARCH["decoder_num_layers"],
+        decoder_num_attention_heads=TINY_ARCH["decoder_num_attention_heads"],
+        decoder_attention_head_dim=TINY_ARCH["decoder_attention_head_dim"],
+        decoder_num_register_tokens=TINY_ARCH["decoder_num_register_tokens"],
+        decoder_ffn_mult=TINY_ARCH["decoder_ffn_mult"],
+        decoder_rope_theta=TINY_ARCH["decoder_rope_theta"],
+        decoder_rope_dim_ratio=TINY_ARCH["decoder_rope_dim_ratio"],
+        decoder_norm_eps=TINY_ARCH["decoder_norm_eps"],
+        clip_length=TINY_ARCH["clip_length"],
+        token_drop=TINY_ARCH["token_drop"],
+        latents_mean=TINY_ARCH["latents_mean"],
+        latents_std=TINY_ARCH["latents_std"],
+    )
+    return MLXMiniMaxH3VideoVAE(transfer_weights(model), view)
+
+
+def _stats(name: str, actual: np.ndarray, expected: np.ndarray, atol: float, rtol: float) -> None:
+    diff = np.abs(actual.astype(np.float64) - expected.astype(np.float64))
+    denom = np.linalg.norm(expected.astype(np.float64)) + 1e-12
+    rel_l2 = float(np.linalg.norm(diff) / denom)
+    print(f"[{name}] max_abs={diff.max():.3e} mean_abs={diff.mean():.3e} rel_l2={rel_l2:.3e} "
+          f"shape={actual.shape} dtype={actual.dtype}")
+    assert diff.max() <= atol + rtol * np.abs(expected).max(), f"{name} drifted beyond tolerance"
+
+
+def _to_np(value) -> np.ndarray:
+    return np.asarray(value, dtype=np.float32)
+
+
+def test_rotary_embedding_matches_torch() -> None:
+    from fastvideo.models.vaes.minimax_h3_video import MiniMaxH3VideoRotaryPosEmbed
+
+    dim = int(TINY_ARCH["decoder_attention_head_dim"] * TINY_ARCH["decoder_rope_dim_ratio"])
+    rope = MiniMaxH3VideoRotaryPosEmbed(dim, theta=TINY_ARCH["decoder_rope_theta"])
+    rng = np.random.default_rng(SEED)
+    positions = rng.standard_normal((1, 7, 3)).astype(np.float32) * 0.5
+    cos_t, sin_t = rope(torch.from_numpy(positions))
+    cos_t = cos_t.numpy()[0].reshape(7, 1, 1, -1)
+    sin_t = sin_t.numpy()[0].reshape(7, 1, 1, -1)
+    cos_m, sin_m = _rotary_cos_sin(mx.array(positions[0]), rotary_dim=dim,
+                                   theta=TINY_ARCH["decoder_rope_theta"])
+    _stats("rope.cos", _to_np(cos_m), cos_t, atol=2e-5, rtol=2e-5)
+    _stats("rope.sin", _to_np(sin_m), sin_t, atol=2e-5, rtol=2e-5)
+
+
+def test_encoder_moments_match_torch() -> None:
+    model = build_torch_model()
+    vae = build_mlx_model(model)
+    rng = np.random.default_rng(SEED + 1)
+    frames = rng.standard_normal((1, 3, 5, 16, 16)).astype(np.float32)  # one clip
+    pixels = mx.array(frames)
+    mean_m, logvar_m = vae.encode(pixels)
+    with torch.no_grad():
+        moments = model._encode(torch.from_numpy(frames))
+    mean_t, logvar_t = torch.chunk(moments, 2, dim=1)
+    logvar_t = logvar_t.clamp(-30.0, 20.0)
+    _stats("encoder.mean", _to_np(mean_m), mean_t.numpy(), atol=2e-4, rtol=2e-4)
+    _stats("encoder.logvar", _to_np(logvar_m), logvar_t.numpy(), atol=2e-4, rtol=2e-4)
+
+
+def test_encode_keyframe_matches_torch() -> None:
+    model = build_torch_model()
+    vae = build_mlx_model(model)
+    rng = np.random.default_rng(SEED + 2)
+    frame = rng.standard_normal((1, 3, 1, 16, 16)).astype(np.float32)
+    mean_m, logvar_m = vae.encode_keyframe(mx.array(frame))
+    with torch.no_grad():
+        moments = model.encode_keyframe(torch.from_numpy(frame)).latent_dist.parameters
+    mean_t, logvar_t = torch.chunk(moments, 2, dim=1)
+    logvar_t = logvar_t.clamp(-30.0, 20.0)
+    _stats("keyframe.mean", _to_np(mean_m), mean_t.numpy(), atol=2e-4, rtol=2e-4)
+    _stats("keyframe.logvar", _to_np(logvar_m), logvar_t.numpy(), atol=2e-4, rtol=2e-4)
+
+
+def test_decoder_clip_matches_torch() -> None:
+    """One clip through post_quant_conv + ViT decoder, unchunked both sides."""
+    model = build_torch_model()
+    vae = build_mlx_model(model)
+    rng = np.random.default_rng(SEED + 3)
+    z_np = rng.standard_normal((1, TINY_ARCH["latent_channels"], 3, 4, 4)).astype(np.float32)
+    with torch.no_grad():
+        ref = model.decoder(model.post_quant_conv(torch.from_numpy(z_np))).numpy()
+    out = vae._decode_clip(mx.array(z_np))
+    assert out.shape == ref.shape
+    _stats("decoder.clip", _to_np(out), ref, atol=5e-4, rtol=5e-4)
+
+
+def test_chunked_decode_matches_torch() -> None:
+    """The full clip-chunking / overlap-blending decode path."""
+    model = build_torch_model()
+    vae = build_mlx_model(model)
+    cfg = vae.config
+    num_tokens = 2 * cfg.tokens_chunk_size - token_pad(cfg)  # forces padding branch
+    rng = np.random.default_rng(SEED + 4)
+    z_np = rng.standard_normal((1, TINY_ARCH["latent_channels"], num_tokens, 4, 4)).astype(np.float32)
+    with torch.no_grad():
+        ref = model.decode(torch.from_numpy(z_np)).sample.numpy()
+    out = vae.decode(mx.array(z_np))
+    assert out.shape == ref.shape
+    _stats("decoder.chunked", _to_np(out), ref, atol=5e-4, rtol=5e-4)
+
+
+def token_pad(vae: MLXMiniMaxH3VideoVAE) -> int:
+    return 0
+
+
+def test_tiled_decode_matches_untiled() -> None:
+    vae = build_mlx_model()
+    rng = np.random.default_rng(SEED + 5)
+    z = mx.array(rng.standard_normal((1, TINY_ARCH["latent_channels"], 3, 4, 8)).astype(np.float32))
+    untiled = vae._decode_clip(z)
+    tiled = vae.decode_clip_tiled(
+        z,
+        tile_sample_min_height=untiled.shape[-2] // 2,
+        tile_sample_min_width=untiled.shape[-1] // 2,
+        tile_sample_min_overlap_height=vae.spatial_compression_ratio,
+        tile_sample_min_overlap_width=vae.spatial_compression_ratio,
+    )
+    assert tiled.shape == untiled.shape
+    _stats("tiled-vs-untiled", _to_np(tiled), _to_np(untiled), atol=2e-3, rtol=2e-3)
+
+
+# ---------------------------------------------------------------------------
+# Real released weights (bounded tile)
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL_ROOT = Path(os.environ.get("MINIMAX_H3_MODEL_ROOT", Path.home() / "models/FastH3-Preview-v0.2"))
+REAL_WEIGHTS_PRESENT = (DEFAULT_MODEL_ROOT / "vae").is_dir() and any(
+    (DEFAULT_MODEL_ROOT / "vae").glob("*.safetensors"))
+
+
+@pytest.mark.skipif(not REAL_WEIGHTS_PRESENT, reason="released H3 VAE snapshot not found")
+def test_real_weights_bounded_tile_decode() -> None:
+    from fastvideo.mlx_runtime.minimax_h3_video_vae import mlx_h3_video_vae_from_dir
+
+    torch_vae = AutoencoderKLMiniMaxH3(MiniMaxH3VideoVAEConfig(arch_config=MiniMaxH3VideoVAEArchConfig()))
+    index = json_load_index(DEFAULT_MODEL_ROOT / "vae")
+    load_released_weights_into_torch(torch_vae, DEFAULT_MODEL_ROOT / "vae", index)
+    torch_vae = torch_vae.float().eval()
+
+    vae_dir = DEFAULT_MODEL_ROOT / "vae"
+    mlx_vae = mlx_h3_video_vae_from_dir(vae_dir, include_encoder=False, storage_dtype="fp32")
+
+    rng = np.random.default_rng(SEED + 6)
+    z_np = rng.standard_normal((1, 24, 7, 4, 6)).astype(np.float32)
+    with torch.no_grad():
+        ref = torch_vae.decoder(torch_vae.post_quant_conv(torch.from_numpy(z_np))).numpy()
+    out = mlx_vae._decode_clip(mx.array(z_np))
+    _stats("real.decoder.tile(fp32)", _to_np(out), ref, atol=2e-4, rtol=2e-4)
+
+
+def json_load_index(vae_dir: Path) -> dict:
+    import json
+    return json.loads((vae_dir / "diffusion_pytorch_model.safetensors.index.json").read_text())
+
+
+def load_released_weights_into_torch(model: AutoencoderKLMiniMaxH3, vae_dir: Path, index: dict) -> None:
+    from safetensors.torch import safe_open
+
+    weight_map = index["weight_map"]
+    shards = {}
+    state = {}
+    for key, shard in weight_map.items():
+        if not key.startswith(("encoder.", "quant_conv.", "post_quant_conv.", "decoder.")):
+            continue
+        if shard not in shards:
+            handle = safe_open(str(Path(vae_dir) / shard), framework="pt", device="cpu")
+            shards[shard] = handle
+        state[key] = shards[shard].get_tensor(key)
+    missing, unexpected = model.load_state_dict(state, strict=False)
+    unexpected = [k for k in unexpected]
+    assert not unexpected, f"unexpected released keys: {unexpected[:5]}"

--- a/tests/local_tests/minimax_h3/test_mlx_video_vae_parity.py
+++ b/tests/local_tests/minimax_h3/test_mlx_video_vae_parity.py
@@ -141,6 +141,15 @@ def test_rotary_embedding_matches_torch() -> None:
     _stats("rope.sin", _to_np(sin_m), sin_t, atol=2e-5, rtol=2e-5)
 
 
+def test_reflect_padding_matches_numpy() -> None:
+    from fastvideo.mlx_runtime.minimax_h3_video_vae import _reflect_pad_axis
+
+    values = np.arange(12, dtype=np.float32).reshape(1, 3, 4, 1)
+    actual = np.asarray(_reflect_pad_axis(mx.array(values), axis=2, left=2, right=1))
+    expected = np.pad(values, ((0, 0), (0, 0), (2, 1), (0, 0)), mode="reflect")
+    np.testing.assert_array_equal(actual, expected)
+
+
 def test_encoder_moments_match_torch() -> None:
     model = build_torch_model()
     vae = build_mlx_model(model)
@@ -188,7 +197,8 @@ def test_chunked_decode_matches_torch() -> None:
     model = build_torch_model()
     vae = build_mlx_model(model)
     cfg = vae.config
-    num_tokens = 2 * cfg.tokens_chunk_size - token_pad(cfg)  # forces padding branch
+    # decode() adds token_drop before chunking, so this hits the padding branch.
+    num_tokens = 2 * cfg.tokens_chunk_size
     rng = np.random.default_rng(SEED + 4)
     z_np = rng.standard_normal((1, TINY_ARCH["latent_channels"], num_tokens, 4, 4)).astype(np.float32)
     with torch.no_grad():
@@ -196,10 +206,6 @@ def test_chunked_decode_matches_torch() -> None:
     out = vae.decode(mx.array(z_np))
     assert out.shape == ref.shape
     _stats("decoder.chunked", _to_np(out), ref, atol=5e-4, rtol=5e-4)
-
-
-def token_pad(vae: MLXMiniMaxH3VideoVAE) -> int:
-    return 0
 
 
 def test_tiled_decode_matches_untiled() -> None:


### PR DESCRIPTION
## Purpose

Add MiniMax H3 Preview text-to-video-with-audio inference to FastVideo's existing Apple Silicon MLX runtime.

The initial scope is intentionally narrow: T2VA baseline generation plus temporal `--fast`. FL2VA, Ref2VA, spatial fast mode, two-pass refinement, VSA, and `VideoGenerator` registry dispatch remain follow-up work.

## Changes

- Add a native MLX MiniMax H3 DiT with the upstream packed audio/video layout, dual schedulers, AdaLN step caching, and affine INT8, INT6, and INT4 checkpoints.
- Stream the Qwen3-VL text conditioner by embedding row and decoder layer so the released encoder does not become fully resident.
- Add native MLX video and audio VAE loaders and decoders, including tiled video decode and stereo 32 kHz audio.
- Add a phased T2VA pipeline that loads one heavyweight component at a time and muxes H.264 video with AAC audio.
- Add temporal fast mode that denoises fewer video rows, preserves full-duration audio, and reconstructs the requested frame count with the existing MLX RIFE backend.
- Add a local checkpoint converter, runnable example, Apple Silicon setup guide, support-matrix entry, and parity coverage.

## Test Plan

```bash
pytest -q \
  fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py \
  fastvideo/tests/mlx/test_mlx_minimax_h3_conditioner.py \
  fastvideo/tests/mlx/test_mlx_minimax_h3_fast_mode.py \
  tests/local_tests/minimax_h3/test_mlx_video_vae_parity.py \
  tests/local_tests/minimax_h3/test_mlx_audio_vae_parity.py

pre-commit run --files \
  fastvideo/mlx_runtime/__init__.py \
  fastvideo/mlx_runtime/fastwan.py \
  fastvideo/mlx_runtime/rife_interp.py \
  fastvideo/mlx_runtime/minimax_h3.py \
  fastvideo/mlx_runtime/minimax_h3_audio_vae.py \
  fastvideo/mlx_runtime/minimax_h3_video_vae.py \
  fastvideo/mlx_runtime/minimax_h3_conditioner.py \
  fastvideo/mlx_runtime/minimax_h3_pipeline.py \
  examples/inference/basic/mlx_fasth3.py \
  docs/getting_started/installation/mps.md \
  docs/inference/support_matrix.md \
  examples/inference/basic/README.md

python -m compileall -q \
  fastvideo/mlx_runtime \
  examples/inference/basic/mlx_fasth3.py \
  scripts/checkpoint_conversion/convert_minimax_h3_mlx.py
```

## Test Results

Validated locally on an Apple M4 Max with 36 GB unified memory.

| Run | Configuration | Output | Phase timings | Peak MLX memory |
| --- | --- | --- | --- | --- |
| Baseline T2VA | INT6, 832x480, 124 frames, 24 fps, 4 denoise steps, seed 2026 | 5.17 s H.264 + stereo AAC 32 kHz; Whisper transcript: "Fast H3 is amazing." | condition 77.26 s; denoise 383.73 s; video decode 103.32 s; audio decode 0.67 s; mux 0.39 s; total 565.37 s | condition 1.93 GiB; denoise 19.63 GiB; video decode 11.03 GiB; audio decode 2.64 GiB |
| Temporal fast T2VA | INT6, 1280x720, 124 frames, 24 fps, 4 denoise steps, seed 2027, `--fast` | 5.17 s H.264 + stereo AAC 32 kHz; Whisper transcript: "Fast mode and Fast H3 is even faster." | condition 85.98 s; denoise 703.12 s; video decode 142.29 s; RIFE 12.59 s; audio decode 0.78 s; mux 0.55 s; total 945.31 s | condition 1.93 GiB; denoise 21.10 GiB; video decode 12.09 GiB; RIFE 1.53 GiB; audio decode 2.48 GiB |

The two runs use different resolutions, so their wall times are not a same-resolution speed comparison. Temporal fast mode reduced the 124-frame request from 37 target video latent frames to 22 denoised video latent frames while retaining all 207 audio latent frames.

<details>
<summary>Focused test output</summary>

```
44 passed, 21 warnings in 13.13s

yapf........................................Passed
ruff (legacy alias)........................Passed
codespell...................................Passed
PyMarkdown.................................Passed
mypy........................................Passed
Check for spaces in all filenames..........Passed
Suggestion.................................Passed
```

</details>

SSIM: Not run. There is no MiniMax H3 MLX reference artifact in the SSIM suite yet. The PR instead includes independent PyTorch/MLX DiT, scheduler, packing, conditioner, and real-weight bounded VAE parity gates plus two end-to-end media runs.

## Checklist

- [x] I ran pre-commit on every changed file covered by the repository hooks and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU and unified-memory impact of my changes

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass (not available for this new MLX path)
- [x] I updated the support matrix if adding a new model
