### PR TITLE
[bugfix]: pin fastvideo-kernel to Torch 2.12.0

### DIFF
--- a/fastvideo-kernel/pyproject.toml
+++ b/fastvideo-kernel/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core>=0.10",
-    "torch>=2.5.0",
+    "torch==2.12.0",
     "setuptools>=61.0.0",
     "wheel"
 ]
@@ -22,7 +22,7 @@ classifiers = [
     "Environment :: GPU :: NVIDIA CUDA",
 ]
 dependencies = [
-    "torch>=2.5.0",
+    "torch==2.12.0",
     "triton>=2.0.0; sys_platform == 'linux'",
 ]
 


### PR DESCRIPTION
## Summary
- pin the fastvideo-kernel build requirement to Torch 2.12.0
- pin the fastvideo-kernel runtime dependency to Torch 2.12.0
- align kernel dependency resolution with the root project, Docker artifacts, and kernel publishing matrix

## Rationale
The previous `torch>=2.5.0` constraints allow uv to resolve Torch 2.13.0, while FastVideo currently builds and publishes the kernel against Torch 2.12.0. An exact pin avoids installing an unvalidated Torch/kernel ABI combination.

## Test plan
- `python3 -c` TOML parse confirms both kernel requirements are `torch==2.12.0`
- `uv pip compile fastvideo-kernel/pyproject.toml --torch-backend cu126` resolves `torch==2.12.0+cu126`
- `uv pip compile fastvideo-kernel/pyproject.toml --torch-backend cu130` resolves `torch==2.12.0+cu130`
- Pre-commit was not runnable from the jj-only workspace because it requires Git worktree metadata; the changed TOML was parsed directly instead
