### PR TITLE
[perf] Add MiniMax H3 MLX VSA and SIMD attention

### DIFF
--- a/.github/workflows/ci-macos-mlx.yml
+++ b/.github/workflows/ci-macos-mlx.yml
@@ -8,6 +8,8 @@ on:
       - "fastvideo/mlx_runtime/**"
       - "fastvideo/tests/mlx/**"
       - "fastvideo/tests/platforms/test_mps_vsa_error.py"
+      - "fastvideo/tests/platforms/test_cpu_sdpa.py"
+      - "fastvideo/platforms/cpu.py"
       - "fastvideo/platforms/mps.py"
       - "fastvideo/platforms/__init__.py"
       - "fastvideo/__init__.py"
@@ -79,6 +81,10 @@ jobs:
             fastvideo/tests/mlx/test_mlx_compile_parity.py \
             fastvideo/tests/mlx/test_mlx_checkpoint.py \
             fastvideo/tests/mlx/test_mlx_checkpoint_compat.py \
+            fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py \
+            fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py \
+            fastvideo/tests/mlx/test_mlx_minimax_h3_vsa_regressions.py \
+            fastvideo/tests/mlx/test_mlx_minimax_h3_fast_mode.py \
             fastvideo/tests/mlx/test_mlx_fastwan_benchmark.py \
             fastvideo/tests/mlx/test_taehv_decode.py \
             fastvideo/tests/mlx/test_frame_upsample.py \
@@ -91,7 +97,8 @@ jobs:
             fastvideo/tests/mlx/test_mlx_rife_interpolation.py::test_rife_download_unavailable_has_specific_error \
             fastvideo/tests/mlx/test_mlx_rife_interpolation.py::test_rife_backend_regression_is_not_skip_eligible \
             fastvideo/tests/platforms/test_mps_vsa_error.py \
-            -q
+            fastvideo/tests/platforms/test_cpu_sdpa.py \
+            -v -s -o faulthandler_timeout=120
 
   # Same tests on MLX's CPU backend. Hosted macOS runners are scarce and
   # slower to schedule; this Linux job gives fast PR signal on the identical
@@ -136,6 +143,10 @@ jobs:
             fastvideo/tests/mlx/test_mlx_compile_parity.py \
             fastvideo/tests/mlx/test_mlx_checkpoint.py \
             fastvideo/tests/mlx/test_mlx_checkpoint_compat.py \
+            fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py \
+            fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py \
+            fastvideo/tests/mlx/test_mlx_minimax_h3_vsa_regressions.py \
+            fastvideo/tests/mlx/test_mlx_minimax_h3_fast_mode.py \
             fastvideo/tests/mlx/test_mlx_fastwan_benchmark.py \
             fastvideo/tests/mlx/test_taehv_decode.py \
             fastvideo/tests/mlx/test_frame_upsample.py \
@@ -148,4 +159,5 @@ jobs:
             fastvideo/tests/mlx/test_mlx_rife_interpolation.py::test_rife_download_unavailable_has_specific_error \
             fastvideo/tests/mlx/test_mlx_rife_interpolation.py::test_rife_backend_regression_is_not_skip_eligible \
             fastvideo/tests/platforms/test_mps_vsa_error.py \
-            -q
+            fastvideo/tests/platforms/test_cpu_sdpa.py \
+            -v -s -o faulthandler_timeout=120

--- a/docs/attention/vsa/index.md
+++ b/docs/attention/vsa/index.md
@@ -23,11 +23,12 @@ the CUDA `fastvideo-kernel` package:
 - **Tile sizes** 64 `(4, 4, 4)` and 256 `(4, 8, 8)`. Prefix keys can be
   `exempt` or `compete`. `--vsa-dense-first-n-steps` and `--vsa-dense-layers`
   force dense SDPA on the selected steps or blocks.
-- **`--vsa-impl auto`** uses the chunked gather+SDPA **reference** path. Pass
-  `--vsa-impl metal` to run the inference-only Metal block-sparse kernel
-  (`mx.fast.metal_kernel`). On MLX 0.31.2 the Metal kernel is a correctness
-  path, not a speedup versus fused SDPA. Use `--vsa-impl reference` for
-  explicit parity tests.
+- **`--vsa-impl auto`** uses the chunked gather+SDPA **reference** path.
+  `--vsa-impl simd` runs the SIMD-group Metal kernel (tile 64, head dim 128)
+  and falls back to reference on unsupported shapes or compilation failure.
+  It is not the default: 480p four-step generation is faster than reference
+  but does not yet match reference video. `--vsa-impl reference` is the same
+  as `auto`.
 
 See the [Apple Silicon guide](../../getting_started/installation/mps.md) for
 conversion and `mlx_fasth3.py` flags. Do not enable VSA on a dense-only

--- a/docs/attention/vsa/index.md
+++ b/docs/attention/vsa/index.md
@@ -25,7 +25,9 @@ the CUDA `fastvideo-kernel` package:
   force dense SDPA on the selected steps or blocks.
 - **`--vsa-impl auto`** uses the chunked gather+SDPA **reference** path.
   `--vsa-impl simd` runs the SIMD-group Metal kernel (tile 64, head dim 128)
-  and falls back to reference on unsupported shapes or compilation failure.
+  and falls back to reference on unsupported shapes or kernel failure. The
+  runtime executes a small kernel probe before use and remembers failures
+  for the process, so later blocks do not retry a broken backend.
   It is not the default: 480p four-step generation is faster than reference
   but does not yet match reference video. `--vsa-impl reference` is the same
   as `auto`.
@@ -33,6 +35,17 @@ the CUDA `fastvideo-kernel` package:
 See the [Apple Silicon guide](../../getting_started/installation/mps.md) for
 conversion and `mlx_fasth3.py` flags. Do not enable VSA on a dense-only
 checkpoint; reconvert with `--include-vsa` first.
+
+H3 uses fused MLX RMSNorm by default, including dense inference. This can
+change BF16 rounding relative to the older explicit normalization path.
+`FASTVIDEO_MLX_FAST_NORM` controls Wan normalization only.
+
+The generation report aggregates VSA statistics across all blocks and steps.
+`impl_counts` and `fallback_reasons` show mixed execution and fallback.
+`video_keep` is the mean number of selected video-key tiles per video query
+tile and head, including dense overrides. `achieved_sparsity` is the matching
+mean video-tile sparsity; in `compete` mode it measures actual selections,
+not the requested top-k budget. These are tile counts, not token-level FLOPs.
 
 ## Usage
 

--- a/docs/attention/vsa/index.md
+++ b/docs/attention/vsa/index.md
@@ -6,6 +6,33 @@ Sparse attention mechanism selecting top-k blocks.
 
 VSA is included in the `fastvideo-kernel` package. See the [main Attention page](../index.md) for build instructions.
 
+## Apple Silicon (MiniMax H3 / FastH3)
+
+The native MLX runtime has an inference-only H3 VSA path that is separate from
+the CUDA `fastvideo-kernel` package:
+
+- **INT8 / INT6 / INT4** are **weight-only**. They cover linear matrices,
+  including `attn.to_gate_compress` when you convert with `--include-vsa`.
+  Attention Q/K/V stay BF16 (or the selected activation dtype). There is no
+  INT6 Q/K/V attention kernel.
+- **Dense-only checkpoints** (the default converter) drop the 50 gate
+  matrices and keep fused SDPA. They remain valid for dense inference.
+- **VSA-capable checkpoints** retain those gates, quantize them on the same
+  affine grid, and record `vsa.capable` in `mlx_h3_dit.json`. Runtime VSA is
+  still off until you pass `--vsa`.
+- **Tile sizes** 64 `(4, 4, 4)` and 256 `(4, 8, 8)`. Prefix keys can be
+  `exempt` or `compete`. `--vsa-dense-first-n-steps` and `--vsa-dense-layers`
+  force dense SDPA on the selected steps or blocks.
+- **`--vsa-impl auto`** uses the chunked gather+SDPA **reference** path. Pass
+  `--vsa-impl metal` to run the inference-only Metal block-sparse kernel
+  (`mx.fast.metal_kernel`). On MLX 0.31.2 the Metal kernel is a correctness
+  path, not a speedup versus fused SDPA. Use `--vsa-impl reference` for
+  explicit parity tests.
+
+See the [Apple Silicon guide](../../getting_started/installation/mps.md) for
+conversion and `mlx_fasth3.py` flags. Do not enable VSA on a dense-only
+checkpoint; reconvert with `--include-vsa` first.
+
 ## Usage
 
 ```python

--- a/docs/getting_started/installation/mps.md
+++ b/docs/getting_started/installation/mps.md
@@ -153,6 +153,20 @@ python scripts/checkpoint_conversion/convert_minimax_h3_mlx.py \
   --formats "int6"
 ```
 
+Dense conversion drops the trained VSA gate projections. To keep them (INT6
+weight-only, same affine grid as the other linear matrices) write a **new**
+directory:
+
+```bash
+python scripts/checkpoint_conversion/convert_minimax_h3_mlx.py \
+  --model-root ./FastH3-Preview-v0.2/transformer \
+  --out ./FastH3-MLX-vsa \
+  --formats "int6" \
+  --include-vsa
+```
+
+Do not overwrite an existing dense export such as `./FastH3-MLX/int6`.
+
 Run the baseline path:
 
 ```bash
@@ -178,10 +192,32 @@ python examples/inference/basic/mlx_fasth3.py \
   --output-path ./outputs/fasth3_int6_fast_720p.mp4
 ```
 
+VSA is off by default. A dense-only checkpoint (no `--include-vsa`) keeps the
+existing fused-SDPA path. After converting with `--include-vsa`, enable the
+sparse path explicitly:
+
+```bash
+python examples/inference/basic/mlx_fasth3.py \
+  --model-root ./FastH3-Preview-v0.2 \
+  --mlx-checkpoint ./FastH3-MLX-vsa/int6 \
+  --vsa --vsa-sparsity 0.9 --vsa-tile-size 64 --vsa-prefix-mode exempt \
+  --prompt "(S1) A presenter says <d>[English] Fast H3 is amazing.</d>" \
+  --height 720 --width 1280 --num-frames 124 --seed 2026 \
+  --output-path ./outputs/fasth3_int6_vsa_720p.mp4
+```
+
+`--vsa-impl auto` uses the chunked gather+SDPA **reference** path. The Metal
+block-sparse kernel is available as `--vsa-impl metal` for parity experiments;
+on MLX 0.31.2 it is much slower than fused SDPA at 720p, so it is not the
+default. `--vsa-impl reference` is the same as `auto` today.
+
 !!! note "Current MLX scope"
-    This source runtime supports T2VA and temporal `--fast`. FL2VA, Ref2VA,
-    spatial fast mode, two-pass refinement, VSA, and `VideoGenerator`
-    registry dispatch are not wired yet. The checkpoint uses the MiniMax H3
+    This source runtime supports T2VA, temporal `--fast`, and opt-in VSA.
+    FL2VA, Ref2VA, spatial fast mode, two-pass refinement, and
+    `VideoGenerator` registry dispatch are not wired yet. INT8/INT6/INT4
+    quantization is **weight-only**; VSA attention Q/K/V stay BF16. Old dense
+    MLX checkpoints remain valid for dense inference and raise a reconvert
+    error if `--vsa` is set. The checkpoint uses the MiniMax H3
     Community License; review the model card before use or redistribution.
 
 ## Development Environment Setup

--- a/docs/getting_started/installation/mps.md
+++ b/docs/getting_started/installation/mps.md
@@ -206,10 +206,10 @@ python examples/inference/basic/mlx_fasth3.py \
   --output-path ./outputs/fasth3_int6_vsa_720p.mp4
 ```
 
-`--vsa-impl auto` uses the chunked gather+SDPA **reference** path. The Metal
-block-sparse kernel is available as `--vsa-impl metal` for parity experiments;
-on MLX 0.31.2 it is much slower than fused SDPA at 720p, so it is not the
-default. `--vsa-impl reference` is the same as `auto` today.
+`--vsa-impl auto` uses the chunked gather+SDPA **reference** path.
+`--vsa-impl simd` is an opt-in SIMD-group kernel (tile 64, head dim 128) that
+falls back to reference on unsupported shapes. It is not the default.
+`--vsa-impl reference` is the same as `auto`.
 
 !!! note "Current MLX scope"
     This source runtime supports T2VA, temporal `--fast`, and opt-in VSA.

--- a/docs/inference/support_matrix.md
+++ b/docs/inference/support_matrix.md
@@ -185,7 +185,7 @@ optimizations: absence means **untested**, not incompatible.
 | MLX FastMetal T2V 1.3B | [`FastVideo/FastMetal-1.3B-QAD`](https://huggingface.co/FastVideo/FastMetal-1.3B-QAD) | 480x832, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 16 GB+ unified memory | Released |
 | MLX FastMetal TI2V 5B | [`FastVideo/FastMetal-5B-QAD`](https://huggingface.co/FastVideo/FastMetal-5B-QAD) | 480p / 720p, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 16 GB+ unified memory | Released |
 | MLX FastMetal T2V 14B | [`FastVideo/FastMetal-14B-QAD`](https://huggingface.co/FastVideo/FastMetal-14B-QAD) | 480p / 720p, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 36 GB+ unified memory | Released |
-| MLX FastH3 Preview T2VA | [`FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2`](https://huggingface.co/FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2) + locally converted DiT | 480p / 720p, 124 frames, 4-step DMD2, INT8/INT6/INT4 DiT, native video + audio VAE; optional temporal RIFE fast mode | Apple M4 Max, 36 GB unified memory | Source runtime; T2VA only |
+| MLX FastH3 Preview T2VA | [`FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2`](https://huggingface.co/FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2) + locally converted DiT | 480p / 720p, 124 frames, 4-step DMD2, INT8/INT6/INT4 **weight-only** DiT, native video + audio VAE; optional temporal RIFE fast mode; optional VSA (tile 64/256, exempt/compete) on `--include-vsa` checkpoints | Apple M4 Max, 36 GB unified memory | Source runtime; T2VA only |
 
 Apple Silicon uses the native MLX runtime. FastMetal-QAD is the packaged Wan
 release, while FastH3 Preview currently uses a source checkout and local DiT

--- a/examples/inference/basic/README.md
+++ b/examples/inference/basic/README.md
@@ -51,9 +51,15 @@ python examples/inference/basic/mlx_fasth3.py \
   --output-path ./outputs/fasth3_int6.mp4
 ```
 
-Pass `--fast` for temporal RIFE fast mode. This MLX entrypoint currently
-supports T2VA only; FL2VA, Ref2VA, spatial fast mode, and two-pass refinement
-remain follow-up work. The complete setup and conversion commands are in the
+Pass `--fast` for temporal RIFE fast mode. VSA is opt-in: convert with
+`--include-vsa` and pass `--vsa` (see the
+[Apple Silicon guide](https://hao-ai-lab.github.io/FastVideo/getting_started/installation/mps/)).
+This MLX entrypoint currently supports T2VA only; FL2VA, Ref2VA, spatial fast
+mode, and two-pass refinement remain follow-up work. INT6/INT8/INT4 are
+weight-only; VSA attention activations stay BF16. Dense-only checkpoints keep
+working for dense inference.
+
+The complete setup and conversion commands are in the
 [Apple Silicon guide](https://hao-ai-lab.github.io/FastVideo/getting_started/installation/mps/).
 
 For an example running DMD+VSA inference:

--- a/examples/inference/basic/mlx_fasth3.py
+++ b/examples/inference/basic/mlx_fasth3.py
@@ -34,7 +34,7 @@ import argparse
 import json
 from pathlib import Path
 
-from fastvideo.mlx_runtime.minimax_h3_vsa import parse_dense_layers
+from fastvideo.mlx_runtime.minimax_h3_vsa import PUBLIC_VSA_IMPLS, parse_dense_layers
 
 
 def parse_args() -> argparse.Namespace:
@@ -93,8 +93,8 @@ def parse_args() -> argparse.Namespace:
                         help="prefix-key policy: always keep (exempt) or FLOP-matched top-k (compete)")
     parser.add_argument("--vsa-dense-first-n-steps", type=int, default=0, help="run the first N denoise steps dense")
     parser.add_argument("--vsa-dense-layers", default="", help="comma-separated layer indices forced dense")
-    parser.add_argument("--vsa-impl", choices=("auto", "reference", "metal"), default="auto",
-                        help="sparse attention implementation; auto uses chunked gather+SDPA (metal is opt-in)")
+    parser.add_argument("--vsa-impl", choices=PUBLIC_VSA_IMPLS, default="auto",
+                        help="sparse attention implementation; auto uses chunked gather+SDPA (simd is opt-in)")
     return parser.parse_args()
 
 

--- a/examples/inference/basic/mlx_fasth3.py
+++ b/examples/inference/basic/mlx_fasth3.py
@@ -80,7 +80,10 @@ def parse_args() -> argparse.Namespace:
         "--vsa",
         action=argparse.BooleanOptionalAction,
         default=False,
-        help="enable MiniMax H3 VSA; requires a VSA-capable MLX checkpoint from --include-vsa",
+        help=(
+            "enable MiniMax H3 VSA; requires a VSA-capable MLX checkpoint "
+            "from --include-vsa"
+        ),
     )
     parser.add_argument(
         "--vsa-sparsity",
@@ -88,13 +91,42 @@ def parse_args() -> argparse.Namespace:
         default=0.9,
         help="VSA sparsity in [0, 1); 0.9 is the trained FastH3 policy",
     )
-    parser.add_argument("--vsa-tile-size", type=int, default=64, choices=(64, 256), help="VSA tile size in tokens")
-    parser.add_argument("--vsa-prefix-mode", choices=("exempt", "compete"), default="exempt",
-                        help="prefix-key policy: always keep (exempt) or FLOP-matched top-k (compete)")
-    parser.add_argument("--vsa-dense-first-n-steps", type=int, default=0, help="run the first N denoise steps dense")
-    parser.add_argument("--vsa-dense-layers", default="", help="comma-separated layer indices forced dense")
-    parser.add_argument("--vsa-impl", choices=PUBLIC_VSA_IMPLS, default="auto",
-                        help="sparse attention implementation; auto uses chunked gather+SDPA (simd is opt-in)")
+    parser.add_argument(
+        "--vsa-tile-size",
+        type=int,
+        default=64,
+        choices=(64, 256),
+        help="VSA tile size in tokens",
+    )
+    parser.add_argument(
+        "--vsa-prefix-mode",
+        choices=("exempt", "compete"),
+        default="exempt",
+        help=(
+            "prefix-key policy: always keep (exempt) or FLOP-matched top-k "
+            "(compete)"
+        ),
+    )
+    parser.add_argument(
+        "--vsa-dense-first-n-steps",
+        type=int,
+        default=0,
+        help="run the first N denoise steps dense",
+    )
+    parser.add_argument(
+        "--vsa-dense-layers",
+        default="",
+        help="comma-separated layer indices forced dense",
+    )
+    parser.add_argument(
+        "--vsa-impl",
+        choices=PUBLIC_VSA_IMPLS,
+        default="auto",
+        help=(
+            "sparse attention implementation; auto uses chunked gather+SDPA "
+            "(simd is opt-in)"
+        ),
+    )
     return parser.parse_args()
 
 

--- a/examples/inference/basic/mlx_fasth3.py
+++ b/examples/inference/basic/mlx_fasth3.py
@@ -21,6 +21,11 @@ center-cropped after decode.
 
 This entrypoint currently supports text-to-video-with-audio only. It does not
 yet wire FL2VA, Ref2VA, spatial fast mode, or two-pass refinement.
+
+VSA is off by default so existing dense MLX checkpoints keep the same
+behavior. Convert with ``--include-vsa`` and pass ``--vsa`` to enable the
+sparse path. Attention activations stay BF16; INT6/INT8/INT4 apply only to
+linear weights, including the optional gate projection.
 """
 
 from __future__ import annotations
@@ -28,6 +33,8 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+
+from fastvideo.mlx_runtime.minimax_h3_vsa import parse_dense_layers
 
 
 def parse_args() -> argparse.Namespace:
@@ -69,6 +76,25 @@ def parse_args() -> argparse.Namespace:
         default=True,
         help="decode with the reference 256px overlapping VAE tiles (disable only for diagnostics)",
     )
+    parser.add_argument(
+        "--vsa",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="enable MiniMax H3 VSA; requires a VSA-capable MLX checkpoint from --include-vsa",
+    )
+    parser.add_argument(
+        "--vsa-sparsity",
+        type=float,
+        default=0.9,
+        help="VSA sparsity in [0, 1); 0.9 is the trained FastH3 policy",
+    )
+    parser.add_argument("--vsa-tile-size", type=int, default=64, choices=(64, 256), help="VSA tile size in tokens")
+    parser.add_argument("--vsa-prefix-mode", choices=("exempt", "compete"), default="exempt",
+                        help="prefix-key policy: always keep (exempt) or FLOP-matched top-k (compete)")
+    parser.add_argument("--vsa-dense-first-n-steps", type=int, default=0, help="run the first N denoise steps dense")
+    parser.add_argument("--vsa-dense-layers", default="", help="comma-separated layer indices forced dense")
+    parser.add_argument("--vsa-impl", choices=("auto", "reference", "metal"), default="auto",
+                        help="sparse attention implementation; auto uses chunked gather+SDPA (metal is opt-in)")
     return parser.parse_args()
 
 
@@ -95,11 +121,19 @@ def main() -> None:
         fast_factor=args.fast_factor,
         fast_sharpen=args.fast_sharpen,
         rife_weights_dir=args.rife_weights_dir,
+        vsa=args.vsa,
+        vsa_sparsity=args.vsa_sparsity,
+        vsa_tile_size=args.vsa_tile_size,
+        vsa_prefix_mode=args.vsa_prefix_mode,
+        vsa_dense_first_n_steps=args.vsa_dense_first_n_steps,
+        vsa_dense_layers=parse_dense_layers(args.vsa_dense_layers),
+        vsa_impl=args.vsa_impl,
     )
     print(json.dumps({
         "video_path": result.video_path,
         "timings_s": {k: round(v, 2) for k, v in result.timings.items()},
         "peak_memory_gib": {k: round(v, 2) for k, v in result.peak_memory_gib.items()},
+        "vsa": result.vsa,
         "audio_samples": int(result.waveform.shape[-1]),
     }, indent=2))
 

--- a/examples/inference/basic/mlx_fasth3.py
+++ b/examples/inference/basic/mlx_fasth3.py
@@ -22,9 +22,10 @@ center-cropped after decode.
 This entrypoint currently supports text-to-video-with-audio only. It does not
 yet wire FL2VA, Ref2VA, spatial fast mode, or two-pass refinement.
 
-VSA is off by default so existing dense MLX checkpoints keep the same
-behavior. Convert with ``--include-vsa`` and pass ``--vsa`` to enable the
-sparse path. Attention activations stay BF16; INT6/INT8/INT4 apply only to
+VSA is off by default; existing dense MLX checkpoints remain supported.
+H3 uses fused MLX RMSNorm, which can change BF16 rounding compared with the
+older explicit normalization path. Convert with ``--include-vsa`` and pass
+``--vsa`` to enable the sparse path. Attention activations stay BF16; INT6/INT8/INT4 apply only to
 linear weights, including the optional gate projection.
 """
 
@@ -34,7 +35,12 @@ import argparse
 import json
 from pathlib import Path
 
-from fastvideo.mlx_runtime.minimax_h3_vsa import PUBLIC_VSA_IMPLS, parse_dense_layers
+
+def _dense_layers(value: str) -> tuple[int, ...]:
+    layers = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    if any(layer < 0 for layer in layers):
+        raise argparse.ArgumentTypeError("dense layer indices must be non-negative")
+    return layers
 
 
 def parse_args() -> argparse.Namespace:
@@ -115,12 +121,13 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--vsa-dense-layers",
-        default="",
+        type=_dense_layers,
+        default=(),
         help="comma-separated layer indices forced dense",
     )
     parser.add_argument(
         "--vsa-impl",
-        choices=PUBLIC_VSA_IMPLS,
+        choices=("auto", "reference", "simd"),
         default="auto",
         help=(
             "sparse attention implementation; auto uses chunked gather+SDPA "
@@ -158,7 +165,7 @@ def main() -> None:
         vsa_tile_size=args.vsa_tile_size,
         vsa_prefix_mode=args.vsa_prefix_mode,
         vsa_dense_first_n_steps=args.vsa_dense_first_n_steps,
-        vsa_dense_layers=parse_dense_layers(args.vsa_dense_layers),
+        vsa_dense_layers=args.vsa_dense_layers,
         vsa_impl=args.vsa_impl,
     )
     print(json.dumps({

--- a/fastvideo/mlx_runtime/fastwan.py
+++ b/fastvideo/mlx_runtime/fastwan.py
@@ -325,12 +325,13 @@ def linear(x, weight, bias=None):
 
 
 def _use_fast_norm() -> bool:
-    """Opt-in to MLX's fused ``mx.fast`` normalization kernels.
+    """Opt-in to MLX's fused ``mx.fast`` normalization kernels for Wan.
 
     Off by default so the numerically-explicit reference path stays the
     baseline. Set ``FASTVIDEO_MLX_FAST_NORM=1`` to route LayerNorm/RMSNorm
     through single fused Metal kernels (fewer intermediates, less memory
     traffic) and benchmark the speedup.
+    H3 uses its own fused RMSNorm default and does not consult this toggle.
     """
     import os
 

--- a/fastvideo/mlx_runtime/minimax_h3.py
+++ b/fastvideo/mlx_runtime/minimax_h3.py
@@ -26,7 +26,13 @@ Apple Silicon memory controls:
   the repeated AdaLN projection work from each denoising step.
 - **Affine INT8, INT6, or INT4 quantization** of attention/FFN matrices
   (group size 64). Modulation, embeddings, norms, and input/output projections
-  remain in higher precision.
+  remain in higher precision. Quantization is weight-only: attention Q/K/V
+  stay BF16 (or the selected activation dtype).
+- **Optional VSA.** Dense conversion still drops
+  ``transformer_blocks.*.attn.to_gate_compress.weight``. ``--include-vsa``
+  keeps those 50 projections, quantizes them with the same affine grid, and
+  records ``vsa.capable`` in the manifest. Runtime VSA is opt-in and never
+  enabled for dense-only checkpoints.
 
 Checkpoint layout: the released H3 checkpoint uses the diffusers reference
 module names 1:1 (``transformer_blocks.{i}.attn.to_out.0.weight``,
@@ -61,6 +67,18 @@ from fastvideo.mlx_runtime.fastwan import (
     silu,
     timestep_embedding,
     weight_dtype,
+)
+from fastvideo.mlx_runtime.minimax_h3_vsa import (
+    MiniMaxH3VSAConfig,
+    MiniMaxH3VSAGeometry,
+    MiniMaxH3VSAStats,
+    VSA_GATE_KEY_SUFFIX,
+    build_h3_tile_geometry,
+    dense_only_vsa_error,
+    dit_seq_shape_from_layout,
+    geometry_is_supported,
+    h3_vsa_attention,
+    prefix_segments_from_layout,
 )
 
 logger = init_logger(__name__)
@@ -107,18 +125,22 @@ _QUANTIZABLE_SUFFIXES = (
     "ff.net.0.proj.weight",
     "ff.net.2.weight",
 )
+_VSA_QUANTIZABLE_SUFFIXES = _QUANTIZABLE_SUFFIXES + (VSA_GATE_KEY_SUFFIX, )
 
-# The released FastH3 student carries VSA routing projections. The MLX path is
-# dense, so retaining these weights wastes about 3.6 GiB without affecting a
-# single output value.
+# The released FastH3 student carries VSA routing projections. Dense MLX
+# conversion drops them (~3.6 GiB BF16) because they do not affect fused SDPA.
+# Pass include_vsa=True to keep and quantize them.
 _IGNORED_DENSE_KEY_PARTS = ("attn.to_gate_compress", )
 
 
-def _is_quantizable(key: str) -> bool:
-    return key.endswith(_QUANTIZABLE_SUFFIXES)
+def _is_quantizable(key: str, *, include_vsa: bool = False) -> bool:
+    suffixes = _VSA_QUANTIZABLE_SUFFIXES if include_vsa else _QUANTIZABLE_SUFFIXES
+    return key.endswith(suffixes)
 
 
-def _is_ignored_dense_key(key: str) -> bool:
+def _is_ignored_dense_key(key: str, *, include_vsa: bool = False) -> bool:
+    if include_vsa:
+        return False
     return any(part in key for part in _IGNORED_DENSE_KEY_PARTS)
 
 
@@ -473,7 +495,38 @@ def apply_h3_rotary(x, cos, sin):
     return mx.concatenate([out.astype(x.dtype), x_pass], axis=-1)
 
 
-def _attention(weights: dict[str, Any], x, cos, sin, *, num_heads: int, head_dim: int, eps: float, use_rope: bool):
+def _gate_weight_is_active(weight: Any) -> bool:
+    import mlx.core as mx
+
+    if weight is None:
+        return False
+    if isinstance(weight, QuantizedMatrix):
+        # Affine dequant is scale * code + bias. Packed codes with a zero scale
+        # do not contribute; a zero-scale / nonzero-bias group is a constant.
+        active = mx.any(weight.scales != 0)
+        if weight.biases is not None:
+            active = active | mx.any(weight.biases != 0)
+        return bool(active.item())
+    return bool(mx.any(weight != 0).item())
+
+
+def _attention(
+    weights: dict[str, Any],
+    x,
+    cos,
+    sin,
+    *,
+    num_heads: int,
+    head_dim: int,
+    eps: float,
+    use_rope: bool,
+    vsa_geometry: MiniMaxH3VSAGeometry | None = None,
+    vsa_sparsity: float = 0.0,
+    vsa_exempt: bool = True,
+    vsa_impl: str = "auto",
+    vsa_stats: MiniMaxH3VSAStats | None = None,
+    use_gate_compress: bool = False,
+):
     """H3 attention: bias-free qkv, per-head qk RMSNorm, partial RoPE."""
     import mlx.core as mx
 
@@ -486,13 +539,35 @@ def _attention(weights: dict[str, Any], x, cos, sin, *, num_heads: int, head_dim
     if use_rope:
         q = apply_h3_rotary(q, cos, sin)
         k = apply_h3_rotary(k, cos, sin)
-    # contiguous() guards against MLX fused-SDPA mis-computation on strided views.
-    attended = mx.fast.scaled_dot_product_attention(
-        mx.contiguous(q.transpose(1, 0, 2))[None],
-        mx.contiguous(k.transpose(1, 0, 2))[None],
-        mx.contiguous(v.transpose(1, 0, 2))[None],
-        scale=head_dim**-0.5,
-    )[0].transpose(1, 0, 2)
+    gate = None
+    if use_gate_compress and "attn.to_gate_compress.weight" in weights:
+        gate = linear(x, weights["attn.to_gate_compress.weight"]).reshape(seq_len, num_heads, head_dim)
+    use_vsa = (vsa_geometry is not None and use_rope and (vsa_sparsity > 0.0 or gate is not None)
+               and vsa_geometry.total_seq_length == seq_len)
+    if use_vsa:
+        assert vsa_geometry is not None
+        attended = h3_vsa_attention(
+            q,
+            k,
+            v,
+            vsa_geometry,
+            sparsity=vsa_sparsity,
+            exempt=vsa_exempt,
+            gate_compress=gate,
+            impl=vsa_impl,  # type: ignore[arg-type]
+            stats=vsa_stats,
+        )
+    else:
+        if vsa_stats is not None and use_rope:
+            vsa_stats.impl = "dense"
+            vsa_stats.dense_fallback_reason = None if vsa_geometry is None else "dense schedule or disabled VSA"
+        # contiguous() guards against MLX fused-SDPA mis-computation on strided views.
+        attended = mx.fast.scaled_dot_product_attention(
+            mx.contiguous(q.transpose(1, 0, 2))[None],
+            mx.contiguous(k.transpose(1, 0, 2))[None],
+            mx.contiguous(v.transpose(1, 0, 2))[None],
+            scale=head_dim**-0.5,
+        )[0].transpose(1, 0, 2)
     attended = mx.contiguous(attended.reshape(seq_len, num_heads * head_dim))
     return linear(attended, weights["attn.to_out.0.weight"])
 
@@ -532,6 +607,12 @@ def _transformer_block(
     head_dim: int,
     norm_eps: float,
     qk_norm_eps: float,
+    vsa_geometry: MiniMaxH3VSAGeometry | None = None,
+    vsa_sparsity: float = 0.0,
+    vsa_exempt: bool = True,
+    vsa_impl: str = "auto",
+    vsa_stats: MiniMaxH3VSAStats | None = None,
+    use_gate_compress: bool = False,
 ):
     shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = tables
 
@@ -547,6 +628,12 @@ def _transformer_block(
         head_dim=head_dim,
         eps=qk_norm_eps,
         use_rope=True,
+        vsa_geometry=vsa_geometry,
+        vsa_sparsity=vsa_sparsity,
+        vsa_exempt=vsa_exempt,
+        vsa_impl=vsa_impl,
+        vsa_stats=vsa_stats,
+        use_gate_compress=use_gate_compress,
     )
     hidden_states = residual + gate_msa[adaln_indices] * attn_output
 
@@ -643,6 +730,11 @@ class MLXMiniMaxH3DiT:
         self.final_norm_eps = float(config["final_norm_eps"])
         self.patch_dim = self.in_channels * math.prod(self.patch_size)
         self._adaln_cache: MiniMaxH3StepCache | None = None
+        self.vsa_config = MiniMaxH3VSAConfig()
+        self._vsa_geometry: MiniMaxH3VSAGeometry | None = None
+        self._vsa_capable = any("attn.to_gate_compress.weight" in block for block in blocks)
+        self._gate_active: list[bool | None] = [None] * len(blocks)
+        self.last_vsa_stats: MiniMaxH3VSAStats | None = None
 
     # -- conditioning ------------------------------------------------------
 
@@ -712,6 +804,56 @@ class MLXMiniMaxH3DiT:
                 block["adaln_proj.linear.bias"] = None
         return self._adaln_cache
 
+    @property
+    def vsa_capable(self) -> bool:
+        return self._vsa_capable
+
+    def configure_vsa(self, config: MiniMaxH3VSAConfig | None) -> None:
+        self.vsa_config = config or MiniMaxH3VSAConfig()
+        if self.vsa_config.enabled and not self._vsa_capable:
+            raise dense_only_vsa_error("this MLX H3 DiT")
+
+    def prepare_vsa_geometry(self, layout: MiniMaxH3PackedLayout) -> MiniMaxH3VSAGeometry | None:
+        if not self.vsa_config.enabled:
+            self._vsa_geometry = None
+            return None
+        prefix = prefix_segments_from_layout(layout, self.patch_size)
+        video_shape = dit_seq_shape_from_layout(layout, self.patch_size)
+        reason = geometry_is_supported(prefix, video_shape, self.vsa_config.tile_size)
+        if reason is not None:
+            raise ValueError(f"H3 VSA cannot run with this packed layout (prefix={prefix}, "
+                             f"video={video_shape}, tile_size={self.vsa_config.tile_size}): {reason}. "
+                             "Disable VSA or pick a supported tile size (64 or 256).")
+        self._vsa_geometry = build_h3_tile_geometry(prefix, video_shape, self.vsa_config.tile_size)
+        return self._vsa_geometry
+
+    def _block_gate_active(self, block_index: int) -> bool:
+        cached = self._gate_active[block_index]
+        if cached is not None:
+            return cached
+        weight = self.blocks[block_index].get("attn.to_gate_compress.weight")
+        active = _gate_weight_is_active(weight)
+        self._gate_active[block_index] = active
+        if weight is not None and not active:
+            logger.info_once("MiniMax H3 VSA compression gate is all-zero; skipping the pooled branch.")
+        return active
+
+    def _vsa_block_kwargs(self, block_index: int, step_index: int) -> dict[str, Any]:
+        geometry = self._vsa_geometry if self.vsa_config.enabled else None
+        sparsity = self.vsa_config.layer_sparsity(block_index, step_index) if geometry is not None else 0.0
+        stats = None
+        if block_index == 0:
+            stats = MiniMaxH3VSAStats()
+            self.last_vsa_stats = stats
+        return {
+            "vsa_geometry": geometry,
+            "vsa_sparsity": sparsity,
+            "vsa_exempt": self.vsa_config.exempt,
+            "vsa_impl": self.vsa_config.impl,
+            "vsa_stats": stats,
+            "use_gate_compress": geometry is not None and self._block_gate_active(block_index),
+        }
+
     # -- forward ------------------------------------------------------------
 
     def forward(
@@ -760,7 +902,7 @@ class MLXMiniMaxH3DiT:
         temb = self.compute_temb(timesteps)
         adaln_indices = (timestep_indices * MINIMAX_H3_MODALITY_NUM + token_tags).astype(mx.int32)
 
-        for block in self.blocks:
+        for block_index, block in enumerate(self.blocks):
             tables = _adaln_tables(block, temb)
             packed = _transformer_block(
                 block,
@@ -773,6 +915,7 @@ class MLXMiniMaxH3DiT:
                 head_dim=self.head_dim,
                 norm_eps=self.norm_eps,
                 qk_norm_eps=self.qk_norm_eps,
+                **self._vsa_block_kwargs(block_index, 0),
             )
             mx.eval(packed)  # per-block sync: see forward_with_cache note
 
@@ -805,6 +948,7 @@ class MLXMiniMaxH3DiT:
         layout: MiniMaxH3PackedLayout,
         step_timesteps: np.ndarray,
         row_timestep_inverse: np.ndarray,
+        step_index: int = 0,
     ):
         """Denoise-step forward served entirely from the AdaLN cache.
 
@@ -817,6 +961,8 @@ class MLXMiniMaxH3DiT:
 
         if self._adaln_cache is None:
             raise RuntimeError("precompute_adaln() must run before forward_with_cache().")
+        if self.vsa_config.enabled and self._vsa_geometry is None:
+            self.prepare_vsa_geometry(layout)
         cache = self._adaln_cache
         positions = mx.array(cache.positions(step_timesteps))
 
@@ -848,7 +994,7 @@ class MLXMiniMaxH3DiT:
         # Sync per block: without this, MLX enqueues the entire 50-block graph
         # while the GPU lags behind, allocating every intermediate at once
         # (observed as an OOM kill on 36 GiB Macs at 480x832).
-        for block, tables in zip(self.blocks, cache.block_tables, strict=True):
+        for block_index, (block, tables) in enumerate(zip(self.blocks, cache.block_tables, strict=True)):
             packed = _transformer_block(
                 block,
                 packed,
@@ -860,6 +1006,7 @@ class MLXMiniMaxH3DiT:
                 head_dim=self.head_dim,
                 norm_eps=self.norm_eps,
                 qk_norm_eps=self.qk_norm_eps,
+                **self._vsa_block_kwargs(block_index, step_index),
             )
             mx.eval(packed)
 
@@ -932,6 +1079,7 @@ def mlx_h3_dit_from_diffusers_safetensors(
     num_blocks: int | None = None,
     quantization: str | MLXQuantizationSpec | None = None,
     adaln_cache_timesteps: np.ndarray | None = None,
+    include_vsa: bool = False,
 ) -> MLXMiniMaxH3DiT:
     """Load the released H3 transformer (diffusers layout) into MLX.
 
@@ -944,6 +1092,10 @@ def mlx_h3_dit_from_diffusers_safetensors(
     block at a time while the checkpoint is read. The 13B projection weights
     are never retained together and are omitted from the returned model. This
     is the memory-bounded build path for the released 33B student.
+
+    ``include_vsa`` keeps ``attn.to_gate_compress`` matrices and quantizes them
+    with the same affine grid as the other linear weights. Dense conversion
+    continues to drop them.
     """
     import mlx.core as mx
     transformer_path = Path(transformer_path)
@@ -1020,7 +1172,7 @@ def mlx_h3_dit_from_diffusers_safetensors(
     for shard in _safetensors_shards(transformer_path):
         shard_arrays = mx.load(str(shard))
         for key, source in shard_arrays.items():
-            if _is_ignored_dense_key(key):
+            if _is_ignored_dense_key(key, include_vsa=include_vsa):
                 continue
             if temb is not None and key.startswith("time_embedder."):
                 continue
@@ -1051,7 +1203,7 @@ def mlx_h3_dit_from_diffusers_safetensors(
                     block["adaln_proj.linear.bias"] = None
                     del pending_adaln[index]
                 continue
-            if spec is not None and _is_quantizable(key) and not keep_fp32:
+            if spec is not None and _is_quantizable(key, include_vsa=include_vsa) and not keep_fp32:
                 value = quantize_matrix(array, spec)
                 del array
             else:
@@ -1087,9 +1239,19 @@ def mlx_h3_dit_from_diffusers_safetensors(
         raise KeyError(f"Missing transformer block weights for indices {missing}.")
     if any(block is None for block in refiner):
         raise KeyError("Missing token refiner weights.")
+    loaded_blocks = [block for block in blocks if block is not None]
+    if include_vsa:
+        missing_gates = [
+            index for index, block in enumerate(loaded_blocks) if "attn.to_gate_compress.weight" not in block
+        ]
+        if missing_gates:
+            raise KeyError("VSA conversion requested but gate projections are missing for transformer blocks "
+                           f"{missing_gates}. The source checkpoint must contain "
+                           f"`transformer_blocks.*.{VSA_GATE_KEY_SUFFIX}`.")
+        logger.info("Retained %d VSA gate projections (%s).", len(loaded_blocks), VSA_GATE_KEY_SUFFIX)
     dit = MLXMiniMaxH3DiT(
         weights,
-        [block for block in blocks if block is not None],
+        loaded_blocks,
         [block for block in refiner if block is not None],
         config,
     )
@@ -1100,6 +1262,19 @@ def mlx_h3_dit_from_diffusers_safetensors(
 H3_FORMAT_VERSION = 1
 H3_WEIGHTS_FILENAME = "mlx_h3_dit.safetensors"
 H3_MANIFEST_FILENAME = "mlx_h3_dit.json"
+
+
+def mlx_h3_checkpoint_vsa_capable(checkpoint_dir: str | Path) -> bool:
+    """True when a saved MLX H3 checkpoint retained the VSA gate projections."""
+    manifest_path = Path(checkpoint_dir) / H3_MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return False
+    manifest = json.loads(manifest_path.read_text())
+    if bool((manifest.get("vsa") or {}).get("capable")):
+        return True
+    quantized_keys = manifest.get("quantized_keys") or {}
+    return any("attn.to_gate_compress.weight" in key for key in quantized_keys)
+
 
 _DTYPE_TO_NAME = {"float16": "fp16", "bfloat16": "bf16", "float32": "fp32"}
 
@@ -1183,6 +1358,18 @@ def save_mlx_h3_checkpoint(dit: MLXMiniMaxH3DiT, checkpoint_dir: str | Path) -> 
         },
         "quantized_keys": quantized,
         "adaln_cache": cache_manifest,
+        "vsa": {
+            "capable":
+            bool(dit.vsa_capable),
+            "num_gate_matrices":
+            sum(1 for block in dit.blocks if "attn.to_gate_compress.weight" in block),
+            "gate_key_suffix":
+            VSA_GATE_KEY_SUFFIX,
+            "attention_activations":
+            "bf16",
+            "note": ("Gate projections are quantized with the checkpoint's affine INT8/INT6/INT4 "
+                     "weight-only grid. VSA attention Q/K/V remain unquantized activations."),
+        },
     }
     weights_path = checkpoint_dir / H3_WEIGHTS_FILENAME
     mx.save_safetensors(str(weights_path), arrays)

--- a/fastvideo/mlx_runtime/minimax_h3.py
+++ b/fastvideo/mlx_runtime/minimax_h3.py
@@ -75,7 +75,6 @@ from fastvideo.mlx_runtime.minimax_h3_vsa import (
     build_h3_tile_geometry,
     dense_only_vsa_error,
     dit_seq_shape_from_layout,
-    geometry_is_supported,
     h3_vsa_attention,
     prefix_segments_from_layout,
 )
@@ -500,9 +499,8 @@ def _gate_weight_is_active(weight: Any) -> bool:
     if weight is None:
         return False
     if isinstance(weight, QuantizedMatrix):
-        # Affine dequant is scale * code + bias. Packed codes with a zero scale
-        # do not contribute; a zero-scale / nonzero-bias group is a constant.
-        active = mx.any(weight.scales != 0)
+        # Affine quantization clamps scales above zero even for an all-zero gate.
+        active = mx.any(weight.weight != 0)
         if weight.biases is not None:
             active = active | mx.any(weight.biases != 0)
         return bool(active.item())
@@ -510,7 +508,7 @@ def _gate_weight_is_active(weight: Any) -> bool:
 
 
 def _h3_rms_norm(x, weight, eps: float):
-    """Use MLX's fused normalization kernel for H3's last-axis RMSNorm."""
+    """H3 uses fused RMSNorm by default; FASTVIDEO_MLX_FAST_NORM is Wan-only."""
     import mlx.core as mx
 
     return mx.fast.rms_norm(x, weight, eps)
@@ -566,7 +564,10 @@ def _attention(
     else:
         if vsa_stats is not None and use_rope:
             vsa_stats.impl = "dense"
-            vsa_stats.dense_fallback_reason = None if vsa_geometry is None else "dense schedule or disabled VSA"
+            if vsa_geometry is not None:
+                vsa_stats.num_prefix_tiles = vsa_geometry.num_prefix_tiles
+                vsa_stats.num_video_tiles = vsa_geometry.num_video_tiles
+                vsa_stats.video_keep = vsa_geometry.num_video_tiles
         attended = mx.fast.scaled_dot_product_attention(
             q.transpose(1, 0, 2)[None],
             k.transpose(1, 0, 2)[None],
@@ -814,22 +815,39 @@ class MLXMiniMaxH3DiT:
         return self._vsa_capable
 
     def configure_vsa(self, config: MiniMaxH3VSAConfig | None) -> None:
-        self.vsa_config = config or MiniMaxH3VSAConfig()
-        if self.vsa_config.enabled and not self._vsa_capable:
+        config = config or MiniMaxH3VSAConfig()
+        if config.enabled and not self._vsa_capable:
             raise dense_only_vsa_error("this MLX H3 DiT")
+        if any(layer >= len(self.blocks) for layer in config.dense_layers):
+            raise ValueError(f"VSA dense_layers must be below the model's block count ({len(self.blocks)}).")
+        self.vsa_config = config
+        self._vsa_geometry = None
+        self.reset_vsa_stats()
+
+    def reset_vsa_stats(self) -> None:
+        self.last_vsa_stats = MiniMaxH3VSAStats(
+            configured_sparsity=self.vsa_config.sparsity,
+            tile_size=self.vsa_config.tile_size,
+            prefix_mode=self.vsa_config.prefix_mode,
+        ) if self.vsa_config.enabled else None
 
     def prepare_vsa_geometry(self, layout: MiniMaxH3PackedLayout) -> MiniMaxH3VSAGeometry | None:
         if not self.vsa_config.enabled:
             self._vsa_geometry = None
             return None
-        prefix = prefix_segments_from_layout(layout, self.patch_size)
+        prefix = tuple(segment for segment in prefix_segments_from_layout(layout, self.patch_size) if segment > 0)
         video_shape = dit_seq_shape_from_layout(layout, self.patch_size)
-        reason = geometry_is_supported(prefix, video_shape, self.vsa_config.tile_size)
-        if reason is not None:
+        geometry = self._vsa_geometry
+        if geometry is not None and (geometry.prefix_segments, geometry.dit_seq_shape,
+                                     geometry.tile_elems) == (prefix, video_shape, self.vsa_config.tile_size):
+            return geometry
+        try:
+            geometry = build_h3_tile_geometry(prefix, video_shape, self.vsa_config.tile_size)
+        except ValueError as error:
             raise ValueError(f"H3 VSA cannot run with this packed layout (prefix={prefix}, "
-                             f"video={video_shape}, tile_size={self.vsa_config.tile_size}): {reason}. "
-                             "Disable VSA or pick a supported tile size (64 or 256).")
-        self._vsa_geometry = build_h3_tile_geometry(prefix, video_shape, self.vsa_config.tile_size)
+                             f"video={video_shape}, tile_size={self.vsa_config.tile_size}): {error}. "
+                             "Disable VSA or pick a supported tile size (64 or 256).") from error
+        self._vsa_geometry = geometry
         return self._vsa_geometry
 
     def _block_gate_active(self, block_index: int) -> bool:
@@ -846,10 +864,7 @@ class MLXMiniMaxH3DiT:
     def _vsa_block_kwargs(self, block_index: int, step_index: int) -> dict[str, Any]:
         geometry = self._vsa_geometry if self.vsa_config.enabled else None
         sparsity = self.vsa_config.layer_sparsity(block_index, step_index) if geometry is not None else 0.0
-        stats = None
-        if block_index == 0:
-            stats = MiniMaxH3VSAStats()
-            self.last_vsa_stats = stats
+        stats = MiniMaxH3VSAStats() if self.vsa_config.enabled else None
         return {
             "vsa_geometry": geometry,
             "vsa_sparsity": sparsity,
@@ -881,9 +896,14 @@ class MLXMiniMaxH3DiT:
         projects *all* packed rows through both heads and then selects; this
         selects first and projects only the relevant rows — row-wise
         identical math at a fraction of the cost.
+
+        This entrypoint is dense-only. VSA requires ``forward_with_cache``
+        with a packed layout and step index.
         """
         import mlx.core as mx
 
+        if self.vsa_config.enabled:
+            raise ValueError("VSA requires forward_with_cache() with layout and step_index; forward() is dense-only.")
         sequence_length = position_ids.shape[0]
         cos, sin = rope_cos_sin(position_ids, self.rope_freq_dim, self.rope_theta)
 
@@ -966,7 +986,7 @@ class MLXMiniMaxH3DiT:
 
         if self._adaln_cache is None:
             raise RuntimeError("precompute_adaln() must run before forward_with_cache().")
-        if self.vsa_config.enabled and self._vsa_geometry is None:
+        if self.vsa_config.enabled:
             self.prepare_vsa_geometry(layout)
         cache = self._adaln_cache
         positions = mx.array(cache.positions(step_timesteps))
@@ -1000,6 +1020,7 @@ class MLXMiniMaxH3DiT:
         # while the GPU lags behind, allocating every intermediate at once
         # (observed as an OOM kill on 36 GiB Macs at 480x832).
         for block_index, (block, tables) in enumerate(zip(self.blocks, cache.block_tables, strict=True)):
+            vsa_kwargs = self._vsa_block_kwargs(block_index, step_index)
             packed = _transformer_block(
                 block,
                 packed,
@@ -1011,9 +1032,11 @@ class MLXMiniMaxH3DiT:
                 head_dim=self.head_dim,
                 norm_eps=self.norm_eps,
                 qk_norm_eps=self.qk_norm_eps,
-                **self._vsa_block_kwargs(block_index, step_index),
+                **vsa_kwargs,
             )
             mx.eval(packed)
+            if self.last_vsa_stats is not None:
+                self.last_vsa_stats.record(vsa_kwargs["vsa_stats"])
 
         row_positions = positions[row_inverse]
         normed = _h3_rms_norm(packed, self.weights["norm_out.norm.weight"], self.final_norm_eps)

--- a/fastvideo/mlx_runtime/minimax_h3.py
+++ b/fastvideo/mlx_runtime/minimax_h3.py
@@ -63,7 +63,6 @@ from fastvideo.mlx_runtime.fastwan import (
     ensure_quantization_supported,
     linear,
     quantize_matrix,
-    rms_norm,
     silu,
     timestep_embedding,
     weight_dtype,
@@ -510,6 +509,13 @@ def _gate_weight_is_active(weight: Any) -> bool:
     return bool(mx.any(weight != 0).item())
 
 
+def _h3_rms_norm(x, weight, eps: float):
+    """Use MLX's fused normalization kernel for H3's last-axis RMSNorm."""
+    import mlx.core as mx
+
+    return mx.fast.rms_norm(x, weight, eps)
+
+
 def _attention(
     weights: dict[str, Any],
     x,
@@ -534,8 +540,8 @@ def _attention(
     q = linear(x, weights["attn.to_q.weight"]).reshape(seq_len, num_heads, head_dim)
     k = linear(x, weights["attn.to_k.weight"]).reshape(seq_len, num_heads, head_dim)
     v = linear(x, weights["attn.to_v.weight"]).reshape(seq_len, num_heads, head_dim)
-    q = rms_norm(q, weights["attn.norm_q.weight"], eps=eps)
-    k = rms_norm(k, weights["attn.norm_k.weight"], eps=eps)
+    q = _h3_rms_norm(q, weights["attn.norm_q.weight"], eps)
+    k = _h3_rms_norm(k, weights["attn.norm_k.weight"], eps)
     if use_rope:
         q = apply_h3_rotary(q, cos, sin)
         k = apply_h3_rotary(k, cos, sin)
@@ -561,14 +567,13 @@ def _attention(
         if vsa_stats is not None and use_rope:
             vsa_stats.impl = "dense"
             vsa_stats.dense_fallback_reason = None if vsa_geometry is None else "dense schedule or disabled VSA"
-        # contiguous() guards against MLX fused-SDPA mis-computation on strided views.
         attended = mx.fast.scaled_dot_product_attention(
-            mx.contiguous(q.transpose(1, 0, 2))[None],
-            mx.contiguous(k.transpose(1, 0, 2))[None],
-            mx.contiguous(v.transpose(1, 0, 2))[None],
+            q.transpose(1, 0, 2)[None],
+            k.transpose(1, 0, 2)[None],
+            v.transpose(1, 0, 2)[None],
             scale=head_dim**-0.5,
         )[0].transpose(1, 0, 2)
-    attended = mx.contiguous(attended.reshape(seq_len, num_heads * head_dim))
+    attended = attended.reshape(seq_len, num_heads * head_dim)
     return linear(attended, weights["attn.to_out.0.weight"])
 
 
@@ -617,7 +622,7 @@ def _transformer_block(
     shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = tables
 
     residual = hidden_states
-    normed = rms_norm(hidden_states, weights["norm1.weight"], eps=norm_eps)
+    normed = _h3_rms_norm(hidden_states, weights["norm1.weight"], norm_eps)
     normed = normed * (1.0 + scale_msa[adaln_indices]) + shift_msa[adaln_indices]
     attn_output = _attention(
         weights,
@@ -638,7 +643,7 @@ def _transformer_block(
     hidden_states = residual + gate_msa[adaln_indices] * attn_output
 
     residual = hidden_states
-    normed = rms_norm(hidden_states, weights["norm2.weight"], eps=norm_eps)
+    normed = _h3_rms_norm(hidden_states, weights["norm2.weight"], norm_eps)
     normed = normed * (1.0 + scale_mlp[adaln_indices]) + shift_mlp[adaln_indices]
     ff_output = _feed_forward(weights, normed.astype(weight_dtype(weights["ff.net.0.proj.weight"])))
     return residual + gate_mlp[adaln_indices] * ff_output
@@ -654,7 +659,7 @@ def _refiner_block(
     qk_norm_eps: float,
 ):
     residual = hidden_states
-    normed = rms_norm(hidden_states, weights["norm1.weight"], eps=norm_eps)
+    normed = _h3_rms_norm(hidden_states, weights["norm1.weight"], norm_eps)
     attn_output = _attention(
         weights,
         normed.astype(weight_dtype(weights["attn.to_q.weight"])),
@@ -666,7 +671,7 @@ def _refiner_block(
         use_rope=False,
     )
     hidden_states = residual + attn_output
-    normed = rms_norm(hidden_states, weights["norm2.weight"], eps=norm_eps)
+    normed = _h3_rms_norm(hidden_states, weights["norm2.weight"], norm_eps)
     return hidden_states + _feed_forward(weights, normed.astype(weight_dtype(weights["ff.net.0.proj.weight"])))
 
 
@@ -768,7 +773,7 @@ class MLXMiniMaxH3DiT:
                 norm_eps=self.norm_eps,
                 qk_norm_eps=self.qk_norm_eps,
             )
-        return rms_norm(hidden, self.weights["token_refiner.final_norm.weight"], eps=self.final_norm_eps)
+        return _h3_rms_norm(hidden, self.weights["token_refiner.final_norm.weight"], self.final_norm_eps)
 
     # -- AdaLN cache --------------------------------------------------------
 
@@ -925,7 +930,7 @@ class MLXMiniMaxH3DiT:
             self.weights["norm_out.linear.bias"],
         )
         shift_rows, scale_rows = mx.split(shift_scale, 2, axis=-1)
-        normed = rms_norm(packed, self.weights["norm_out.norm.weight"], eps=self.final_norm_eps)
+        normed = _h3_rms_norm(packed, self.weights["norm_out.norm.weight"], self.final_norm_eps)
         normed = normed * (1.0 + scale_rows[timestep_indices]) + shift_rows[timestep_indices]
         video_output = linear(
             normed[_as_mx_indices(video_indices)].astype(weight_dtype(self.weights["proj_out.weight"])),
@@ -1011,7 +1016,7 @@ class MLXMiniMaxH3DiT:
             mx.eval(packed)
 
         row_positions = positions[row_inverse]
-        normed = rms_norm(packed, self.weights["norm_out.norm.weight"], eps=self.final_norm_eps)
+        normed = _h3_rms_norm(packed, self.weights["norm_out.norm.weight"], self.final_norm_eps)
         normed = normed * (1.0 + cache.norm_out_scale[row_positions]) + cache.norm_out_shift[row_positions]
         video_output = linear(
             normed[mx.array(layout.video_indices)].astype(weight_dtype(self.weights["proj_out.weight"])),

--- a/fastvideo/mlx_runtime/minimax_h3_pipeline.py
+++ b/fastvideo/mlx_runtime/minimax_h3_pipeline.py
@@ -375,6 +375,8 @@ class MiniMaxH3MLXPipeline:
             logger.info("Loaded MLX H3 DiT from %s in %.1fs", self.dit_checkpoint, time.perf_counter() - t0)
         if vsa_config is not None:
             dit.configure_vsa(vsa_config)
+        if hasattr(dit, "reset_vsa_stats"):
+            dit.reset_vsa_stats()
 
         layout = build_packed_layout(
             len(token_tags),
@@ -454,6 +456,10 @@ class MiniMaxH3MLXPipeline:
             "num_video_tiles": stats.num_video_tiles,
             "video_keep": stats.video_keep,
             "dense_fallback_reason": stats.dense_fallback_reason,
+            "attention_calls": stats.attention_calls,
+            "sparse_calls": stats.sparse_calls,
+            "impl_counts": stats.impl_counts,
+            "fallback_reasons": stats.fallback_reasons,
             "checkpoint_vsa_capable": bool(getattr(dit, "vsa_capable", False)),
         }
 
@@ -645,7 +651,7 @@ class MiniMaxH3MLXPipeline:
             dense_first_n_steps=vsa_dense_first_n_steps,
             dense_layers=vsa_dense_layers,
             impl=vsa_impl,  # type: ignore[arg-type]
-        )
+        ) if vsa else MiniMaxH3VSAConfig()
         if vsa_config.enabled and not mlx_h3_checkpoint_vsa_capable(self.dit_checkpoint):
             raise dense_only_vsa_error(self.dit_checkpoint)
         _preflight_media_dependencies(

--- a/fastvideo/mlx_runtime/minimax_h3_pipeline.py
+++ b/fastvideo/mlx_runtime/minimax_h3_pipeline.py
@@ -44,12 +44,15 @@ from fastvideo.mlx_runtime.minimax_h3 import (
     audio_latent_num_frames,
     build_packed_layout,
     build_row_timesteps,
+    dense_only_vsa_error,
     load_mlx_h3_checkpoint,
+    mlx_h3_checkpoint_vsa_capable,
     temporal_position_grid,
     unpatchify_video_tokens,
     unpack_audio_tokens,
     video_latent_num_frames,
 )
+from fastvideo.mlx_runtime.minimax_h3_vsa import MiniMaxH3VSAConfig
 
 logger = init_logger(__name__)
 
@@ -62,6 +65,7 @@ class GenerationResult:
     sample_rate: int
     timings: dict[str, float] = field(default_factory=dict)
     peak_memory_gib: dict[str, float] = field(default_factory=dict)
+    vsa: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -252,6 +256,8 @@ class MiniMaxH3MLXPipeline:
             raise ValueError(f"H3 DiT patch_size must have three dimensions, got {patch_size}.")
         self._dit_patch_size = (int(patch_size[0]), int(patch_size[1]), int(patch_size[2]))
         self._dit_in_channels = int(dit_config["in_channels"])
+        self.last_dit_forward_s = 0.0
+        self.last_vsa_stats: dict[str, Any] | None = None
 
     # -- input validation (before anything heavy loads) -------------------
 
@@ -353,6 +359,7 @@ class MiniMaxH3MLXPipeline:
         seed: int,
         num_steps: int = 4,
         dit: Any | None = None,
+        vsa_config: MiniMaxH3VSAConfig | None = None,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Denoise joint latents; returns (normalized video rows, audio rows)."""
         import mlx.core as mx
@@ -366,6 +373,8 @@ class MiniMaxH3MLXPipeline:
             t0 = time.perf_counter()
             dit = load_mlx_h3_checkpoint(self.dit_checkpoint)
             logger.info("Loaded MLX H3 DiT from %s in %.1fs", self.dit_checkpoint, time.perf_counter() - t0)
+        if vsa_config is not None:
+            dit.configure_vsa(vsa_config)
 
         layout = build_packed_layout(
             len(token_tags),
@@ -377,6 +386,8 @@ class MiniMaxH3MLXPipeline:
             text_token_tags=np.asarray(token_tags, dtype=np.int64),
             video_temporal_scale=video_temporal_scale,
         )
+        if getattr(dit, "vsa_config", None) is not None and dit.vsa_config.enabled:
+            dit.prepare_vsa_geometry(layout)
 
         video_scheduler = MiniMaxH3SchedulerState.create(MINIMAX_H3_VIDEO_SHIFT, num_steps)
         audio_scheduler = MiniMaxH3SchedulerState.create(MINIMAX_H3_AUDIO_SHIFT, num_steps)
@@ -399,6 +410,7 @@ class MiniMaxH3MLXPipeline:
         x_v = mx.random.normal((target_video_rows, dit.patch_dim), key=video_key)
         x_a = mx.random.normal((target_audio_rows, dit.audio_in_channels), key=audio_key)
         text = mx.array(text_rows.astype(np.float32))
+        dit_forward_s = 0.0
 
         for step_index in range(num_steps):
             video_t = float(video_scheduler.timesteps[step_index])
@@ -410,6 +422,7 @@ class MiniMaxH3MLXPipeline:
                 condition_video_timestep=max(video_t, MINIMAX_H3_KEYFRAME_NOISE_AUG),
                 condition_audio_timestep=1.0,
             )
+            step_started = time.perf_counter()
             video_velocity, audio_velocity = dit.forward_with_cache(
                 x_v,
                 x_a,
@@ -417,6 +430,7 @@ class MiniMaxH3MLXPipeline:
                 layout=layout,
                 step_timesteps=unique,
                 row_timestep_inverse=inverse,
+                step_index=step_index,
             )
             # Only target rows are being denoised (no conditions in T2VA).
             video_velocity = video_velocity[layout.num_condition_video_rows:]
@@ -424,6 +438,24 @@ class MiniMaxH3MLXPipeline:
             x_v = video_scheduler.step(video_velocity, step_index, x_v)
             x_a = audio_scheduler.step(audio_velocity, step_index, x_a)
             mx.eval(x_v, x_a)
+            dit_forward_s += time.perf_counter() - step_started
+
+        self.last_dit_forward_s = dit_forward_s
+        stats = getattr(dit, "last_vsa_stats", None)
+        self.last_vsa_stats = None if stats is None else {
+            "enabled": bool(getattr(dit.vsa_config, "enabled", False)),
+            "configured_sparsity": stats.configured_sparsity,
+            "layer_sparsity": stats.layer_sparsity,
+            "achieved_sparsity": stats.achieved_sparsity,
+            "tile_size": stats.tile_size,
+            "prefix_mode": stats.prefix_mode,
+            "impl": stats.impl,
+            "num_prefix_tiles": stats.num_prefix_tiles,
+            "num_video_tiles": stats.num_video_tiles,
+            "video_keep": stats.video_keep,
+            "dense_fallback_reason": stats.dense_fallback_reason,
+            "checkpoint_vsa_capable": bool(getattr(dit, "vsa_capable", False)),
+        }
 
         video_rows = np.asarray(x_v, dtype=np.float32)
         audio_rows = np.asarray(x_a, dtype=np.float32)
@@ -576,21 +608,28 @@ class MiniMaxH3MLXPipeline:
     # -- end-to-end ----------------------------------------------------------
 
     def generate(
-        self,
-        prompt: str,
-        *,
-        output_path: str | Path,
-        height: int = 480,
-        width: int = 832,
-        num_frames: int = 124,
-        seed: int = 0,
-        num_steps: int = 4,
-        save_frames: bool = False,
-        tiled_video_decode: bool = True,
-        fast: bool = False,
-        fast_factor: int = 2,
-        fast_sharpen: float = 0.6,
-        rife_weights_dir: str | Path | None = None,
+            self,
+            prompt: str,
+            *,
+            output_path: str | Path,
+            height: int = 480,
+            width: int = 832,
+            num_frames: int = 124,
+            seed: int = 0,
+            num_steps: int = 4,
+            save_frames: bool = False,
+            tiled_video_decode: bool = True,
+            fast: bool = False,
+            fast_factor: int = 2,
+            fast_sharpen: float = 0.6,
+            rife_weights_dir: str | Path | None = None,
+            vsa: bool = False,
+            vsa_sparsity: float = 0.9,
+            vsa_tile_size: int = 64,
+            vsa_prefix_mode: str = "exempt",
+            vsa_dense_first_n_steps: int = 0,
+            vsa_dense_layers: tuple[int, ...] = (),
+            vsa_impl: str = "auto",
     ) -> GenerationResult:
         timings: dict[str, float] = {}
         peaks: dict[str, float] = {}
@@ -598,6 +637,17 @@ class MiniMaxH3MLXPipeline:
         if fast_sharpen < 0:
             raise ValueError(f"fast_sharpen must be non-negative, got {fast_sharpen}.")
         _validate_checkpoint_step_ladder(self.dit_checkpoint, num_steps)
+        vsa_config = MiniMaxH3VSAConfig(
+            enabled=vsa,
+            sparsity=vsa_sparsity,
+            tile_size=vsa_tile_size,
+            prefix_mode=vsa_prefix_mode,  # type: ignore[arg-type]
+            dense_first_n_steps=vsa_dense_first_n_steps,
+            dense_layers=vsa_dense_layers,
+            impl=vsa_impl,  # type: ignore[arg-type]
+        )
+        if vsa_config.enabled and not mlx_h3_checkpoint_vsa_capable(self.dit_checkpoint):
+            raise dense_only_vsa_error(self.dit_checkpoint)
         _preflight_media_dependencies(
             fast=fast,
             fast_sharpen=fast_sharpen,
@@ -645,8 +695,10 @@ class MiniMaxH3MLXPipeline:
             video_temporal_scale=video_temporal_scale,
             seed=seed,
             num_steps=num_steps,
+            vsa_config=vsa_config,
         )
         timings["denoise_s"] = time.perf_counter() - started
+        timings["dit_forward_s"] = float(getattr(self, "last_dit_forward_s", 0.0))
         peaks["denoise_gib"] = _peak_memory_gib()
         del text_rows
         _cleanup_mlx()
@@ -700,6 +752,9 @@ class MiniMaxH3MLXPipeline:
         started = time.perf_counter()
         video_path = self.mux(frames, waveform, output_path)
         timings["mux_s"] = time.perf_counter() - started
+        timings["generate_s"] = sum(
+            timings.get(key, 0.0)
+            for key in ("condition_s", "denoise_s", "video_decode_s", "rife_s", "audio_decode_s", "mux_s"))
 
         result = GenerationResult(
             video_path=str(video_path),
@@ -708,6 +763,10 @@ class MiniMaxH3MLXPipeline:
             sample_rate=32000,
             timings=timings,
             peak_memory_gib=peaks,
+            vsa=getattr(self, "last_vsa_stats", None) or {
+                "enabled": vsa_config.enabled,
+                "checkpoint_vsa_capable": mlx_h3_checkpoint_vsa_capable(self.dit_checkpoint),
+            },
         )
         logger.info("Generation complete: %s | timings=%s peaks=%s", video_path, timings, peaks)
         return result

--- a/fastvideo/mlx_runtime/minimax_h3_vsa.py
+++ b/fastvideo/mlx_runtime/minimax_h3_vsa.py
@@ -1,0 +1,894 @@
+# SPDX-License-Identifier: Apache-2.0
+# mypy: disable-error-code=no-untyped-call
+"""Inference-only MiniMax H3 Video Sparse Attention for the MLX runtime.
+
+Ports the packed-sequence VSA-H3 contract from
+``fastvideo/attention/backends/video_sparse_attn_h3.py``:
+
+- Tiles are ``[segment-pure prefix chunks] + [3D video tiles]``.
+- Tile sizes 64 ``(4, 4, 4)`` and 256 ``(4, 8, 8)``.
+- Per-head pooled Q/K scoring and top-k routing.
+- Prefix queries are always dense; prefix keys are ``exempt`` (always kept)
+  or ``compete`` (FLOP-matched top-k).
+- Optional dense-first steps and per-layer dense overrides.
+- Trained ``to_gate_compress`` pooled-compression branch.
+
+Two execution paths:
+
+- **reference** (``auto`` default) — grouped gather plus batched
+  ``mx.fast.scaled_dot_product_attention``. Correctness baseline. On MLX 0.31.2
+  / M4 Max this is close to dense fused SDPA at 720p; the Metal kernel is not.
+- **metal** — inference-only ``mx.fast.metal_kernel`` block-sparse attention
+  over BF16 Q/K/V activations and an explicit per-query block index. Kept for
+  parity testing. INT6 applies only to linear weights (including the gate
+  projection), not to Q/K/V. ``compile_options`` is used on MLX 0.32.2+ and
+  omitted on 0.31.2.
+
+Dense fused SDPA remains the default when VSA is disabled, the geometry is
+unsupported, or a dense-only checkpoint is loaded.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import numpy as np
+
+from fastvideo.logger import init_logger
+
+logger = init_logger(__name__)
+
+VSA_H3_TILE_SHAPES: dict[int, tuple[int, int, int]] = {
+    256: (4, 8, 8),
+    64: (4, 4, 4),
+}
+VSA_GATE_KEY_SUFFIX = "attn.to_gate_compress.weight"
+VSA_PREFIX_MODES = ("exempt", "compete")
+VSA_IMPLS = ("auto", "reference", "metal")
+_METAL_MAX_HEAD_DIM = 128
+_REFERENCE_FULL_MASK_TILE_LIMIT = 24
+
+PrefixMode = Literal["exempt", "compete"]
+VSAImpl = Literal["auto", "reference", "metal"]
+
+
+class DenseOnlyVSACheckpointError(ValueError):
+    """VSA was requested for a checkpoint that dropped the gate weights."""
+
+
+@dataclass(frozen=True)
+class MiniMaxH3VSAConfig:
+    """Runtime VSA knobs. Defaults preserve dense MLX H3 behavior."""
+
+    enabled: bool = False
+    sparsity: float = 0.9
+    tile_size: int = 64
+    prefix_mode: PrefixMode = "exempt"
+    dense_first_n_steps: int = 0
+    dense_layers: tuple[int, ...] = ()
+    impl: VSAImpl = "auto"
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.sparsity < 1.0:
+            raise ValueError(f"VSA sparsity must be in [0, 1), got {self.sparsity}.")
+        if self.tile_size not in VSA_H3_TILE_SHAPES:
+            raise ValueError(f"VSA tile_size must be one of {sorted(VSA_H3_TILE_SHAPES)}, got {self.tile_size}.")
+        if self.prefix_mode not in VSA_PREFIX_MODES:
+            raise ValueError(f"VSA prefix_mode must be one of {VSA_PREFIX_MODES}, got {self.prefix_mode!r}.")
+        if self.impl not in VSA_IMPLS:
+            raise ValueError(f"VSA impl must be one of {VSA_IMPLS}, got {self.impl!r}.")
+        if self.dense_first_n_steps < 0:
+            raise ValueError(f"vsa_dense_first_n_steps must be >= 0, got {self.dense_first_n_steps}.")
+        object.__setattr__(self, "dense_layers", tuple(int(layer) for layer in self.dense_layers))
+
+    @property
+    def exempt(self) -> bool:
+        return self.prefix_mode == "exempt"
+
+    def layer_sparsity(self, layer_idx: int, step_index: int) -> float:
+        if not self.enabled:
+            return 0.0
+        if step_index < self.dense_first_n_steps:
+            return 0.0
+        if layer_idx in self.dense_layers:
+            return 0.0
+        return self.sparsity
+
+
+@dataclass(frozen=True)
+class MiniMaxH3VSAGeometry:
+    """Packed-sequence tile map shared by routing, reference, and Metal paths."""
+
+    prefix_segments: tuple[int, ...]
+    dit_seq_shape: tuple[int, int, int]
+    tile_shape: tuple[int, int, int]
+    tile_elems: int
+    total_seq_length: int
+    num_prefix_tiles: int
+    num_video_tiles: int
+    variable_block_sizes: np.ndarray
+    untile_combined_index: np.ndarray
+    tile_partition_indices: np.ndarray
+
+    @property
+    def num_tiles(self) -> int:
+        return int(self.variable_block_sizes.shape[0])
+
+    @property
+    def padded_length(self) -> int:
+        return self.num_tiles * self.tile_elems
+
+    @property
+    def prefix_length(self) -> int:
+        return int(sum(self.prefix_segments))
+
+
+@dataclass
+class MiniMaxH3VSAStats:
+    """Filled during a sparse forward so the pipeline can report achieved sparsity."""
+
+    configured_sparsity: float = 0.0
+    layer_sparsity: float = 0.0
+    tile_size: int = 64
+    prefix_mode: str = "exempt"
+    impl: str = "dense"
+    num_prefix_tiles: int = 0
+    num_video_tiles: int = 0
+    video_keep: int = 0
+    achieved_sparsity: float = 0.0
+    dense_fallback_reason: str | None = None
+
+
+def vsa_gate_key(block_index: int) -> str:
+    return f"transformer_blocks.{block_index}.{VSA_GATE_KEY_SUFFIX}"
+
+
+def expected_vsa_gate_keys(num_layers: int) -> tuple[str, ...]:
+    return tuple(vsa_gate_key(index) for index in range(num_layers))
+
+
+def is_vsa_gate_key(key: str) -> bool:
+    return key.endswith(VSA_GATE_KEY_SUFFIX)
+
+
+def dense_only_vsa_error(checkpoint_dir: str | Any) -> DenseOnlyVSACheckpointError:
+    return DenseOnlyVSACheckpointError(
+        f"VSA was requested but {checkpoint_dir} is a dense-only MLX H3 checkpoint "
+        f"(no `{VSA_GATE_KEY_SUFFIX}` matrices / manifest vsa.capable). "
+        "Reconvert with `--include-vsa`, for example:\n"
+        "  python scripts/checkpoint_conversion/convert_minimax_h3_mlx.py \\\n"
+        "    --model-root <FastH3 transformer dir> --out <new dir> --formats int6 --include-vsa")
+
+
+def compute_topk(sparsity: float, num_blocks: int) -> int:
+    """Blocks to keep for a sparsity level, clamped to [1, num_blocks]."""
+    if num_blocks <= 0:
+        return 0
+    return max(1, min(math.ceil((1.0 - sparsity) * num_blocks), num_blocks))
+
+
+def parse_dense_layers(value: str | None) -> tuple[int, ...]:
+    if value is None or value.strip() == "":
+        return ()
+    layers = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    if any(layer < 0 for layer in layers):
+        raise ValueError(f"vsa dense layers must be non-negative, got {value!r}.")
+    return layers
+
+
+def prefix_segments_from_layout(layout: Any, patch_size: tuple[int, int, int]) -> tuple[int, ...]:
+    """Segment sizes preceding the generated-video tail, matching the PyTorch stage."""
+    n_text = int(layout.text_indices.shape[0])
+    n_cond = int(layout.num_condition_video_rows)
+    n_audio = int(layout.audio_indices.shape[0])
+    n_video = ((layout.num_video_latent_frames // patch_size[0]) * (layout.latent_height // patch_size[1]) *
+               (layout.latent_width // patch_size[2]))
+    if n_text + n_cond + n_audio + n_video != int(layout.sequence_length):
+        raise ValueError("VSA-H3 supports the standard [text|cond|audio|video] packing only; "
+                         f"segments ({n_text}, {n_cond}, {n_audio}) + video {n_video} do not sum to "
+                         f"sequence length {layout.sequence_length}.")
+    return n_text, n_cond, n_audio
+
+
+def dit_seq_shape_from_layout(layout: Any, patch_size: tuple[int, int, int]) -> tuple[int, int, int]:
+    return (
+        int(layout.num_video_latent_frames // patch_size[0]),
+        int(layout.latent_height // patch_size[1]),
+        int(layout.latent_width // patch_size[2]),
+    )
+
+
+def _video_tile_sizes(dit_seq_shape: tuple[int, int, int], tile_shape: tuple[int, int, int]) -> np.ndarray:
+    t, h, w = dit_seq_shape
+    ts_t, ts_h, ts_w = tile_shape
+    n_t, n_h, n_w = math.ceil(t / ts_t), math.ceil(h / ts_h), math.ceil(w / ts_w)
+
+    def _sizes(dim_len: int, tile: int, n_tiles: int) -> np.ndarray:
+        sizes = np.full((n_tiles, ), tile, dtype=np.int64)
+        remainder = dim_len - (n_tiles - 1) * tile
+        sizes[-1] = remainder if remainder > 0 else tile
+        return sizes
+
+    t_sizes = _sizes(t, ts_t, n_t)
+    h_sizes = _sizes(h, ts_h, n_h)
+    w_sizes = _sizes(w, ts_w, n_w)
+    return (t_sizes[:, None, None] * h_sizes[None, :, None] * w_sizes[None, None, :]).reshape(-1)
+
+
+def _video_tile_partition_indices(dit_seq_shape: tuple[int, int, int], tile_shape: tuple[int, int, int]) -> np.ndarray:
+    t, h, w = dit_seq_shape
+    ts_t, ts_h, ts_w = tile_shape
+    indices = np.arange(t * h * w, dtype=np.int64).reshape(t, h, w)
+    chunks: list[np.ndarray] = []
+    for tt in range(math.ceil(t / ts_t)):
+        for hh in range(math.ceil(h / ts_h)):
+            for ww in range(math.ceil(w / ts_w)):
+                chunks.append(indices[tt * ts_t:min(tt * ts_t + ts_t, t), hh * ts_h:min(hh * ts_h + ts_h, h),
+                                      ww * ts_w:min(ww * ts_w + ts_w, w)].reshape(-1))
+    return np.concatenate(chunks, axis=0)
+
+
+def _non_pad_index(variable_block_sizes: np.ndarray, tile_elems: int) -> np.ndarray:
+    n_win = int(variable_block_sizes.shape[0])
+    starts = np.arange(n_win, dtype=np.int64) * tile_elems
+    index_pad = starts[:, None] + np.arange(tile_elems, dtype=np.int64)[None, :]
+    index_mask = np.arange(tile_elems, dtype=np.int64)[None, :] < variable_block_sizes[:, None]
+    return index_pad[index_mask]
+
+
+def validate_h3_tile_geometry(
+    prefix_segments: tuple[int, ...],
+    dit_seq_shape: tuple[int, int, int],
+    variable_block_sizes: np.ndarray,
+    untile_combined_index: np.ndarray,
+    tile_elems: int,
+) -> None:
+    total = sum(prefix_segments) + math.prod(dit_seq_shape)
+    n_pad = int(variable_block_sizes.size) * tile_elems
+    sizes_min = int(variable_block_sizes.min()) if variable_block_sizes.size else 0
+    sizes_max = int(variable_block_sizes.max()) if variable_block_sizes.size else 0
+    sizes_sum = int(variable_block_sizes.sum())
+    if sizes_min < 1 or sizes_max > tile_elems or sizes_sum != total:
+        raise ValueError(f"VSA-H3 tile sizes out of bounds for prefix={prefix_segments}, video={dit_seq_shape}, "
+                         f"tile_elems={tile_elems}: min={sizes_min}, max={sizes_max}, sum={sizes_sum}, "
+                         f"expected sum={total}.")
+    if int(untile_combined_index.size) != total:
+        raise ValueError(f"VSA-H3 untile index has {untile_combined_index.size} entries for a packed "
+                         f"sequence of {total} rows (prefix={prefix_segments}, video={dit_seq_shape}).")
+    idx_min = int(untile_combined_index.min())
+    idx_max = int(untile_combined_index.max())
+    if idx_min < 0 or idx_max >= n_pad:
+        raise ValueError(f"VSA-H3 untile index is not an injective map into non-pad slots: range "
+                         f"[{idx_min}, {idx_max}] vs padded length {n_pad} "
+                         f"(prefix={prefix_segments}, video={dit_seq_shape}).")
+    in_tile_offset = untile_combined_index % tile_elems
+    maps_into_pad = bool((in_tile_offset >= variable_block_sizes[untile_combined_index // tile_elems]).any())
+    if maps_into_pad or int(np.unique(untile_combined_index).size) != total:
+        raise ValueError(f"VSA-H3 untile index is not an injective map into non-pad slots: "
+                         f"pad-slot hit={maps_into_pad} "
+                         f"(prefix={prefix_segments}, video={dit_seq_shape}).")
+
+
+def build_h3_tile_geometry(
+    prefix_segments: tuple[int, ...],
+    dit_seq_shape: tuple[int, int, int],
+    tile_size: int = 64,
+) -> MiniMaxH3VSAGeometry:
+    """Tile the packed sequence: segment-pure prefix chunks, then video tiles."""
+    tile_shape = VSA_H3_TILE_SHAPES.get(int(tile_size))
+    if tile_shape is None:
+        raise ValueError(f"VSA-H3 tile_size must be one of {sorted(VSA_H3_TILE_SHAPES)}, got {tile_size!r}")
+    tile_elems = math.prod(tile_shape)
+    prefix_segments = tuple(int(segment) for segment in prefix_segments if int(segment) > 0)
+    prefix_len = sum(prefix_segments)
+
+    prefix_sizes: list[int] = []
+    for segment in prefix_segments:
+        full, rem = divmod(segment, tile_elems)
+        prefix_sizes.extend([tile_elems] * full)
+        if rem:
+            prefix_sizes.append(rem)
+    num_prefix_tiles = len(prefix_sizes)
+
+    video_sizes = _video_tile_sizes(dit_seq_shape, tile_shape)
+    num_video_tiles = int(video_sizes.size)
+    video_indices = _video_tile_partition_indices(dit_seq_shape, tile_shape) + prefix_len
+    tile_partition_indices = np.concatenate(
+        [np.arange(prefix_len, dtype=np.int64), video_indices],
+        axis=0,
+    )
+    variable_block_sizes = np.concatenate(
+        [np.asarray(prefix_sizes, dtype=np.int64),
+         video_sizes.astype(np.int64)],
+        axis=0,
+    )
+    non_pad_index = _non_pad_index(variable_block_sizes, tile_elems)
+    untile_combined_index = non_pad_index[np.argsort(tile_partition_indices, kind="stable")]
+    validate_h3_tile_geometry(prefix_segments, dit_seq_shape, variable_block_sizes, untile_combined_index, tile_elems)
+    return MiniMaxH3VSAGeometry(
+        prefix_segments=prefix_segments,
+        dit_seq_shape=dit_seq_shape,
+        tile_shape=tile_shape,
+        tile_elems=tile_elems,
+        total_seq_length=prefix_len + math.prod(dit_seq_shape),
+        num_prefix_tiles=num_prefix_tiles,
+        num_video_tiles=num_video_tiles,
+        variable_block_sizes=variable_block_sizes,
+        untile_combined_index=untile_combined_index,
+        tile_partition_indices=tile_partition_indices,
+    )
+
+
+def token_tile_and_valid(variable_block_sizes: np.ndarray, tile_elems: int) -> tuple[np.ndarray, np.ndarray]:
+    token_tile = np.repeat(np.arange(variable_block_sizes.size, dtype=np.int64), tile_elems)
+    token_valid = (np.arange(tile_elems, dtype=np.int64)[None, :] < variable_block_sizes[:, None]).reshape(-1)
+    return token_tile, token_valid
+
+
+def build_block_mask(
+    scores: np.ndarray,
+    num_prefix_tiles: int,
+    num_video_tiles: int,
+    sparsity: float,
+    exempt: bool,
+) -> np.ndarray:
+    """scores: [..., n_tiles, n_tiles] -> bool mask, same shape.
+
+    Mirrors ``_build_block_mask`` in the PyTorch H3 backend.
+    """
+    n_tiles = scores.shape[-1]
+    k_vid = compute_topk(sparsity, num_video_tiles)
+    if k_vid == num_video_tiles:
+        return np.ones_like(scores, dtype=bool)
+    mask = np.zeros_like(scores, dtype=bool)
+    if exempt or num_prefix_tiles == 0:
+        video_cols = scores[..., num_prefix_tiles:]
+        idx = np.argsort(-video_cols, axis=-1)[..., :k_vid] + num_prefix_tiles
+        np.put_along_axis(mask, idx, True, axis=-1)
+        mask[..., :num_prefix_tiles] = True
+    else:
+        k_total = min(k_vid + num_prefix_tiles, n_tiles)
+        idx = np.argsort(-scores, axis=-1)[..., :k_total]
+        np.put_along_axis(mask, idx, True, axis=-1)
+    mask[..., :num_prefix_tiles, :] = True
+    return mask
+
+
+def _tile_hidden(x, geometry: MiniMaxH3VSAGeometry):
+    """Scatter packed rows ``[S, H, D]`` into the zero-padded tile buffer."""
+    import mlx.core as mx
+
+    seq, heads, dim = x.shape
+    if seq != geometry.total_seq_length:
+        raise ValueError(f"VSA-H3 metadata was built for sequence length {geometry.total_seq_length}, got {seq}.")
+    buf = mx.zeros((geometry.padded_length, heads, dim), dtype=x.dtype)
+    buf = buf.at[mx.array(geometry.untile_combined_index)].add(x)
+    return buf
+
+
+def _untile_hidden(tiled, geometry: MiniMaxH3VSAGeometry):
+    import mlx.core as mx
+
+    return tiled[mx.array(geometry.untile_combined_index)]
+
+
+def _pool_tiles(x, variable_block_sizes, tile_elems: int):
+    """fp32 mean over each tile. x: [S_pad, H, D] -> [H, n_tiles, D]."""
+    import mlx.core as mx
+
+    seq_len, heads, dim = x.shape
+    n_tiles = seq_len // tile_elems
+    pooled = x.astype(mx.float32).reshape(n_tiles, tile_elems, heads, dim).sum(axis=1)
+    pooled = pooled / mx.array(variable_block_sizes, dtype=mx.float32)[:, None, None]
+    return pooled.transpose(1, 0, 2)
+
+
+def _dense_sdpa(q, k, v, scale: float):
+    import mlx.core as mx
+
+    return mx.fast.scaled_dot_product_attention(
+        mx.contiguous(q.transpose(1, 0, 2))[None],
+        mx.contiguous(k.transpose(1, 0, 2))[None],
+        mx.contiguous(v.transpose(1, 0, 2))[None],
+        scale=scale,
+    )[0].transpose(1, 0, 2)
+
+
+def _selected_keep(sparsity: float, num_prefix_tiles: int, num_video_tiles: int, exempt: bool) -> int:
+    k_vid = compute_topk(sparsity, num_video_tiles)
+    if k_vid == num_video_tiles:
+        return num_prefix_tiles + num_video_tiles
+    if exempt or num_prefix_tiles == 0:
+        return num_prefix_tiles + k_vid
+    return min(k_vid + num_prefix_tiles, num_prefix_tiles + num_video_tiles)
+
+
+def _block_indices_from_scores(
+    scores,
+    num_prefix_tiles: int,
+    num_video_tiles: int,
+    sparsity: float,
+    exempt: bool,
+):
+    """Return (block_idx [H, n_video_tiles, k_sel], block_num [H, n_video_tiles])."""
+    import mlx.core as mx
+
+    n_tiles = scores.shape[-1]
+    heads = scores.shape[0]
+    k_vid = compute_topk(sparsity, num_video_tiles)
+    video_scores = scores[:, num_prefix_tiles:, :]
+    if k_vid == num_video_tiles:
+        idx = mx.broadcast_to(mx.arange(n_tiles, dtype=mx.int32)[None, None, :], (heads, num_video_tiles, n_tiles))
+        counts = mx.full((heads, num_video_tiles), n_tiles, dtype=mx.int32)
+        return idx, counts
+
+    if exempt or num_prefix_tiles == 0:
+        k_sel = num_prefix_tiles + k_vid
+        video_cols = video_scores[:, :, num_prefix_tiles:]
+        top = mx.argpartition(-video_cols, kth=k_vid - 1, axis=-1)[:, :, :k_vid].astype(mx.int32) + num_prefix_tiles
+        if num_prefix_tiles:
+            prefix = mx.broadcast_to(
+                mx.arange(num_prefix_tiles, dtype=mx.int32)[None, None, :],
+                (heads, num_video_tiles, num_prefix_tiles),
+            )
+            idx = mx.concatenate([prefix, top], axis=-1)
+        else:
+            idx = top
+    else:
+        k_sel = min(k_vid + num_prefix_tiles, n_tiles)
+        top = mx.argpartition(-video_scores, kth=k_sel - 1, axis=-1)[:, :, :k_sel].astype(mx.int32)
+        idx = top
+    counts = mx.full((heads, num_video_tiles), idx.shape[-1], dtype=mx.int32)
+    return idx, counts
+
+
+def _token_mask_from_block_mask(block_mask: np.ndarray, geometry: MiniMaxH3VSAGeometry) -> np.ndarray:
+    token_tile, token_valid = token_tile_and_valid(geometry.variable_block_sizes, geometry.tile_elems)
+    # block_mask: [H, n_tiles, n_tiles]
+    allow = block_mask[:, token_tile][:, :, token_tile] & token_valid[None, None, :]
+    return allow
+
+
+def _reference_token_sdpa(q_tiled, k_tiled, v_tiled, block_mask: np.ndarray, geometry: MiniMaxH3VSAGeometry,
+                          scale: float):
+    import mlx.core as mx
+
+    allow = _token_mask_from_block_mask(block_mask, geometry)
+    bias = mx.where(mx.array(allow), mx.array(0.0, dtype=mx.float32), mx.array(-1e9, dtype=mx.float32))
+    return mx.fast.scaled_dot_product_attention(
+        mx.contiguous(q_tiled.transpose(1, 0, 2))[None],
+        mx.contiguous(k_tiled.transpose(1, 0, 2))[None],
+        mx.contiguous(v_tiled.transpose(1, 0, 2))[None],
+        scale=scale,
+        mask=bias[None],
+    )[0].transpose(1, 0, 2)
+
+
+def _gather_selected_kv(k_tiles, v_tiles, block_idx, tile_elems: int):
+    """Gather K/V tiles for one query-tile batch.
+
+    k_tiles/v_tiles: [H, n_tiles, tile_elems, D]
+    block_idx: [H, n_q, k_sel]
+    returns K/V: [H, n_q, k_sel * tile_elems, D]
+    """
+    import mlx.core as mx
+
+    heads, n_q, k_sel = block_idx.shape
+    dim = k_tiles.shape[-1]
+    gathered_k = k_tiles[mx.arange(heads)[:, None, None], block_idx]
+    gathered_v = v_tiles[mx.arange(heads)[:, None, None], block_idx]
+    return (
+        gathered_k.reshape(heads, n_q, k_sel * tile_elems, dim),
+        gathered_v.reshape(heads, n_q, k_sel * tile_elems, dim),
+    )
+
+
+def _key_valid_mask(block_idx, variable_block_sizes, tile_elems: int):
+    import mlx.core as mx
+
+    vbs = mx.array(variable_block_sizes, dtype=mx.int32)
+    selected_sizes = vbs[block_idx]  # [H, n_q, k_sel]
+    offsets = mx.arange(tile_elems, dtype=mx.int32)
+    return offsets[None, None, None, :] < selected_sizes[:, :, :, None]
+
+
+_REFERENCE_GATHER_TARGET_BYTES = 2 * 1024**3
+
+
+def _reference_gather_query_chunk(heads: int, dim: int, k_sel: int, tile_elems: int, n_q: int) -> int:
+    """Batch as many query tiles as fit in ~2 GiB of gathered BF16 K/V."""
+    bytes_per_query = 4 * heads * max(k_sel, 1) * tile_elems * dim
+    chunk = min(n_q, max(1, _REFERENCE_GATHER_TARGET_BYTES // max(bytes_per_query, 1)))
+    return int(chunk)
+
+
+def _reference_gather_sdpa(
+    q_tiled,
+    k_tiled,
+    v_tiled,
+    block_idx,
+    geometry: MiniMaxH3VSAGeometry,
+    scale: float,
+):
+    """Grouped gather + batched SDPA over video query tiles; prefix stays dense-equivalent.
+
+    Full-sequence gather at 720p materializes tens of GiB of selected K/V, so
+    query tiles are processed in memory-bounded chunks. This is the correctness
+    baseline and the default ``auto`` path: on MLX 0.31.2 / M4 Max the fused
+    SDPA gather is much faster than the scalar Metal kernel.
+    """
+    import mlx.core as mx
+
+    tile_elems = geometry.tile_elems
+    heads, dim = q_tiled.shape[1], q_tiled.shape[2]
+    n_tiles = geometry.num_tiles
+    q_tiles = q_tiled.reshape(n_tiles, tile_elems, heads, dim).transpose(2, 0, 1, 3)
+    k_tiles = k_tiled.reshape(n_tiles, tile_elems, heads, dim).transpose(2, 0, 1, 3)
+    v_tiles = v_tiled.reshape(n_tiles, tile_elems, heads, dim).transpose(2, 0, 1, 3)
+    q_video = q_tiles[:, geometry.num_prefix_tiles:]  # [H, V, tile_elems, D]
+    n_q = int(q_video.shape[1])
+    k_sel = int(block_idx.shape[-1])
+    query_chunk = _reference_gather_query_chunk(heads, dim, k_sel, tile_elems, n_q)
+    chunks = []
+    for start in range(0, n_q, query_chunk):
+        end = min(start + query_chunk, n_q)
+        idx = block_idx[:, start:end, :]
+        n_chunk = end - start
+        k_sel = int(idx.shape[-1])
+        gathered_k, gathered_v = _gather_selected_kv(k_tiles, v_tiles, idx, tile_elems)
+        valid = _key_valid_mask(idx, geometry.variable_block_sizes, tile_elems)
+        valid = valid.reshape(heads, n_chunk, k_sel * tile_elems)
+        q_bh = mx.contiguous(q_video[:, start:end].reshape(heads * n_chunk, tile_elems, dim)[None])
+        k_bh = mx.contiguous(gathered_k.reshape(heads * n_chunk, k_sel * tile_elems, dim)[None])
+        v_bh = mx.contiguous(gathered_v.reshape(heads * n_chunk, k_sel * tile_elems, dim)[None])
+        mask = valid.reshape(1, heads * n_chunk, 1, k_sel * tile_elems)
+        out = mx.fast.scaled_dot_product_attention(q_bh, k_bh, v_bh, scale=scale, mask=mask)[0]
+        out = out.reshape(heads, n_chunk, tile_elems, dim)
+        mx.eval(out)
+        chunks.append(out)
+    out = mx.concatenate(chunks, axis=1) if len(chunks) > 1 else chunks[0]
+    video_flat = out.transpose(1, 2, 0, 3).reshape(n_q * tile_elems, heads, dim)
+    prefix = q_tiled[:geometry.num_prefix_tiles * tile_elems]
+    return mx.concatenate([prefix, video_flat], axis=0)
+
+
+_METAL_KERNEL = None
+_METAL_KERNEL_ERROR: str | None = None
+
+# Cooperative K/V staging: 32 tokens x 128 dims x 4 bytes = 16 KiB of threadgroup
+# memory. Every query thread in the tile reuses that staging buffer instead of
+# reloading the same K/V rows from device memory. Do not early-return before
+# barriers — padded query lanes still participate.
+_METAL_SOURCE = """
+    const int CHUNK = 32;
+    const int MAXD = 128;
+    threadgroup float smem[32 * 128];
+    uint token = thread_position_in_grid.x;
+    uint q_tile = thread_position_in_grid.y;
+    uint head = thread_position_in_grid.z;
+    uint tid = thread_position_in_threadgroup.x;
+    uint nthreads = threads_per_threadgroup.x;
+    int D = meta_i[0];
+    int TILE = meta_i[1];
+    int S = meta_i[2];
+    int k_max = meta_i[4];
+    int n_prefix = meta_i[5];
+    int n_video = meta_i[6];
+    float scale = meta_f[0];
+    if ((int)token >= TILE || (int)q_tile >= n_video || (int)head >= (int)q_shape[0]) {
+        return;
+    }
+    int qt = n_prefix + (int)q_tile;
+    int q_valid = vbs[qt];
+    int q_base = (((int)head * S) + qt * TILE + (int)token) * D;
+    float qreg[128];
+    for (int d = 0; d < MAXD; d++) {
+        qreg[d] = (d < D && (int)token < q_valid) ? float(q[q_base + d]) : 0.0f;
+    }
+    int nsel = block_num[(int)head * n_video + (int)q_tile];
+    float m = -3.402823466e+38f;
+    float lse = 0.0f;
+    float acc[128];
+    for (int d = 0; d < MAXD; d++) {
+        acc[d] = 0.0f;
+    }
+    for (int s = 0; s < nsel; s++) {
+        int kt = block_idx[(((int)head * n_video) + (int)q_tile) * k_max + s];
+        int k_valid = vbs[kt];
+        int tile_base = (((int)head * S) + kt * TILE) * D;
+        for (int j0 = 0; j0 < TILE; j0 += CHUNK) {
+            int n_elems = CHUNK * MAXD;
+            for (uint i = tid; (int)i < n_elems; i += nthreads) {
+                int tok = (int)i / MAXD;
+                int d = (int)i - tok * MAXD;
+                int gtok = j0 + tok;
+                float val = 0.0f;
+                if (gtok < k_valid && gtok < TILE && d < D) {
+                    val = float(k[tile_base + gtok * D + d]);
+                }
+                smem[i] = val;
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            float scores[32];
+            float cmax = -3.402823466e+38f;
+            for (int t = 0; t < CHUNK; t++) {
+                int gtok = j0 + t;
+                float score = 0.0f;
+                if (gtok < k_valid && gtok < TILE) {
+                    int sbase = t * MAXD;
+                    for (int d = 0; d < D && d < MAXD; d++) {
+                        score += qreg[d] * smem[sbase + d];
+                    }
+                    score *= scale;
+                } else {
+                    score = -3.402823466e+38f;
+                }
+                scores[t] = score;
+                cmax = metal::max(cmax, score);
+            }
+            float m_new = metal::max(m, cmax);
+            float alpha = metal::exp(m - m_new);
+            lse *= alpha;
+            for (int d = 0; d < D && d < MAXD; d++) {
+                acc[d] *= alpha;
+            }
+            m = m_new;
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            for (uint i = tid; (int)i < n_elems; i += nthreads) {
+                int tok = (int)i / MAXD;
+                int d = (int)i - tok * MAXD;
+                int gtok = j0 + tok;
+                float val = 0.0f;
+                if (gtok < k_valid && gtok < TILE && d < D) {
+                    val = float(v[tile_base + gtok * D + d]);
+                }
+                smem[i] = val;
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            for (int t = 0; t < CHUNK; t++) {
+                float weight = ((j0 + t) < k_valid && (j0 + t) < TILE) ? metal::exp(scores[t] - m) : 0.0f;
+                lse += weight;
+                int sbase = t * MAXD;
+                for (int d = 0; d < D && d < MAXD; d++) {
+                    acc[d] += weight * smem[sbase + d];
+                }
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+        }
+    }
+    float denom = lse > 0.0f ? lse : 1.0f;
+    for (int d = 0; d < D && d < MAXD; d++) {
+        out[q_base + d] = ((int)token < q_valid) ? T(acc[d] / denom) : T(0);
+    }
+"""
+
+
+def metal_kernel_available() -> bool:
+    try:
+        import mlx.core as mx
+    except ImportError:
+        return False
+    return hasattr(getattr(mx, "fast", None), "metal_kernel")
+
+
+def _metal_kernel():
+    global _METAL_KERNEL, _METAL_KERNEL_ERROR
+    if _METAL_KERNEL is not None:
+        return _METAL_KERNEL
+    if _METAL_KERNEL_ERROR is not None:
+        return None
+    try:
+        import mlx.core as mx
+
+        if not hasattr(mx.fast, "metal_kernel"):
+            _METAL_KERNEL_ERROR = "mx.fast.metal_kernel is not available in this MLX build"
+            return None
+        kwargs = {
+            "name": "h3_vsa_block_sparse",
+            "input_names": ["q", "k", "v", "block_idx", "block_num", "vbs", "meta_i", "meta_f"],
+            "output_names": ["out"],
+            "source": _METAL_SOURCE,
+        }
+        try:
+            # MLX 0.32.2+ accepts compile_options (math_mode=safe).
+            _METAL_KERNEL = mx.fast.metal_kernel(**kwargs, compile_options={"math_mode": "safe"})
+        except TypeError:
+            # MLX 0.31.2's metal_kernel() has no compile_options argument.
+            _METAL_KERNEL = mx.fast.metal_kernel(**kwargs)
+    except Exception as error:  # noqa: BLE001 - keep dense/reference usable
+        _METAL_KERNEL_ERROR = str(error)
+        _METAL_KERNEL = None
+    return _METAL_KERNEL
+
+
+def metal_supported(head_dim: int, tile_elems: int) -> bool:
+    if not (0 < head_dim <= _METAL_MAX_HEAD_DIM and tile_elems in VSA_H3_TILE_SHAPES):
+        return False
+    return _metal_kernel() is not None
+
+
+def _metal_block_sparse(
+    q_tiled,
+    k_tiled,
+    v_tiled,
+    block_idx,
+    block_num,
+    geometry: MiniMaxH3VSAGeometry,
+    scale: float,
+):
+    import mlx.core as mx
+
+    kernel = _metal_kernel()
+    if kernel is None:
+        raise RuntimeError(_METAL_KERNEL_ERROR or "Metal VSA kernel is unavailable")
+    heads, dim = q_tiled.shape[1], q_tiled.shape[2]
+    q = mx.contiguous(q_tiled.transpose(1, 0, 2))  # [H, S, D]
+    k = mx.contiguous(k_tiled.transpose(1, 0, 2))
+    v = mx.contiguous(v_tiled.transpose(1, 0, 2))
+    meta_i = mx.array(
+        [
+            dim,
+            geometry.tile_elems,
+            geometry.padded_length,
+            geometry.num_tiles,
+            int(block_idx.shape[-1]),
+            geometry.num_prefix_tiles,
+            geometry.num_video_tiles,
+        ],
+        dtype=mx.int32,
+    )
+    meta_f = mx.array([scale], dtype=mx.float32)
+    call_kwargs = {
+        "inputs": [
+            q,
+            k,
+            v,
+            mx.contiguous(block_idx.astype(mx.int32)),
+            mx.contiguous(block_num.astype(mx.int32)),
+            mx.array(geometry.variable_block_sizes.astype(np.int32)),
+            meta_i,
+            meta_f,
+        ],
+        "template": [("T", q.dtype)],
+        "grid": (geometry.tile_elems, geometry.num_video_tiles, heads),
+        "threadgroup": (min(geometry.tile_elems, 256), 1, 1),
+        "output_shapes": [q.shape],
+        "output_dtypes": [q.dtype],
+    }
+    try:
+        outputs = kernel(**call_kwargs, init_value=0)
+    except TypeError:
+        outputs = kernel(**call_kwargs)
+    return outputs[0].transpose(1, 0, 2)
+
+
+def _gate_compress_output(scores, v_tiled, gate_tiled, geometry: MiniMaxH3VSAGeometry):
+    import mlx.core as mx
+
+    v_pooled = _pool_tiles(v_tiled, geometry.variable_block_sizes, geometry.tile_elems)
+    attn = mx.softmax(scores, axis=-1)
+    out_c = attn @ v_pooled  # [H, n_tiles, D]
+    out_c = out_c.transpose(1, 0, 2)  # [n_tiles, H, D]
+    heads, dim = gate_tiled.shape[1], gate_tiled.shape[2]
+    gate_view = gate_tiled.reshape(geometry.num_tiles, geometry.tile_elems, heads, dim)
+    return (out_c[:, None, :, :] * gate_view).reshape(geometry.padded_length, heads, dim)
+
+
+def resolve_impl(requested: VSAImpl, head_dim: int, tile_elems: int) -> str:
+    if requested == "reference":
+        return "reference"
+    if requested == "metal":
+        if not metal_supported(head_dim, tile_elems):
+            reason = _METAL_KERNEL_ERROR or "Metal VSA kernel is unavailable for this shape"
+            raise RuntimeError(reason)
+        return "metal"
+    # Measured on M4 Max / MLX 0.31.2 at 720p (H=56, D=128, tile=64, sparsity=0.9):
+    # dense fused SDPA ~2.5s, chunked gather+SDPA ~2.9s, Metal kernel ~29s.
+    # Prefer the gather reference unless the caller explicitly asked for Metal.
+    return "reference"
+
+
+def h3_vsa_attention(
+    query,
+    key,
+    value,
+    geometry: MiniMaxH3VSAGeometry,
+    *,
+    sparsity: float,
+    exempt: bool = True,
+    gate_compress=None,
+    impl: VSAImpl = "auto",
+    stats: MiniMaxH3VSAStats | None = None,
+):
+    """Packed ``[S, H, D]`` VSA attention. Falls back to dense SDPA when sparsity is 0."""
+    import mlx.core as mx
+
+    seq, heads, dim = query.shape
+    scale = dim**-0.5
+    if stats is not None:
+        stats.configured_sparsity = sparsity
+        stats.layer_sparsity = sparsity
+        stats.tile_size = geometry.tile_elems
+        stats.prefix_mode = "exempt" if exempt else "compete"
+        stats.num_prefix_tiles = geometry.num_prefix_tiles
+        stats.num_video_tiles = geometry.num_video_tiles
+
+    if sparsity <= 0.0 and gate_compress is None:
+        if stats is not None:
+            stats.impl = "dense"
+            stats.achieved_sparsity = 0.0
+            stats.video_keep = geometry.num_video_tiles
+        return _dense_sdpa(query, key, value, scale)
+
+    q_tiled = _tile_hidden(query, geometry)
+    k_tiled = _tile_hidden(key, geometry)
+    v_tiled = _tile_hidden(value, geometry)
+    q_pooled = _pool_tiles(q_tiled, geometry.variable_block_sizes, geometry.tile_elems)
+    k_pooled = _pool_tiles(k_tiled, geometry.variable_block_sizes, geometry.tile_elems)
+    scores = (q_pooled @ k_pooled.transpose(0, 2, 1)) / (dim**0.5)
+
+    k_vid = compute_topk(sparsity, geometry.num_video_tiles)
+    if stats is not None:
+        stats.video_keep = k_vid if sparsity > 0.0 else geometry.num_video_tiles
+        stats.achieved_sparsity = (1.0 - (k_vid / geometry.num_video_tiles) if geometry.num_video_tiles else 0.0)
+
+    if sparsity <= 0.0:
+        out_tiled = _tile_hidden(_dense_sdpa(query, key, value, scale), geometry)
+        chosen = "dense"
+    else:
+        block_idx, block_num = _block_indices_from_scores(
+            scores,
+            geometry.num_prefix_tiles,
+            geometry.num_video_tiles,
+            sparsity,
+            exempt,
+        )
+        chosen = resolve_impl(impl, dim, geometry.tile_elems)
+        prefix_out = _dense_sdpa(query[:geometry.prefix_length], key, value, scale)
+        if chosen == "metal":
+            video_tiled = _metal_block_sparse(q_tiled, k_tiled, v_tiled, block_idx, block_num, geometry, scale)
+            out_tiled = video_tiled
+        elif geometry.num_tiles <= _REFERENCE_FULL_MASK_TILE_LIMIT:
+            scores_np = np.array(scores, dtype=np.float32)
+            mask = build_block_mask(
+                scores_np,
+                geometry.num_prefix_tiles,
+                geometry.num_video_tiles,
+                sparsity,
+                exempt,
+            )
+            out_tiled = _reference_token_sdpa(q_tiled, k_tiled, v_tiled, mask, geometry, scale)
+        else:
+            out_tiled = _reference_gather_sdpa(q_tiled, k_tiled, v_tiled, block_idx, geometry, scale)
+        out_tiled = out_tiled.astype(query.dtype)
+        prefix_tiled = _tile_hidden(
+            mx.concatenate([
+                prefix_out,
+                mx.zeros((seq - geometry.prefix_length, heads, dim), dtype=query.dtype),
+            ],
+                           axis=0),
+            geometry,
+        )
+        # Prefix query tiles are dense; keep fused-SDPA prefix rows and sparse video tiles.
+        n_prefix_pad = geometry.num_prefix_tiles * geometry.tile_elems
+        out_tiled = mx.concatenate([prefix_tiled[:n_prefix_pad], out_tiled[n_prefix_pad:]], axis=0)
+
+    if gate_compress is not None:
+        gate_tiled = _tile_hidden(gate_compress, geometry)
+        out_tiled = out_tiled + _gate_compress_output(scores, v_tiled, gate_tiled, geometry).astype(out_tiled.dtype)
+
+    if stats is not None:
+        stats.impl = chosen if sparsity > 0.0 else "dense"
+    return _untile_hidden(out_tiled, geometry)
+
+
+def geometry_is_supported(prefix_segments: tuple[int, ...], dit_seq_shape: tuple[int, int, int],
+                          tile_size: int) -> str | None:
+    """Return a fallback reason, or None when VSA can run."""
+    try:
+        build_h3_tile_geometry(prefix_segments, dit_seq_shape, tile_size)
+    except ValueError as error:
+        return str(error)
+    return None

--- a/fastvideo/mlx_runtime/minimax_h3_vsa.py
+++ b/fastvideo/mlx_runtime/minimax_h3_vsa.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # mypy: disable-error-code=no-untyped-call
-"""Inference-only MiniMax H3 Video Sparse Attention for the MLX runtime.
+"""MiniMax H3 Video Sparse Attention for the native MLX runtime.
 
 Ports the packed-sequence VSA-H3 contract from
 ``fastvideo/attention/backends/video_sparse_attn_h3.py``:
@@ -13,16 +13,13 @@ Ports the packed-sequence VSA-H3 contract from
 - Optional dense-first steps and per-layer dense overrides.
 - Trained ``to_gate_compress`` pooled-compression branch.
 
-Two execution paths:
+Execution backends:
 
 - **reference** (``auto`` default) — grouped gather plus batched
-  ``mx.fast.scaled_dot_product_attention``. Correctness baseline. On MLX 0.31.2
-  / M4 Max this is close to dense fused SDPA at 720p; the Metal kernel is not.
-- **metal** — inference-only ``mx.fast.metal_kernel`` block-sparse attention
-  over BF16 Q/K/V activations and an explicit per-query block index. Kept for
-  parity testing. INT6 applies only to linear weights (including the gate
-  projection), not to Q/K/V. ``compile_options`` is used on MLX 0.32.2+ and
-  omitted on 0.31.2.
+  ``mx.fast.scaled_dot_product_attention``. Correctness baseline.
+- **simd** — opt-in SIMD-group 8x8 matrix operations over the reference tile
+  map for tile size 64 and head dimension 128. Unsupported shapes and kernel
+  failures fall back to the reference backend.
 
 Dense fused SDPA remains the default when VSA is disabled, the geometry is
 unsupported, or a dense-only checkpoint is loaded.
@@ -46,12 +43,14 @@ VSA_H3_TILE_SHAPES: dict[int, tuple[int, int, int]] = {
 }
 VSA_GATE_KEY_SUFFIX = "attn.to_gate_compress.weight"
 VSA_PREFIX_MODES = ("exempt", "compete")
-VSA_IMPLS = ("auto", "reference", "metal")
-_METAL_MAX_HEAD_DIM = 128
+PUBLIC_VSA_IMPLS = ("auto", "reference", "simd")
+VSA_IMPLS = PUBLIC_VSA_IMPLS
+# SIMD is opt-in until its dynamically routed output is accepted as the default.
+_AUTO_PREFERS_SIMD = False
 _REFERENCE_FULL_MASK_TILE_LIMIT = 24
 
 PrefixMode = Literal["exempt", "compete"]
-VSAImpl = Literal["auto", "reference", "metal"]
+VSAImpl = Literal["auto", "reference", "simd"]
 
 
 class DenseOnlyVSACheckpointError(ValueError):
@@ -516,8 +515,7 @@ def _reference_gather_sdpa(
 
     Full-sequence gather at 720p materializes tens of GiB of selected K/V, so
     query tiles are processed in memory-bounded chunks. This is the correctness
-    baseline and the default ``auto`` path: on MLX 0.31.2 / M4 Max the fused
-    SDPA gather is much faster than the scalar Metal kernel.
+    baseline and the default ``auto`` path.
     """
     import mlx.core as mx
 
@@ -554,216 +552,6 @@ def _reference_gather_sdpa(
     return mx.concatenate([prefix, video_flat], axis=0)
 
 
-_METAL_KERNEL = None
-_METAL_KERNEL_ERROR: str | None = None
-
-# Cooperative K/V staging: 32 tokens x 128 dims x 4 bytes = 16 KiB of threadgroup
-# memory. Every query thread in the tile reuses that staging buffer instead of
-# reloading the same K/V rows from device memory. Do not early-return before
-# barriers — padded query lanes still participate.
-_METAL_SOURCE = """
-    const int CHUNK = 32;
-    const int MAXD = 128;
-    threadgroup float smem[32 * 128];
-    uint token = thread_position_in_grid.x;
-    uint q_tile = thread_position_in_grid.y;
-    uint head = thread_position_in_grid.z;
-    uint tid = thread_position_in_threadgroup.x;
-    uint nthreads = threads_per_threadgroup.x;
-    int D = meta_i[0];
-    int TILE = meta_i[1];
-    int S = meta_i[2];
-    int k_max = meta_i[4];
-    int n_prefix = meta_i[5];
-    int n_video = meta_i[6];
-    float scale = meta_f[0];
-    if ((int)token >= TILE || (int)q_tile >= n_video || (int)head >= (int)q_shape[0]) {
-        return;
-    }
-    int qt = n_prefix + (int)q_tile;
-    int q_valid = vbs[qt];
-    int q_base = (((int)head * S) + qt * TILE + (int)token) * D;
-    float qreg[128];
-    for (int d = 0; d < MAXD; d++) {
-        qreg[d] = (d < D && (int)token < q_valid) ? float(q[q_base + d]) : 0.0f;
-    }
-    int nsel = block_num[(int)head * n_video + (int)q_tile];
-    float m = -3.402823466e+38f;
-    float lse = 0.0f;
-    float acc[128];
-    for (int d = 0; d < MAXD; d++) {
-        acc[d] = 0.0f;
-    }
-    for (int s = 0; s < nsel; s++) {
-        int kt = block_idx[(((int)head * n_video) + (int)q_tile) * k_max + s];
-        int k_valid = vbs[kt];
-        int tile_base = (((int)head * S) + kt * TILE) * D;
-        for (int j0 = 0; j0 < TILE; j0 += CHUNK) {
-            int n_elems = CHUNK * MAXD;
-            for (uint i = tid; (int)i < n_elems; i += nthreads) {
-                int tok = (int)i / MAXD;
-                int d = (int)i - tok * MAXD;
-                int gtok = j0 + tok;
-                float val = 0.0f;
-                if (gtok < k_valid && gtok < TILE && d < D) {
-                    val = float(k[tile_base + gtok * D + d]);
-                }
-                smem[i] = val;
-            }
-            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
-            float scores[32];
-            float cmax = -3.402823466e+38f;
-            for (int t = 0; t < CHUNK; t++) {
-                int gtok = j0 + t;
-                float score = 0.0f;
-                if (gtok < k_valid && gtok < TILE) {
-                    int sbase = t * MAXD;
-                    for (int d = 0; d < D && d < MAXD; d++) {
-                        score += qreg[d] * smem[sbase + d];
-                    }
-                    score *= scale;
-                } else {
-                    score = -3.402823466e+38f;
-                }
-                scores[t] = score;
-                cmax = metal::max(cmax, score);
-            }
-            float m_new = metal::max(m, cmax);
-            float alpha = metal::exp(m - m_new);
-            lse *= alpha;
-            for (int d = 0; d < D && d < MAXD; d++) {
-                acc[d] *= alpha;
-            }
-            m = m_new;
-            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
-            for (uint i = tid; (int)i < n_elems; i += nthreads) {
-                int tok = (int)i / MAXD;
-                int d = (int)i - tok * MAXD;
-                int gtok = j0 + tok;
-                float val = 0.0f;
-                if (gtok < k_valid && gtok < TILE && d < D) {
-                    val = float(v[tile_base + gtok * D + d]);
-                }
-                smem[i] = val;
-            }
-            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
-            for (int t = 0; t < CHUNK; t++) {
-                float weight = ((j0 + t) < k_valid && (j0 + t) < TILE) ? metal::exp(scores[t] - m) : 0.0f;
-                lse += weight;
-                int sbase = t * MAXD;
-                for (int d = 0; d < D && d < MAXD; d++) {
-                    acc[d] += weight * smem[sbase + d];
-                }
-            }
-            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
-        }
-    }
-    float denom = lse > 0.0f ? lse : 1.0f;
-    for (int d = 0; d < D && d < MAXD; d++) {
-        out[q_base + d] = ((int)token < q_valid) ? T(acc[d] / denom) : T(0);
-    }
-"""
-
-
-def metal_kernel_available() -> bool:
-    try:
-        import mlx.core as mx
-    except ImportError:
-        return False
-    return hasattr(getattr(mx, "fast", None), "metal_kernel")
-
-
-def _metal_kernel():
-    global _METAL_KERNEL, _METAL_KERNEL_ERROR
-    if _METAL_KERNEL is not None:
-        return _METAL_KERNEL
-    if _METAL_KERNEL_ERROR is not None:
-        return None
-    try:
-        import mlx.core as mx
-
-        if not hasattr(mx.fast, "metal_kernel"):
-            _METAL_KERNEL_ERROR = "mx.fast.metal_kernel is not available in this MLX build"
-            return None
-        kwargs = {
-            "name": "h3_vsa_block_sparse",
-            "input_names": ["q", "k", "v", "block_idx", "block_num", "vbs", "meta_i", "meta_f"],
-            "output_names": ["out"],
-            "source": _METAL_SOURCE,
-        }
-        try:
-            # MLX 0.32.2+ accepts compile_options (math_mode=safe).
-            _METAL_KERNEL = mx.fast.metal_kernel(**kwargs, compile_options={"math_mode": "safe"})
-        except TypeError:
-            # MLX 0.31.2's metal_kernel() has no compile_options argument.
-            _METAL_KERNEL = mx.fast.metal_kernel(**kwargs)
-    except Exception as error:  # noqa: BLE001 - keep dense/reference usable
-        _METAL_KERNEL_ERROR = str(error)
-        _METAL_KERNEL = None
-    return _METAL_KERNEL
-
-
-def metal_supported(head_dim: int, tile_elems: int) -> bool:
-    if not (0 < head_dim <= _METAL_MAX_HEAD_DIM and tile_elems in VSA_H3_TILE_SHAPES):
-        return False
-    return _metal_kernel() is not None
-
-
-def _metal_block_sparse(
-    q_tiled,
-    k_tiled,
-    v_tiled,
-    block_idx,
-    block_num,
-    geometry: MiniMaxH3VSAGeometry,
-    scale: float,
-):
-    import mlx.core as mx
-
-    kernel = _metal_kernel()
-    if kernel is None:
-        raise RuntimeError(_METAL_KERNEL_ERROR or "Metal VSA kernel is unavailable")
-    heads, dim = q_tiled.shape[1], q_tiled.shape[2]
-    q = mx.contiguous(q_tiled.transpose(1, 0, 2))  # [H, S, D]
-    k = mx.contiguous(k_tiled.transpose(1, 0, 2))
-    v = mx.contiguous(v_tiled.transpose(1, 0, 2))
-    meta_i = mx.array(
-        [
-            dim,
-            geometry.tile_elems,
-            geometry.padded_length,
-            geometry.num_tiles,
-            int(block_idx.shape[-1]),
-            geometry.num_prefix_tiles,
-            geometry.num_video_tiles,
-        ],
-        dtype=mx.int32,
-    )
-    meta_f = mx.array([scale], dtype=mx.float32)
-    call_kwargs = {
-        "inputs": [
-            q,
-            k,
-            v,
-            mx.contiguous(block_idx.astype(mx.int32)),
-            mx.contiguous(block_num.astype(mx.int32)),
-            mx.array(geometry.variable_block_sizes.astype(np.int32)),
-            meta_i,
-            meta_f,
-        ],
-        "template": [("T", q.dtype)],
-        "grid": (geometry.tile_elems, geometry.num_video_tiles, heads),
-        "threadgroup": (min(geometry.tile_elems, 256), 1, 1),
-        "output_shapes": [q.shape],
-        "output_dtypes": [q.dtype],
-    }
-    try:
-        outputs = kernel(**call_kwargs, init_value=0)
-    except TypeError:
-        outputs = kernel(**call_kwargs)
-    return outputs[0].transpose(1, 0, 2)
-
-
 def _gate_compress_output(scores, v_tiled, gate_tiled, geometry: MiniMaxH3VSAGeometry):
     import mlx.core as mx
 
@@ -777,17 +565,24 @@ def _gate_compress_output(scores, v_tiled, gate_tiled, geometry: MiniMaxH3VSAGeo
 
 
 def resolve_impl(requested: VSAImpl, head_dim: int, tile_elems: int) -> str:
-    if requested == "reference":
+    if requested in ("reference", "auto") and not _AUTO_PREFERS_SIMD:
         return "reference"
-    if requested == "metal":
-        if not metal_supported(head_dim, tile_elems):
-            reason = _METAL_KERNEL_ERROR or "Metal VSA kernel is unavailable for this shape"
-            raise RuntimeError(reason)
-        return "metal"
-    # Measured on M4 Max / MLX 0.31.2 at 720p (H=56, D=128, tile=64, sparsity=0.9):
-    # dense fused SDPA ~2.5s, chunked gather+SDPA ~2.9s, Metal kernel ~29s.
-    # Prefer the gather reference unless the caller explicitly asked for Metal.
-    return "reference"
+
+    from fastvideo.mlx_runtime.minimax_h3_vsa_simd import simd_kernel_available, simd_kernel_error
+
+    if tile_elems != 64 or head_dim != 128:
+        if requested == "simd":
+            logger.warning(
+                "SIMD VSA requires tile 64 and head dim 128 (got tile=%s head_dim=%s); using reference VSA",
+                tile_elems,
+                head_dim,
+            )
+        return "reference"
+    if not simd_kernel_available():
+        reason = simd_kernel_error() or "SIMD-group VSA kernel is unavailable"
+        logger.warning("SIMD VSA kernel unavailable (%s); using reference VSA", reason)
+        return "reference"
+    return "simd"
 
 
 def h3_vsa_attention(
@@ -847,8 +642,17 @@ def h3_vsa_attention(
         )
         chosen = resolve_impl(impl, dim, geometry.tile_elems)
         prefix_out = _dense_sdpa(query[:geometry.prefix_length], key, value, scale)
-        if chosen == "metal":
-            video_tiled = _metal_block_sparse(q_tiled, k_tiled, v_tiled, block_idx, block_num, geometry, scale)
+        if chosen == "simd":
+            from fastvideo.mlx_runtime.minimax_h3_vsa_simd import simd_block_sparse
+
+            try:
+                video_tiled = simd_block_sparse(q_tiled, k_tiled, v_tiled, block_idx, block_num, geometry, scale)
+            except Exception as error:  # noqa: BLE001 - keep generation alive on kernel failure
+                logger.warning("SIMD VSA kernel failed (%s); falling back to reference gather+SDPA", error)
+                chosen = "reference"
+                if stats is not None:
+                    stats.dense_fallback_reason = f"simd kernel failed: {error}"
+                video_tiled = _reference_gather_sdpa(q_tiled, k_tiled, v_tiled, block_idx, geometry, scale)
             out_tiled = video_tiled
         elif geometry.num_tiles <= _REFERENCE_FULL_MASK_TILE_LIMIT:
             scores_np = np.array(scores, dtype=np.float32)

--- a/fastvideo/mlx_runtime/minimax_h3_vsa.py
+++ b/fastvideo/mlx_runtime/minimax_h3_vsa.py
@@ -28,7 +28,9 @@ unsupported, or a dense-only checkpoint is loaded.
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from functools import cached_property
+from numbers import Integral
 from typing import Any, Literal
 
 import numpy as np
@@ -81,6 +83,9 @@ class MiniMaxH3VSAConfig:
             raise ValueError(f"VSA impl must be one of {VSA_IMPLS}, got {self.impl!r}.")
         if self.dense_first_n_steps < 0:
             raise ValueError(f"vsa_dense_first_n_steps must be >= 0, got {self.dense_first_n_steps}.")
+        if isinstance(self.dense_layers, str) or any(
+                not isinstance(layer, Integral) or isinstance(layer, bool) or layer < 0 for layer in self.dense_layers):
+            raise ValueError("VSA dense_layers must be a sequence of non-negative integer indices.")
         object.__setattr__(self, "dense_layers", tuple(int(layer) for layer in self.dense_layers))
 
     @property
@@ -124,6 +129,28 @@ class MiniMaxH3VSAGeometry:
     def prefix_length(self) -> int:
         return int(sum(self.prefix_segments))
 
+    @cached_property
+    def tile_gather_index(self):
+        import mlx.core as mx
+
+        index = np.full(self.padded_length, self.total_seq_length, dtype=np.int32)
+        index[self.untile_combined_index] = np.arange(self.total_seq_length, dtype=np.int32)
+        return mx.array(index)
+
+    @cached_property
+    def prefix_gather_index(self):
+        import mlx.core as mx
+
+        index = np.full(self.num_prefix_tiles * self.tile_elems, self.prefix_length, dtype=np.int32)
+        index[self.untile_combined_index[:self.prefix_length]] = np.arange(self.prefix_length, dtype=np.int32)
+        return mx.array(index)
+
+    @cached_property
+    def untile_index(self):
+        import mlx.core as mx
+
+        return mx.array(self.untile_combined_index, dtype=mx.int32)
+
 
 @dataclass
 class MiniMaxH3VSAStats:
@@ -136,9 +163,28 @@ class MiniMaxH3VSAStats:
     impl: str = "dense"
     num_prefix_tiles: int = 0
     num_video_tiles: int = 0
-    video_keep: int = 0
+    video_keep: float = 0.0
     achieved_sparsity: float = 0.0
     dense_fallback_reason: str | None = None
+    attention_calls: int = 0
+    sparse_calls: int = 0
+    impl_counts: dict[str, int] = field(default_factory=dict)
+    fallback_reasons: list[str] = field(default_factory=list)
+
+    def record(self, call: MiniMaxH3VSAStats) -> None:
+        """Aggregate equally sized video-query tile maps across blocks and steps."""
+        self.attention_calls += 1
+        self.sparse_calls += int(call.layer_sparsity > 0.0)
+        self.impl_counts[call.impl] = self.impl_counts.get(call.impl, 0) + 1
+        self.impl = next(iter(self.impl_counts)) if len(self.impl_counts) == 1 else "mixed"
+        for name in ("layer_sparsity", "video_keep", "achieved_sparsity"):
+            old = getattr(self, name)
+            setattr(self, name, old + (getattr(call, name) - old) / self.attention_calls)
+        self.num_prefix_tiles = call.num_prefix_tiles
+        self.num_video_tiles = call.num_video_tiles
+        if call.dense_fallback_reason and call.dense_fallback_reason not in self.fallback_reasons:
+            self.fallback_reasons.append(call.dense_fallback_reason)
+        self.dense_fallback_reason = "; ".join(self.fallback_reasons) or None
 
 
 def vsa_gate_key(block_index: int) -> str:
@@ -280,6 +326,8 @@ def build_h3_tile_geometry(
     tile_shape = VSA_H3_TILE_SHAPES.get(int(tile_size))
     if tile_shape is None:
         raise ValueError(f"VSA-H3 tile_size must be one of {sorted(VSA_H3_TILE_SHAPES)}, got {tile_size!r}")
+    if len(dit_seq_shape) != 3 or any(axis <= 0 for axis in dit_seq_shape):
+        raise ValueError(f"VSA-H3 video axes must be positive, got {dit_seq_shape}.")
     tile_elems = math.prod(tile_shape)
     prefix_segments = tuple(int(segment) for segment in prefix_segments if int(segment) > 0)
     prefix_len = sum(prefix_segments)
@@ -357,21 +405,17 @@ def build_block_mask(
 
 
 def _tile_hidden(x, geometry: MiniMaxH3VSAGeometry):
-    """Scatter packed rows ``[S, H, D]`` into the zero-padded tile buffer."""
+    """Gather packed rows into tiles, mapping every padding slot to one zero row."""
     import mlx.core as mx
 
     seq, heads, dim = x.shape
     if seq != geometry.total_seq_length:
         raise ValueError(f"VSA-H3 metadata was built for sequence length {geometry.total_seq_length}, got {seq}.")
-    buf = mx.zeros((geometry.padded_length, heads, dim), dtype=x.dtype)
-    buf = buf.at[mx.array(geometry.untile_combined_index)].add(x)
-    return buf
+    return mx.concatenate([x, mx.zeros((1, heads, dim), dtype=x.dtype)])[geometry.tile_gather_index]
 
 
 def _untile_hidden(tiled, geometry: MiniMaxH3VSAGeometry):
-    import mlx.core as mx
-
-    return tiled[mx.array(geometry.untile_combined_index)]
+    return tiled[geometry.untile_index]
 
 
 def _pool_tiles(x, variable_block_sizes, tile_elems: int):
@@ -389,9 +433,9 @@ def _dense_sdpa(q, k, v, scale: float):
     import mlx.core as mx
 
     return mx.fast.scaled_dot_product_attention(
-        mx.contiguous(q.transpose(1, 0, 2))[None],
-        mx.contiguous(k.transpose(1, 0, 2))[None],
-        mx.contiguous(v.transpose(1, 0, 2))[None],
+        q.transpose(1, 0, 2)[None],
+        k.transpose(1, 0, 2)[None],
+        v.transpose(1, 0, 2)[None],
         scale=scale,
     )[0].transpose(1, 0, 2)
 
@@ -456,13 +500,12 @@ def _reference_token_sdpa(q_tiled, k_tiled, v_tiled, block_mask: np.ndarray, geo
     import mlx.core as mx
 
     allow = _token_mask_from_block_mask(block_mask, geometry)
-    bias = mx.where(mx.array(allow), mx.array(0.0, dtype=mx.float32), mx.array(-1e9, dtype=mx.float32))
     return mx.fast.scaled_dot_product_attention(
         mx.contiguous(q_tiled.transpose(1, 0, 2))[None],
         mx.contiguous(k_tiled.transpose(1, 0, 2))[None],
         mx.contiguous(v_tiled.transpose(1, 0, 2))[None],
         scale=scale,
-        mask=bias[None],
+        mask=mx.array(allow)[None],
     )[0].transpose(1, 0, 2)
 
 
@@ -571,22 +614,20 @@ def _gate_compress_output(scores, v_tiled, gate_tiled, geometry: MiniMaxH3VSAGeo
 
 
 def resolve_impl(requested: VSAImpl, head_dim: int, tile_elems: int) -> str:
-    if requested in ("reference", "auto") and not _AUTO_PREFERS_SIMD:
+    if requested == "reference" or (requested == "auto" and not _AUTO_PREFERS_SIMD):
         return "reference"
 
     from fastvideo.mlx_runtime.minimax_h3_vsa_simd import simd_kernel_available, simd_kernel_error
 
     if tile_elems != 64 or head_dim != 128:
         if requested == "simd":
-            logger.warning(
-                "SIMD VSA requires tile 64 and head dim 128 (got tile=%s head_dim=%s); using reference VSA",
-                tile_elems,
-                head_dim,
-            )
+            logger.warning_once(
+                f"SIMD VSA requires tile 64 and head dim 128 (got tile={tile_elems} head_dim={head_dim}); "
+                "using reference VSA")
         return "reference"
     if not simd_kernel_available():
         reason = simd_kernel_error() or "SIMD-group VSA kernel is unavailable"
-        logger.warning("SIMD VSA kernel unavailable (%s); using reference VSA", reason)
+        logger.warning_once(f"SIMD VSA kernel unavailable ({reason}); using reference VSA")
         return "reference"
     return "simd"
 
@@ -606,7 +647,7 @@ def h3_vsa_attention(
     """Packed ``[S, H, D]`` VSA attention. Falls back to dense SDPA when sparsity is 0."""
     import mlx.core as mx
 
-    seq, heads, dim = query.shape
+    _, heads, dim = query.shape
     scale = dim**-0.5
     if stats is not None:
         stats.configured_sparsity = sparsity
@@ -646,17 +687,29 @@ def h3_vsa_attention(
             sparsity,
             exempt,
         )
+        if stats is not None and not exempt:
+            stats.video_keep = float(mx.mean(mx.sum(block_idx >= geometry.num_prefix_tiles, axis=-1)).item())
+            stats.achieved_sparsity = 1.0 - stats.video_keep / geometry.num_video_tiles
         chosen = resolve_impl(impl, dim, geometry.tile_elems)
-        prefix_out = _dense_sdpa(query[:geometry.prefix_length], key, value, scale)
+        if stats is not None and impl == "simd" and chosen != "simd":
+            from fastvideo.mlx_runtime.minimax_h3_vsa_simd import simd_kernel_error
+
+            stats.dense_fallback_reason = ("SIMD requires tile 64 and head dim 128"
+                                           if geometry.tile_elems != 64 or dim != 128 else simd_kernel_error())
+        prefix_out = (_dense_sdpa(query[:geometry.prefix_length], key, value, scale)
+                      if geometry.prefix_length else query[:0])
         n_prefix_pad = geometry.num_prefix_tiles * geometry.tile_elems
         if chosen == "simd":
-            from fastvideo.mlx_runtime.minimax_h3_vsa_simd import simd_block_sparse
+            from fastvideo.mlx_runtime.minimax_h3_vsa_simd import disable_simd_kernel, simd_block_sparse
 
             try:
                 video_tiled = simd_block_sparse(q_tiled, k_tiled, v_tiled, block_idx, block_num, geometry, scale)
+                # MLX compiles and executes custom Metal kernels lazily.
+                mx.eval(video_tiled)
                 video_tiled = video_tiled[n_prefix_pad:]
             except Exception as error:  # noqa: BLE001 - keep generation alive on kernel failure
-                logger.warning("SIMD VSA kernel failed (%s); falling back to reference gather+SDPA", error)
+                disable_simd_kernel(error)
+                logger.warning_once(f"SIMD VSA kernel failed ({error}); falling back to reference gather+SDPA")
                 chosen = "reference"
                 if stats is not None:
                     stats.dense_fallback_reason = f"simd kernel failed: {error}"
@@ -674,16 +727,12 @@ def h3_vsa_attention(
         else:
             video_tiled = _reference_gather_sdpa(q_tiled, k_tiled, v_tiled, block_idx, geometry, scale)
         video_tiled = video_tiled.astype(query.dtype)
-        prefix_tiled = _tile_hidden(
-            mx.concatenate([
-                prefix_out,
-                mx.zeros((seq - geometry.prefix_length, heads, dim), dtype=query.dtype),
-            ],
-                           axis=0),
-            geometry,
-        )
+        prefix_tiled = mx.concatenate([
+            prefix_out,
+            mx.zeros((1, heads, dim), dtype=query.dtype),
+        ])[geometry.prefix_gather_index]
         # Prefix query tiles are dense; keep fused-SDPA prefix rows and sparse video tiles.
-        out_tiled = mx.concatenate([prefix_tiled[:n_prefix_pad], video_tiled], axis=0)
+        out_tiled = mx.concatenate([prefix_tiled, video_tiled], axis=0)
 
     if gate_compress is not None:
         gate_tiled = _tile_hidden(gate_compress, geometry)

--- a/fastvideo/mlx_runtime/minimax_h3_vsa.py
+++ b/fastvideo/mlx_runtime/minimax_h3_vsa.py
@@ -48,6 +48,7 @@ VSA_IMPLS = PUBLIC_VSA_IMPLS
 # SIMD is opt-in until its dynamically routed output is accepted as the default.
 _AUTO_PREFERS_SIMD = False
 _REFERENCE_FULL_MASK_TILE_LIMIT = 24
+_REFERENCE_FULL_MASK_MAX_ELEMENTS = 256 * 1024**2
 
 PrefixMode = Literal["exempt", "compete"]
 VSAImpl = Literal["auto", "reference", "simd"]
@@ -465,6 +466,13 @@ def _reference_token_sdpa(q_tiled, k_tiled, v_tiled, block_mask: np.ndarray, geo
     )[0].transpose(1, 0, 2)
 
 
+def _reference_full_mask_fits(geometry: MiniMaxH3VSAGeometry, heads: int) -> bool:
+    """Bound the dense token mask by both tile count and materialized size."""
+    mask_elements = heads * geometry.padded_length**2
+    return (geometry.num_tiles <= _REFERENCE_FULL_MASK_TILE_LIMIT
+            and mask_elements <= _REFERENCE_FULL_MASK_MAX_ELEMENTS)
+
+
 def _gather_selected_kv(k_tiles, v_tiles, block_idx, tile_elems: int):
     """Gather K/V tiles for one query-tile batch.
 
@@ -511,7 +519,7 @@ def _reference_gather_sdpa(
     geometry: MiniMaxH3VSAGeometry,
     scale: float,
 ):
-    """Grouped gather + batched SDPA over video query tiles; prefix stays dense-equivalent.
+    """Grouped gather + batched SDPA over video query tiles.
 
     Full-sequence gather at 720p materializes tens of GiB of selected K/V, so
     query tiles are processed in memory-bounded chunks. This is the correctness
@@ -547,9 +555,7 @@ def _reference_gather_sdpa(
         mx.eval(out)
         chunks.append(out)
     out = mx.concatenate(chunks, axis=1) if len(chunks) > 1 else chunks[0]
-    video_flat = out.transpose(1, 2, 0, 3).reshape(n_q * tile_elems, heads, dim)
-    prefix = q_tiled[:geometry.num_prefix_tiles * tile_elems]
-    return mx.concatenate([prefix, video_flat], axis=0)
+    return out.transpose(1, 2, 0, 3).reshape(n_q * tile_elems, heads, dim)
 
 
 def _gate_compress_output(scores, v_tiled, gate_tiled, geometry: MiniMaxH3VSAGeometry):
@@ -642,19 +648,20 @@ def h3_vsa_attention(
         )
         chosen = resolve_impl(impl, dim, geometry.tile_elems)
         prefix_out = _dense_sdpa(query[:geometry.prefix_length], key, value, scale)
+        n_prefix_pad = geometry.num_prefix_tiles * geometry.tile_elems
         if chosen == "simd":
             from fastvideo.mlx_runtime.minimax_h3_vsa_simd import simd_block_sparse
 
             try:
                 video_tiled = simd_block_sparse(q_tiled, k_tiled, v_tiled, block_idx, block_num, geometry, scale)
+                video_tiled = video_tiled[n_prefix_pad:]
             except Exception as error:  # noqa: BLE001 - keep generation alive on kernel failure
                 logger.warning("SIMD VSA kernel failed (%s); falling back to reference gather+SDPA", error)
                 chosen = "reference"
                 if stats is not None:
                     stats.dense_fallback_reason = f"simd kernel failed: {error}"
                 video_tiled = _reference_gather_sdpa(q_tiled, k_tiled, v_tiled, block_idx, geometry, scale)
-            out_tiled = video_tiled
-        elif geometry.num_tiles <= _REFERENCE_FULL_MASK_TILE_LIMIT:
+        elif _reference_full_mask_fits(geometry, heads):
             scores_np = np.array(scores, dtype=np.float32)
             mask = build_block_mask(
                 scores_np,
@@ -663,10 +670,10 @@ def h3_vsa_attention(
                 sparsity,
                 exempt,
             )
-            out_tiled = _reference_token_sdpa(q_tiled, k_tiled, v_tiled, mask, geometry, scale)
+            video_tiled = _reference_token_sdpa(q_tiled, k_tiled, v_tiled, mask, geometry, scale)[n_prefix_pad:]
         else:
-            out_tiled = _reference_gather_sdpa(q_tiled, k_tiled, v_tiled, block_idx, geometry, scale)
-        out_tiled = out_tiled.astype(query.dtype)
+            video_tiled = _reference_gather_sdpa(q_tiled, k_tiled, v_tiled, block_idx, geometry, scale)
+        video_tiled = video_tiled.astype(query.dtype)
         prefix_tiled = _tile_hidden(
             mx.concatenate([
                 prefix_out,
@@ -676,8 +683,7 @@ def h3_vsa_attention(
             geometry,
         )
         # Prefix query tiles are dense; keep fused-SDPA prefix rows and sparse video tiles.
-        n_prefix_pad = geometry.num_prefix_tiles * geometry.tile_elems
-        out_tiled = mx.concatenate([prefix_tiled[:n_prefix_pad], out_tiled[n_prefix_pad:]], axis=0)
+        out_tiled = mx.concatenate([prefix_tiled[:n_prefix_pad], video_tiled], axis=0)
 
     if gate_compress is not None:
         gate_tiled = _tile_hidden(gate_compress, geometry)

--- a/fastvideo/mlx_runtime/minimax_h3_vsa_simd.py
+++ b/fastvideo/mlx_runtime/minimax_h3_vsa_simd.py
@@ -73,6 +73,7 @@ _SIMD_SOURCE = """
 
     thread simdgroup_float8x8 qfrag[16];
     for (int kk = 0; kk < 16; kk++) {
+        simdgroup_barrier(mem_flags::mem_threadgroup);
         int r0 = (int)lane / 8;
         int c0 = (int)lane % 8;
         int g0 = qrow0 + r0;
@@ -218,6 +219,13 @@ def simd_kernel_error() -> str | None:
     return _SIMD_KERNEL_ERROR
 
 
+def disable_simd_kernel(error: Exception) -> None:
+    """Remember a failed compile or execution so subsequent blocks use reference."""
+    global _SIMD_KERNEL, _SIMD_KERNEL_ERROR
+    _SIMD_KERNEL_ERROR = str(error)
+    _SIMD_KERNEL = None
+
+
 def simd_kernel_available() -> bool:
     return _simd_kernel() is not None
 
@@ -231,6 +239,9 @@ def _simd_kernel() -> Any | None:
     try:
         import mlx.core as mx
 
+        if not mx.metal.is_available():
+            _SIMD_KERNEL_ERROR = "Metal is not available in this MLX build"
+            return None
         if not hasattr(mx.fast, "metal_kernel"):
             _SIMD_KERNEL_ERROR = "mx.fast.metal_kernel is not available in this MLX build"
             return None
@@ -242,9 +253,21 @@ def _simd_kernel() -> Any | None:
             "header": _SIMD_HEADER,
         }
         try:
-            _SIMD_KERNEL = mx.fast.metal_kernel(**kwargs, compile_options={"math_mode": "safe"})
+            kernel = mx.fast.metal_kernel(**kwargs, compile_options={"math_mode": "safe"})
         except TypeError:
-            _SIMD_KERNEL = mx.fast.metal_kernel(**kwargs)
+            kernel = mx.fast.metal_kernel(**kwargs)
+        from fastvideo.mlx_runtime.minimax_h3_vsa import build_h3_tile_geometry
+
+        geometry = build_h3_tile_geometry((1, ), (4, 4, 4), 64)
+        indices = mx.array([[[0, 1]]], dtype=mx.int32)
+        counts = mx.array([[2]], dtype=mx.int32)
+        # Constructing a CustomKernel does not compile it. Execute every
+        # supported dtype once before advertising this backend as available.
+        for dtype in (mx.float32, mx.float16, mx.bfloat16):
+            q = mx.zeros((geometry.padded_length, 1, 128), dtype=dtype)
+            probe = _launch_simd_block_sparse(kernel, q, q, q, indices, counts, geometry, 128**-0.5)
+            mx.eval(probe)
+        _SIMD_KERNEL = kernel
     except Exception as error:  # noqa: BLE001 - keep reference usable
         _SIMD_KERNEL_ERROR = str(error)
         _SIMD_KERNEL = None
@@ -261,11 +284,17 @@ def simd_block_sparse(
     scale: float,
 ):
     """Block-sparse attention over tiled ``[S, H, D]`` using the reference tile map."""
-    import mlx.core as mx
 
     kernel = _simd_kernel()
     if kernel is None:
         raise RuntimeError(_SIMD_KERNEL_ERROR or "SIMD-group VSA kernel is unavailable")
+    return _launch_simd_block_sparse(kernel, q_tiled, k_tiled, v_tiled, block_idx, block_num, geometry, scale)
+
+
+def _launch_simd_block_sparse(kernel: Any, q_tiled: Any, k_tiled: Any, v_tiled: Any, block_idx: Any, block_num: Any,
+                              geometry: Any, scale: float) -> Any:
+    import mlx.core as mx
+
     if geometry.tile_elems != 64:
         raise ValueError(f"SIMD-group VSA kernel supports tile 64 only, got {geometry.tile_elems}")
     heads, dim = q_tiled.shape[1], q_tiled.shape[2]

--- a/fastvideo/mlx_runtime/minimax_h3_vsa_simd.py
+++ b/fastvideo/mlx_runtime/minimax_h3_vsa_simd.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SIMD-group block-sparse attention for MiniMax H3 VSA.
+
+This backend is an explicit opt-in. It supports tile size 64 and head dimension
+128, evaluates the tile map selected by the reference router, and leaves
+unsupported shapes to the reference implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+_SIMD_KERNEL = None
+_SIMD_KERNEL_ERROR: str | None = None
+
+_SIMD_HEADER = """
+#include <metal_stdlib>
+#include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
+using namespace metal;
+
+METAL_FUNC void scale_rows_simd8x8(thread simdgroup_float8x8 &mat, const threadgroup float *row_scale,
+                                   threadgroup float *tmp, uint lane) {
+    simdgroup_store(mat, tmp, 8);
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+    if (lane < 8) {
+        float s = row_scale[lane];
+        for (int c = 0; c < 8; c++) {
+            tmp[lane * 8 + c] *= s;
+        }
+    }
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+    simdgroup_load(mat, tmp, 8);
+}
+"""
+
+# One threadgroup = one (head, video query tile). 8 SIMD-groups x 32 = 256
+# threads cover 64 query rows. Q is half smem (16 KiB). K/V stage 8 keys.
+_SIMD_SOURCE = """
+    const int TILE = 64;
+    const int D = 128;
+    const int SG = 32;
+    const int N_SG = 8;
+    const int ROWS = 8;
+    const int KCHUNK = 8;
+    threadgroup float kvsmem[8 * 128];
+    threadgroup float score_smem[8 * 64];
+    threadgroup float scale_tmp[8 * 64];
+    threadgroup float qtile[8 * 64];
+    threadgroup float row_alpha[8 * 8];
+
+    uint tid = thread_position_in_threadgroup.x;
+    uint sid = tid / SG;
+    uint lane = tid % SG;
+    uint q_tile = thread_position_in_grid.y;
+    uint head = thread_position_in_grid.z;
+    int k_max = meta_i[4];
+    int n_prefix = meta_i[5];
+    int n_video = meta_i[6];
+    int S = meta_i[2];
+    float scale = meta_f[0];
+    bool active = ((int)q_tile < n_video && (int)head < (int)q_shape[0]);
+    int qt = n_prefix + (int)q_tile;
+    int q_valid = active ? vbs[qt] : 0;
+    int q_base_tile = (((int)head * S) + qt * TILE) * D;
+    threadgroup float *sg_scores = score_smem + sid * 64;
+    threadgroup float *sg_tmp = scale_tmp + sid * 64;
+    threadgroup float *sg_qtile = qtile + sid * 64;
+    threadgroup float *sg_alpha = row_alpha + sid * 8;
+    int qrow0 = (int)sid * ROWS;
+
+    thread simdgroup_float8x8 qfrag[16];
+    for (int kk = 0; kk < 16; kk++) {
+        int r0 = (int)lane / 8;
+        int c0 = (int)lane % 8;
+        int g0 = qrow0 + r0;
+        int g1 = qrow0 + r0 + 4;
+        float v0 = 0.0f;
+        float v1 = 0.0f;
+        if (active && g0 < q_valid) {
+            v0 = float(q[q_base_tile + g0 * D + kk * 8 + c0]);
+        }
+        if (active && g1 < q_valid) {
+            v1 = float(q[q_base_tile + g1 * D + kk * 8 + c0]);
+        }
+        sg_qtile[lane] = v0;
+        sg_qtile[lane + 32] = v1;
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        simdgroup_load(qfrag[kk], sg_qtile, 8);
+    }
+
+    thread simdgroup_float8x8 acc[16];
+    for (int kk = 0; kk < 16; kk++) {
+        acc[kk] = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+    }
+    float row_m = -3.402823466e+38f;
+    float row_lse = 0.0f;
+    int nsel = active ? block_num[(int)head * n_video + (int)q_tile] : 0;
+
+    for (int s = 0; s < nsel; s++) {
+        int kt = block_idx[(((int)head * n_video) + (int)q_tile) * k_max + s];
+        int k_valid = vbs[kt];
+        int kv_base = (((int)head * S) + kt * TILE) * D;
+        for (int j0 = 0; j0 < TILE; j0 += KCHUNK) {
+            for (uint i = tid; i < (uint)(KCHUNK * D); i += N_SG * SG) {
+                int row = (int)i / D;
+                int col = (int)i - row * D;
+                int gtok = j0 + row;
+                float val = 0.0f;
+                if (gtok < k_valid && gtok < TILE && col < D) {
+                    val = float(k[kv_base + gtok * D + col]);
+                }
+                kvsmem[i] = val;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            thread simdgroup_float8x8 smat = make_filled_simdgroup_matrix<float, 8, 8>(0.0f);
+            for (int kk = 0; kk < 16; kk++) {
+                simdgroup_float8x8 kmat;
+                simdgroup_load(kmat, (const threadgroup float*)(kvsmem + kk * 8), D, ulong2(0, 0), true);
+                simdgroup_multiply_accumulate(smat, qfrag[kk], kmat, smat);
+            }
+            simdgroup_store(smat, sg_scores, KCHUNK);
+            simdgroup_barrier(mem_flags::mem_threadgroup);
+
+            float scores[8];
+            float cmax = -3.402823466e+38f;
+            if (lane < (uint)ROWS) {
+                int grow = qrow0 + (int)lane;
+                for (int t = 0; t < KCHUNK; t++) {
+                    int gtok = j0 + t;
+                    float sc = -3.402823466e+38f;
+                    if (grow < q_valid && gtok < k_valid && gtok < TILE) {
+                        sc = sg_scores[(int)lane * KCHUNK + t] * scale;
+                    }
+                    scores[t] = sc;
+                    cmax = metal::max(cmax, sc);
+                }
+                float m_new = metal::max(row_m, cmax);
+                float alpha = metal::exp(row_m - m_new);
+                row_lse *= alpha;
+                row_m = m_new;
+                sg_alpha[(int)lane] = alpha;
+            }
+            simdgroup_barrier(mem_flags::mem_threadgroup);
+            for (int kk = 0; kk < 16; kk++) {
+                scale_rows_simd8x8(acc[kk], sg_alpha, sg_tmp, lane);
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            for (uint i = tid; i < (uint)(KCHUNK * D); i += N_SG * SG) {
+                int row = (int)i / D;
+                int col = (int)i - row * D;
+                int gtok = j0 + row;
+                float val = 0.0f;
+                if (gtok < k_valid && gtok < TILE && col < D) {
+                    val = float(v[kv_base + gtok * D + col]);
+                }
+                kvsmem[i] = val;
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            float local = 0.0f;
+            if (lane < (uint)ROWS) {
+                int grow = qrow0 + (int)lane;
+                for (int t = 0; t < KCHUNK; t++) {
+                    float w = 0.0f;
+                    if (grow < q_valid) {
+                        w = metal::exp(scores[t] - row_m);
+                    }
+                    sg_scores[(int)lane * KCHUNK + t] = w;
+                    local += w;
+                }
+                row_lse += local;
+            }
+            simdgroup_barrier(mem_flags::mem_threadgroup);
+
+            thread simdgroup_float8x8 pmat;
+            simdgroup_load(pmat, sg_scores, KCHUNK);
+            for (int kk = 0; kk < 16; kk++) {
+                simdgroup_float8x8 vmat;
+                simdgroup_load(vmat, (const threadgroup float*)(kvsmem + kk * 8), D);
+                simdgroup_multiply_accumulate(acc[kk], pmat, vmat, acc[kk]);
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+    }
+
+    if (lane < (uint)ROWS) {
+        sg_alpha[(int)lane] = row_lse > 0.0f ? 1.0f / row_lse : 0.0f;
+    }
+    simdgroup_barrier(mem_flags::mem_threadgroup);
+    for (int kk = 0; kk < 16; kk++) {
+        scale_rows_simd8x8(acc[kk], sg_alpha, sg_tmp, lane);
+        simdgroup_store(acc[kk], sg_tmp, 8);
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+        if (active) {
+            int r0 = (int)lane / 8;
+            int c0 = (int)lane % 8;
+            int g0 = qrow0 + r0;
+            int g1 = qrow0 + r0 + 4;
+            if (g0 < TILE) {
+                out[q_base_tile + g0 * D + kk * 8 + c0] = (g0 < q_valid) ? T(sg_tmp[lane]) : T(0);
+            }
+            if (g1 < TILE) {
+                out[q_base_tile + g1 * D + kk * 8 + c0] = (g1 < q_valid) ? T(sg_tmp[lane + 32]) : T(0);
+            }
+        }
+        simdgroup_barrier(mem_flags::mem_threadgroup);
+    }
+"""
+
+
+def simd_kernel_error() -> str | None:
+    _simd_kernel()
+    return _SIMD_KERNEL_ERROR
+
+
+def simd_kernel_available() -> bool:
+    return _simd_kernel() is not None
+
+
+def _simd_kernel() -> Any | None:
+    global _SIMD_KERNEL, _SIMD_KERNEL_ERROR
+    if _SIMD_KERNEL is not None:
+        return _SIMD_KERNEL
+    if _SIMD_KERNEL_ERROR is not None:
+        return None
+    try:
+        import mlx.core as mx
+
+        if not hasattr(mx.fast, "metal_kernel"):
+            _SIMD_KERNEL_ERROR = "mx.fast.metal_kernel is not available in this MLX build"
+            return None
+        kwargs: dict[str, Any] = {
+            "name": "h3_vsa_simdgroup_mma",
+            "input_names": ["q", "k", "v", "block_idx", "block_num", "vbs", "meta_i", "meta_f"],
+            "output_names": ["out"],
+            "source": _SIMD_SOURCE,
+            "header": _SIMD_HEADER,
+        }
+        try:
+            _SIMD_KERNEL = mx.fast.metal_kernel(**kwargs, compile_options={"math_mode": "safe"})
+        except TypeError:
+            _SIMD_KERNEL = mx.fast.metal_kernel(**kwargs)
+    except Exception as error:  # noqa: BLE001 - keep reference usable
+        _SIMD_KERNEL_ERROR = str(error)
+        _SIMD_KERNEL = None
+    return _SIMD_KERNEL
+
+
+def simd_block_sparse(
+    q_tiled,
+    k_tiled,
+    v_tiled,
+    block_idx,
+    block_num,
+    geometry,
+    scale: float,
+):
+    """Block-sparse attention over tiled ``[S, H, D]`` using the reference tile map."""
+    import mlx.core as mx
+
+    kernel = _simd_kernel()
+    if kernel is None:
+        raise RuntimeError(_SIMD_KERNEL_ERROR or "SIMD-group VSA kernel is unavailable")
+    if geometry.tile_elems != 64:
+        raise ValueError(f"SIMD-group VSA kernel supports tile 64 only, got {geometry.tile_elems}")
+    heads, dim = q_tiled.shape[1], q_tiled.shape[2]
+    if dim != 128:
+        raise ValueError(f"SIMD-group VSA kernel supports head dim 128, got {dim}")
+    q = mx.contiguous(q_tiled.transpose(1, 0, 2))
+    k = mx.contiguous(k_tiled.transpose(1, 0, 2))
+    v = mx.contiguous(v_tiled.transpose(1, 0, 2))
+    meta_i = mx.array(
+        [
+            dim,
+            geometry.tile_elems,
+            geometry.padded_length,
+            geometry.num_tiles,
+            int(block_idx.shape[-1]),
+            geometry.num_prefix_tiles,
+            geometry.num_video_tiles,
+        ],
+        dtype=mx.int32,
+    )
+    meta_f = mx.array([scale], dtype=mx.float32)
+    call_kwargs = {
+        "inputs": [
+            q,
+            k,
+            v,
+            mx.contiguous(block_idx.astype(mx.int32)),
+            mx.contiguous(block_num.astype(mx.int32)),
+            mx.array(geometry.variable_block_sizes.astype(np.int32)),
+            meta_i,
+            meta_f,
+        ],
+        "template": [("T", q.dtype)],
+        "grid": (256, geometry.num_video_tiles, heads),
+        "threadgroup": (256, 1, 1),
+        "output_shapes": [q.shape],
+        "output_dtypes": [q.dtype],
+    }
+    try:
+        outputs = kernel(**call_kwargs, init_value=0)
+    except TypeError:
+        outputs = kernel(**call_kwargs)
+    return outputs[0].transpose(1, 0, 2)

--- a/fastvideo/platforms/cpu.py
+++ b/fastvideo/platforms/cpu.py
@@ -5,7 +5,7 @@ import platform
 
 import torch
 
-from fastvideo.platforms.interface import CpuArchEnum, Platform, PlatformEnum
+from fastvideo.platforms.interface import AttentionBackendEnum, CpuArchEnum, Platform, PlatformEnum
 
 
 class CpuPlatform(Platform):
@@ -13,6 +13,14 @@ class CpuPlatform(Platform):
     device_name = "CPU"
     device_type = "cpu"
     dispatch_key = "CPU"
+
+    @classmethod
+    def get_attn_backend_cls(cls, selected_backend: AttentionBackendEnum | None, head_size: int,
+                             dtype: torch.dtype) -> str:
+        if selected_backend not in (None, AttentionBackendEnum.TORCH_SDPA):
+            raise NotImplementedError(f"{selected_backend.name} is not supported on CPU. "
+                                      "Set FASTVIDEO_ATTENTION_BACKEND to TORCH_SDPA.")
+        return "fastvideo.attention.backends.sdpa.SDPABackend"
 
     @classmethod
     def get_cpu_architecture(cls) -> CpuArchEnum:

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py
@@ -411,6 +411,19 @@ def test_reference_gather_path_matches_token_mask() -> None:
     assert mx.allclose(gather, masked, atol=2e-4, rtol=2e-4).item()
 
 
+def test_reference_full_mask_is_bounded_by_materialized_size() -> None:
+    from fastvideo.mlx_runtime import minimax_h3_vsa as vsa_mod
+
+    small = build_h3_tile_geometry((8, 0, 8), (4, 8, 8), tile_size=64)
+    assert vsa_mod._reference_full_mask_fits(small, heads=40)
+
+    # Twenty-four 256-token tiles pass the tile-count gate, but a 40-head
+    # token mask would contain more than 1.5 billion elements.
+    large = build_h3_tile_geometry((256, ), (4, 8, 184), tile_size=256)
+    assert large.num_tiles == 24
+    assert not vsa_mod._reference_full_mask_fits(large, heads=40)
+
+
 def test_prefix_segments_from_t2va_layout_drop_empty_condition() -> None:
     layout = MiniMaxH3PackedLayout(
         sequence_length=20,

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MLX MiniMax H3 VSA: geometry, routing, attention, converter, and Metal parity.
+
+None of these tests require a CUDA GPU. Geometry and routing compare against
+the CPU PyTorch H3 backend; attention tests use tiny deterministic MLX tensors.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("mlx.core", reason="MLX is required for MiniMax H3 VSA tests")
+torch = pytest.importorskip("torch", reason="PyTorch CPU supplies the H3 VSA routing oracle")
+
+import mlx.core as mx  # noqa: E402
+
+from fastvideo.attention.backends.video_sparse_attn_h3 import (  # noqa: E402
+    MiniMaxH3VSAMetadataBuilder,
+    _build_block_mask,
+)
+from fastvideo.mlx_runtime.fastwan import MLXQuantizationSpec, quantize_matrix  # noqa: E402
+from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
+    MiniMaxH3PackedLayout,
+    _is_ignored_dense_key,
+    _is_quantizable,
+    load_mlx_h3_checkpoint,
+    mlx_h3_checkpoint_vsa_capable,
+    save_mlx_h3_checkpoint,
+)
+from fastvideo.mlx_runtime.minimax_h3_vsa import (  # noqa: E402
+    MiniMaxH3VSAConfig,
+    VSA_GATE_KEY_SUFFIX,
+    build_block_mask,
+    build_h3_tile_geometry,
+    compute_topk,
+    expected_vsa_gate_keys,
+    h3_vsa_attention,
+    metal_kernel_available,
+    metal_supported,
+    parse_dense_layers,
+    prefix_segments_from_layout,
+    token_tile_and_valid,
+)
+
+_TINY = dict(raw_latent_shape=(8, 8, 12), patch_size=(1, 2, 2), prefix_segments=(7, 5, 3))
+_TINY64 = dict(raw_latent_shape=(9, 20, 26), patch_size=(1, 2, 2), prefix_segments=(70, 5, 130))
+_720P = dict(raw_latent_shape=(30, 44, 80), patch_size=(1, 2, 2), prefix_segments=(512, 1760, 400))
+_CPU = torch.device("cpu")
+
+
+def _dit_shape(spec: dict) -> tuple[int, int, int]:
+    raw, patch = spec["raw_latent_shape"], spec["patch_size"]
+    return raw[0] // patch[0], raw[1] // patch[1], raw[2] // patch[2]
+
+
+def _torch_meta(spec: dict, tile_size: int = 256, sparsity: float = 0.0):
+    return MiniMaxH3VSAMetadataBuilder().build(
+        current_timestep=0,
+        raw_latent_shape=spec["raw_latent_shape"],
+        patch_size=spec["patch_size"],
+        VSA_sparsity=sparsity,
+        prefix_segments=spec["prefix_segments"],
+        device=_CPU,
+        tile_size=tile_size,
+    )
+
+
+def test_geometry_matches_pytorch_720p_and_packed_order() -> None:
+    spec = _720P
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), tile_size=256)
+    meta = _torch_meta(spec, tile_size=256)
+    assert geo.total_seq_length == meta.total_seq_length == 512 + 1760 + 400 + 26400
+    assert geo.num_prefix_tiles == int(meta.num_prefix_tiles)
+    assert geo.num_video_tiles == int(meta.num_video_tiles)
+    assert np.array_equal(geo.variable_block_sizes, meta.variable_block_sizes.numpy())
+    assert np.array_equal(geo.untile_combined_index, meta.untile_combined_index.numpy())
+    boundaries = [512, 512 + 1760, 512 + 1760 + 400]
+    start = 0
+    for size in geo.variable_block_sizes[:geo.num_prefix_tiles].tolist():
+        end = start + size
+        assert all(not (start < boundary < end) for boundary in boundaries)
+        start = end
+    x = np.arange(geo.total_seq_length, dtype=np.int64)
+    buf = np.zeros(geo.padded_length, dtype=np.int64)
+    buf[geo.untile_combined_index] = x
+    assert np.array_equal(buf[geo.untile_combined_index], x)
+
+
+def test_geometry_tile64_ragged_tails() -> None:
+    spec = _TINY64
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), tile_size=64)
+    meta = _torch_meta(spec, tile_size=64)
+    assert geo.tile_elems == 64
+    assert geo.variable_block_sizes[:geo.num_prefix_tiles].tolist() == [64, 6, 5, 64, 64, 2]
+    assert np.array_equal(geo.variable_block_sizes, meta.variable_block_sizes.numpy())
+    assert np.array_equal(geo.untile_combined_index, meta.untile_combined_index.numpy())
+
+
+def test_routing_mask_parity_exempt_and_compete() -> None:
+    spec = _720P
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), 256)
+    rng = np.random.default_rng(0)
+    n = geo.num_tiles
+    scores = rng.standard_normal((1, 2, n, n)).astype(np.float32)
+    p, v = geo.num_prefix_tiles, geo.num_video_tiles
+    k_vid = compute_topk(0.9, v)
+    for exempt in (True, False):
+        mlx_mask = build_block_mask(scores, p, v, 0.9, exempt=exempt)
+        torch_mask = _build_block_mask(torch.tensor(scores), p, v, 0.9, exempt=exempt).numpy()
+        assert mlx_mask[:, :, :p].all()
+        if exempt:
+            assert mlx_mask[..., :p].all()
+            assert (mlx_mask[:, :, p:, p:].sum(-1) == k_vid).all()
+        else:
+            assert (mlx_mask[:, :, p:].sum(-1) == min(k_vid + p, n)).all()
+        assert np.array_equal(mlx_mask, torch_mask)
+
+
+def test_dense_non_video_queries_and_sparsity_zero_select_all() -> None:
+    spec = _TINY
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), 256)
+    scores = np.random.default_rng(1).standard_normal((1, 2, geo.num_tiles, geo.num_tiles))
+    dense = build_block_mask(scores, geo.num_prefix_tiles, geo.num_video_tiles, 0.0, exempt=True)
+    assert dense.all()
+    sparse = build_block_mask(scores, geo.num_prefix_tiles, geo.num_video_tiles, 0.75, exempt=True)
+    assert sparse[:, :, :geo.num_prefix_tiles].all()
+
+
+def test_pool_tiles_uses_fp32_accumulation() -> None:
+    from fastvideo.attention.backends.video_sparse_attn_h3 import _pool_tiles as torch_pool
+    from fastvideo.mlx_runtime.minimax_h3_vsa import _pool_tiles, _tile_hidden
+
+    spec = _TINY
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), 256)
+    mx.random.seed(11)
+    packed = mx.random.normal((geo.total_seq_length, 2, 8)).astype(mx.bfloat16)
+    tiled = _tile_hidden(packed, geo)
+    mlx_pooled = np.array(_pool_tiles(tiled, geo.variable_block_sizes, geo.tile_elems))
+    tiled_f32 = np.array(tiled.astype(mx.float32))
+    torch_pooled = torch_pool(
+        torch.tensor(tiled_f32, dtype=torch.bfloat16)[None],
+        torch.tensor(geo.variable_block_sizes, dtype=torch.int64),
+        geo.tile_elems,
+    )[0].float().numpy()
+    np.testing.assert_allclose(mlx_pooled, torch_pooled, rtol=2e-3, atol=2e-3)
+
+
+def test_block_indices_sets_match_argsort_mask() -> None:
+    from fastvideo.mlx_runtime.minimax_h3_vsa import _block_indices_from_scores
+
+    spec = _TINY64
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), 64)
+    rng = np.random.default_rng(12)
+    scores = rng.standard_normal((2, geo.num_tiles, geo.num_tiles)).astype(np.float32)
+    mask = build_block_mask(scores, geo.num_prefix_tiles, geo.num_video_tiles, 0.75, exempt=True)
+    idx, counts = _block_indices_from_scores(
+        mx.array(scores),
+        geo.num_prefix_tiles,
+        geo.num_video_tiles,
+        0.75,
+        True,
+    )
+    idx_np = np.array(idx)
+    counts_np = np.array(counts)
+    video_mask = mask[:, geo.num_prefix_tiles:]
+    for head in range(2):
+        for qtile in range(geo.num_video_tiles):
+            selected = set(idx_np[head, qtile, :int(counts_np[head, qtile])].tolist())
+            expected = set(np.flatnonzero(video_mask[head, qtile]).tolist())
+            assert selected == expected
+
+
+def test_dense_first_and_dense_layer_scheduling() -> None:
+    config = MiniMaxH3VSAConfig(enabled=True, sparsity=0.9, dense_first_n_steps=2, dense_layers=(3, 7))
+    assert config.layer_sparsity(0, 0) == 0.0
+    assert config.layer_sparsity(0, 1) == 0.0
+    assert config.layer_sparsity(0, 2) == pytest.approx(0.9)
+    assert config.layer_sparsity(3, 2) == 0.0
+    assert config.layer_sparsity(4, 2) == pytest.approx(0.9)
+    assert parse_dense_layers("0, 3, 7") == (0, 3, 7)
+    assert parse_dense_layers("") == ()
+
+
+def _tiny_qkv(seq: int, heads: int = 2, dim: int = 8, seed: int = 0):
+    mx.random.seed(seed)
+    q = mx.random.normal((seq, heads, dim))
+    k = mx.random.normal((seq, heads, dim))
+    v = mx.random.normal((seq, heads, dim))
+    return q, k, v
+
+
+def test_sparse_attention_parity_on_deterministic_small_tensors() -> None:
+    spec = _TINY
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), 256)
+    q, k, v = _tiny_qkv(geo.total_seq_length, seed=3)
+    out = h3_vsa_attention(q, k, v, geo, sparsity=0.5, exempt=True, impl="reference")
+    assert out.shape == q.shape
+    dense = h3_vsa_attention(q, k, v, geo, sparsity=0.0, exempt=True, impl="reference")
+    prefix = geo.prefix_length
+    assert mx.allclose(out[:prefix], dense[:prefix], atol=2e-4, rtol=2e-4).item()
+    assert not mx.allclose(out[prefix:], dense[prefix:], atol=1e-5, rtol=1e-5).item()
+
+
+def test_zero_gate_dense_mask_equivalence() -> None:
+    spec = _TINY
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), 256)
+    q, k, v = _tiny_qkv(geo.total_seq_length, seed=4)
+    zero_gate = mx.zeros_like(q)
+    sparse = h3_vsa_attention(q, k, v, geo, sparsity=0.0, gate_compress=zero_gate, impl="reference")
+    dense = h3_vsa_attention(q, k, v, geo, sparsity=0.0, gate_compress=None, impl="reference")
+    assert mx.allclose(sparse, dense, atol=2e-4, rtol=2e-4).item()
+
+
+def test_nonzero_gate_compression_changes_output() -> None:
+    spec = _TINY
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), 256)
+    q, k, v = _tiny_qkv(geo.total_seq_length, seed=5)
+    mx.random.seed(6)
+    gate = mx.random.normal(q.shape) * 0.1
+    with_gate = h3_vsa_attention(q, k, v, geo, sparsity=0.5, gate_compress=gate, impl="reference")
+    without = h3_vsa_attention(q, k, v, geo, sparsity=0.5, gate_compress=None, impl="reference")
+    assert not mx.allclose(with_gate, without, atol=1e-5, rtol=1e-5).item()
+
+
+def test_int6_converter_round_trip_fifty_gate_matrices() -> None:
+    spec = MLXQuantizationSpec.from_name("int6")
+    from fastvideo.mlx_runtime.fastwan import quantization_support_error
+
+    if quantization_support_error(spec) is not None:
+        pytest.skip(f"INT6 is not supported by this MLX build: {quantization_support_error(spec)}")
+    keys = expected_vsa_gate_keys(50)
+    assert len(keys) == 50
+    assert all(_is_quantizable(key, include_vsa=True) for key in keys)
+    assert not any(_is_ignored_dense_key(key, include_vsa=True) for key in keys)
+    assert all(_is_ignored_dense_key(key, include_vsa=False) for key in keys)
+    mx.random.seed(7)
+    snrs = []
+    for key in keys:
+        weight = mx.random.normal((64, 256)).astype(mx.float32)
+        quantized = quantize_matrix(weight, spec)
+        if hasattr(mx, "dequantize"):
+            restored = mx.dequantize(
+                quantized.weight,
+                quantized.scales,
+                quantized.biases,
+                group_size=spec.group_size,
+                bits=spec.bits,
+                mode=spec.mode,
+            )
+        else:
+            eye = mx.eye(weight.shape[1], dtype=weight.dtype)
+            restored = mx.quantized_matmul(
+                eye,
+                quantized.weight,
+                quantized.scales,
+                quantized.biases,
+                transpose=True,
+                group_size=spec.group_size,
+                bits=spec.bits,
+                mode=spec.mode,
+            ).T
+        noise = mx.mean((weight - restored.astype(weight.dtype))**2)
+        signal = mx.mean(weight**2)
+        snr = float((10.0 * mx.log10(signal / mx.maximum(noise, 1e-12))).item())
+        snrs.append(snr)
+        assert key.endswith(VSA_GATE_KEY_SUFFIX)
+    assert len(snrs) == 50
+    assert min(snrs) > 15.0
+
+
+def test_dense_legacy_checkpoint_compatible(tmp_path: Path) -> None:
+    from fastvideo.mlx_runtime.minimax_h3 import MLXMiniMaxH3DiT
+
+    config = {
+        "hidden_size": 4,
+        "num_attention_heads": 1,
+        "attention_head_dim": 4,
+        "ffn_dim": 4,
+        "in_channels": 4,
+        "audio_in_channels": 4,
+        "patch_size": [1, 2, 2],
+        "text_dim": 4,
+        "freq_dim": 4,
+        "time_embed_dim": 4,
+        "rope_freq_dim": 1,
+        "rope_theta": 10000.0,
+        "norm_eps": 1e-5,
+        "qk_norm_eps": 1e-5,
+        "final_norm_eps": 1e-5,
+    }
+    dit = MLXMiniMaxH3DiT(
+        {"proj_in.weight": mx.zeros((4, 8))},
+        [{"attn.to_q.weight": mx.zeros((4, 4))}],
+        [{"attn.to_q.weight": mx.zeros((4, 4))}],
+        config,
+    )
+    assert not dit.vsa_capable
+    out_dir = tmp_path / "dense"
+    save_mlx_h3_checkpoint(dit, out_dir)
+    loaded = load_mlx_h3_checkpoint(out_dir)
+    assert not loaded.vsa_capable
+    assert not mlx_h3_checkpoint_vsa_capable(out_dir)
+    loaded.configure_vsa(MiniMaxH3VSAConfig(enabled=False))
+    with pytest.raises(Exception, match="dense-only|include-vsa|to_gate_compress"):
+        loaded.configure_vsa(MiniMaxH3VSAConfig(enabled=True))
+
+
+def test_vsa_rejected_for_dense_only_checkpoint(tmp_path: Path) -> None:
+    from fastvideo.mlx_runtime.minimax_h3_pipeline import MiniMaxH3MLXPipeline
+
+    manifest = {
+        "format_version": 1,
+        "config": {"patch_size": [1, 2, 2], "in_channels": 8},
+        "quantized_keys": {},
+    }
+    ckpt = tmp_path / "dense_ckpt"
+    ckpt.mkdir()
+    (ckpt / "mlx_h3_dit.json").write_text(json.dumps(manifest))
+    (ckpt / "mlx_h3_dit.safetensors").write_bytes(b"")
+    model_root = tmp_path / "model"
+    (model_root / "vae").mkdir(parents=True)
+    (model_root / "audio_vae").mkdir()
+    (model_root / "vae" / "dummy.safetensors").write_bytes(b"x")
+    (model_root / "audio_vae" / "dummy.safetensors").write_bytes(b"x")
+    pipeline = MiniMaxH3MLXPipeline(model_root=model_root, mlx_dit_checkpoint=ckpt)
+    with pytest.raises(Exception, match="dense-only|include-vsa|to_gate_compress"):
+        pipeline.generate(
+            "prompt",
+            output_path=tmp_path / "out.mp4",
+            vsa=True,
+        )
+
+
+def test_metal_kernel_parity_with_reference() -> None:
+    if not metal_kernel_available():
+        pytest.skip("mx.fast.metal_kernel is not available")
+    spec = _TINY
+    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), 256)
+    if not metal_supported(8, geo.tile_elems):
+        pytest.skip("Metal VSA kernel does not support this tiny head dim/tile pair")
+    q, k, v = _tiny_qkv(geo.total_seq_length, seed=8)
+    reference = h3_vsa_attention(q, k, v, geo, sparsity=0.5, exempt=True, impl="reference")
+    metal = h3_vsa_attention(
+        q.astype(mx.bfloat16),
+        k.astype(mx.bfloat16),
+        v.astype(mx.bfloat16),
+        geo,
+        sparsity=0.5,
+        exempt=True,
+        impl="metal",
+    )
+    assert mx.allclose(metal.astype(mx.float32), reference.astype(mx.float32), atol=5e-2, rtol=5e-2).item()
+
+
+def test_reference_gather_path_matches_token_mask() -> None:
+    """Force the chunked gather fallback (n_tiles > 24) against the full-mask path."""
+    geo = build_h3_tile_geometry((8, 0, 8), (16, 8, 16), tile_size=64)
+    assert geo.num_tiles > 24
+    q, k, v = _tiny_qkv(geo.total_seq_length, seed=9)
+    gather = h3_vsa_attention(q, k, v, geo, sparsity=0.5, exempt=True, impl="reference")
+    from fastvideo.mlx_runtime import minimax_h3_vsa as vsa_mod
+
+    previous = vsa_mod._REFERENCE_FULL_MASK_TILE_LIMIT
+    vsa_mod._REFERENCE_FULL_MASK_TILE_LIMIT = geo.num_tiles + 1
+    try:
+        masked = h3_vsa_attention(q, k, v, geo, sparsity=0.5, exempt=True, impl="reference")
+    finally:
+        vsa_mod._REFERENCE_FULL_MASK_TILE_LIMIT = previous
+    assert mx.allclose(gather, masked, atol=2e-4, rtol=2e-4).item()
+
+
+def test_prefix_segments_from_t2va_layout_drop_empty_condition() -> None:
+    layout = MiniMaxH3PackedLayout(
+        sequence_length=20,
+        position_ids=np.zeros((20, 3)),
+        token_tags=np.zeros(20, dtype=np.int64),
+        video_indices=np.arange(12, 20),
+        audio_indices=np.arange(6, 12),
+        text_indices=np.arange(6),
+        num_condition_video_rows=0,
+        num_condition_audio_rows=0,
+        num_video_latent_frames=2,
+        latent_height=4,
+        latent_width=4,
+        num_audio_latents=3,
+    )
+    assert prefix_segments_from_layout(layout, (1, 2, 2)) == (6, 0, 6)
+
+
+def test_token_tile_and_valid_covers_pad_slots() -> None:
+    geo = build_h3_tile_geometry((7, 5, 3), (8, 4, 6), 256)
+    tile, valid = token_tile_and_valid(geo.variable_block_sizes, geo.tile_elems)
+    assert tile.shape == valid.shape == (geo.padded_length, )
+    assert int(valid.sum()) == geo.total_seq_length

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py
@@ -342,7 +342,10 @@ def test_simd_kernel_parity_with_reference_identical_tiles() -> None:
         pytest.skip("SIMD-group VSA kernel is not available")
     geo = build_h3_tile_geometry((16, 16), (8, 8, 8), tile_size=64)
     q, k, v = _tiny_qkv(geo.total_seq_length, heads=2, dim=128, seed=11)
+    q, k, v = [x.astype(mx.bfloat16) for x in (q, k, v)]
     reference = h3_vsa_attention(q, k, v, geo, sparsity=0.5, exempt=True, impl="reference")
+    from fastvideo.mlx_runtime.minimax_h3_vsa import MiniMaxH3VSAStats
+    stats = MiniMaxH3VSAStats()
     simd = h3_vsa_attention(
         q.astype(mx.bfloat16),
         k.astype(mx.bfloat16),
@@ -351,7 +354,10 @@ def test_simd_kernel_parity_with_reference_identical_tiles() -> None:
         sparsity=0.5,
         exempt=True,
         impl="simd",
+        stats=stats,
     )
+    mx.eval(simd)
+    assert stats.impl == "simd" and stats.dense_fallback_reason is None
     _, valid = token_tile_and_valid(geo.variable_block_sizes, geo.tile_elems)
     # Packed rows are valid tokens only after untile.
     assert mx.allclose(simd.astype(mx.float32), reference.astype(mx.float32), atol=5e-2, rtol=5e-2).item()

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""MLX MiniMax H3 VSA: geometry, routing, attention, converter, and Metal parity.
+"""MLX MiniMax H3 VSA: geometry, routing, conversion, and SIMD parity.
 
 None of these tests require a CUDA GPU. Geometry and routing compare against
 the CPU PyTorch H3 backend; attention tests use tiny deterministic MLX tensors.
@@ -33,18 +33,20 @@ from fastvideo.mlx_runtime.minimax_h3 import (  # noqa: E402
 )
 from fastvideo.mlx_runtime.minimax_h3_vsa import (  # noqa: E402
     MiniMaxH3VSAConfig,
+    PUBLIC_VSA_IMPLS,
     VSA_GATE_KEY_SUFFIX,
+    _untile_hidden,
     build_block_mask,
     build_h3_tile_geometry,
     compute_topk,
     expected_vsa_gate_keys,
     h3_vsa_attention,
-    metal_kernel_available,
-    metal_supported,
     parse_dense_layers,
     prefix_segments_from_layout,
+    resolve_impl,
     token_tile_and_valid,
 )
+from fastvideo.mlx_runtime.minimax_h3_vsa_simd import simd_kernel_available  # noqa: E402
 
 _TINY = dict(raw_latent_shape=(8, 8, 12), patch_size=(1, 2, 2), prefix_segments=(7, 5, 3))
 _TINY64 = dict(raw_latent_shape=(9, 20, 26), patch_size=(1, 2, 2), prefix_segments=(70, 5, 130))
@@ -335,25 +337,61 @@ def test_vsa_rejected_for_dense_only_checkpoint(tmp_path: Path) -> None:
         )
 
 
-def test_metal_kernel_parity_with_reference() -> None:
-    if not metal_kernel_available():
-        pytest.skip("mx.fast.metal_kernel is not available")
-    spec = _TINY
-    geo = build_h3_tile_geometry(spec["prefix_segments"], _dit_shape(spec), 256)
-    if not metal_supported(8, geo.tile_elems):
-        pytest.skip("Metal VSA kernel does not support this tiny head dim/tile pair")
-    q, k, v = _tiny_qkv(geo.total_seq_length, seed=8)
+def test_simd_kernel_parity_with_reference_identical_tiles() -> None:
+    if not simd_kernel_available():
+        pytest.skip("SIMD-group VSA kernel is not available")
+    geo = build_h3_tile_geometry((16, 16), (8, 8, 8), tile_size=64)
+    q, k, v = _tiny_qkv(geo.total_seq_length, heads=2, dim=128, seed=11)
     reference = h3_vsa_attention(q, k, v, geo, sparsity=0.5, exempt=True, impl="reference")
-    metal = h3_vsa_attention(
+    simd = h3_vsa_attention(
         q.astype(mx.bfloat16),
         k.astype(mx.bfloat16),
         v.astype(mx.bfloat16),
         geo,
         sparsity=0.5,
         exempt=True,
-        impl="metal",
+        impl="simd",
     )
-    assert mx.allclose(metal.astype(mx.float32), reference.astype(mx.float32), atol=5e-2, rtol=5e-2).item()
+    _, valid = token_tile_and_valid(geo.variable_block_sizes, geo.tile_elems)
+    # Packed rows are valid tokens only after untile.
+    assert mx.allclose(simd.astype(mx.float32), reference.astype(mx.float32), atol=5e-2, rtol=5e-2).item()
+    assert valid.sum() == geo.total_seq_length
+
+
+def test_untile_hidden_never_consumes_padded_query_rows() -> None:
+    """Pad slots exist in the tiled buffer; _untile_hidden must never gather them.
+
+    The SIMD kernel may zero padded query rows only because this gather map is
+    the exclusive consumer of tiled attention output.
+    """
+    geo = build_h3_tile_geometry((18, 414), (37, 15, 26), tile_size=64)
+    _, valid = token_tile_and_valid(geo.variable_block_sizes, geo.tile_elems)
+    pad_slots = np.flatnonzero(~valid.astype(bool))
+    assert pad_slots.size > 0
+    gathered = set(int(i) for i in geo.untile_combined_index.tolist())
+    assert gathered.isdisjoint(int(i) for i in pad_slots.tolist())
+    assert geo.untile_combined_index.shape == (geo.total_seq_length, )
+
+    buf = np.ones((geo.padded_length, 2, 4), dtype=np.float32)
+    buf[~valid.astype(bool)] = 999.0
+    out = _untile_hidden(mx.array(buf), geo)
+    mx.eval(out)
+    assert out.shape[0] == geo.total_seq_length
+    assert not bool(mx.any(out == 999.0).item())
+    assert bool(mx.all(out == 1.0).item())
+
+
+def test_simd_unsupported_tile_falls_back_to_reference() -> None:
+    assert PUBLIC_VSA_IMPLS == ("auto", "reference", "simd")
+    assert "metal" not in PUBLIC_VSA_IMPLS
+    assert resolve_impl("simd", head_dim=128, tile_elems=256) == "reference"
+    assert resolve_impl("simd", head_dim=64, tile_elems=64) == "reference"
+    assert resolve_impl("auto", head_dim=128, tile_elems=64) == "reference"
+    geo = build_h3_tile_geometry((8, 0, 8), (8, 8, 8), tile_size=256)
+    q, k, v = _tiny_qkv(geo.total_seq_length, heads=2, dim=128, seed=12)
+    explicit = h3_vsa_attention(q, k, v, geo, sparsity=0.5, exempt=True, impl="reference")
+    fallback = h3_vsa_attention(q, k, v, geo, sparsity=0.5, exempt=True, impl="simd")
+    assert mx.allclose(explicit, fallback, atol=0, rtol=0).item()
 
 
 def test_reference_gather_path_matches_token_mask() -> None:

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa_regressions.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_vsa_regressions.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression coverage for H3 VSA configuration, conversion, and lazy dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from fastvideo.mlx_runtime import minimax_h3 as h3
+from fastvideo.mlx_runtime import minimax_h3_vsa as vsa
+from fastvideo.mlx_runtime import minimax_h3_vsa_simd as simd
+from fastvideo.mlx_runtime.fastwan import MLXQuantizationSpec, QuantizedMatrix, quantize_matrix
+
+
+def _config():
+    return dict(hidden_size=64, num_attention_heads=1, attention_head_dim=64,
+                ffn_dim=64, in_channels=4, audio_in_channels=4, patch_size=[1, 2, 2],
+                text_dim=64, freq_dim=64, time_embed_dim=64, rope_freq_dim=8,
+                rope_theta=10000., norm_eps=1e-5, qk_norm_eps=1e-5, final_norm_eps=1e-5,
+                num_layers=2, num_refiner_layers=0)
+
+
+def _dit(capable=True):
+    blocks = [{"attn.to_q.weight": mx.zeros((64, 64))} for _ in range(2)]
+    if capable:
+        for block in blocks:
+            block["attn.to_gate_compress.weight"] = mx.zeros((64, 64))
+    return h3.MLXMiniMaxH3DiT({}, blocks, [], _config())
+
+
+@pytest.mark.parametrize("dtype", [mx.float32, mx.float16, mx.bfloat16])
+@pytest.mark.parametrize("prefix", [(), (7, 5)])
+def test_gather_tiling_equals_scatter_with_ragged_padding(dtype, prefix):
+    geometry = vsa.build_h3_tile_geometry(prefix, (5, 3, 7), 64)
+    x = mx.random.normal((geometry.total_seq_length, 2, 8)).astype(dtype)
+    expected = mx.zeros((geometry.padded_length, 2, 8), dtype=dtype)
+    expected = expected.at[mx.array(geometry.untile_combined_index)].add(x)
+    actual = vsa._tile_hidden(x, geometry)
+    assert mx.array_equal(actual, expected).item()
+    assert mx.array_equal(vsa._untile_hidden(actual, geometry), x).item()
+    assert geometry.tile_gather_index is geometry.tile_gather_index
+    prefix_tiled = mx.concatenate([x[:geometry.prefix_length], mx.zeros((1, 2, 8), dtype=dtype)])[
+        geometry.prefix_gather_index]
+    assert mx.array_equal(prefix_tiled, expected[:geometry.num_prefix_tiles * 64]).item()
+
+
+@pytest.mark.parametrize("exempt", [True, False])
+def test_small_canvas_bf16_mask_and_compete_stats(monkeypatch, exempt):
+    geometry = vsa.build_h3_tile_geometry((7, 5), (8, 4, 8), 64)
+    mx.random.seed(13)
+    q, k, value = [mx.random.normal((geometry.total_seq_length, 2, 128)).astype(mx.bfloat16)
+                   for _ in range(3)]
+    stats = vsa.MiniMaxH3VSAStats()
+    out = vsa.h3_vsa_attention(q, k, value, geometry, sparsity=.75, exempt=exempt,
+                               impl="reference", stats=stats)
+    mx.eval(out)
+    assert out.dtype == mx.bfloat16
+    assert mx.all(mx.isfinite(out)).item()
+    qt, kt = vsa._tile_hidden(q, geometry), vsa._tile_hidden(k, geometry)
+    scores = (vsa._pool_tiles(qt, geometry.variable_block_sizes, 64) @
+              vsa._pool_tiles(kt, geometry.variable_block_sizes, 64).transpose(0, 2, 1)) / 128**.5
+    mask = vsa.build_block_mask(np.asarray(scores), geometry.num_prefix_tiles,
+                               geometry.num_video_tiles, .75, exempt)
+    kept = mask[:, geometry.num_prefix_tiles:, geometry.num_prefix_tiles:].sum(-1).mean()
+    assert stats.video_keep == pytest.approx(kept)
+    assert stats.achieved_sparsity == pytest.approx(1 - kept / geometry.num_video_tiles)
+    monkeypatch.setattr(vsa, "_REFERENCE_FULL_MASK_TILE_LIMIT", 0)
+    gathered = vsa.h3_vsa_attention(q, k, value, geometry, sparsity=.75, exempt=exempt, impl="reference")
+    np.testing.assert_allclose(np.asarray(out.astype(mx.float32)), np.asarray(gathered.astype(mx.float32)),
+                               atol=.004, rtol=.004)
+
+
+def test_reference_dispatch_ignores_auto_preference(monkeypatch):
+    monkeypatch.setattr(vsa, "_AUTO_PREFERS_SIMD", True)
+    monkeypatch.setattr(simd, "simd_kernel_available", lambda: pytest.fail("reference must not probe SIMD"))
+    assert vsa.resolve_impl("reference", 128, 64) == "reference"
+
+
+@pytest.mark.parametrize("shape", [(0, 4, 4), (4, -1, 4), (4, 4, 0)])
+def test_invalid_video_axes_return_a_reason(shape):
+    assert "positive" in vsa.geometry_is_supported((4,), shape, 64)
+
+
+@pytest.mark.parametrize("layers", ["10", (-1,), (1.5,), (True,)])
+def test_invalid_dense_layers_are_rejected(layers):
+    with pytest.raises(ValueError, match="non-negative integer"):
+        vsa.MiniMaxH3VSAConfig(dense_layers=layers)
+
+
+def test_configuration_is_transactional_and_invalidates_geometry():
+    dense = _dit(capable=False)
+    before = dense.vsa_config
+    with pytest.raises(vsa.DenseOnlyVSACheckpointError):
+        dense.configure_vsa(vsa.MiniMaxH3VSAConfig(enabled=True))
+    assert dense.vsa_config is before
+    dit = _dit()
+    dit.configure_vsa(vsa.MiniMaxH3VSAConfig(enabled=True))
+    layout = h3.build_packed_layout(6, 2, 8, 16, 3, patch_size=(1, 2, 2))
+    first = dit.prepare_vsa_geometry(layout)
+    assert dit.prepare_vsa_geometry(layout) is first
+    swapped = h3.build_packed_layout(6, 2, 16, 8, 3, patch_size=(1, 2, 2))
+    second = dit.prepare_vsa_geometry(swapped)
+    assert first.total_seq_length == second.total_seq_length
+    assert second.dit_seq_shape != first.dit_seq_shape
+    assert second is not first
+    with pytest.raises(ValueError, match="block count"):
+        dit.configure_vsa(vsa.MiniMaxH3VSAConfig(enabled=True, dense_layers=(2,)))
+    assert dit._vsa_geometry is second
+    dit.configure_vsa(vsa.MiniMaxH3VSAConfig(enabled=True, tile_size=256))
+    assert dit._vsa_geometry is None
+    assert dit.prepare_vsa_geometry(layout).tile_elems == 256
+
+
+@pytest.fixture
+def tiny_h3_model(monkeypatch, request):
+    from fastvideo.tests.mlx.tiny_h3 import build_hf_config, build_tiny_h3_config, build_torch_model
+    from fastvideo.tests.mlx.tiny_h3 import mlx_dit_from_torch_model
+
+    monkeypatch.setenv("MASTER_ADDR", "localhost")
+    monkeypatch.setenv("MASTER_PORT", "29513")
+    request.getfixturevalue("distributed_setup")
+    return mlx_dit_from_torch_model(build_torch_model(), build_hf_config(build_tiny_h3_config()))
+
+
+def test_cached_forward_refreshes_geometry_and_collects_every_block(tiny_h3_model):
+    source = tiny_h3_model
+    for block in source.blocks:
+        block["attn.to_gate_compress.weight"] = mx.full((512, 256), .001)
+    dit = h3.MLXMiniMaxH3DiT(source.weights, source.blocks, source.refiner, source.config)
+    dit.configure_vsa(vsa.MiniMaxH3VSAConfig(enabled=True, sparsity=.5, dense_layers=(0,)))
+    first_geometry = None
+    for height, width in ((4, 8), (8, 4)):
+        layout = h3.build_packed_layout(6, 8, height, width, 3, patch_size=(1, 2, 2))
+        timesteps, inverse = h3.build_row_timesteps(layout, .7, .4)
+        if dit._adaln_cache is None:
+            dit.precompute_adaln(timesteps)
+        output = dit.forward_with_cache(
+            mx.zeros((len(layout.video_indices), dit.patch_dim)),
+            mx.zeros((len(layout.audio_indices), dit.audio_in_channels)),
+            mx.zeros((6, dit.text_dim)), layout=layout,
+            step_timesteps=timesteps, row_timestep_inverse=inverse)
+        mx.eval(output)
+        assert all(mx.all(mx.isfinite(x)).item() for x in output)
+        if first_geometry is None:
+            first_geometry = dit._vsa_geometry
+        else:
+            assert dit._vsa_geometry is not first_geometry
+            assert dit._vsa_geometry.dit_seq_shape == (8, 4, 2)
+    assert dit.last_vsa_stats.attention_calls == 4
+    assert dit.last_vsa_stats.impl_counts == {"dense": 2, "reference": 2}
+
+
+def test_dense_generate_ignores_unused_vsa_parameters(tmp_path, monkeypatch):
+    from fastvideo.mlx_runtime import minimax_h3_pipeline as pipeline_mod
+
+    pipeline = object.__new__(pipeline_mod.MiniMaxH3MLXPipeline)
+    pipeline.dit_checkpoint = tmp_path
+    monkeypatch.setattr(pipeline_mod, "_validate_checkpoint_step_ladder", lambda *a: None)
+    def stop_at_media_preflight(**kwargs):
+        raise RuntimeError("reached media preflight")
+    monkeypatch.setattr(pipeline_mod, "_preflight_media_dependencies", stop_at_media_preflight)
+    with pytest.raises(RuntimeError, match="reached media preflight"):
+        pipeline.generate("test", output_path=tmp_path / "unused.mp4", vsa=False,
+                          vsa_sparsity=1., vsa_tile_size=-1, vsa_dense_layers="10", vsa_impl="invalid")
+    with pytest.raises(ValueError, match="sparsity"):
+        pipeline.generate("test", output_path=tmp_path / "unused.mp4", vsa=True, vsa_sparsity=1.)
+
+
+def test_forward_rejects_vsa_before_computing():
+    dit = _dit()
+    dit.configure_vsa(vsa.MiniMaxH3VSAConfig(enabled=True))
+    with pytest.raises(ValueError, match="forward_with_cache"):
+        dit.forward(None, None, None, position_ids=None, token_tags=None,
+                    timestep_indices=None, timesteps=None, video_indices=None,
+                    audio_indices=None, text_indices=None)
+
+
+@pytest.mark.parametrize("fmt", ["int8", "int6", "int4"])
+def test_quantized_zero_and_constant_gate_detection(fmt):
+    spec = MLXQuantizationSpec.from_name(fmt)
+    zero = quantize_matrix(mx.zeros((64, 64), dtype=mx.bfloat16), spec)
+    constant = quantize_matrix(mx.full((64, 64), .25, dtype=mx.bfloat16), spec)
+    assert not h3._gate_weight_is_active(zero)
+    assert h3._gate_weight_is_active(constant)
+
+
+@pytest.mark.parametrize("fmt", ["int8", "int6", "int4"])
+def test_convert_save_load_preserves_quantized_gates(tmp_path, fmt):
+    source = tmp_path / "source.safetensors"
+    mx.random.seed(17)
+    arrays = {}
+    for i in range(2):
+        arrays[f"transformer_blocks.{i}.attn.to_q.weight"] = mx.random.normal((64, 64))
+        arrays[vsa.vsa_gate_key(i)] = mx.random.normal((64, 64))
+    mx.save_safetensors(str(source), arrays)
+    converted = h3.mlx_h3_dit_from_diffusers_safetensors(
+        source, _config(), dtype="bf16", quantization=fmt, include_vsa=True)
+    output = tmp_path / fmt
+    h3.save_mlx_h3_checkpoint(converted, output)
+    loaded = h3.load_mlx_h3_checkpoint(output)
+    assert loaded.vsa_capable and h3.mlx_h3_checkpoint_vsa_capable(output)
+    manifest = json.loads((output / h3.H3_MANIFEST_FILENAME).read_text())
+    assert manifest["vsa"]["num_gate_matrices"] == 2
+    for i in range(2):
+        gate = loaded.blocks[i]["attn.to_gate_compress.weight"]
+        original = converted.blocks[i]["attn.to_gate_compress.weight"]
+        assert isinstance(gate, QuantizedMatrix)
+        assert f"blocks.{i}.attn.to_gate_compress.weight" in manifest["quantized_keys"]
+        for name in ("weight", "scales", "biases"):
+            assert mx.array_equal(getattr(gate, name), getattr(original, name)).item()
+    del arrays[vsa.vsa_gate_key(1)]
+    mx.save_safetensors(str(source), arrays)
+    with pytest.raises(KeyError, match="gate projections are missing"):
+        h3.mlx_h3_dit_from_diffusers_safetensors(source, _config(), include_vsa=True)
+
+
+def test_stats_include_dense_overrides_and_later_fallbacks():
+    dit = _dit()
+    dit.configure_vsa(vsa.MiniMaxH3VSAConfig(enabled=True, sparsity=.75, dense_layers=(0,)))
+    dit.prepare_vsa_geometry(h3.build_packed_layout(6, 8, 8, 16, 3, patch_size=(1, 2, 2)))
+    geometry = dit._vsa_geometry
+    q = mx.random.normal((geometry.total_seq_length, 1, 8))
+    for step in range(2):
+        for block in range(2):
+            kwargs = dit._vsa_block_kwargs(block, step)
+            call = kwargs["vsa_stats"]
+            vsa.h3_vsa_attention(q, q, q, geometry, sparsity=kwargs["vsa_sparsity"],
+                                 impl="reference", stats=call)
+            if step == 1 and block == 1:
+                call.dense_fallback_reason = "simulated later-block failure"
+            dit.last_vsa_stats.record(call)
+    stats = dit.last_vsa_stats
+    assert stats.configured_sparsity == .75
+    assert stats.attention_calls == 4 and stats.sparse_calls == 2
+    assert stats.impl_counts == {"dense": 2, "reference": 2}
+    assert stats.impl == "mixed"
+    assert stats.achieved_sparsity == pytest.approx(.375)
+    assert stats.fallback_reasons == ["simulated later-block failure"]
+    dit.reset_vsa_stats()
+    assert dit.last_vsa_stats.attention_calls == 0
+
+
+def test_no_metal_probe_is_cached(monkeypatch):
+    monkeypatch.setattr(simd, "_SIMD_KERNEL", None)
+    monkeypatch.setattr(simd, "_SIMD_KERNEL_ERROR", None)
+    monkeypatch.setattr(mx.metal, "is_available", lambda: False)
+    assert not simd.simd_kernel_available()
+    assert "Metal is not available" in simd.simd_kernel_error()
+    monkeypatch.setattr(mx.metal, "is_available", lambda: pytest.fail("failed probe retried"))
+    assert not simd.simd_kernel_available()
+
+
+def _require_metal():
+    if not mx.metal.is_available() or mx.default_device() != mx.gpu:
+        pytest.skip("requires actual Metal execution")
+
+
+def test_probe_evaluates_lazy_compile_and_caches_failure(monkeypatch):
+    _require_metal()
+    monkeypatch.setattr(simd, "_SIMD_KERNEL", None)
+    monkeypatch.setattr(simd, "_SIMD_KERNEL_ERROR", None)
+    monkeypatch.setattr(simd, "_SIMD_SOURCE", "invalid_metal_source_for_test;")
+    assert not simd.simd_kernel_available()
+    assert simd.simd_kernel_error()
+    monkeypatch.setattr(mx.fast, "metal_kernel", lambda **kwargs: pytest.fail("failed compile retried"))
+    assert not simd.simd_kernel_available()
+
+
+def test_lazy_execution_failure_falls_back_and_disables_simd(monkeypatch):
+    _require_metal()
+    monkeypatch.setattr(simd, "_SIMD_KERNEL", None)
+    monkeypatch.setattr(simd, "_SIMD_KERNEL_ERROR", None)
+    monkeypatch.setattr(vsa, "resolve_impl", lambda *args: "simd")
+    kernel = mx.fast.metal_kernel(name="h3_test_invalid_kernel", input_names=["x"],
+                                 output_names=["out"], source="invalid_metal_source_for_test;")
+    def fail_lazily(q, *args):
+        return kernel(inputs=[q], grid=(1, 1, 1), threadgroup=(1, 1, 1),
+                      output_shapes=[q.shape], output_dtypes=[q.dtype])[0]
+    monkeypatch.setattr(simd, "simd_block_sparse", fail_lazily)
+    geometry = vsa.build_h3_tile_geometry((4,), (4, 4, 4), 64)
+    q = mx.ones((geometry.total_seq_length, 1, 128), dtype=mx.bfloat16)
+    stats = vsa.MiniMaxH3VSAStats()
+    out = vsa.h3_vsa_attention(q, q, q, geometry, sparsity=.5, impl="simd", stats=stats)
+    mx.eval(out)
+    assert mx.array_equal(out, q).item()
+    assert stats.impl == "reference" and "simd kernel failed" in stats.dense_fallback_reason
+    assert not simd.simd_kernel_available()
+
+
+def test_cli_help_and_validation_without_site_packages():
+    script = Path(__file__).resolve().parents[3] / "examples/inference/basic/mlx_fasth3.py"
+    result = subprocess.run([sys.executable, "-S", str(script), "--help"], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert "--vsa-impl" in result.stdout
+    for value in ("-1", "oops"):
+        result = subprocess.run([sys.executable, "-S", str(script), "--mlx-checkpoint", "missing",
+                                 "--prompt", "test", "--output-path", "unused.mp4",
+                                 "--vsa-dense-layers", value], capture_output=True, text=True)
+        assert result.returncode == 2
+        assert "--vsa-dense-layers" in result.stderr and "Traceback" not in result.stderr
+
+
+def test_converter_continues_past_mismatched_existing_format(tmp_path, monkeypatch):
+    path = Path(__file__).resolve().parents[3] / "scripts/checkpoint_conversion/convert_minimax_h3_mlx.py"
+    spec = importlib.util.spec_from_file_location("h3_converter_regression", path)
+    converter = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(converter)
+    existing = tmp_path / "int8"
+    existing.mkdir()
+    (existing / h3.H3_MANIFEST_FILENAME).write_text(json.dumps({"vsa": {"capable": False}}))
+    (existing / h3.H3_WEIGHTS_FILENAME).write_bytes(b"existing")
+    monkeypatch.setattr(converter, "parse_args", lambda: argparse.Namespace(
+        formats="int8 int6", out=tmp_path, model_root="unused", include_vsa=True))
+    monkeypatch.setattr(converter, "mlx_h3_dit_from_diffusers_safetensors", lambda *a, **k: _dit())
+    saved = []
+    monkeypatch.setattr(converter, "save_mlx_h3_checkpoint", lambda model, path: saved.append(path.name))
+    converter.main()
+    assert saved == ["int6"]
+    assert (existing / h3.H3_WEIGHTS_FILENAME).read_bytes() == b"existing"

--- a/fastvideo/tests/platforms/test_cpu_sdpa.py
+++ b/fastvideo/tests/platforms/test_cpu_sdpa.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU reference models must resolve real SDPA without a CUDA backend."""
+
+import pytest
+import torch
+
+from fastvideo.platforms.cpu import CpuPlatform
+from fastvideo.platforms.interface import AttentionBackendEnum
+
+
+@pytest.mark.parametrize("requested", [None, AttentionBackendEnum.TORCH_SDPA])
+def test_cpu_sdpa_resolution_through_selector(monkeypatch, requested):
+    from fastvideo import platforms
+    from fastvideo.attention.backends.sdpa import SDPABackend
+    from fastvideo.attention.selector import _cached_get_attn_backend, get_attn_backend
+
+    monkeypatch.setattr(platforms, "current_platform", CpuPlatform())
+    _cached_get_attn_backend.cache_clear()
+    try:
+        backend = get_attn_backend(64, torch.float32, (AttentionBackendEnum.TORCH_SDPA,), requested=requested)
+        assert backend is SDPABackend
+    finally:
+        _cached_get_attn_backend.cache_clear()
+
+
+def test_cpu_rejects_sparse_backend_instead_of_changing_attention():
+    with pytest.raises(NotImplementedError, match="not supported on CPU"):
+        CpuPlatform.get_attn_backend_cls(AttentionBackendEnum.VIDEO_SPARSE_ATTN, 64, torch.float32)

--- a/scripts/checkpoint_conversion/convert_minimax_h3_mlx.py
+++ b/scripts/checkpoint_conversion/convert_minimax_h3_mlx.py
@@ -13,6 +13,16 @@ Usage (on the target Mac):
         --out ~/models/FastH3-MLX \\
         --formats "int8 int6 int4"
 
+Dense conversion drops the 50 ``attn.to_gate_compress`` matrices (~3.6 GiB BF16).
+Add ``--include-vsa`` to keep them, quantize them with the selected affine
+INT8/INT6/INT4 grid, and record ``vsa.capable`` in the manifest. Write VSA
+checkpoints to a new directory — do not overwrite an existing dense export.
+
+    python scripts/checkpoint_conversion/convert_minimax_h3_mlx.py \\
+        --model-root ~/models/FastH3-Preview-v0.2/transformer \\
+        --out ~/models/FastH3-MLX-vsa \\
+        --formats int6 --include-vsa
+
 Output layout: `~/models/FastH3-MLX/<format>/mlx_h3_dit.safetensors` + manifest.
 """
 
@@ -32,6 +42,7 @@ from fastvideo.mlx_runtime.minimax_h3 import (
     H3_WEIGHTS_FILENAME,
     MINIMAX_H3_AUDIO_SHIFT,
     MINIMAX_H3_VIDEO_SHIFT,
+    mlx_h3_checkpoint_vsa_capable,
     mlx_h3_dit_from_diffusers_safetensors,
     minimax_h3_sigmas,
     save_mlx_h3_checkpoint,
@@ -54,6 +65,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model-root", required=True, help="transformer/ dir of the diffusers snapshot")
     parser.add_argument("--out", required=True, help="base dir for the per-format MLX checkpoints")
     parser.add_argument("--formats", default=DEFAULT_FORMATS)
+    parser.add_argument(
+        "--include-vsa",
+        action="store_true",
+        help=("retain and quantize transformer_blocks.*.attn.to_gate_compress.weight "
+              "(required for MLX VSA inference; omitted by dense conversion)"),
+    )
     return parser.parse_args()
 
 
@@ -76,10 +93,17 @@ def main() -> None:
         ensure_quantization_supported(spec)
         dtype = "bf16"
         out_dir = out_base / fmt
-        if (out_dir / H3_MANIFEST_FILENAME).exists() and (out_dir / H3_WEIGHTS_FILENAME).exists():
-            print(f"[skip] {fmt} already converted at {out_dir}", flush=True)
-            continue
-        print(f"[convert] {fmt} (dtype={dtype}, spec={spec})", flush=True)
+        already = (out_dir / H3_MANIFEST_FILENAME).exists() and (out_dir / H3_WEIGHTS_FILENAME).exists()
+        if already:
+            capable = mlx_h3_checkpoint_vsa_capable(out_dir)
+            if bool(capable) == bool(args.include_vsa):
+                print(f"[skip] {fmt} already converted at {out_dir} (vsa.capable={capable})", flush=True)
+                continue
+            raise SystemExit(
+                f"{out_dir} already exists as a {'VSA-capable' if capable else 'dense-only'} checkpoint, "
+                f"but this run requested include_vsa={args.include_vsa}. "
+                "Write to a new directory (do not overwrite an existing dense export).")
+        print(f"[convert] {fmt} (dtype={dtype}, spec={spec}, include_vsa={args.include_vsa})", flush=True)
         if hasattr(mx, "reset_peak_memory"):
             mx.reset_peak_memory()
         t0 = time.perf_counter()
@@ -88,6 +112,7 @@ def main() -> None:
             quantization=spec,
             dtype=dtype,
             adaln_cache_timesteps=cache_timesteps,
+            include_vsa=args.include_vsa,
         )
         mx.eval()
         save_mlx_h3_checkpoint(dit, out_dir)

--- a/scripts/checkpoint_conversion/convert_minimax_h3_mlx.py
+++ b/scripts/checkpoint_conversion/convert_minimax_h3_mlx.py
@@ -99,10 +99,12 @@ def main() -> None:
             if bool(capable) == bool(args.include_vsa):
                 print(f"[skip] {fmt} already converted at {out_dir} (vsa.capable={capable})", flush=True)
                 continue
-            raise SystemExit(
-                f"{out_dir} already exists as a {'VSA-capable' if capable else 'dense-only'} checkpoint, "
-                f"but this run requested include_vsa={args.include_vsa}. "
-                "Write to a new directory (do not overwrite an existing dense export).")
+            logger.warning(
+                "Skipping %s: existing checkpoint has vsa.capable=%s, requested include_vsa=%s. "
+                "Use a new output directory to convert this format in the requested mode.",
+                out_dir, capable, args.include_vsa,
+            )
+            continue
         print(f"[convert] {fmt} (dtype={dtype}, spec={spec}, include_vsa={args.include_vsa})", flush=True)
         if hasattr(mx, "reset_peak_memory"):
             mx.reset_peak_memory()


### PR DESCRIPTION
Depends on #1770. This PR is stacked on its MLX H3 runtime branch and narrows to the changes below after #1770 merges.

## Summary

- Add VSA-capable H3 MLX conversion, checkpoint metadata, runtime routing, CLI controls, and dense-checkpoint guards.
- Keep the chunked gather plus SDPA backend as `auto`; add an explicit `--vsa-impl simd` Metal backend for tile size 64 and head dimension 128, with automatic reference fallback.
- Use fused MLX RMSNorm in H3 and remove redundant contiguous copies from dense SDPA.
- Remove the slower scalar Metal prototype. Custom quantized GEMM, packed QKV, compile-once blocks, and quality-changing VAE defaults are intentionally excluded.

## Performance

Development measurements on an M4 Max with 36 GB unified memory, MLX 0.31.2, INT6, 832x480x124, four steps, tile 64, and 0.9 sparsity:

| Measurement | Reference VSA | SIMD VSA |
| --- | ---: | ---: |
| DiT forward | 499.3 s | 436.4 s (-12.6%) |
| Denoise peak | 21.85 GiB | 21.15 GiB |
| Sparse attention microbenchmark | 586 ms | 444 ms (-24.2%) |

SIMD is intentionally opt-in. Dynamic sparse routing produces a different valid sample from the reference path (17.7 dB video PSNR in the development comparison), so `auto` remains on reference VSA.

## Validation

- `pre-commit run --files <stacked diff>`
- `38 passed` for the focused H3 MLX VSA, parity, and fast-mode tests on MLX 0.31.2
- `38 passed` for the same tests on MLX 0.32.2
- Not run: 720p end-to-end generation or a final combined 480p generation after aggregation
