### PR TITLE
[misc] pin fastvideo-kernel to exact 0.3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,11 +81,11 @@ dependencies = [
     # (MPS) and other non-Linux platforms don't try to build it from source;
     # every fastvideo_kernel import elsewhere is already guarded to degrade
     # gracefully when the package is absent.
-    # Keep ordinary installs compatible with the currently published wheel
-    # while the in-repo FastH3 extra selects this checkout's kernel source.
-    # Fresh registry installs select 0.3.4 once the version-bump publisher
-    # completes after merge.
-    "fastvideo-kernel>=0.3.2,<0.3.5; sys_platform == 'linux'",
+    # Pin the exact published kernel so every install resolves the same
+    # tested wheel; the in-repo FastH3 extra still selects this checkout's
+    # kernel source via the uv sources mapping. Bump this pin in the
+    # companion PR of each kernel release.
+    "fastvideo-kernel==0.3.5; sys_platform == 'linux'",
     "wheel",
 
     # Training Dependencies
@@ -186,7 +186,7 @@ dev = [ "fastvideo[lint]", "fastvideo[test]", ]
 # installs without putting a direct URL in published package metadata.
 fasth3 = [
     "flash-attn-4",
-    "fastvideo-kernel>=0.3.2,<0.3.5; sys_platform == 'linux'",
+    "fastvideo-kernel==0.3.5; sys_platform == 'linux'",
 ]
 
 prompt-safety = [


### PR DESCRIPTION
Replace the bounded range (>=0.3.2,<0.3.5) with an exact pin ==0.3.5 in both the main linux dependency and the fasth3 extra, now that kernel 0.3.5 is on PyPI (#1775, publish action green).

Rationale (author call): every install resolves the same tested kernel wheel, and each kernel release's companion PR moves the single pin — no more range ceiling to remember to widen. Torch alignment: kernel 0.3.5 itself pins torch==2.12.0 (#1774), matching this repo's pin.

0.3.5 ships: #1774 Torch 2.12.0 pin, #1706 VSA Triton autotune widening, #1754 opt-in sm_100a VSA route.

Note: environments holding kernel 0.3.2-0.3.4 will reinstall on next sync — intended. aarch64 (DGX Spark/GB10) still resolves the kernel from the in-repo source path via the uv sources mapping, unaffected by the registry pin.

Note for reviewer: pyproject_other.toml still pins fastvideo-kernel==0.3.0 — left untouched to match precedent, may deserve its own cleanup.

Stacked under the v0.2.1 release PR (#1778).