### PR TITLE
[bugfix] Harden OpenAI serving after post-merge review

### DIFF
--- a/docs/design/inference_schema_parity_inventory.yaml
+++ b/docs/design/inference_schema_parity_inventory.yaml
@@ -626,7 +626,6 @@ surfaces:
       max_sequence_length: request.sampling.max_sequence_length
       boundary_ratio: request.sampling.boundary_ratio
       extra_params: request.extensions
-      output_path: request.output.output_path
     compatibility_only:
       seconds:
         target: request.sampling.num_frames

--- a/docs/design/server_contracts/openai.md
+++ b/docs/design/server_contracts/openai.md
@@ -73,8 +73,9 @@ spellings.
 Reference objects support URL or local-path strings through `image_url`,
 `video_url`, and `audio_url`. `file_id` references are schema-compatible but
 return HTTP 400 because FastVideo does not provide an OpenAI Files store.
-Multipart `input_reference` uploads are saved under the configured output
-directory.
+Image URLs, data URLs, local paths, and multipart `input_reference` uploads are
+materialized and decoded under the configured output directory during
+admission. Invalid media returns HTTP 400 before a job is created.
 
 ## Jobs and synchronous responses
 
@@ -85,7 +86,12 @@ timings, and peak-memory metadata when the pipeline reports them.
 
 `POST /v1/videos/sync` returns `video/mp4` bytes. It includes
 `X-Request-Id`, `X-Model`, `X-Inference-Time-S`, `X-Stage-Durations`, and
-`X-Peak-Memory-MB` headers.
+`X-Peak-Memory-MB` headers. Its temporary MP4 is removed after the response is
+streamed. Asynchronous artifacts remain available until their job is deleted.
+
+Output paths are controlled by the server. Clients cannot choose filesystem
+destinations; every video is written beneath `server.output_dir` with a unique
+request id.
 
 FastVideo's synchronous CUDA execution cannot be interrupted after launch.
 Deleting an in-progress resource removes it from the API immediately; the
@@ -98,8 +104,8 @@ checkpoint path is used. Requests that name another model fail with HTTP 400.
 
 LoRAs are configured under
 `generator.pipeline.components.{lora_path,lora_nickname,lora_strength}`. The
-startup adapter appears in `/v1/models`, and requests can use either its model
-nickname or a vLLM-Omni selector:
+startup adapter is the only model advertised by a LoRA server, and requests can
+select it by its model nickname or with a selector:
 
 ```json
 {
@@ -156,3 +162,9 @@ Errors use the OpenAI envelope:
 Parse, model-selection, startup-LoRA, and unsupported-parameter failures are
 HTTP 400; missing resources are HTTP 404; generation failures are stored on
 asynchronous jobs and returned as HTTP 500 when that job is retrieved.
+Unknown top-level fields are rejected. `extra_params` accepts only the explicit
+request-batch passthrough fields supported by the typed request adapter.
+
+`GET /health` also verifies that the generation engine is open and all local
+multiprocess workers are alive. It returns HTTP 503 when the worker pool is no
+longer usable.

--- a/examples/serving/openai_fasth3_lora.yaml
+++ b/examples/serving/openai_fasth3_lora.yaml
@@ -34,7 +34,7 @@ server:
   host: 0.0.0.0
   port: 8000
   output_dir: outputs/openai_fasth3_lora
-  served_model_name: minimax-h3
+  served_model_name: fasth3-dense-datafree
 
 default_request:
   negative_prompt: ""
@@ -49,4 +49,3 @@ default_request:
     seed: 1000
   output:
     return_frames: false
-

--- a/fastvideo/entrypoints/cli/bench_serving.py
+++ b/fastvideo/entrypoints/cli/bench_serving.py
@@ -626,7 +626,9 @@ async def benchmark(args: argparse.Namespace) -> None:
         ) as resp:
             if resp.status == 200:
                 info = await resp.json()
-                if "model_path" in info and info["model_path"]:
+                if info.get("served_model_name"):
+                    args.model = info["served_model_name"]
+                elif info.get("model_path"):
                     args.model = info["model_path"]
                     logger.info("Updated model name from server: %s", args.model)
     except Exception as e:

--- a/fastvideo/entrypoints/openai/api_server.py
+++ b/fastvideo/entrypoints/openai/api_server.py
@@ -3,6 +3,7 @@
 
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
+import os
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
@@ -151,6 +152,11 @@ def create_app(
 
     @app.get("/health")
     async def health():
+        from fastvideo.entrypoints.openai.state import get_serving_engine
+
+        engine = get_serving_engine()
+        if not engine.healthy:
+            raise HTTPException(status_code=503, detail=engine.unhealthy_reason or "generation engine is unhealthy")
         return {"status": "ok"}
 
     return app
@@ -187,6 +193,7 @@ def run_server(
     served_model_name: str | None = None,
 ):
     """Create the app and run it with uvicorn"""
+    os.environ.setdefault("FASTVIDEO_STAGE_LOGGING", "1")
     if default_request is not None:
         _validate_default_request_against_preset(default_request, fastvideo_args.model_path)
 

--- a/fastvideo/entrypoints/openai/common_api.py
+++ b/fastvideo/entrypoints/openai/common_api.py
@@ -29,8 +29,6 @@ async def available_models():
     """Show available models"""
     args = get_server_args()
     cards = [ModelCard(id=get_served_model_name(), root=args.model_path)]
-    if args.lora_path and args.lora_nickname != get_served_model_name():
-        cards.append(ModelCard(id=args.lora_nickname, root=args.model_path))
     return {"object": "list", "data": [card.model_dump() for card in cards]}
 
 
@@ -40,8 +38,6 @@ async def retrieve_model(model: str):
     args = get_server_args()
     served_model_name = get_served_model_name()
     available = {served_model_name}
-    if args.lora_path:
-        available.add(args.lora_nickname)
     if model not in available:
         return ORJSONResponse(
             status_code=404,

--- a/fastvideo/entrypoints/openai/protocol.py
+++ b/fastvideo/entrypoints/openai/protocol.py
@@ -6,7 +6,7 @@ import uuid
 from enum import Enum
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
 
 
 class ImageResponseData(BaseModel):
@@ -82,7 +82,7 @@ class FileImageReference(BaseModel):
 
 class UrlImageReference(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    image_url: str
+    image_url: str = Field(min_length=1)
 
 
 ImageReference = UrlImageReference | FileImageReference
@@ -95,7 +95,7 @@ class FileVideoReference(BaseModel):
 
 class UrlVideoReference(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    video_url: str
+    video_url: str = Field(min_length=1)
 
 
 VideoReference = UrlVideoReference | FileVideoReference
@@ -103,7 +103,7 @@ VideoReference = UrlVideoReference | FileVideoReference
 
 class UrlAudioReference(BaseModel):
     model_config = ConfigDict(extra="forbid")
-    audio_url: str
+    audio_url: str = Field(min_length=1)
 
 
 AudioReference = UrlAudioReference
@@ -117,11 +117,11 @@ class VideoGenerationRequest(BaseModel):
     predate vLLM-Omni's typed reference objects.
     """
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
-    prompt: str
+    prompt: str = Field(min_length=1)
     model: str | None = None
-    seconds: int | SecondStr | None = None
+    seconds: Annotated[int, Field(ge=1, le=_INT64_MAX)] | SecondStr | None = None
     size: SizeStr | None = None
     image_reference: ImageReference | list[ImageReference] | None = None
     video_reference: VideoReference | list[VideoReference] | None = None
@@ -145,7 +145,7 @@ class VideoGenerationRequest(BaseModel):
     # SGLang spelling retained as an alias-like input field.
     n: int | None = Field(default=None, ge=1, le=10)
     start_time_seconds: float | None = Field(default=None, ge=0.0)
-    quality: str | None = None
+    quality: Literal["auto", "default", "standard", "hd"] | None = None
     negative_prompt: str | None = None
     num_inference_steps: int | None = Field(default=None, ge=1, le=200)
     guidance_scale: float | None = Field(default=None, ge=0.0, le=20.0)
@@ -166,7 +166,13 @@ class VideoGenerationRequest(BaseModel):
 
     lora: dict[str, Any] | None = None
     extra_params: dict[str, Any] | None = None
-    output_path: str | None = None
+
+    @field_validator("prompt")
+    @classmethod
+    def validate_prompt(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("prompt must not be empty")
+        return value
 
     def resolve_video_params(self) -> VideoParams:
         """Resolve top-level, nested, and ``size`` dimensions like vLLM-Omni."""

--- a/fastvideo/entrypoints/openai/request_adapter.py
+++ b/fastvideo/entrypoints/openai/request_adapter.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import math
 import os
 from typing import Any
 
 from fastvideo.api.compat import (
+    REQUEST_BATCH_EXTRA_PASSTHROUGH_FIELDS,
     explicit_request_updates,
     legacy_generate_call_to_request,
     request_to_sampling_param,
@@ -16,8 +18,10 @@ from fastvideo.api.schema import GenerationRequest
 from fastvideo.entrypoints.openai.protocol import (
     FileImageReference,
     FileVideoReference,
+    UrlImageReference,
     VideoGenerationRequest,
 )
+from fastvideo.entrypoints.openai.utils import save_image_to_path
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.models.vision_utils import load_image
 from fastvideo.registry import get_preset_selection
@@ -39,12 +43,61 @@ def _image_sources(request: VideoGenerationRequest) -> list[str]:
         if isinstance(reference, FileImageReference):
             raise RequestAdaptationError("file_id image references are not supported; provide image_url instead")
         sources.append(reference.image_url)
-    legacy = request.input_reference or request.reference_url
+    legacy_sources = [source for source in (request.input_reference, request.reference_url) if source]
+    if len(legacy_sources) > 1:
+        raise RequestAdaptationError("Provide only one of input_reference or reference_url.")
+    legacy = legacy_sources[0] if legacy_sources else None
     if legacy is not None:
         if sources:
             raise RequestAdaptationError("Provide only one of input_reference/reference_url or image_reference.")
         sources.append(legacy)
     return sources
+
+
+async def prepare_reference_media(
+    request_id: str,
+    request: VideoGenerationRequest,
+    output_dir: str,
+) -> None:
+    """Materialize and decode image references before a job reaches workers."""
+    _image_sources(request)
+    uploads_dir = os.path.join(os.path.abspath(output_dir), "uploads")
+
+    async def materialize(source: str, index: int) -> str:
+        source = source.strip()
+        if not source:
+            raise RequestAdaptationError("Image references must not be empty.")
+        if source.lower().startswith(("http://", "https://", "data:image")):
+            target = os.path.join(uploads_dir, f"{request_id}_{index}")
+            try:
+                local_path = await save_image_to_path(source, target)
+            except Exception as error:
+                raise RequestAdaptationError(f"Unable to fetch image reference: {error}") from error
+        else:
+            local_path = os.path.abspath(os.path.expanduser(source))
+            if not os.path.isfile(local_path):
+                raise RequestAdaptationError(f"Image reference does not exist: {source}")
+        try:
+            await asyncio.to_thread(load_image, local_path)
+        except Exception as error:
+            raise RequestAdaptationError(f"Unable to decode image reference: {error}") from error
+        return local_path
+
+    index = 0
+    references = _as_list(request.image_reference)
+    for reference in references:
+        if isinstance(reference, UrlImageReference):
+            reference.image_url = await materialize(reference.image_url, index)
+            index += 1
+    if request.input_reference:
+        request.input_reference = await materialize(request.input_reference, index)
+        index += 1
+    elif request.input_reference == "":
+        request.input_reference = None
+    if request.reference_url:
+        request.reference_url = await materialize(request.reference_url, index)
+    elif request.reference_url == "":
+        request.reference_url = None
 
 
 def _video_sources(request: VideoGenerationRequest) -> list[str]:
@@ -71,7 +124,7 @@ def _parse_aspect_ratio(value: str) -> tuple[float, float]:
         result = float(width), float(height)
     except (AttributeError, TypeError, ValueError) as error:
         raise RequestAdaptationError(f"Invalid aspect_ratio {value!r}; expected WIDTH:HEIGHT") from error
-    if result[0] <= 0 or result[1] <= 0:
+    if not all(math.isfinite(term) for term in result) or result[0] <= 0 or result[1] <= 0:
         raise RequestAdaptationError(f"Invalid aspect_ratio {value!r}; both terms must be positive")
     return result
 
@@ -82,7 +135,7 @@ def _apply_aspect_ratio(
     *,
     model_family: str | None,
 ) -> None:
-    if request.aspect_ratio is None or ("width" in kwargs and "height" in kwargs):
+    if request.aspect_ratio is None:
         return
     aspect_width, aspect_height = _parse_aspect_ratio(request.aspect_ratio)
     if model_family == "minimax_h3":
@@ -91,7 +144,10 @@ def _apply_aspect_ratio(
         if request.short_edge is not None and request.short_edge != MINIMAX_H3_SHORT_EDGE:
             raise RequestAdaptationError(
                 f"MiniMax-H3 currently uses a fixed short_edge={MINIMAX_H3_SHORT_EDGE}, got {request.short_edge}.")
-        height, width = resolve_canvas_size(aspect_width, aspect_height)
+        try:
+            height, width = resolve_canvas_size(aspect_width, aspect_height)
+        except ValueError as error:
+            raise RequestAdaptationError(str(error)) from error
     elif request.short_edge is not None:
         if aspect_width >= aspect_height:
             height = request.short_edge
@@ -116,9 +172,7 @@ def validate_model_and_lora(
     loaded and cannot be swapped safely between concurrent requests. The API
     accepts vLLM's selector shape, but it must identify the startup adapter.
     """
-    allowed_models = {served_model_name}
-    if args.lora_path:
-        allowed_models.add(args.lora_nickname)
+    allowed_models = {args.lora_nickname} if args.lora_path else {served_model_name}
     if request.model is not None and request.model not in allowed_models:
         choices = ", ".join(sorted(allowed_models))
         raise RequestAdaptationError(
@@ -137,7 +191,7 @@ def validate_model_and_lora(
     scale = next((body[key] for key in ("scale", "lora_scale") if body.get(key) is not None), None)
     if name is None and path is None:
         raise RequestAdaptationError("lora must provide a name or path")
-    if name is not None and str(name) not in {args.lora_nickname, served_model_name}:
+    if name is not None and str(name) != args.lora_nickname:
         raise RequestAdaptationError(f"Requested LoRA {name!r} is not the startup adapter {args.lora_nickname!r}.")
     if path is not None and str(path) != args.lora_path:
         raise RequestAdaptationError(
@@ -181,12 +235,16 @@ def _apply_reference_inputs(
 
     if ref2va:
         from fastvideo.pipelines.basic.minimax_h3 import MiniMaxH3Reference
+        from fastvideo.pipelines.basic.minimax_h3.reference import validate_references
 
         references = [MiniMaxH3Reference(source=source, media_type="image") for source in images]
         references.extend(MiniMaxH3Reference(source=source, media_type="video") for source in videos)
         references.extend(MiniMaxH3Reference(source=source, media_type="audio") for source in audios)
         if references:
-            kwargs["references"] = references
+            try:
+                kwargs["references"] = validate_references(references)
+            except (TypeError, ValueError) as error:
+                raise RequestAdaptationError(str(error)) from error
         return
 
     if request.task is not None and model_family != "minimax_h3":
@@ -239,14 +297,18 @@ def build_generation_request(
         elif "video_params" in body_set and "height" in nested_set and request.video_params.height is not None:
             kwargs["height"] = request.video_params.height
 
-    fps_explicit = "fps" in body_set or ("video_params" in body_set and "fps" in nested_set)
+    fps_explicit = ("fps" in body_set
+                    and request.fps is not None) or ("video_params" in body_set and "fps" in nested_set
+                                                     and request.video_params.fps is not None)
     if fps_explicit:
         fps = request.fps if "fps" in body_set else request.video_params.fps
         if fps is not None:
             kwargs["fps"] = fps
     kwargs.setdefault("fps", 24)
 
-    frames_explicit = "num_frames" in body_set or ("video_params" in body_set and "num_frames" in nested_set)
+    frames_explicit = ("num_frames" in body_set
+                       and request.num_frames is not None) or ("video_params" in body_set and "num_frames" in nested_set
+                                                               and request.video_params.num_frames is not None)
     if frames_explicit:
         num_frames = request.num_frames if "num_frames" in body_set else request.video_params.num_frames
         if num_frames is not None:
@@ -277,12 +339,14 @@ def build_generation_request(
         _, model_family = get_preset_selection(args.model_path)
     except (RuntimeError, ValueError):
         model_family = None
-    if model_family == "minimax_h3" and request.resolved_num_outputs != 1:
-        raise RequestAdaptationError("MiniMax-H3 currently generates exactly one packed video/audio output.")
+    if request.resolved_num_outputs != 1:
+        raise RequestAdaptationError("FastVideo serving currently supports exactly one video output per request.")
+    if "short_edge" in body_set and request.short_edge is not None and request.aspect_ratio is None:
+        raise RequestAdaptationError("short_edge requires aspect_ratio.")
     _apply_aspect_ratio(kwargs, request, model_family=model_family)
     _apply_reference_inputs(kwargs, request, args, model_family=model_family)
 
-    extension_fields = ("quality", "flow_shift", "sound_duration", "start_time_seconds")
+    extension_fields = ("flow_shift", "sound_duration", "start_time_seconds")
     for name in extension_fields:
         if name in body_set and getattr(request, name) is not None:
             kwargs[name] = getattr(request, name)
@@ -297,18 +361,48 @@ def build_generation_request(
         ):
             kwargs[name] = getattr(request, name)
     if request.extra_params:
+        unknown_extra_params = sorted(set(request.extra_params) - set(REQUEST_BATCH_EXTRA_PASSTHROUGH_FIELDS))
+        if unknown_extra_params:
+            raise RequestAdaptationError("Unsupported extra_params fields: " + ", ".join(unknown_extra_params))
         kwargs.update(request.extra_params)
-    if request.model_extra:
-        kwargs.update(request.model_extra)
 
-    configured_output = kwargs.pop("output_path", None)
-    requested_output = request.output_path if "output_path" in body_set else None
-    destination = requested_output or configured_output or os.path.join(output_dir, "videos")
-    if os.path.splitext(destination)[1].lower() == ".mp4":
-        output_path = destination
-    else:
-        output_path = os.path.join(destination, f"{request_id}.mp4")
-    os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+    width = kwargs.get("width")
+    height = kwargs.get("height")
+    if width is not None and (not isinstance(width, int) or width <= 0):
+        raise RequestAdaptationError(f"width must be a positive integer, got {width!r}")
+    if height is not None and (not isinstance(height, int) or height <= 0):
+        raise RequestAdaptationError(f"height must be a positive integer, got {height!r}")
+
+    if model_family == "minimax_h3":
+        from fastvideo.pipelines.basic.minimax_h3.packing import (
+            MINIMAX_H3_CANVAS_MULTIPLE,
+            MINIMAX_H3_MAX_PIXELS,
+        )
+        from fastvideo.pipelines.basic.minimax_h3.stages.minimax_h3_input_preparation import (
+            resolve_target_num_frames, )
+
+        if kwargs["fps"] != 24:
+            raise RequestAdaptationError(f"MiniMax-H3 requires fps=24, got {kwargs['fps']}.")
+        if width is None or height is None:
+            raise RequestAdaptationError("MiniMax-H3 requires both width and height.")
+        if width % MINIMAX_H3_CANVAS_MULTIPLE or height % MINIMAX_H3_CANVAS_MULTIPLE:
+            raise RequestAdaptationError("MiniMax-H3 width and height must be positive multiples of "
+                                         f"{MINIMAX_H3_CANVAS_MULTIPLE}, got {width}x{height}.")
+        if width * height > MINIMAX_H3_MAX_PIXELS:
+            raise RequestAdaptationError(
+                f"MiniMax-H3 canvas exceeds the {MINIMAX_H3_MAX_PIXELS}-pixel limit: {width}x{height}.")
+        try:
+            requested_num_frames = kwargs.get("num_frames")
+            aligned_num_frames = resolve_target_num_frames(requested_num_frames)
+        except (TypeError, ValueError) as error:
+            raise RequestAdaptationError(str(error)) from error
+        if frames_explicit and aligned_num_frames != requested_num_frames:
+            raise RequestAdaptationError("MiniMax-H3 num_frames must be on the causal-VAE grid (17 * n + 5); "
+                                         f"got {requested_num_frames}, next valid value is {aligned_num_frames}.")
+        kwargs["num_frames"] = aligned_num_frames
+
+    output_path = os.path.join(os.path.abspath(output_dir), "videos", f"{request_id}.mp4")
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
     kwargs.update({
         "output_path": output_path,
         "save_video": True,
@@ -327,5 +421,6 @@ def build_generation_request(
 __all__ = [
     "RequestAdaptationError",
     "build_generation_request",
+    "prepare_reference_media",
     "validate_model_and_lora",
 ]

--- a/fastvideo/entrypoints/openai/serving_engine.py
+++ b/fastvideo/entrypoints/openai/serving_engine.py
@@ -28,6 +28,7 @@ class OpenAIServingEngine:
         self._generator = generator
         self._generation_lock = asyncio.Lock()
         self._closed = False
+        self._unhealthy_reason: str | None = None
 
     @property
     def generator(self) -> VideoGenerator:
@@ -37,17 +38,48 @@ class OpenAIServingEngine:
     def closed(self) -> bool:
         return self._closed
 
-    async def generate(self, request: GenerationRequest) -> Any:
-        """Generate one typed request without blocking the event loop."""
-        return await self.run_serialized(self._generator.generate, request)
+    @property
+    def healthy(self) -> bool:
+        if self._closed or self._unhealthy_reason is not None:
+            return False
+        executor = getattr(self._generator, "executor", None)
+        workers = getattr(executor, "workers", None)
+        if workers is None:
+            return True
+        return bool(workers) and all(worker.proc.is_alive() for worker in workers)
 
-    async def run_serialized(self, function: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
+    @property
+    def unhealthy_reason(self) -> str | None:
+        if self._unhealthy_reason is not None:
+            return self._unhealthy_reason
+        if not self.healthy:
+            return "one or more generation workers are not alive"
+        return None
+
+    async def generate(
+        self,
+        request: GenerationRequest,
+        *,
+        on_start: Callable[[], Awaitable[None]] | None = None,
+    ) -> Any:
+        """Generate one typed request without blocking the event loop."""
+        return await self.run_serialized(self._generator.generate, request, on_start=on_start)
+
+    async def run_serialized(
+        self,
+        function: Callable[..., _T],
+        *args: Any,
+        on_start: Callable[[], Awaitable[None]] | None = None,
+        **kwargs: Any,
+    ) -> _T:
         """Run a synchronous pipeline operation under the serving lock."""
         if self._closed:
             raise RuntimeError("FastVideo serving engine is shutting down")
         async with self._generation_lock:
             if self._closed:
                 raise RuntimeError("FastVideo serving engine is shutting down")
+            if on_start is not None:
+                await on_start()
             worker = asyncio.create_task(asyncio.to_thread(function, *args, **kwargs))
             try:
                 return await asyncio.shield(worker)
@@ -55,7 +87,10 @@ class OpenAIServingEngine:
                 # Python cannot stop a running worker thread. Keep the lock
                 # until the pipeline call really exits so cancellation cannot
                 # expose mutable model state to a second request.
-                await asyncio.shield(worker)
+                await self._wait_after_cancellation(worker)
+                raise
+            except (BrokenPipeError, EOFError) as error:
+                self._unhealthy_reason = str(error)
                 raise
 
     async def run_async_serialized(self, function: Callable[[], Awaitable[_T]]) -> _T:
@@ -69,8 +104,21 @@ class OpenAIServingEngine:
             try:
                 return await asyncio.shield(worker)
             except asyncio.CancelledError:
-                await asyncio.shield(worker)
+                await self._wait_after_cancellation(worker)
                 raise
+
+    @staticmethod
+    async def _wait_after_cancellation(worker: asyncio.Future[Any]) -> None:
+        """Keep waiting for an uninterruptible worker despite repeated cancellation."""
+        while not worker.done():
+            try:
+                await asyncio.shield(worker)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+        if not worker.cancelled():
+            worker.exception()
 
     async def shutdown(self) -> None:
         """Stop accepting requests and release the generator after in-flight work."""

--- a/fastvideo/entrypoints/openai/state.py
+++ b/fastvideo/entrypoints/openai/state.py
@@ -51,6 +51,8 @@ def get_output_dir() -> str:
 def get_served_model_name() -> str:
     """Return the public model id advertised by the OpenAI server."""
     args = get_server_args()
+    if args.lora_path:
+        return args.lora_nickname
     return _served_model_name or args.model_path
 
 

--- a/fastvideo/entrypoints/openai/video_api.py
+++ b/fastvideo/entrypoints/openai/video_api.py
@@ -13,6 +13,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Path, Query, Request
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import ValidationError
+from starlette.background import BackgroundTask
 from starlette.datastructures import UploadFile
 
 from fastvideo.api.compat import explicit_request_updates, request_to_sampling_param
@@ -25,7 +26,11 @@ from fastvideo.entrypoints.openai.protocol import (
     VideoResponse,
     generate_request_id,
 )
-from fastvideo.entrypoints.openai.request_adapter import RequestAdaptationError, build_generation_request
+from fastvideo.entrypoints.openai.request_adapter import (
+    build_generation_request,
+    prepare_reference_media,
+    validate_model_and_lora,
+)
 from fastvideo.entrypoints.openai.state import (
     get_default_request,
     get_output_dir,
@@ -50,6 +55,7 @@ _JSON_FORM_FIELDS = {
     "lora",
     "extra_params",
 }
+_VIDEO_EXTENSIONS = {".avi", ".mkv", ".mov", ".mp4", ".mpeg", ".mpg", ".webm"}
 
 
 def _build_generation_kwargs(
@@ -115,9 +121,8 @@ def _build_generation_kwargs(
     if "input_reference" in body_set and req.input_reference is not None:
         kwargs["image_path"] = req.input_reference
 
-    configured_output = kwargs.pop("output_path", None)
-    requested_output = req.output_path if "output_path" in body_set else None
-    output_dir = requested_output or configured_output or os.path.join(get_output_dir(), "videos")
+    kwargs.pop("output_path", None)
+    output_dir = os.path.join(os.path.abspath(get_output_dir()), "videos")
     os.makedirs(output_dir, exist_ok=True)
     kwargs["output_path"] = os.path.join(output_dir, f"{request_id}.mp4")
     kwargs["save_video"] = True
@@ -128,6 +133,15 @@ def _result_value(result: Any, name: str, default: Any = None) -> Any:
     if isinstance(result, dict):
         return result.get(name, default)
     return getattr(result, name, default)
+
+
+def _remove_artifact(file_path: str | None) -> None:
+    if not file_path or not os.path.isfile(file_path):
+        return
+    try:
+        os.unlink(file_path)
+    except OSError:
+        logger.warning("Failed to delete video artifact %s", file_path, exc_info=True)
 
 
 def _stage_durations(result: Any) -> dict[str, float]:
@@ -163,7 +177,8 @@ def _make_video_job(
         "quality": req.quality or "default",
         # ``file_path`` is a FastVideo compatibility extension. vLLM-Omni's
         # public job shape uses ``file_name`` after completion.
-        "file_path": generation_request.output.output_path,
+        "file_path": None,
+        "_sequence": time.monotonic_ns(),
     }
 
 
@@ -171,16 +186,22 @@ async def _run_generation(
     request_id: str,
     generation_request: GenerationRequest,
 ) -> None:
-    await VIDEO_STORE.update_fields(
-        request_id,
-        {
-            "status": VideoGenerationStatus.IN_PROGRESS,
-            "progress": 0
-        },
-    )
-    started = time.perf_counter()
+    started = 0.0
+    video_path = generation_request.output.output_path
+
+    async def mark_started() -> None:
+        nonlocal started
+        started = time.perf_counter()
+        await VIDEO_STORE.update_fields(
+            request_id,
+            {
+                "status": VideoGenerationStatus.IN_PROGRESS,
+                "progress": 0
+            },
+        )
+
     try:
-        result = await get_serving_engine().generate(generation_request)
+        result = await get_serving_engine().generate(generation_request, on_start=mark_started)
         if isinstance(result, list):
             if not result:
                 raise RuntimeError("FastVideo returned no generation results")
@@ -215,18 +236,17 @@ async def _run_generation(
                     "code": 500,
                     "message": str(error)
                 },
-                "inference_time_s": time.perf_counter() - started,
+                "inference_time_s": time.perf_counter() - started if started else 0.0,
             },
         )
     finally:
         if request_id in _DELETED_VIDEO_IDS:
             _DELETED_VIDEO_IDS.discard(request_id)
-            output_path = generation_request.output.output_path
-            if output_path and os.path.isfile(output_path):
+            if video_path and os.path.isfile(video_path):
                 try:
-                    os.unlink(output_path)
+                    os.unlink(video_path)
                 except OSError:
-                    logger.warning("Failed to clean up deleted video artifact %s", output_path, exc_info=True)
+                    logger.warning("Failed to clean up deleted video artifact %s", video_path, exc_info=True)
 
 
 def _track_video_job(request_id: str, task: asyncio.Task[None]) -> None:
@@ -270,7 +290,8 @@ async def _parse_video_request(raw_request: Request) -> VideoGenerationRequest:
                 filename = os.path.basename(value.filename or "reference")
                 target = os.path.join(uploads_dir, f"{generate_request_id()}_{filename}")
                 saved_path = await save_image_to_path(value, target)
-                if (value.content_type or "").lower().startswith("video/"):
+                upload_ext = os.path.splitext(filename)[1].lower()
+                if (value.content_type or "").lower().startswith("video/") or upload_ext in _VIDEO_EXTENSIONS:
                     payload["video_reference"] = {"video_url": saved_path}
                 else:
                     payload["input_reference"] = saved_path
@@ -308,9 +329,12 @@ async def _parse_video_request(raw_request: Request) -> VideoGenerationRequest:
         raise HTTPException(status_code=400, detail=f"Invalid request body: {error}") from error
 
 
-def _adapt_request(request_id: str, request: VideoGenerationRequest) -> GenerationRequest:
+async def _adapt_request(request_id: str, request: VideoGenerationRequest) -> GenerationRequest:
     try:
-        return build_generation_request(
+        validate_model_and_lora(request, get_server_args(), get_served_model_name())
+        await prepare_reference_media(request_id, request, get_output_dir())
+        return await asyncio.to_thread(
+            build_generation_request,
             request_id,
             request,
             get_server_args(),
@@ -318,7 +342,7 @@ def _adapt_request(request_id: str, request: VideoGenerationRequest) -> Generati
             output_dir=get_output_dir(),
             default_request=get_default_request(),
         )
-    except RequestAdaptationError as error:
+    except Exception as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
 
 
@@ -328,7 +352,7 @@ async def create_video(raw_request: Request) -> VideoResponse:
     """Create an asynchronous video generation job."""
     request = await _parse_video_request(raw_request)
     request_id = f"video_gen_{generate_request_id()}"
-    generation_request = _adapt_request(request_id, request)
+    generation_request = await _adapt_request(request_id, request)
     job = _make_video_job(request_id, request, generation_request)
     await VIDEO_STORE.upsert(request_id, job)
     task = asyncio.create_task(_run_generation(request_id, generation_request), name=f"video-job-{request_id}")
@@ -341,7 +365,7 @@ async def create_video_sync(raw_request: Request) -> FileResponse:
     """Generate synchronously and return raw MP4 bytes with vLLM headers."""
     request = await _parse_video_request(raw_request)
     request_id = f"video_sync-{generate_request_id()}"
-    generation_request = _adapt_request(request_id, request)
+    generation_request = await _adapt_request(request_id, request)
     started = time.perf_counter()
     try:
         result = await get_serving_engine().generate(generation_request)
@@ -367,17 +391,21 @@ async def create_video_sync(raw_request: Request) -> FileResponse:
             "X-Stage-Durations": json.dumps(_stage_durations(result), separators=(",", ":")),
             "X-Peak-Memory-MB": f"{float(_result_value(result, 'peak_memory_mb', 0.0) or 0.0):.3f}",
         },
+        background=BackgroundTask(_remove_artifact, video_path),
     )
 
 
 @router.get("", response_model=VideoListResponse)
 async def list_videos(
         after: str | None = Query(None),
-        limit: int | None = Query(None, ge=0, le=100),
-        order: str = Query("desc", pattern="^(asc|desc)$"),
+        limit: int | None = Query(None, ge=1, le=100),
+        order: str = Query("desc"),
 ) -> VideoListResponse:
+    order = order.lower()
+    if order not in {"asc", "desc"}:
+        raise HTTPException(status_code=400, detail="order must be 'asc' or 'desc'")
     jobs = await VIDEO_STORE.list_values()
-    jobs.sort(key=lambda job: job.get("created_at", 0), reverse=order == "desc")
+    jobs.sort(key=lambda job: (job.get("created_at", 0), job.get("_sequence", 0)), reverse=order == "desc")
     if after is not None:
         index = next((i for i, job in enumerate(jobs) if job.get("id") == after), None)
         jobs = [] if index is None else jobs[index + 1:]
@@ -410,18 +438,20 @@ async def delete_video(video_id: str = Path(...)) -> VideoDeleteResponse:
     if job is None:
         raise HTTPException(status_code=404, detail="Video not found")
     task = _VIDEO_JOB_TASKS.get(video_id)
-    if task is not None:
+    status = VideoGenerationStatus(job.get("status", VideoGenerationStatus.QUEUED))
+    if task is not None and not task.done():
         # The current synchronous generator cannot abort a CUDA call once it
         # starts. Remove the API resource immediately and let the tracked task
         # clean up its artifact on exit while the serving lock stays held.
-        _DELETED_VIDEO_IDS.add(video_id)
+        if status is VideoGenerationStatus.QUEUED:
+            task.cancel()
+        else:
+            _DELETED_VIDEO_IDS.add(video_id)
+            task.cancel()
     popped = await VIDEO_STORE.pop(video_id)
     file_path = None if popped is None else popped.get("file_path")
-    if file_path and os.path.isfile(file_path):
-        try:
-            os.unlink(file_path)
-        except OSError:
-            logger.warning("Failed to delete video artifact %s", file_path, exc_info=True)
+    if status in {VideoGenerationStatus.COMPLETED, VideoGenerationStatus.FAILED}:
+        _remove_artifact(file_path)
     return VideoDeleteResponse(id=video_id, deleted=True)
 
 

--- a/fastvideo/tests/api/test_cli_translation.py
+++ b/fastvideo/tests/api/test_cli_translation.py
@@ -443,7 +443,7 @@ def test_serve_subcommand_dispatches_via_typed_config(tmp_path, monkeypatch):
         captured["config"] = config
         return SimpleNamespace(model_path=config.model_path)
 
-    def fake_run_server(fastvideo_args, host, port, output_dir, default_request):
+    def fake_run_server(fastvideo_args, host, port, output_dir, default_request, served_model_name=None):
         captured["fastvideo_args"] = fastvideo_args
         captured["host"] = host
         captured["port"] = port
@@ -482,7 +482,7 @@ def test_serve_subcommand_forwards_default_request(tmp_path, monkeypatch):
     def fake_generator_config_to_fastvideo_args(config):
         return SimpleNamespace(model_path=config.model_path)
 
-    def fake_run_server(fastvideo_args, host, port, output_dir, default_request):
+    def fake_run_server(fastvideo_args, host, port, output_dir, default_request, served_model_name=None):
         captured["default_request"] = default_request
 
     monkeypatch.setattr(

--- a/fastvideo/tests/api/test_configs.py
+++ b/fastvideo/tests/api/test_configs.py
@@ -36,6 +36,7 @@ def test_serve_config_includes_server_and_default_request_defaults() -> None:
         "host": "0.0.0.0",
         "port": 8000,
         "output_dir": "outputs/",
+        "served_model_name": None,
     }
     assert dumped["default_request"]["sampling"]["fps"] == 24
     assert dumped["default_request"]["runtime"]["enable_teacache"] is False

--- a/fastvideo/tests/api/test_parser.py
+++ b/fastvideo/tests/api/test_parser.py
@@ -148,6 +148,8 @@ def test_load_run_config_supports_yaml_roundtrip(tmp_path) -> None:
                     "vae_weights": None,
                     "upsampler_weights": None,
                     "lora_path": None,
+                    "lora_nickname": "default",
+                    "lora_strength": 1.0,
                     "override_pipeline_cls_name": None,
                     "override_transformer_cls_name": None,
                 },

--- a/fastvideo/tests/entrypoints/test_openai_api.py
+++ b/fastvideo/tests/entrypoints/test_openai_api.py
@@ -207,10 +207,9 @@ class TestVideoBuildGenerationKwargs:
         kw = self._build(seed=123)
         assert kw["seed"] == 123
 
-    def test_custom_output_path_overrides_default(self, tmp_path):
-        custom = str(tmp_path / "custom")
-        kw = self._build(output_path=custom)
-        assert kw["output_path"].startswith(custom)
+    def test_client_output_path_is_rejected(self, tmp_path):
+        with pytest.raises(Exception, match="output_path"):
+            self._build(output_path=str(tmp_path / "custom"))
 
 
 # ---------------------------------------------------------------------------
@@ -291,22 +290,14 @@ class TestVideoDefaultRequestMerge:
         assert kw["width"] == 640
         assert kw["height"] == 360
 
-    def test_default_output_path_used_as_output_dir(self, tmp_path):
+    def test_default_output_path_does_not_escape_server_directory(self, tmp_path):
         custom = str(tmp_path / "from_default")
         kw = self._build(default_raw={"output": {"output_path": custom}})
-        assert kw["output_path"].startswith(custom)
+        assert kw["output_path"].startswith(os.path.join(str(tmp_path), "videos"))
 
-    def test_body_output_path_overrides_default(self, tmp_path):
-        body_dir = str(tmp_path / "body")
-        default_dir = str(tmp_path / "default")
-        kw = self._build(
-            default_raw={"output": {
-                "output_path": default_dir
-            }},
-            output_path=body_dir,
-        )
-        assert kw["output_path"].startswith(body_dir)
-        assert default_dir not in kw["output_path"]
+    def test_body_output_path_is_not_public(self, tmp_path):
+        with pytest.raises(Exception, match="output_path"):
+            self._build(output_path=str(tmp_path / "body"))
 
     def test_default_negative_prompt_flows_through(self):
         kw = self._build(default_raw={"negative_prompt": "low quality, blur"})

--- a/fastvideo/tests/entrypoints/test_openai_serving_engine.py
+++ b/fastvideo/tests/entrypoints/test_openai_serving_engine.py
@@ -13,10 +13,13 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from fastvideo.api.parser import parse_config
+from fastvideo.api.schema import GenerationRequest
 from fastvideo.entrypoints.openai.protocol import VideoGenerationRequest
 from fastvideo.entrypoints.openai.request_adapter import (
     RequestAdaptationError,
     build_generation_request,
+    prepare_reference_media,
 )
 from fastvideo.entrypoints.openai.serving_engine import OpenAIServingEngine
 from fastvideo.entrypoints.openai.stores import VIDEO_STORE
@@ -40,8 +43,12 @@ class _BlockingGenerator:
 
 class _FileGenerator:
 
+    def __init__(self) -> None:
+        self.last_output: Path | None = None
+
     def generate(self, request):
         output = Path(request.output.output_path)
+        self.last_output = output
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_bytes(b"\x00\x00\x00\x18ftypmp42fastvideo-test")
         return SimpleNamespace(
@@ -78,6 +85,8 @@ async def _assert_engine_cancellation_keeps_pipeline_locked() -> None:
     first = asyncio.create_task(engine.generate("first"))  # type: ignore[arg-type]
     await asyncio.to_thread(generator.started.wait, 2)
     first.cancel()
+    await asyncio.sleep(0)
+    first.cancel()
 
     second_started = threading.Event()
 
@@ -96,6 +105,45 @@ async def _assert_engine_cancellation_keeps_pipeline_locked() -> None:
 
     await engine.shutdown()
     assert generator.shutdown_called
+
+
+def test_protocol_rejects_unknown_and_client_output_fields() -> None:
+    with pytest.raises(Exception, match="prompt_path"):
+        VideoGenerationRequest(prompt="a fox", prompt_path="/srv/prompts.txt")
+    with pytest.raises(Exception, match="output_path"):
+        VideoGenerationRequest(prompt="a fox", output_path="/srv/keep.mp4")
+
+
+def test_request_adapter_restricts_extra_params(tmp_path: Path) -> None:
+    request = VideoGenerationRequest(prompt="a fox", extra_params={"prompt_path": "/srv/prompts.txt"})
+    with pytest.raises(RequestAdaptationError, match="Unsupported extra_params fields: prompt_path"):
+        build_generation_request(
+            "video_gen_test",
+            request,
+            _args("Wan-AI/Wan2.1-T2V-1.3B-Diffusers"),
+            served_model_name="wan",
+            output_dir=str(tmp_path),
+        )
+
+
+def test_request_adapter_owns_output_path(tmp_path: Path) -> None:
+    request = VideoGenerationRequest(prompt="a fox", size="64x64", num_frames=1)
+    default_request = parse_config(GenerationRequest, {"output": {"output_path": "/srv/untrusted-default.mp4"}})
+    adapted = build_generation_request(
+        "video_gen_test",
+        request,
+        _args("Wan-AI/Wan2.1-T2V-1.3B-Diffusers"),
+        served_model_name="wan",
+        output_dir=str(tmp_path),
+        default_request=default_request,
+    )
+    assert adapted.output.output_path == str(tmp_path / "videos" / "video_gen_test.mp4")
+
+
+def test_missing_reference_fails_during_admission(tmp_path: Path) -> None:
+    request = VideoGenerationRequest(prompt="a fox", input_reference=str(tmp_path / "missing.png"))
+    with pytest.raises(RequestAdaptationError, match="does not exist"):
+        asyncio.run(prepare_reference_media("request", request, str(tmp_path)))
 
 
 def test_request_adapter_resolves_vllm_nested_params(tmp_path: Path) -> None:
@@ -184,6 +232,103 @@ def test_fasth3_request_uses_the_general_adapter(tmp_path: Path) -> None:
     assert adapted.sampling.num_frames == 124
 
 
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"aspect_ratio": "16:9", "num_frames": 22}, "generates 5-15 seconds"),
+        ({"size": "100x100", "num_frames": 124}, "positive multiples of 32"),
+        ({"aspect_ratio": "1:9", "num_frames": 124}, "supports aspect ratios"),
+        ({"aspect_ratio": "16:9", "num_frames": 120}, "causal-VAE grid"),
+    ],
+)
+def test_fasth3_invalid_geometry_fails_at_admission(tmp_path: Path, overrides, message) -> None:
+    request = VideoGenerationRequest(prompt="a fox", **overrides)
+    with pytest.raises(RequestAdaptationError, match=message):
+        build_generation_request(
+            "video_gen_test",
+            request,
+            _args("FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2"),
+            served_model_name="fasth3",
+            output_dir=str(tmp_path),
+        )
+
+
+def test_fasth3_seconds_align_to_causal_vae_grid(tmp_path: Path) -> None:
+    request = VideoGenerationRequest(prompt="a fox", aspect_ratio="16:9", seconds="5")
+    adapted = build_generation_request(
+        "video_gen_test",
+        request,
+        _args("FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2"),
+        served_model_name="fasth3",
+        output_dir=str(tmp_path),
+    )
+    assert adapted.sampling.num_frames == 124
+
+
+def test_fasth3_ref2va_limits_references_at_admission(tmp_path: Path) -> None:
+    request = VideoGenerationRequest(
+        prompt="a fox",
+        task="ref2va",
+        aspect_ratio="16:9",
+        num_frames=124,
+        image_reference=[{"image_url": f"/tmp/reference-{index}.png"} for index in range(10)],
+    )
+    with pytest.raises(RequestAdaptationError, match="at most 9 image references"):
+        build_generation_request(
+            "video_gen_test",
+            request,
+            _args(
+                "MiniMaxAI/MiniMax-H3",
+                override_pipeline_cls_name="MiniMaxH3Ref2VAModularPipeline",
+            ),
+            served_model_name="minimax-h3",
+            output_dir=str(tmp_path),
+        )
+
+
+def test_aspect_ratio_overrides_operator_dimensions(tmp_path: Path) -> None:
+    default_request = parse_config(
+        GenerationRequest,
+        {"sampling": {
+            "width": 1344,
+            "height": 768,
+            "num_frames": 124,
+        }},
+    )
+    request = VideoGenerationRequest(prompt="a fox", aspect_ratio="9:16")
+    adapted = build_generation_request(
+        "video_gen_test",
+        request,
+        _args("FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2"),
+        served_model_name="fasth3",
+        output_dir=str(tmp_path),
+        default_request=default_request,
+    )
+    assert adapted.sampling.width == 768
+    assert adapted.sampling.height == 1344
+
+
+def test_explicit_null_uses_seconds_and_operator_fps(tmp_path: Path) -> None:
+    default_request = parse_config(
+        GenerationRequest,
+        {"sampling": {
+            "fps": 30,
+            "num_frames": 99,
+        }},
+    )
+    request = VideoGenerationRequest(prompt="a fox", seconds=2, fps=None, num_frames=None)
+    adapted = build_generation_request(
+        "video_gen_test",
+        request,
+        _args("Wan-AI/Wan2.1-T2V-1.3B-Diffusers"),
+        served_model_name="wan",
+        output_dir=str(tmp_path),
+        default_request=default_request,
+    )
+    assert adapted.sampling.fps == 30
+    assert adapted.sampling.num_frames == 60
+
+
 def test_unsupported_vllm_postprocessing_fails_at_admission(tmp_path: Path) -> None:
     request = VideoGenerationRequest(prompt="a fox", enable_frame_interpolation=True)
 
@@ -264,6 +409,8 @@ def test_video_routes_cover_async_sync_list_content_and_delete(tmp_path: Path) -
             assert sync.status_code == 200
             assert sync.headers["x-model"] == "wan-test"
             assert sync.content[4:8] == b"ftyp"
+            assert generator.last_output is not None
+            assert not generator.last_output.exists()
     finally:
         asyncio.run(VIDEO_STORE.clear())
         state.clear_state()

--- a/fastvideo/tests/worker/test_multiproc_executor.py
+++ b/fastvideo/tests/worker/test_multiproc_executor.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
+from fastvideo.worker.multiproc_executor import (
+    _RPC_ERROR_KEY,
+    _raise_for_rpc_errors,
+    WorkerMultiprocProc,
+)
+
+
+class _ScriptedPipe:
+
+    def __init__(self, messages):
+        self.messages = list(messages)
+        self.responses = []
+
+    def recv(self):
+        return self.messages.pop(0)
+
+    def send(self, response):
+        self.responses.append(response)
+
+
+class _RecoveringWorker:
+
+    def __init__(self):
+        self.calls = 0
+
+    def execute_forward(self, forward_batch, fastvideo_args):
+        del forward_batch, fastvideo_args
+        self.calls += 1
+        if self.calls == 1:
+            raise ValueError("bad request")
+        return ForwardBatch(data_type="video", output=torch.ones(1))
+
+    def shutdown(self):
+        return {"status": "shutdown"}
+
+
+def test_worker_rpc_error_does_not_exit_busy_loop(monkeypatch) -> None:
+    request = {
+        "method": "execute_forward",
+        "kwargs": {
+            "forward_batch": SimpleNamespace(),
+            "fastvideo_args": SimpleNamespace(),
+        },
+    }
+    pipe = _ScriptedPipe([request, request, {"method": "shutdown"}])
+    proc = WorkerMultiprocProc.__new__(WorkerMultiprocProc)
+    proc.rank = 0
+    proc.pipe = pipe
+    proc.worker = _RecoveringWorker()
+    monkeypatch.setattr(torch.cuda, "max_memory_allocated", lambda: 0)
+
+    proc.worker_busy_loop()
+
+    assert pipe.responses[0][_RPC_ERROR_KEY] is True
+    assert "ValueError: bad request" in pipe.responses[0]["error"]
+    assert torch.equal(pipe.responses[1]["output_batch"], torch.ones(1))
+    assert pipe.responses[2] == {"status": "shutdown"}
+
+
+def test_parent_raises_worker_rpc_error() -> None:
+    with pytest.raises(RuntimeError, match="worker 0: ValueError: bad request"):
+        _raise_for_rpc_errors("execute_forward", [{_RPC_ERROR_KEY: True, "error": "ValueError: bad request"}])

--- a/fastvideo/worker/multiproc_executor.py
+++ b/fastvideo/worker/multiproc_executor.py
@@ -34,6 +34,16 @@ from fastvideo.worker.executor import Executor
 from fastvideo.worker.worker_base import WorkerWrapperBase
 
 logger = init_logger(__name__)
+_RPC_ERROR_KEY = "__fastvideo_rpc_error__"
+
+
+def _raise_for_rpc_errors(method: str | Callable, responses: list[Any]) -> None:
+    errors = []
+    for rank, response in enumerate(responses):
+        if isinstance(response, dict) and response.get(_RPC_ERROR_KEY):
+            errors.append(f"worker {rank}: {response.get('error', 'unknown error')}")
+    if errors:
+        raise RuntimeError(f"RPC {method!r} failed: " + "; ".join(errors))
 
 
 def _make_queue_log_handler(log_queue: Queue) -> logging.Handler:
@@ -285,6 +295,7 @@ class MultiprocExecutor(Executor):
             for worker in self.workers:
                 response = worker.pipe.recv()
                 responses.append(response)
+            _raise_for_rpc_errors(method, responses)
             return responses
         except TimeoutError as e:
             raise TimeoutError(f"RPC call to {method} timed out.") from e
@@ -314,7 +325,9 @@ class MultiprocExecutor(Executor):
             return await loop.run_in_executor(None, worker.pipe.recv)
 
         responses = await asyncio.gather(*[recv_from_worker(worker) for worker in self.workers])
-        return list(responses)
+        result = list(responses)
+        _raise_for_rpc_errors(method, result)
+        return result
 
     def shutdown(self) -> None:
         """Properly shut down the executor and its workers"""
@@ -710,6 +723,9 @@ class WorkerMultiprocProc:
                 else:
                     result = self.worker.execute_method(method, *args, **kwargs)
                     self.pipe.send(result)
+            except EOFError:
+                logger.info("Worker %d RPC pipe closed; exiting event loop", self.rank)
+                break
             except KeyboardInterrupt:
                 logger.error("Worker %d in loop received KeyboardInterrupt, aborting forward pass", self.rank)
                 try:
@@ -718,6 +734,17 @@ class WorkerMultiprocProc:
                 except Exception as e:
                     logger.error("Worker %d failed to send error response: %s", self.rank, str(e))
                 continue
+            except Exception as error:
+                logger.exception("Worker %d failed RPC without exiting", self.rank)
+                try:
+                    self.pipe.send({
+                        _RPC_ERROR_KEY: True,
+                        "error": f"{type(error).__name__}: {error}",
+                        "traceback": get_exception_traceback(),
+                    })
+                except Exception:
+                    logger.exception("Worker %d could not return its RPC error", self.rank)
+                    break
 
     def streaming_queue_loop(self) -> None:
         if self.streaming_input_queue is None or self.streaming_output_queue is None:


### PR DESCRIPTION
## Summary

Address the post-merge review findings from #1781 across the general serving engine and video API.

This makes invalid worker requests recoverable, rejects unsafe or unsupported request fields at admission, keeps every generated artifact under the server output directory, validates reference media before dispatch, and tightens cancellation, health, cleanup, pagination, model selection, and benchmark-client behavior.

## Testing

- `pre-commit run --files <18 changed files>`
- `pytest -q fastvideo/tests/api fastvideo/tests/entrypoints/test_openai_api.py fastvideo/tests/entrypoints/test_openai_serving_engine.py fastvideo/tests/worker/test_multiproc_executor.py`
- Real four-GPU FastH3 full-checkpoint admission and generation validation

## Evidence

- Pre-commit: passed, including formatting, lint, spelling, Markdown, and mypy
- API and serving tests: 334 passed
- Worker recovery regression: a failed RPC returns a request error and the same worker handles the next forward
- Full FastH3 server returned HTTP 400 for invalid frame count, invalid canvas, missing image, client `output_path`, and client `prompt_path`
- The same four-worker server accepted a valid request and produced a 124-frame, 1344x768, 24-fps MP4 in 12.18 seconds
- Tracked validation run: `20260828T204946Z-pr1781-serving-hardening-e2e`

## Notable contract changes

- Video `output_path` is no longer a public request field; server output paths are unique and contained under `server.output_dir`
- Unknown top-level fields are forbidden, and `extra_params` uses an explicit allowlist
- Startup-LoRA servers advertise only the loaded adapter model id
- Synchronous MP4 artifacts are removed after response streaming
- `/health` returns 503 when the local worker pool is unavailable
