### PR TITLE
[bugfix] Shut down Inductor workers gracefully

### DIFF
--- a/fastvideo/tests/worker/test_multiproc_executor.py
+++ b/fastvideo/tests/worker/test_multiproc_executor.py
@@ -1,3 +1,4 @@
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -6,8 +7,12 @@ import torch
 from fastvideo.pipelines.pipeline_batch_info import ForwardBatch
 from fastvideo.worker.multiproc_executor import (
     _RPC_ERROR_KEY,
+    _WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
     _raise_for_rpc_errors,
+    _shutdown_torch_compile_workers,
+    MultiprocExecutor,
     WorkerMultiprocProc,
+    WorkerProcHandle,
 )
 
 
@@ -40,6 +45,61 @@ class _RecoveringWorker:
         return {"status": "shutdown"}
 
 
+class _CountingWorker:
+
+    def __init__(self):
+        self.shutdown_calls = 0
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+        return {"status": "shutdown"}
+
+
+class _GracefulProcess:
+
+    def __init__(self, required_timeout: float):
+        self.required_timeout = required_timeout
+        self.alive = True
+        self.join_timeouts = []
+        self.terminate_calls = 0
+        self.kill_calls = 0
+
+    def is_alive(self):
+        return self.alive
+
+    def join(self, timeout=None):
+        self.join_timeouts.append(timeout)
+        if timeout is not None and timeout >= self.required_timeout:
+            self.alive = False
+
+    def terminate(self):
+        self.terminate_calls += 1
+        self.alive = False
+
+    def kill(self):
+        self.kill_calls += 1
+        self.alive = False
+
+
+class _StuckProcess(_GracefulProcess):
+
+    def terminate(self):
+        self.terminate_calls += 1
+
+
+class _RecordingPipe:
+
+    def __init__(self):
+        self.messages = []
+        self.closed = False
+
+    def send(self, message):
+        self.messages.append(message)
+
+    def close(self):
+        self.closed = True
+
+
 def test_worker_rpc_error_does_not_exit_busy_loop(monkeypatch) -> None:
     request = {
         "method": "execute_forward",
@@ -66,3 +126,78 @@ def test_worker_rpc_error_does_not_exit_busy_loop(monkeypatch) -> None:
 def test_parent_raises_worker_rpc_error() -> None:
     with pytest.raises(RuntimeError, match="worker 0: ValueError: bad request"):
         _raise_for_rpc_errors("execute_forward", [{_RPC_ERROR_KEY: True, "error": "ValueError: bad request"}])
+
+
+def test_worker_shutdown_closes_worker_and_compile_pool_once(monkeypatch) -> None:
+    worker = _CountingWorker()
+    compile_shutdowns = []
+    proc = WorkerMultiprocProc.__new__(WorkerMultiprocProc)
+    proc.worker = worker
+    proc._shutdown_complete = False
+    proc._shutdown_response = None
+    monkeypatch.setattr(
+        "fastvideo.worker.multiproc_executor._shutdown_torch_compile_workers",
+        lambda: compile_shutdowns.append(True),
+    )
+
+    first = proc.shutdown()
+    second = proc.shutdown()
+
+    assert first == {"status": "shutdown"}
+    assert second == first
+    assert worker.shutdown_calls == 1
+    assert compile_shutdowns == [True]
+
+
+def test_compile_worker_cleanup_uses_only_an_already_loaded_inductor(monkeypatch) -> None:
+    compile_shutdowns = []
+    fake_async_compile = SimpleNamespace(shutdown_compile_workers=lambda: compile_shutdowns.append(True))
+    monkeypatch.setitem(sys.modules, "torch._inductor.async_compile", fake_async_compile)
+
+    _shutdown_torch_compile_workers()
+
+    assert compile_shutdowns == [True]
+
+
+def test_compile_worker_cleanup_does_not_import_inductor(monkeypatch) -> None:
+    monkeypatch.delitem(sys.modules, "torch._inductor.async_compile", raising=False)
+
+    _shutdown_torch_compile_workers()
+
+    assert "torch._inductor.async_compile" not in sys.modules
+
+
+def test_executor_allows_slow_graceful_worker_exit_before_sigterm() -> None:
+    # Regression for torch.compile workers: Inductor cleanup can take longer
+    # than the old five-second grace period, especially under `nice -n 19`.
+    process = _GracefulProcess(required_timeout=6.0)
+    pipe = _RecordingPipe()
+    executor = MultiprocExecutor.__new__(MultiprocExecutor)
+    executor.shutting_down = False
+    executor.workers = [WorkerProcHandle(proc=process, rank=0, pipe=pipe)]
+
+    executor.shutdown()
+
+    assert pipe.messages == [{"method": "shutdown", "args": (), "kwargs": {}}]
+    assert pipe.closed is True
+    assert process.join_timeouts[0] > 6.0
+    assert process.join_timeouts[0] <= _WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_S
+    assert process.terminate_calls == 0
+    assert process.kill_calls == 0
+    assert executor.workers == []
+
+
+def test_executor_still_kills_worker_that_ignores_graceful_exit_and_sigterm() -> None:
+    process = _StuckProcess(required_timeout=float("inf"))
+    pipe = _RecordingPipe()
+    executor = MultiprocExecutor.__new__(MultiprocExecutor)
+    executor.shutting_down = False
+    executor.workers = [WorkerProcHandle(proc=process, rank=0, pipe=pipe)]
+
+    executor.shutdown()
+
+    assert process.terminate_calls == 1
+    assert process.kill_calls == 1
+    assert process.alive is False
+    assert pipe.closed is True
+    assert executor.workers == []

--- a/fastvideo/tests/worker/test_multiproc_executor.py
+++ b/fastvideo/tests/worker/test_multiproc_executor.py
@@ -55,6 +55,16 @@ class _CountingWorker:
         return {"status": "shutdown"}
 
 
+class _FailingWorker:
+
+    def __init__(self):
+        self.shutdown_calls = 0
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+        raise RuntimeError("interrupted shutdown")
+
+
 class _GracefulProcess:
 
     def __init__(self, required_timeout: float):
@@ -145,6 +155,29 @@ def test_worker_shutdown_closes_worker_and_compile_pool_once(monkeypatch) -> Non
 
     assert first == {"status": "shutdown"}
     assert second == first
+    assert worker.shutdown_calls == 1
+    assert compile_shutdowns == [True]
+
+
+def test_worker_shutdown_still_idempotent_after_failure(monkeypatch) -> None:
+    worker = _FailingWorker()
+    compile_shutdowns = []
+    proc = WorkerMultiprocProc.__new__(WorkerMultiprocProc)
+    proc.rank = 0
+    proc.worker = worker
+    proc._shutdown_started = False
+    proc._shutdown_complete = False
+    proc._shutdown_response = None
+    monkeypatch.setattr(
+        "fastvideo.worker.multiproc_executor._shutdown_torch_compile_workers",
+        lambda: compile_shutdowns.append(True),
+    )
+
+    first = proc.shutdown()
+    second = proc.shutdown()
+
+    assert first == {"status": "shutdown"}
+    assert second == {"status": "shutdown"}
     assert worker.shutdown_calls == 1
     assert compile_shutdowns == [True]
 

--- a/fastvideo/worker/multiproc_executor.py
+++ b/fastvideo/worker/multiproc_executor.py
@@ -522,6 +522,7 @@ class WorkerMultiprocProc:
         self.streaming_input_queue = streaming_input_queue
         self.streaming_output_queue = streaming_output_queue
         self._initial_log_handler = _initial_log_handler
+        self._shutdown_started = False
         self._shutdown_complete = False
         self._shutdown_response: dict[str, Any] | None = None
         wrapper = WorkerWrapperBase(fastvideo_args=fastvideo_args, rpc_rank=rank)
@@ -719,10 +720,26 @@ class WorkerMultiprocProc:
             assert self._shutdown_response is not None
             return self._shutdown_response
 
-        response = self.worker.shutdown()
-        _shutdown_torch_compile_workers()
-        self._shutdown_response = response
-        self._shutdown_complete = True
+        if getattr(self, "_shutdown_started", False):
+            if self._shutdown_response is None:
+                self._shutdown_response = {"status": "shutdown"}
+            return self._shutdown_response
+
+        self._shutdown_started = True
+        response = {"status": "shutdown"}
+        shutdown_succeeded = False
+
+        try:
+            response = self.worker.shutdown()
+            shutdown_succeeded = True
+        except Exception:
+            logger.exception("Worker %d failed to shut down", self.rank)
+        finally:
+            _shutdown_torch_compile_workers()
+            if shutdown_succeeded:
+                self._shutdown_complete = True
+            self._shutdown_response = response
+
         return response
 
     def worker_busy_loop(self) -> None:

--- a/fastvideo/worker/multiproc_executor.py
+++ b/fastvideo/worker/multiproc_executor.py
@@ -15,6 +15,7 @@ from multiprocessing.queues import Queue
 import os
 import queue
 import signal
+import sys
 import time
 from collections.abc import Callable
 from multiprocessing.process import BaseProcess
@@ -35,6 +36,45 @@ from fastvideo.worker.worker_base import WorkerWrapperBase
 
 logger = init_logger(__name__)
 _RPC_ERROR_KEY = "__fastvideo_rpc_error__"
+_WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_S = 30.0
+_WORKER_TERMINATE_TIMEOUT_S = 2.0
+_WORKER_KILL_JOIN_TIMEOUT_S = 1.0
+
+
+def _shutdown_torch_compile_workers() -> None:
+    """Close an already-initialized Inductor pool before interpreter exit.
+
+    PyTorch registers the same cleanup as an ``atexit`` callback. Running it
+    while the FastVideo worker is still in its graceful shutdown phase avoids
+    having the parent send SIGTERM while that callback is waiting for the
+    compiler subprocess. Do not import Inductor here: eager workers should not
+    initialize compiler state just because they are exiting.
+    """
+    async_compile = sys.modules.get("torch._inductor.async_compile")
+    if async_compile is None:
+        return
+
+    shutdown_compile_workers = getattr(async_compile, "shutdown_compile_workers", None)
+    if not callable(shutdown_compile_workers):
+        return
+
+    try:
+        shutdown_compile_workers()
+    except Exception:
+        # Compiler cleanup must not prevent the worker process from exiting.
+        # PyTorch's atexit callback can make one final best-effort attempt.
+        logger.exception("Failed to shut down torch.compile workers cleanly")
+
+
+def _wait_for_processes_to_exit(processes: list[BaseProcess], timeout: float) -> bool:
+    """Join processes against one shared deadline and report if all exited."""
+    deadline = time.monotonic() + timeout
+    for process in processes:
+        if not process.is_alive():
+            continue
+        remaining = max(0.0, deadline - time.monotonic())
+        process.join(timeout=remaining)
+    return all(not process.is_alive() for process in processes)
 
 
 def _raise_for_rpc_errors(method: str | Callable, responses: list[Any]) -> None:
@@ -350,30 +390,34 @@ class MultiprocExecutor(Executor):
                 with contextlib.suppress(Exception):
                     worker.pipe.send({"method": "shutdown", "args": (), "kwargs": {}})
 
-            # Give workers some time to exit gracefully
-            start_time = time.perf_counter()
-            while time.perf_counter() - start_time < 5.0:  # 5 seconds timeout
-                if all(not worker.proc.is_alive() for worker in self.workers):
-                    break
-                time.sleep(0.1)
+            worker_processes = [worker.proc for worker in self.workers]
+
+            # torch.compile keeps an Inductor subprocess pool alive. Let the
+            # worker close that pool before escalating to SIGTERM; five seconds
+            # is too short on low-priority or memory-constrained hosts.
+            exited_gracefully = _wait_for_processes_to_exit(
+                worker_processes,
+                _WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
+            )
 
             # Force terminate any remaining workers
-            for worker in self.workers:
-                if worker.proc.is_alive():
-                    worker.proc.terminate()
+            if not exited_gracefully:
+                logger.warning(
+                    "Workers did not exit within %.1f seconds; sending SIGTERM",
+                    _WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
+                )
+                for process in worker_processes:
+                    if process.is_alive():
+                        process.terminate()
 
             # Final timeout for terminate
-            start_time = time.perf_counter()
-            while time.perf_counter() - start_time < 2.0:  # 2 seconds timeout
-                if all(not worker.proc.is_alive() for worker in self.workers):
-                    break
-                time.sleep(0.1)
+            _wait_for_processes_to_exit(worker_processes, _WORKER_TERMINATE_TIMEOUT_S)
 
             # Kill if still alive
-            for worker in self.workers:
-                if worker.proc.is_alive():
-                    worker.proc.kill()
-                worker.proc.join(timeout=1.0)
+            for process in worker_processes:
+                if process.is_alive():
+                    process.kill()
+                process.join(timeout=_WORKER_KILL_JOIN_TIMEOUT_S)
 
         except Exception as e:
             logger.error("Error during shutdown: %s", e)
@@ -478,6 +522,8 @@ class WorkerMultiprocProc:
         self.streaming_input_queue = streaming_input_queue
         self.streaming_output_queue = streaming_output_queue
         self._initial_log_handler = _initial_log_handler
+        self._shutdown_complete = False
+        self._shutdown_response: dict[str, Any] | None = None
         wrapper = WorkerWrapperBase(fastvideo_args=fastvideo_args, rpc_rank=rank)
 
         all_kwargs: list[dict] = [{} for _ in range(fastvideo_args.num_gpus)]
@@ -669,7 +715,15 @@ class WorkerMultiprocProc:
         return cast(list[WorkerProcHandle], ready_proc_handles)
 
     def shutdown(self) -> dict[str, Any]:
-        return self.worker.shutdown()
+        if getattr(self, "_shutdown_complete", False):
+            assert self._shutdown_response is not None
+            return self._shutdown_response
+
+        response = self.worker.shutdown()
+        _shutdown_torch_compile_workers()
+        self._shutdown_response = response
+        self._shutdown_complete = True
+        return response
 
     def worker_busy_loop(self) -> None:
         """Main busy loop for Multiprocessing Workers"""


### PR DESCRIPTION
## Purpose

Fix noisy and potentially incomplete worker shutdown after `torch.compile` inference.

Compiled multiprocessing runs could end with:

```text
Exception ignored in atexit callback: shutdown_compile_workers
...
SystemExit
```

FastVideo allowed workers only five seconds to exit before sending SIGTERM. On slower or low-priority hosts, the signal could interrupt PyTorch Inductor while its atexit callback was waiting for compiler subprocesses to stop.
Worker cleanup was also invoked twice: once by the shutdown RPC and again from the worker process's finally block.

## Changes

Close an already-initialized PyTorch Inductor compilation pool during normal worker shutdown.
- Inspect sys.modules instead of importing Inductor, so eager inference does not initialize compiler state during shutdown.

Make WorkerMultiprocProc.shutdown() idempotent.
Extend the parent worker's graceful shutdown period from 5 seconds to 30 seconds.
Join workers against a shared deadline instead of polling.
Preserve the existing SIGTERM and SIGKILL fallbacks for unresponsive workers.
Add CPU regression coverage for:- idempotent worker and compiler-pool cleanup;
- cleanup of an already-loaded Inductor pool;
- avoiding an Inductor import for eager workers;
- workers requiring more than the previous five-second grace period;
- workers that ignore graceful shutdown and SIGTERM.

## Test Plan

conda run -n fastvideo python -m pytest \
  fastvideo/tests/worker/test_multiproc_executor.py -q

conda run -n fastvideo python -m pytest \
  fastvideo/tests/worker/ -q

conda run -n fastvideo pre-commit run --files \
  fastvideo/worker/multiproc_executor.py \
  fastvideo/tests/worker/test_multiproc_executor.py

git diff --check