### PR TITLE
[docs]: Cookbook catalog improvements

### DIFF
--- a/docs/assets/cookbook-recipes.json
+++ b/docs/assets/cookbook-recipes.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "recipes": [
     {
       "id": "fastwan21-t2v",
@@ -82,15 +82,18 @@
       },
       "evidence": "Verified",
       "expected_artifact": "MP4 video at outputs/fastmetal_1_3b.mp4",
-      "limitations": ["This is the native MLX FastMetal path. basic_mps.py is the older PyTorch MPS demo."]
+      "modes": ["T2V", "temporal --fast", "spatial --fast-spatial", "two-pass --refine"],
+      "limitations": [
+        "Native MLX FastMetal T2V. Add --fast for temporal RIFE, --fast-spatial to denoise at half resolution, or --refine for a two-pass upsample. basic_mps.py is the older PyTorch MPS demo."
+      ]
     },
     {
       "id": "fastmetal-5b-mlx",
       "family": "wan",
       "stage": "inference",
-      "task": "Text or image to video",
+      "task": "Text to video",
       "label": "FastMetal 5B",
-      "summary": "Run the released Wan2.2 5B FastMetal checkpoint with MLX DiT denoising and MLX TAEHV decode.",
+      "summary": "Run the released Wan2.2 5B FastMetal checkpoint as MLX T2V with MLX DiT denoising and MLX TAEHV decode. The CUDA Wan2.2 TI2V 5B recipe is the image-capable path.",
       "model": "FastVideo/FastMetal-5B-QAD",
       "source": "examples/inference/basic/mlx_wan22_generate.py",
       "command": "hf download FastVideo/FastMetal-5B-QAD --local-dir ./FastMetal-5B-QAD\npython examples/inference/basic/mlx_wan22_generate.py --mlx-checkpoint ./FastMetal-5B-QAD --text-encoder-root ./FastMetal-5B-QAD --vae-root ./FastMetal-5B-QAD/vae --height 704 --width 1280 --num-frames 81 --prompt \"A cinematic portrait with soft neon lighting and smooth camera motion.\" --output-path ./outputs/fastmetal_5b.mp4",
@@ -105,7 +108,11 @@
         "evidence_url": "https://github.com/hao-ai-lab/FastVideo/pull/1638"
       },
       "evidence": "Verified",
-      "expected_artifact": "MP4 video at outputs/fastmetal_5b.mp4"
+      "expected_artifact": "MP4 video at outputs/fastmetal_5b.mp4",
+      "modes": ["T2V", "temporal --fast", "spatial --fast-spatial", "two-pass --refine"],
+      "limitations": [
+        "The checked-in MLX example is T2V. Image-to-video is not in mlx_wan22_generate.py. Add --fast, --fast-spatial, or --refine on the same script."
+      ]
     },
     {
       "id": "fastmetal-14b-mlx",
@@ -128,7 +135,11 @@
         "evidence_url": "https://github.com/hao-ai-lab/FastVideo/pull/1638"
       },
       "evidence": "Verified",
-      "expected_artifact": "MP4 video at outputs/fastmetal_14b.mp4"
+      "expected_artifact": "MP4 video at outputs/fastmetal_14b.mp4",
+      "modes": ["T2V", "temporal --fast", "spatial --fast-spatial", "two-pass --refine"],
+      "limitations": [
+        "Native MLX FastMetal T2V on 36 GB+ unified memory. Same --fast, --fast-spatial, and --refine flags as the 1.3B script."
+      ]
     },
     {
       "id": "turbodiffusion-wan21-1-3b-t2v",
@@ -425,6 +436,7 @@
       "hardware": {"platform": "cuda", "gpu_count": 4, "evidence": "source-configured"},
       "evidence": "Source-backed",
       "expected_artifact": "MP4 with synchronized audio at outputs/minimax_h3_t2v/minimax_h3_t2v.mp4",
+      "modes": ["T2VA"],
       "limitations": ["The checked-in example defaults to four-way sequence parallelism. It does not record a GPU model or memory requirement."]
     },
     {
@@ -450,6 +462,7 @@
       },
       "evidence": "Verified",
       "expected_artifact": "Warmup and measured MP4 files under outputs/fasth3/",
+      "modes": ["T2VA", "4-step FastH3"],
       "limitations": ["The default all profile is the measured GB200 performance route and can change floating-point operation order. Use --profile strict --no-inference-torch-compile for the eager strict route."]
     },
     {
@@ -476,7 +489,10 @@
       },
       "evidence": "Verified",
       "expected_artifact": "MP4 with H.264 video and stereo AAC audio at outputs/fasth3_int6.mp4",
-      "limitations": ["The MLX path supports T2VA and optional temporal --fast and spatial --fast-spatial modes. FL2VA, Ref2VA, two-pass refinement, and VSA are not wired."]
+      "modes": ["T2VA", "temporal --fast", "spatial --fast-spatial", "opt-in VSA"],
+      "limitations": [
+        "The MLX path supports T2VA, optional temporal --fast, optional spatial --fast-spatial, and opt-in VSA on --include-vsa checkpoints. FL2VA, Ref2VA, and two-pass refinement are not wired."
+      ]
     },
     {
       "id": "minimax-h3-fl2va",
@@ -492,6 +508,7 @@
       "hardware": {"platform": "cuda", "gpu_count": 4, "evidence": "source-configured"},
       "evidence": "Source-backed",
       "expected_artifact": "MP4 with synchronized audio at outputs/minimax_h3_fl2va/minimax_h3_fl2va.mp4",
+      "modes": ["FL2VA"],
       "limitations": ["Pass --last-image to constrain the final frame. The checked-in source defaults to four GPUs."]
     },
     {
@@ -508,6 +525,7 @@
       "hardware": {"platform": "cuda", "gpu_count": 4, "evidence": "source-configured"},
       "evidence": "Source-backed",
       "expected_artifact": "MP4 with synchronized audio at outputs/minimax_h3_ref2va/minimax_h3_ref2va.mp4",
+      "modes": ["Ref2VA"],
       "limitations": ["Pass --reference-audio for an additional audio reference. The checked-in source defaults to four GPUs."]
     },
     {
@@ -530,6 +548,7 @@
       },
       "evidence": "Verified",
       "expected_artifact": "Warmup and measured MP4 files under outputs/fasth3_lora_preview/",
+      "modes": ["T2VA", "FastH3 LoRA"],
       "limitations": ["Supply a compatible FastH3 adapter. The script infers dense or VSA attention from the adapter payload unless you override it."]
     },
     {

--- a/docs/assets/cookbook.js
+++ b/docs/assets/cookbook.js
@@ -1,5 +1,7 @@
 (() => {
-  const patternCharacters = "0123456789ABCDEF";
+  const PATTERN_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const PATTERN_LENGTH = 900;
+  const SCRAMBLE_MS = 140;
 
   const loadRecipes = (url) =>
     fetch(url).then((response) => {
@@ -7,18 +9,81 @@
       return response.json();
     });
 
-  const initPatterns = (root) => {
-    root.querySelectorAll("[data-cookbook-pattern]").forEach((pattern, patternIndex) => {
-      if (pattern.dataset.patternReady) return;
-      pattern.dataset.patternReady = "true";
-      let value = "";
-      for (let index = 0; index < 1800; index += 1) {
-        const characterIndex = (index * 7 + patternIndex * 11) % patternCharacters.length;
-        value += patternCharacters.charAt(characterIndex);
-        if (index % 4 === 3 && index % 32 !== 31) value += " ";
-        if (index % 32 === 31) value += "\n";
-      }
-      pattern.textContent = value;
+  const generatePattern = (length) => {
+    const chars = new Array(length);
+    for (let index = 0; index < length; index += 1) {
+      chars[index] = PATTERN_CHARS.charAt((Math.random() * PATTERN_CHARS.length) | 0);
+    }
+    return chars.join("");
+  };
+
+  const motionQuery = () =>
+    window.matchMedia("(hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference)");
+
+  const initEvervault = (root) => {
+    root.querySelectorAll("[data-evervault]").forEach((visual) => {
+      if (visual.dataset.evervaultReady) return;
+      visual.dataset.evervaultReady = "true";
+      const noise = visual.querySelector("[data-cookbook-pattern]");
+      if (!noise) return;
+
+      const query = motionQuery();
+      if (!query.matches) return;
+
+      let rect = null;
+      let pointerX = 0;
+      let pointerY = 0;
+      let frame = 0;
+      let lastScramble = 0;
+      let patternReady = false;
+
+      const paint = (scramble) => {
+        visual.style.setProperty("--mouse-x", `${pointerX}px`);
+        visual.style.setProperty("--mouse-y", `${pointerY}px`);
+        if (scramble) noise.textContent = generatePattern(PATTERN_LENGTH);
+        frame = 0;
+      };
+
+      const onEnter = () => {
+        rect = visual.getBoundingClientRect();
+        if (!patternReady) {
+          noise.textContent = generatePattern(PATTERN_LENGTH);
+          patternReady = true;
+        }
+      };
+      const onMove = (event) => {
+        if (!rect) rect = visual.getBoundingClientRect();
+        pointerX = event.clientX - rect.left;
+        pointerY = event.clientY - rect.top;
+        if (frame) return;
+        frame = window.requestAnimationFrame(() => {
+          const now = performance.now();
+          const scramble = now - lastScramble >= SCRAMBLE_MS;
+          if (scramble) lastScramble = now;
+          paint(scramble);
+        });
+      };
+      const onLeave = () => {
+        if (frame) window.cancelAnimationFrame(frame);
+        frame = 0;
+        rect = null;
+        pointerX = 0;
+        pointerY = 0;
+        visual.style.setProperty("--mouse-x", "50%");
+        visual.style.setProperty("--mouse-y", "50%");
+      };
+      visual.addEventListener("mouseenter", onEnter);
+      visual.addEventListener("mousemove", onMove);
+      visual.addEventListener("mouseleave", onLeave);
+    });
+  };
+
+  let familyPopstate = null;
+  const bindFamilyPopstate = () => {
+    if (bindFamilyPopstate.bound) return;
+    bindFamilyPopstate.bound = true;
+    window.addEventListener("popstate", () => {
+      if (typeof familyPopstate === "function") familyPopstate();
     });
   };
 
@@ -137,28 +202,9 @@
 
     compactLifecycle(root);
 
-    const builderHeading = root.querySelector(".cookbook-builder__intro h2");
-    const builderIntro = root.querySelector(".cookbook-builder__intro > p");
-    if (builderHeading) builderHeading.textContent = "Pick a recipe and runtime";
-    if (builderIntro) {
-      builderIntro.textContent =
-        "Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.";
-    }
-
-    const selectionLabels = root.querySelectorAll(".cookbook-selection-row__label");
-    if (selectionLabels[0]) {
-      selectionLabels[0].querySelector("strong").textContent = "Recipe";
-      selectionLabels[0].querySelector("span").textContent = "Task and checkpoint";
-    }
-    if (selectionLabels[1]) {
-      selectionLabels[1].querySelector("strong").textContent = "Runtime";
-      selectionLabels[1].querySelector("span").textContent = "Maintained paths only";
-    }
-
     const modelOptions = root.querySelector("[data-cookbook-model-options]");
     const hardwareOptions = root.querySelector("[data-cookbook-hardware-options]");
     const description = root.querySelector("[data-cookbook-description]");
-    const hardwareNote = root.querySelector(".cookbook-hardware-note");
     const label = root.querySelector("[data-cookbook-label]");
     const model = root.querySelector("[data-cookbook-model]");
     const task = root.querySelector("[data-cookbook-task]");
@@ -178,12 +224,6 @@
     modelOptions.setAttribute("aria-label", "Recipe");
     hardwareOptions.setAttribute("aria-label", "Runtime");
 
-    if (hardwareNote) {
-      hardwareNote.textContent = "Exact device and memory details appear only when a recorded run supports them.";
-    }
-    const runtimeFactLabel = hardwareValue?.closest("div")?.querySelector("dt");
-    if (runtimeFactLabel) runtimeFactLabel.textContent = "Hardware";
-
     let recipes;
     try {
       ({ recipes } = await loadRecipes(root.dataset.recipes));
@@ -192,6 +232,7 @@
       console.error("Failed to load FastVideo cookbook recipes", error);
       return;
     }
+    if (!root.isConnected) return;
 
     const familyRecipes = recipes.filter((recipe) => recipe.family === family);
     if (!familyRecipes.length) return;
@@ -225,6 +266,7 @@
     const defaultRecipeId = familyRecipes[0].id;
     let selectedRecipeId = requestedRecipe && byId.has(requestedRecipe) ? requestedRecipe : defaultRecipeId;
     let selectedGroupId = groupIdFor(byId.get(selectedRecipeId));
+    let renderedRuntimeGroup = null;
 
     const renderRuntimeOptions = () => {
       const groupRecipes = groups.get(selectedGroupId) || [];
@@ -255,6 +297,7 @@
     }
 
     const render = ({ groupChanged = false, historyMode = "replace" } = {}) => {
+      if (!root.isConnected) return;
       if (!byId.has(selectedRecipeId)) selectedRecipeId = defaultRecipeId;
       let recipe = byId.get(selectedRecipeId);
       if (groupChanged || groupIdFor(recipe) !== selectedGroupId) {
@@ -265,7 +308,10 @@
       }
 
       selectedGroupId = groupIdFor(recipe);
-      renderRuntimeOptions();
+      if (renderedRuntimeGroup !== selectedGroupId) {
+        renderRuntimeOptions();
+        renderedRuntimeGroup = selectedGroupId;
+      }
       const runtime = runtimeFor(recipe);
 
       modelOptions.querySelectorAll("button").forEach((option) => {
@@ -337,17 +383,19 @@
 
     render();
 
-    window.addEventListener("popstate", () => {
+    familyPopstate = () => {
+      if (!root.isConnected) return;
       const nextQuery = new URLSearchParams(window.location.search);
       const nextRecipe = nextQuery.get("recipe");
       selectedRecipeId = nextRecipe && byId.has(nextRecipe) ? nextRecipe : defaultRecipeId;
       selectedGroupId = groupIdFor(byId.get(selectedRecipeId));
       render({ historyMode: "none" });
-    });
+    };
+    bindFamilyPopstate();
   };
 
   const init = () => {
-    initPatterns(document);
+    initEvervault(document);
     document.querySelectorAll("[data-cookbook][data-family]").forEach((root) => {
       if (root.dataset.initialized) return;
       root.dataset.initialized = "true";

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -145,62 +145,6 @@ img {
     background: transparent;
 }
 
-.md-typeset .cookbook-journey {
-    display: grid !important;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0;
-    padding: 0;
-    margin: 2.5rem 0 0;
-    list-style: none;
-    border-top: 1px solid var(--cookbook-border);
-}
-
-.cookbook-journey li {
-    position: relative;
-    min-width: 0;
-    padding: 1.2rem 1.5rem 0 0;
-    margin: 0;
-}
-
-.cookbook-journey li:not(:last-child)::after {
-    position: absolute;
-    top: 1.85rem;
-    right: 0.75rem;
-    width: 1.25rem;
-    height: 1px;
-    background: var(--cookbook-border);
-    content: "";
-}
-
-.cookbook-journey li > span {
-    display: inline-grid;
-    width: 1.35rem;
-    height: 1.35rem;
-    margin-bottom: 0.55rem;
-    place-items: center;
-    border-radius: 999px;
-    color: #fff;
-    background: var(--cookbook-accent);
-    font-size: 0.58rem;
-    font-weight: 720;
-}
-
-.cookbook-journey strong,
-.cookbook-journey small {
-    display: block;
-}
-
-.cookbook-journey strong {
-    font-size: 0.72rem;
-}
-
-.cookbook-journey small {
-    margin-top: 0.2rem;
-    color: var(--md-default-fg-color--light);
-    font-size: 0.62rem;
-    line-height: 1.4;
-}
-
 .cookbook-section,
 .cookbook-builder,
 .cookbook-roadmap {
@@ -217,8 +161,14 @@ img {
 }
 
 .cookbook-catalog .cookbook-section {
-    padding-top: 0;
+    padding: 2.25rem 0 0.5rem;
     border-top: 0;
+}
+
+.cookbook-catalog .cookbook-section + .cookbook-section {
+    margin-top: 1.5rem;
+    padding-top: 1.75rem;
+    border-top: 1px solid var(--cookbook-border);
 }
 
 .cookbook-section__heading {
@@ -254,27 +204,27 @@ img {
 }
 
 .md-typeset .cookbook-family-tile {
-    display: block;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
     border: 1px solid var(--cookbook-border);
-    border-radius: 0.75rem;
+    border-radius: 0.95rem;
     color: var(--md-default-fg-color);
     background: var(--cookbook-surface);
     text-decoration: none;
-    transition: border-color 180ms ease;
+    transition-property: border-color, box-shadow;
+    transition-duration: 150ms;
+    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
 }
 
-/* Identical restrained hover/focus treatment for every tile: a border and
-   accent change plus the pattern reveal. No transforms, so card geometry
-   never shifts on hover. */
 .md-typeset a.cookbook-family-tile:focus-visible,
 .cookbook-family-tile--coming:focus-visible {
     border-color: var(--cookbook-accent);
     color: var(--md-default-fg-color);
 }
 
-.cookbook-family-tile--ready {
-    border-color: color-mix(in srgb, var(--cookbook-accent) 54%, var(--cookbook-border));
+.cookbook-family-tile--featured {
+    border-color: color-mix(in srgb, var(--cookbook-accent) 48%, var(--cookbook-border));
 }
 
 .cookbook-family-tile--coming {
@@ -286,41 +236,63 @@ img {
     display: grid;
     aspect-ratio: 4 / 3;
     overflow: hidden;
+    isolation: isolate;
     place-items: center;
     border-bottom: 1px solid var(--cookbook-border);
-    background: #f7f7f5;
+    background: linear-gradient(145deg, #fafafa, #f0f1f5);
+    --mouse-x: 50%;
+    --mouse-y: 50%;
 }
 
-.cookbook-card-pattern {
+.cookbook-evervault {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    opacity: 0;
+    mask-image: radial-gradient(42% at var(--mouse-x) var(--mouse-y), #fff 18%, transparent 72%);
+    -webkit-mask-image: radial-gradient(42% at var(--mouse-x) var(--mouse-y), #fff 18%, transparent 72%);
+    transition-property: opacity;
+    transition-duration: 150ms;
+    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
+}
+
+.cookbook-evervault__gradient {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to right in oklab, #4f46e5, #0ea5e9);
+}
+
+.cookbook-evervault__noise {
     position: absolute;
     inset: 0;
     overflow: hidden;
-    color: rgba(255, 255, 255, 0.8);
-    background: var(--cookbook-accent);
+    color: #fff;
     font-family: var(--md-code-font-family);
-    font-size: 0.52rem;
+    font-size: 0.5rem;
     font-weight: 700;
-    line-height: 1.04;
-    opacity: 0;
+    line-height: 1.05;
+    letter-spacing: 0.04em;
+    word-break: break-all;
     overflow-wrap: anywhere;
-    transition: opacity 200ms ease;
+    mix-blend-mode: overlay;
 }
 
-/* Every tile gets the same reveal on hover; links also reveal it when they
-   receive keyboard focus, so hover is never the only cue. */
-a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
+.md-typeset a.cookbook-family-tile:focus-visible .cookbook-evervault {
     opacity: 1;
 }
 
 @media (hover: hover) and (pointer: fine) {
-    .md-typeset a.cookbook-family-tile:hover,
-    .cookbook-family-tile--coming:hover {
-        border-color: var(--cookbook-accent);
+    .md-typeset a.cookbook-family-tile:hover {
+        border-color: color-mix(in srgb, var(--cookbook-accent) 62%, var(--cookbook-border));
         color: var(--md-default-fg-color);
     }
 
-    .cookbook-family-tile:hover .cookbook-card-pattern {
+    .md-typeset a.cookbook-family-tile:hover .cookbook-evervault {
         opacity: 1;
+    }
+
+    .cookbook-family-tile--coming:hover {
+        border-color: var(--cookbook-border);
     }
 }
 
@@ -332,8 +304,8 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
     height: 8.4rem;
     place-items: center;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.96);
-    box-shadow: 0 0.7rem 2rem rgba(34, 29, 92, 0.12);
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 0.8rem 2rem rgba(15, 23, 42, 0.12);
     backdrop-filter: blur(8px);
 }
 
@@ -367,17 +339,44 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
 
 .cookbook-family-tile__footer {
     display: flex;
-    min-height: 4.25rem;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.8rem 0.9rem;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    padding: 0.85rem 0.95rem 1rem;
 }
 
-.cookbook-family-tile__footer > span:first-child,
+.cookbook-family-tile__footer-top {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
 .cookbook-family-tile__footer strong,
 .cookbook-family-tile__footer small {
     display: block;
+}
+
+.md-typeset ul.cookbook-mode-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.md-typeset .cookbook-mode-row li {
+    display: inline-flex;
+    padding: 0.18rem 0.45rem;
+    border: 1px solid var(--cookbook-border);
+    border-radius: 999px;
+    color: var(--md-default-fg-color--light);
+    background: var(--cookbook-surface-raised);
+    font-size: 0.7rem;
+    font-weight: 650;
+    line-height: 1.25;
+    white-space: nowrap;
 }
 
 .cookbook-family-page {
@@ -440,7 +439,7 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
     margin-bottom: 0.4rem;
 }
 
-.cookbook-family-header__body p:last-child {
+.cookbook-family-header__body h2 + p {
     margin: 0.55rem 0 0;
     color: var(--md-default-fg-color--light);
     font-size: 0.76rem;
@@ -858,17 +857,18 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
 }
 
 @media (max-width: 52rem) {
-    .md-typeset .cookbook-journey {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        row-gap: 1rem;
-    }
-
-    .cookbook-journey li::after {
-        display: none;
-    }
-
     .cookbook-family-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .cookbook-section__heading {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.45rem;
+    }
+
+    .cookbook-section__heading > p {
+        text-align: start;
     }
 
     .cookbook-selection-row {
@@ -889,11 +889,24 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
         padding-top: 1.5rem;
     }
 
-    .md-typeset .cookbook-journey,
     .cookbook-family-grid,
     .cookbook-option-grid--models,
     .cookbook-result__facts {
         grid-template-columns: 1fr;
+    }
+
+    .cookbook-family-tile__visual {
+        max-height: 12rem;
+    }
+
+    .cookbook-family-tile__logo-wrap {
+        width: 6.5rem;
+        height: 6.5rem;
+    }
+
+    .cookbook-family-tile__logo-wrap img {
+        width: 4.75rem;
+        height: 4.75rem;
     }
 
     .cookbook-section__heading,
@@ -903,7 +916,7 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
     }
 
     .cookbook-section__heading > p {
-        text-align: left;
+        text-align: start;
     }
 
     .cookbook-builder {
@@ -927,14 +940,19 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
 @media (prefers-reduced-motion: reduce) {
     .md-typeset .cookbook-button,
     .md-typeset .cookbook-family-tile,
-    .cookbook-card-pattern,
+    .cookbook-evervault,
     .cookbook-option-grid button {
         transition: none;
     }
 
-    .md-typeset .cookbook-button:hover,
-    .md-typeset .cookbook-family-tile:hover {
-        transform: none;
+    .cookbook-evervault {
+        mask-image: none;
+        -webkit-mask-image: none;
+    }
+
+    .md-typeset a.cookbook-family-tile:hover .cookbook-evervault,
+    .md-typeset a.cookbook-family-tile:focus-visible .cookbook-evervault {
+        opacity: 0.28;
     }
 }
 
@@ -958,12 +976,8 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
 .md-typeset .cookbook-family-tile,
 .md-typeset .cookbook-family-tile--ready {
     border-color: var(--cookbook-border);
-    border-radius: 0.95rem;
     background: var(--cookbook-surface);
     box-shadow: 0 0.1rem 0.25rem rgba(15, 23, 42, 0.04);
-    transition-property: transform, border-color, box-shadow;
-    transition-duration: 180ms;
-    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
 }
 
 .cookbook-family-tile--featured {
@@ -971,75 +985,77 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
     box-shadow: 0 0 0 1px color-mix(in srgb, var(--cookbook-accent) 12%, transparent);
 }
 
-.cookbook-family-tile__visual {
-    background: linear-gradient(145deg, #fafafa, #f0f1f5);
-}
-
-.cookbook-card-pattern {
-    color: rgba(255, 255, 255, 0.58);
-    background:
-        radial-gradient(circle at 20% 10%, rgba(129, 140, 248, 0.95), transparent 38%),
-        linear-gradient(145deg, #3730a3, #111827 76%);
-    opacity: 0;
-    transform: scale(1.035);
-    transition-property: opacity, transform;
-    transition-duration: 200ms;
-    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
-}
-
-.cookbook-family-tile__logo-wrap {
-    box-shadow: 0 0.8rem 2rem rgba(15, 23, 42, 0.12);
-    transition-property: transform, box-shadow;
-    transition-duration: 200ms;
-    transition-timing-function: cubic-bezier(0.2, 0, 0, 1);
-}
-
-.cookbook-family-tile__footer {
-    min-height: 4.7rem;
-    padding: 0.9rem 1rem;
-}
-
 .cookbook-family-tile__footer strong {
     font-size: 0.8rem;
-    transition: color 150ms ease;
 }
 
 .cookbook-family-tile__footer small {
-    max-width: 19ch;
+    max-width: 28ch;
     margin-top: 0.18rem;
     font-size: 0.61rem;
     line-height: 1.35;
 }
 
-.cookbook-family-tile:focus-visible .cookbook-card-pattern {
-    opacity: 1;
-    transform: scale(1);
+[data-md-color-scheme="slate"] .cookbook-family-tile__visual {
+    background: linear-gradient(145deg, #1c2130, #11151f);
 }
 
-.cookbook-family-tile:focus-visible .cookbook-family-tile__logo-wrap {
-    transform: translateY(-0.2rem) scale(0.96);
+[data-md-color-scheme="slate"] .cookbook-family-tile__logo-wrap {
+    background: rgba(17, 21, 31, 0.92);
+    box-shadow: 0 0.8rem 2rem rgba(0, 0, 0, 0.35);
 }
 
-@media (hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference) {
-    .md-typeset .cookbook-family-tile:hover {
-        border-color: color-mix(in srgb, var(--cookbook-accent) 62%, var(--cookbook-border));
-        box-shadow: 0 1rem 2.4rem rgba(15, 23, 42, 0.14);
-        transform: translateY(-0.3rem);
-    }
+[data-md-color-scheme="slate"] .cookbook-family-tile__monogram {
+    color: #d7dbe7;
+}
 
-    .cookbook-family-tile:hover .cookbook-card-pattern {
-        opacity: 1;
-        transform: scale(1);
-    }
+.cookbook-modes {
+    margin: 0 0 2rem;
+    text-align: start;
+}
 
-    .cookbook-family-tile:hover .cookbook-family-tile__logo-wrap {
-        box-shadow: 0 1.1rem 2.4rem rgba(15, 23, 42, 0.22);
-        transform: translateY(-0.2rem) scale(0.96);
-    }
+.cookbook-family-page .cookbook-modes {
+    max-width: 48rem;
+    margin-inline: auto;
+}
 
-    .cookbook-family-tile:hover .cookbook-family-tile__footer strong {
-        color: var(--cookbook-accent-strong);
-    }
+.md-typeset .cookbook-modes h2 {
+    margin: 0 0 0.5rem;
+    font-size: 1.05rem;
+    letter-spacing: -0.02em;
+}
+
+.cookbook-modes > p {
+    max-width: 66ch;
+    margin: 0 0 0.85rem;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.74rem;
+    line-height: 1.55;
+}
+
+.cookbook-modes__table-wrap {
+    overflow-x: auto;
+}
+
+.md-typeset .cookbook-modes table {
+    display: table;
+    width: 100%;
+    margin: 0;
+    font-size: 0.68rem;
+}
+
+.md-typeset .cookbook-modes th,
+.md-typeset .cookbook-modes td {
+    padding: 0.55rem 0.7rem;
+    vertical-align: top;
+}
+
+.md-typeset [data-cookbook-modes-row] {
+    grid-column: 1 / -1;
+}
+
+.md-typeset [data-cookbook-modes-row] dd {
+    overflow-wrap: anywhere;
 }
 
 .cookbook-family-page {
@@ -1092,7 +1108,7 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
     text-wrap: balance;
 }
 
-.cookbook-family-header__body p:last-child {
+.cookbook-family-header__body h2 + p {
     max-width: 66ch;
     font-size: 0.8rem;
     line-height: 1.6;
@@ -1446,7 +1462,7 @@ a.cookbook-family-tile:focus-visible .cookbook-card-pattern {
 
 @media (prefers-reduced-motion: reduce) {
     .md-typeset .cookbook-family-tile,
-    .cookbook-card-pattern,
+    .cookbook-evervault,
     .cookbook-family-tile__logo-wrap,
     .cookbook-option-grid button {
         transition: none;

--- a/docs/cookbook/cosmos.md
+++ b/docs/cookbook/cosmos.md
@@ -5,7 +5,7 @@ hide:
 
 # Cosmos recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="cosmos" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="cosmos" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/flux.md
+++ b/docs/cookbook/flux.md
@@ -5,7 +5,7 @@ hide:
 
 # FLUX recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="flux" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="flux" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/glm-image.md
+++ b/docs/cookbook/glm-image.md
@@ -5,7 +5,7 @@ hide:
 
 # GLM-Image recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="glm_image" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="glm_image" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/hunyuan.md
+++ b/docs/cookbook/hunyuan.md
@@ -5,7 +5,7 @@ hide:
 
 # Hunyuan recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="hunyuan" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="hunyuan" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -8,278 +8,447 @@ hide:
 <div class="cookbook-shell cookbook-catalog" data-cookbook-gallery>
   <header class="cookbook-hero">
     <p class="cookbook-eyebrow">FastVideo inference cookbook</p>
-    <h2>Choose a model family.</h2>
+    <h2>Choose by output, then by family.</h2>
     <p class="cookbook-hero__lede">
       Open a family to pick a maintained recipe and a runtime FastVideo
       actually supports. Every command runs a checked-in source, so the model,
-      platform, offload, and attention settings stay tied to that example. The catalog
-      is derived from the model families registered in
-      <code>fastvideo/registry.py</code>.
+      platform, offload, and attention settings stay tied to that example.
+      Cards below group video, image, audio, and interactive world models.
+      Mode chips on each card are the workloads FastVideo maintains for that
+      family, not a promise that every flag works on every runtime.
     </p>
     <a class="cookbook-inline-link" href="../inference/support_matrix/">
       View the full support matrix <span aria-hidden="true">→</span>
     </a>
   </header>
 
-  <section class="cookbook-section" id="model-families" aria-label="Model families">
+  <section class="cookbook-section" id="video-models" aria-labelledby="video-models-heading">
+    <div class="cookbook-section__heading">
+      <h2 id="video-models-heading">Video</h2>
+    </div>
     <div class="cookbook-family-grid">
       <a class="cookbook-family-tile cookbook-family-tile--ready cookbook-family-tile--featured" href="./minimax-h3/" aria-label="Open MiniMax H3 recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
             <img class="off-glb" src="../assets/logos/minimax.webp" alt="" width="132" height="132" loading="eager">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>MiniMax H3</strong><small>Video + audio · CUDA + MLX</small></span>
-          <span class="cookbook-count">6 recipes</span>
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>MiniMax H3</strong><small>Video + stereo audio</small></span>
+            <span class="cookbook-count">6 recipes</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2VA</li>
+            <li>FL2VA</li>
+            <li>Ref2VA</li>
+            <li>MLX T2VA</li>
+          </ul>
         </span>
       </a>
 
       <a class="cookbook-family-tile cookbook-family-tile--ready" href="./wan/" aria-label="Open Wan recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
             <img class="off-glb" src="../assets/logos/wan-ai.webp" alt="" width="132" height="132" loading="eager">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>Wan</strong><small>Video generation · CUDA + MLX</small></span>
-          <span class="cookbook-count">7 recipes</span>
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>Wan</strong><small>FastWan CUDA and FastMetal MLX</small></span>
+            <span class="cookbook-count">7 recipes</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2V</li>
+            <li>I2V</li>
+            <li>TI2V</li>
+            <li>MLX T2V</li>
+          </ul>
         </span>
       </a>
 
       <a class="cookbook-family-tile cookbook-family-tile--ready" href="./ltx/" aria-label="Open LTX recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
             <img class="off-glb" src="../assets/logos/ltx.webp" alt="" width="132" height="132" loading="lazy">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>LTX</strong><small>Video and audio generation</small></span>
-          <span class="cookbook-count">2 recipes</span>
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>LTX</strong><small>Video with synchronized audio</small></span>
+            <span class="cookbook-count">2 recipes</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2V</li>
+          </ul>
         </span>
       </a>
 
       <a class="cookbook-family-tile cookbook-family-tile--ready" href="./hunyuan/" aria-label="Open Hunyuan recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
             <img class="off-glb" src="../assets/logos/tencent-hunyuan.webp" alt="" width="132" height="132" loading="lazy">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>Hunyuan</strong><small>Video generation</small></span>
-          <span class="cookbook-count">2 recipes</span>
-        </span>
-      </a>
-
-      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./cosmos/" aria-label="Open Cosmos recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
-          <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/nvidia.webp" alt="" width="132" height="132" loading="lazy">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>Hunyuan</strong><small>480p and 1080p upscale</small></span>
+            <span class="cookbook-count">2 recipes</span>
           </span>
-        </span>
-        <span class="cookbook-family-tile__footer">
-          <span><strong>Cosmos</strong><small>World and video generation</small></span>
-          <span class="cookbook-count">1 recipe</span>
+          <ul class="cookbook-mode-row">
+            <li>T2V</li>
+          </ul>
         </span>
       </a>
 
       <a class="cookbook-family-tile cookbook-family-tile--ready" href="./kandinsky5/" aria-label="Open Kandinsky 5 recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
             <img class="off-glb" src="../assets/logos/kandinsky.webp" alt="" width="132" height="132" loading="lazy">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>Kandinsky 5</strong><small>Text and image to video</small></span>
-          <span class="cookbook-count">2 recipes</span>
-        </span>
-      </a>
-
-      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./flux/" aria-label="Open FLUX recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
-          <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/black-forest-labs.webp" alt="" width="132" height="132" loading="lazy">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>Kandinsky 5</strong><small>Text and image to video</small></span>
+            <span class="cookbook-count">2 recipes</span>
           </span>
-        </span>
-        <span class="cookbook-family-tile__footer">
-          <span><strong>FLUX</strong><small>Image generation</small></span>
-          <span class="cookbook-count">3 recipes</span>
-        </span>
-      </a>
-
-      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./glm-image/" aria-label="Open GLM-Image recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
-          <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/zai.webp" alt="" width="132" height="132" loading="lazy">
-          </span>
-        </span>
-        <span class="cookbook-family-tile__footer">
-          <span><strong>GLM-Image</strong><small>Image generation and editing</small></span>
-          <span class="cookbook-count">2 recipes</span>
-        </span>
-      </a>
-
-      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./z-image/" aria-label="Open Z-Image recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
-          <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/tongyi.webp" alt="" width="132" height="132" loading="lazy">
-          </span>
-        </span>
-        <span class="cookbook-family-tile__footer">
-          <span><strong>Z-Image</strong><small>Image generation</small></span>
-          <span class="cookbook-count">1 recipe</span>
-        </span>
-      </a>
-
-      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./stable-diffusion/" aria-label="Open Stable Diffusion recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
-          <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/stabilityai.webp" alt="" width="132" height="132" loading="lazy">
-          </span>
-        </span>
-        <span class="cookbook-family-tile__footer">
-          <span><strong>Stable Diffusion</strong><small>Image generation</small></span>
-          <span class="cookbook-count">1 recipe</span>
+          <ul class="cookbook-mode-row">
+            <li>T2V</li>
+            <li>I2V</li>
+          </ul>
         </span>
       </a>
 
       <a class="cookbook-family-tile cookbook-family-tile--ready" href="./longcat/" aria-label="Open LongCat recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
             <img class="off-glb" src="../assets/logos/meituan-longcat.webp" alt="" width="132" height="132" loading="lazy">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>LongCat</strong><small>Video generation</small></span>
-          <span class="cookbook-count">2 recipes</span>
-        </span>
-      </a>
-
-      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./stable-audio/" aria-label="Open Stable Audio recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
-          <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/stabilityai.webp" alt="" width="132" height="132" loading="lazy">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>LongCat</strong><small>T2V, I2V, optional refine</small></span>
+            <span class="cookbook-count">2 recipes</span>
           </span>
-        </span>
-        <span class="cookbook-family-tile__footer">
-          <span><strong>Stable Audio</strong><small>Audio generation</small></span>
-          <span class="cookbook-count">2 recipes</span>
-        </span>
-      </a>
-
-      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./mmaudio/" aria-label="Open MMAudio recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
-          <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/fastvideo.webp" alt="" width="132" height="132" loading="lazy">
-          </span>
-        </span>
-        <span class="cookbook-family-tile__footer">
-          <span><strong>MMAudio</strong><small>Audio generation</small></span>
-          <span class="cookbook-count">1 recipe</span>
-        </span>
-      </a>
-
-      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./matrix-game/" aria-label="Open Matrix Game recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
-          <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/fastvideo.webp" alt="" width="132" height="132" loading="lazy">
-          </span>
-        </span>
-        <span class="cookbook-family-tile__footer">
-          <span><strong>Matrix Game</strong><small>Interactive world generation</small></span>
-          <span class="cookbook-count">2 recipes</span>
+          <ul class="cookbook-mode-row">
+            <li>T2V</li>
+            <li>I2V</li>
+          </ul>
         </span>
       </a>
 
       <a class="cookbook-family-tile cookbook-family-tile--ready" href="./turbodiffusion/" aria-label="Open TurboDiffusion recipes">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
             <span class="cookbook-family-tile__monogram" aria-hidden="true">Turbo</span>
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>TurboDiffusion</strong><small>Accelerated Wan profiles</small></span>
-          <span class="cookbook-count">3 recipes</span>
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>TurboDiffusion</strong><small>Accelerated Wan profiles</small></span>
+            <span class="cookbook-count">3 recipes</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2V</li>
+            <li>I2V</li>
+          </ul>
+        </span>
+      </a>
+    </div>
+  </section>
+
+  <section class="cookbook-section" id="image-models" aria-labelledby="image-models-heading">
+    <div class="cookbook-section__heading">
+      <h2 id="image-models-heading">Image</h2>
+    </div>
+    <div class="cookbook-family-grid">
+      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./flux/" aria-label="Open FLUX recipes">
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
+          <span class="cookbook-family-tile__logo-wrap">
+            <img class="off-glb" src="../assets/logos/black-forest-labs.webp" alt="" width="132" height="132" loading="lazy">
+          </span>
+        </span>
+        <span class="cookbook-family-tile__footer">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>FLUX</strong><small>FLUX.1 and FLUX.2</small></span>
+            <span class="cookbook-count">3 recipes</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2I</li>
+          </ul>
         </span>
       </a>
 
-      <article class="cookbook-family-tile cookbook-family-tile--coming" aria-label="GameCraft cookbook page planned; runnable examples exist">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./glm-image/" aria-label="Open GLM-Image recipes">
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/tencent-hunyuan.webp" alt="" width="132" height="132" loading="lazy">
+            <img class="off-glb" src="../assets/logos/zai.webp" alt="" width="132" height="132" loading="lazy">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>GameCraft</strong><small>Game world generation</small></span>
-          <span class="cookbook-count">Page planned</span>
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>GLM-Image</strong><small>Generate and edit</small></span>
+            <span class="cookbook-count">2 recipes</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2I</li>
+            <li>Edit</li>
+          </ul>
         </span>
-      </article>
+      </a>
 
-      <article class="cookbook-family-tile cookbook-family-tile--coming" aria-label="GEN3C cookbook page planned; runnable examples exist">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./z-image/" aria-label="Open Z-Image recipes">
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
-            <img class="off-glb" src="../assets/logos/nvidia.webp" alt="" width="132" height="132" loading="lazy">
+            <img class="off-glb" src="../assets/logos/tongyi.webp" alt="" width="132" height="132" loading="lazy">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>GEN3C</strong><small>Novel-view video</small></span>
-          <span class="cookbook-count">Page planned</span>
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>Z-Image</strong><small>Turbo text to image</small></span>
+            <span class="cookbook-count">1 recipe</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2I</li>
+          </ul>
         </span>
-      </article>
+      </a>
 
-      <article class="cookbook-family-tile cookbook-family-tile--coming" aria-label="HY-World cookbook page planned; runnable examples exist">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./stable-diffusion/" aria-label="Open Stable Diffusion recipes">
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
-            <span class="cookbook-family-tile__monogram" aria-hidden="true">HY</span>
+            <img class="off-glb" src="../assets/logos/stabilityai.webp" alt="" width="132" height="132" loading="lazy">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>HY-World</strong><small>Interactive world play</small></span>
-          <span class="cookbook-count">Page planned</span>
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>Stable Diffusion</strong><small>SD 3.5 Medium</small></span>
+            <span class="cookbook-count">1 recipe</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2I</li>
+          </ul>
         </span>
-      </article>
+      </a>
+    </div>
+  </section>
 
-      <article class="cookbook-family-tile cookbook-family-tile--coming" aria-label="DreamX cookbook page planned; runnable examples exist">
-        <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
+  <section class="cookbook-section" id="audio-models" aria-labelledby="audio-models-heading">
+    <div class="cookbook-section__heading">
+      <h2 id="audio-models-heading">Audio</h2>
+    </div>
+    <div class="cookbook-family-grid">
+      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./stable-audio/" aria-label="Open Stable Audio recipes">
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
+          <span class="cookbook-family-tile__logo-wrap">
+            <img class="off-glb" src="../assets/logos/stabilityai.webp" alt="" width="132" height="132" loading="lazy">
+          </span>
+        </span>
+        <span class="cookbook-family-tile__footer">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>Stable Audio</strong><small>Open 1.0 and Small</small></span>
+            <span class="cookbook-count">2 recipes</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2A</li>
+          </ul>
+        </span>
+      </a>
+
+      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./mmaudio/" aria-label="Open MMAudio recipes">
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
           <span class="cookbook-family-tile__logo-wrap">
             <img class="off-glb" src="../assets/logos/fastvideo.webp" alt="" width="132" height="132" loading="lazy">
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>DreamX</strong><small>World generation</small></span>
-          <span class="cookbook-count">Page planned</span>
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>MMAudio</strong><small>Video or text to audio</small></span>
+            <span class="cookbook-count">1 recipe</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>V2A</li>
+            <li>T2A</li>
+          </ul>
+        </span>
+      </a>
+    </div>
+  </section>
+
+  <section class="cookbook-section" id="world-models" aria-labelledby="world-models-heading">
+    <div class="cookbook-section__heading">
+      <h2 id="world-models-heading">World and interactive</h2>
+    </div>
+    <div class="cookbook-family-grid">
+      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./cosmos/" aria-label="Open Cosmos recipes">
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
+          <span class="cookbook-family-tile__logo-wrap">
+            <img class="off-glb" src="../assets/logos/nvidia.webp" alt="" width="132" height="132" loading="lazy">
+          </span>
+        </span>
+        <span class="cookbook-family-tile__footer">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>Cosmos</strong><small>Text to world video</small></span>
+            <span class="cookbook-count">1 recipe</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>T2W</li>
+          </ul>
+        </span>
+      </a>
+
+      <a class="cookbook-family-tile cookbook-family-tile--ready" href="./matrix-game/" aria-label="Open Matrix Game recipes">
+        <span class="cookbook-family-tile__visual" data-evervault>
+          <span class="cookbook-evervault" aria-hidden="true">
+            <span class="cookbook-evervault__gradient"></span>
+            <span class="cookbook-evervault__noise" data-cookbook-pattern></span>
+          </span>
+          <span class="cookbook-family-tile__logo-wrap">
+            <img class="off-glb" src="../assets/logos/fastvideo.webp" alt="" width="132" height="132" loading="lazy">
+          </span>
+        </span>
+        <span class="cookbook-family-tile__footer">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>Matrix Game</strong><small>Image-conditioned worlds</small></span>
+            <span class="cookbook-count">2 recipes</span>
+          </span>
+          <ul class="cookbook-mode-row">
+            <li>I2W</li>
+          </ul>
+        </span>
+      </a>
+    </div>
+  </section>
+
+  <section class="cookbook-section" id="planned-families" aria-labelledby="planned-families-heading">
+    <div class="cookbook-section__heading">
+      <h2 id="planned-families-heading">Pages still to write</h2>
+      <p>These families already have runnable examples. The cookbook page is not ready, so the cards are not links.</p>
+    </div>
+    <div class="cookbook-family-grid">
+      <article class="cookbook-family-tile cookbook-family-tile--coming" aria-label="GameCraft cookbook page planned; runnable examples exist">
+        <span class="cookbook-family-tile__visual">
+          <span class="cookbook-family-tile__logo-wrap">
+            <img class="off-glb" src="../assets/logos/tencent-hunyuan.webp" alt="" width="132" height="132" loading="lazy">
+          </span>
+        </span>
+        <span class="cookbook-family-tile__footer">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>GameCraft</strong><small>Game world generation</small></span>
+            <span class="cookbook-count">Page planned</span>
+          </span>
+        </span>
+      </article>
+
+      <article class="cookbook-family-tile cookbook-family-tile--coming" aria-label="GEN3C cookbook page planned; runnable examples exist">
+        <span class="cookbook-family-tile__visual">
+          <span class="cookbook-family-tile__logo-wrap">
+            <img class="off-glb" src="../assets/logos/nvidia.webp" alt="" width="132" height="132" loading="lazy">
+          </span>
+        </span>
+        <span class="cookbook-family-tile__footer">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>GEN3C</strong><small>Novel-view video</small></span>
+            <span class="cookbook-count">Page planned</span>
+          </span>
+        </span>
+      </article>
+
+      <article class="cookbook-family-tile cookbook-family-tile--coming" aria-label="HY-World cookbook page planned; runnable examples exist">
+        <span class="cookbook-family-tile__visual">
+          <span class="cookbook-family-tile__logo-wrap">
+            <span class="cookbook-family-tile__monogram" aria-hidden="true">HY</span>
+          </span>
+        </span>
+        <span class="cookbook-family-tile__footer">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>HY-World</strong><small>Interactive world play</small></span>
+            <span class="cookbook-count">Page planned</span>
+          </span>
+        </span>
+      </article>
+
+      <article class="cookbook-family-tile cookbook-family-tile--coming" aria-label="DreamX cookbook page planned; runnable examples exist">
+        <span class="cookbook-family-tile__visual">
+          <span class="cookbook-family-tile__logo-wrap">
+            <img class="off-glb" src="../assets/logos/fastvideo.webp" alt="" width="132" height="132" loading="lazy">
+          </span>
+        </span>
+        <span class="cookbook-family-tile__footer">
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>DreamX</strong><small>World generation</small></span>
+            <span class="cookbook-count">Page planned</span>
+          </span>
         </span>
       </article>
 
       <article class="cookbook-family-tile cookbook-family-tile--coming" aria-label="LingBot cookbook page planned; runnable examples exist">
         <span class="cookbook-family-tile__visual">
-          <span class="cookbook-card-pattern" data-cookbook-pattern aria-hidden="true"></span>
           <span class="cookbook-family-tile__logo-wrap">
             <span class="cookbook-family-tile__monogram" aria-hidden="true">LB</span>
           </span>
         </span>
         <span class="cookbook-family-tile__footer">
-          <span><strong>LingBot</strong><small>Video and world models</small></span>
-          <span class="cookbook-count">Page planned</span>
+          <span class="cookbook-family-tile__footer-top">
+            <span><strong>LingBot</strong><small>Video and world models</small></span>
+            <span class="cookbook-count">Page planned</span>
+          </span>
         </span>
       </article>
     </div>

--- a/docs/cookbook/kandinsky5.md
+++ b/docs/cookbook/kandinsky5.md
@@ -5,7 +5,7 @@ hide:
 
 # Kandinsky 5 recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="kandinsky5" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="kandinsky5" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/longcat.md
+++ b/docs/cookbook/longcat.md
@@ -5,7 +5,7 @@ hide:
 
 # LongCat recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="longcat" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="longcat" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/ltx.md
+++ b/docs/cookbook/ltx.md
@@ -5,7 +5,7 @@ hide:
 
 # LTX recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="ltx2" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="ltx2" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/matrix-game.md
+++ b/docs/cookbook/matrix-game.md
@@ -5,7 +5,7 @@ hide:
 
 # Matrix Game recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="matrixgame" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="matrixgame" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/minimax-h3.md
+++ b/docs/cookbook/minimax-h3.md
@@ -5,7 +5,7 @@ hide:
 
 # MiniMax H3 recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="minimax_h3" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="minimax_h3" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -15,7 +15,7 @@ hide:
       <div>
         <p class="cookbook-eyebrow">Primary focus · Inference</p>
         <h2>MiniMax H3 recipes</h2>
-        <p>Generate synchronized video and audio with the full H3 checkpoint, the four-step FastH3 Preview, reference and frame-conditioned paths, or the native Apple Silicon MLX runtime.</p>
+        <p>Generate synchronized video and audio with the full H3 checkpoint, the four-step FastH3 Preview, reference and frame-conditioned CUDA paths, or the native Apple Silicon MLX T2VA runtime.</p>
         <span class="cookbook-count" data-cookbook-count>6 maintained recipes</span>
       </div>
     </div>
@@ -29,6 +29,64 @@ hide:
       <span class="cookbook-lifecycle__stage">Deployment <small>planned</small></span>
     </div>
   </header>
+
+  <section class="cookbook-modes" aria-labelledby="h3-modes-heading">
+    <h2 id="h3-modes-heading">Supported modes</h2>
+    <p>
+      CUDA covers T2VA, FL2VA, and Ref2VA on the full checkpoint, plus FastH3
+      Preview and FastH3 LoRA. MLX is T2VA only. Temporal <code>--fast</code>,
+      spatial <code>--fast-spatial</code>, and opt-in VSA are flags on the same
+      MLX script, not extra recipes.
+    </p>
+    <div class="cookbook-modes__table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Mode</th>
+            <th>CUDA</th>
+            <th>MLX FastH3</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>T2VA</td>
+            <td>Full H3, FastH3 Preview, FastH3 LoRA</td>
+            <td>FastH3 Preview after a local DiT conversion</td>
+          </tr>
+          <tr>
+            <td>FL2VA</td>
+            <td>Full H3</td>
+            <td>Not wired</td>
+          </tr>
+          <tr>
+            <td>Ref2VA</td>
+            <td>Full H3</td>
+            <td>Not wired</td>
+          </tr>
+          <tr>
+            <td>Temporal <code>--fast</code></td>
+            <td>No cookbook recipe</td>
+            <td>Shorter video denoise, MLX RIFE back to <code>--num-frames</code>, full-duration audio</td>
+          </tr>
+          <tr>
+            <td>VSA</td>
+            <td>Trained sparse attention on FastH3 CUDA</td>
+            <td>Opt-in. Convert with <code>--include-vsa</code> into a new directory such as <code>./FastH3-MLX-vsa</code>, then pass <code>--vsa</code>. Do not overwrite an existing dense export.</td>
+          </tr>
+          <tr>
+            <td>Spatial <code>--fast-spatial</code></td>
+            <td>No cookbook recipe</td>
+            <td>Denoise and decode at height/width divided by <code>--fast-spatial-scale</code>, then resample. Composes with <code>--fast</code>.</td>
+          </tr>
+          <tr>
+            <td>Two-pass refine</td>
+            <td>No cookbook recipe</td>
+            <td>Not wired</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
@@ -135,7 +193,7 @@ for the download, conversion, and storage requirements.
 
 - The full CUDA H3 examples request four GPUs by default. Their sources do not claim a GPU model or memory minimum.
 - The FastH3 CUDA performance profile was measured on four GB200 GPUs. Use its strict profile when exact operation order matters more than the measured performance configuration.
-- The MLX source runtime is limited to T2VA. FL2VA, Ref2VA, VSA, and two-pass refinement are not wired on MLX.
+- The MLX source runtime supports T2VA, optional temporal `--fast`, optional spatial `--fast-spatial`, and opt-in VSA on `--include-vsa` checkpoints. FL2VA, Ref2VA, and two-pass refinement are not wired.
 - Gated or missing checkpoints: run `huggingface-cli login` and confirm you accepted the model's license on Hugging Face.
 
 ## Evidence status

--- a/docs/cookbook/mmaudio.md
+++ b/docs/cookbook/mmaudio.md
@@ -5,7 +5,7 @@ hide:
 
 # MMAudio recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="mmaudio" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="mmaudio" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/stable-audio.md
+++ b/docs/cookbook/stable-audio.md
@@ -5,7 +5,7 @@ hide:
 
 # Stable Audio recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="stable_audio" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="stable_audio" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/stable-diffusion.md
+++ b/docs/cookbook/stable-diffusion.md
@@ -5,7 +5,7 @@ hide:
 
 # Stable Diffusion recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="sd35" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="sd35" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/turbodiffusion.md
+++ b/docs/cookbook/turbodiffusion.md
@@ -5,7 +5,7 @@ hide:
 
 # TurboDiffusion recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="turbodiffusion" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="turbodiffusion" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/cookbook/wan.md
+++ b/docs/cookbook/wan.md
@@ -5,7 +5,7 @@ hide:
 
 # Wan recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="wan" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="wan" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -15,7 +15,7 @@ hide:
       <div>
         <p class="cookbook-eyebrow">Maintained family · Inference</p>
         <h2>Wan inference recipes</h2>
-        <p>Wan recipes span maintained CUDA examples and the released FastMetal 1.3B, 5B, and 14B native MLX paths for Apple Silicon.</p>
+        <p>CUDA covers FastWan and Wan2.1/2.2 text and image recipes. Apple Silicon uses the released FastMetal 1.3B, 5B, and 14B MLX T2V paths. The speed flags below are switches on those same scripts, not extra recipes.</p>
         <span class="cookbook-count" data-cookbook-count>7 maintained recipes</span>
       </div>
     </div>
@@ -29,6 +29,62 @@ hide:
       <span class="cookbook-lifecycle__stage">Deployment <small>planned</small></span>
     </div>
   </header>
+
+  <section class="cookbook-modes" aria-labelledby="wan-modes-heading">
+    <h2 id="wan-modes-heading">Supported modes</h2>
+    <p>
+      FastMetal MLX is T2V in the checked-in examples. Image-to-video and
+      TI2V stay on the CUDA recipes. Temporal <code>--fast</code> composes
+      with either spatial path. <code>--refine</code> and
+      <code>--fast-spatial</code> cannot run together.
+      <code>--refine</code> wins if both are set.
+      <code>basic_mps.py</code> is the older PyTorch MPS demo and is not a
+      FastMetal recipe.
+    </p>
+    <div class="cookbook-modes__table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Mode</th>
+            <th>CUDA</th>
+            <th>MLX FastMetal</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>T2V</td>
+            <td>FastWan2.1 1.3B, Wan2.2 A14B</td>
+            <td>1.3B, 5B, and 14B</td>
+          </tr>
+          <tr>
+            <td>I2V</td>
+            <td>Wan2.1 14B 480P</td>
+            <td>Not in the released examples</td>
+          </tr>
+          <tr>
+            <td>TI2V</td>
+            <td>Wan2.2 TI2V 5B</td>
+            <td>FastMetal 5B is T2V in <code>mlx_wan22_generate.py</code></td>
+          </tr>
+          <tr>
+            <td>Temporal <code>--fast</code></td>
+            <td>No cookbook recipe</td>
+            <td>RIFE. Fewer frames, then interpolate to <code>--num-frames</code></td>
+          </tr>
+          <tr>
+            <td>Spatial <code>--fast-spatial</code></td>
+            <td>No cookbook recipe</td>
+            <td>Denoise and decode at half resolution, then upsample. No second denoise</td>
+          </tr>
+          <tr>
+            <td>Two-pass <code>--refine</code></td>
+            <td>No cookbook recipe</td>
+            <td>Denoise at base resolution, upsample, re-noise, denoise again. Wins over <code>--fast-spatial</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
@@ -123,6 +179,8 @@ the supported model and optimization surface.
 
 - Out of memory on the A14B recipes: the checked-in sources already enable CPU offload; see [Configuration](../inference/configuration.md) for the offload surface before reducing resolution or frames.
 - The FastWan2.1 recipe requires `VIDEO_SPARSE_ATTN`; confirm the environment variable in the command was set in the same shell.
+- FastMetal MLX: install with `uv pip install -e ".[mlx]"`, then follow the [Apple Silicon guide](../getting_started/installation/mps.md). CUDA FastWan-QAD checkpoints are refused on the MLX runtime.
+- FastMetal 5B uses `mlx_wan22_generate.py`. 1.3B and 14B use `mlx_wan_prompt_to_video.py`.
 - Gated or missing checkpoints: run `huggingface-cli login` and confirm you accepted the model's license on Hugging Face.
 
 ## Evidence status

--- a/docs/cookbook/z-image.md
+++ b/docs/cookbook/z-image.md
@@ -5,7 +5,7 @@ hide:
 
 # Z-Image recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="zimage" data-recipes="../../assets/cookbook-recipes.json?v=4">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="zimage" data-recipes="../../assets/cookbook-recipes.json?v=5">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -31,10 +31,8 @@ hide:
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
-      <h2 id="builder-heading">Choose a model and GPU count</h2>
-      <p>Choose a model, then pick a GPU count. Each selection maps to one
-      checked-in recipe. If that recipe does not use your chosen count, the
-      page says so instead of guessing.</p>
+      <h2 id="builder-heading">Pick a recipe and runtime</h2>
+      <p>Start with the result you want, then choose one of the runtimes FastVideo actually maintains for it.</p>
     </div>
 
     <div class="cookbook-builder__layout">

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -151,10 +151,9 @@ def validate_cookbook() -> None:
             raise ValueError(f"Cookbook recipe related must be a list of recipe ids: {recipe['id']}")
 
         modes = recipe.get("modes")
-        if modes is not None:
-            if (not isinstance(modes, list) or not modes
-                    or any(not isinstance(item, str) or not item.strip() for item in modes)):
-                raise ValueError(f"Cookbook recipe modes must be a non-empty list of strings: {recipe['id']}")
+        if modes is not None and (not isinstance(modes, list) or not modes
+                                  or any(not isinstance(item, str) or not item.strip() for item in modes)):
+            raise ValueError(f"Cookbook recipe modes must be a non-empty list of strings: {recipe['id']}")
 
         source = (ROOT_DIR / recipe["source"]).resolve()
         if not any(source.is_relative_to(root.resolve()) for root in COOKBOOK_SOURCE_ROOTS):

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -81,6 +81,9 @@ COOKBOOK_HARDWARE_TEXT_FIELDS = {
 def validate_cookbook() -> None:
     """Keep cookbook entries tied to checked-in runnable sources."""
     data = json.loads(COOKBOOK_DATA.read_text(encoding="utf-8"))
+    version = data.get("version")
+    if not isinstance(version, int):
+        raise ValueError(f"{COOKBOOK_DATA}: version must be an integer")
     recipes = data.get("recipes")
     if not isinstance(recipes, list) or not recipes:
         raise ValueError(f"{COOKBOOK_DATA}: recipes must be a non-empty list")
@@ -147,6 +150,12 @@ def validate_cookbook() -> None:
         if not isinstance(related, list):
             raise ValueError(f"Cookbook recipe related must be a list of recipe ids: {recipe['id']}")
 
+        modes = recipe.get("modes")
+        if modes is not None:
+            if (not isinstance(modes, list) or not modes
+                    or any(not isinstance(item, str) or not item.strip() for item in modes)):
+                raise ValueError(f"Cookbook recipe modes must be a non-empty list of strings: {recipe['id']}")
+
         source = (ROOT_DIR / recipe["source"]).resolve()
         if not any(source.is_relative_to(root.resolve()) for root in COOKBOOK_SOURCE_ROOTS):
             raise ValueError(f"Cookbook source is outside an approved directory: {recipe['source']}")
@@ -168,6 +177,15 @@ def validate_cookbook() -> None:
         for related_id in recipe.get("related", []):
             if related_id not in ids:
                 raise ValueError(f"Cookbook recipe references unknown related id: {recipe['id']}: {related_id}")
+
+    cache_bust = f"cookbook-recipes.json?v={version}"
+    cookbook_pages = ROOT_DIR / "docs/cookbook"
+    for page in sorted(cookbook_pages.glob("*.md")):
+        text = page.read_text(encoding="utf-8")
+        if "cookbook-recipes.json" not in text:
+            continue
+        if cache_bust not in text:
+            raise ValueError(f"{page}: recipe JSON cache-bust must be {cache_bust}")
 
 
 def fix_case(text: str) -> str:

--- a/docs/inference/support_matrix.md
+++ b/docs/inference/support_matrix.md
@@ -183,7 +183,7 @@ optimizations: absence means **untested**, not incompatible.
 | Release path | Model | Mode | Validated hardware | Status |
 | --- | --- | --- | --- | --- |
 | MLX FastMetal T2V 1.3B | [`FastVideo/FastMetal-1.3B-QAD`](https://huggingface.co/FastVideo/FastMetal-1.3B-QAD) | 480x832, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 16 GB+ unified memory | Released |
-| MLX FastMetal TI2V 5B | [`FastVideo/FastMetal-5B-QAD`](https://huggingface.co/FastVideo/FastMetal-5B-QAD) | 480p / 720p, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 16 GB+ unified memory | Released |
+| MLX FastMetal T2V 5B | [`FastVideo/FastMetal-5B-QAD`](https://huggingface.co/FastVideo/FastMetal-5B-QAD) | 480p / 720p, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode; optional `--fast`, `--fast-spatial`, `--refine`. The checked-in example is T2V. CUDA Wan2.2 TI2V 5B is the image-capable path. | Apple M4 Max, 16 GB+ unified memory | Released |
 | MLX FastMetal T2V 14B | [`FastVideo/FastMetal-14B-QAD`](https://huggingface.co/FastVideo/FastMetal-14B-QAD) | 480p / 720p, 81 frames, 3-step DMD, INT8 DiT + TAEHV decode | Apple M4 Max, 36 GB+ unified memory | Released |
 | MLX FastH3 Preview T2VA | [`FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2`](https://huggingface.co/FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2) + locally converted DiT | 480p / 720p, 124 frames, 4-step DMD2, INT8/INT6/INT4 **weight-only** DiT, native video + audio VAE; optional temporal RIFE fast mode; optional spatial fast mode; optional VSA (tile 64/256, exempt/compete) on `--include-vsa` checkpoints | Apple M4 Max, 36 GB unified memory | Source runtime; T2VA only |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,22 +155,26 @@ nav:
     - Quick Start: getting_started/quick_start.md
     - V1 API: getting_started/v1_api.md
   - Cookbook:
-    - Model Families: cookbook/index.md
-    - Wan: cookbook/wan.md
-    - LTX: cookbook/ltx.md
-    - Hunyuan: cookbook/hunyuan.md
-    - Cosmos: cookbook/cosmos.md
-    - Kandinsky 5: cookbook/kandinsky5.md
-    - FLUX: cookbook/flux.md
-    - GLM-Image: cookbook/glm-image.md
-    - Z-Image: cookbook/z-image.md
-    - Stable Diffusion: cookbook/stable-diffusion.md
-    - MiniMax H3: cookbook/minimax-h3.md
-    - LongCat: cookbook/longcat.md
-    - Stable Audio: cookbook/stable-audio.md
-    - MMAudio: cookbook/mmaudio.md
-    - Matrix Game: cookbook/matrix-game.md
-    - TurboDiffusion: cookbook/turbodiffusion.md
+    - Overview: cookbook/index.md
+    - Video:
+      - MiniMax H3: cookbook/minimax-h3.md
+      - Wan: cookbook/wan.md
+      - LTX: cookbook/ltx.md
+      - Hunyuan: cookbook/hunyuan.md
+      - Kandinsky 5: cookbook/kandinsky5.md
+      - LongCat: cookbook/longcat.md
+      - TurboDiffusion: cookbook/turbodiffusion.md
+    - Image:
+      - FLUX: cookbook/flux.md
+      - GLM-Image: cookbook/glm-image.md
+      - Z-Image: cookbook/z-image.md
+      - Stable Diffusion: cookbook/stable-diffusion.md
+    - Audio:
+      - Stable Audio: cookbook/stable-audio.md
+      - MMAudio: cookbook/mmaudio.md
+    - World:
+      - Cosmos: cookbook/cosmos.md
+      - Matrix Game: cookbook/matrix-game.md
   - Inference:
     - Quick Start: inference/inference_quick_start.md
     - Configuration: inference/configuration.md


### PR DESCRIPTION
## Summary
- Group the inference cookbook by output (video, image, audio, world) and nest the same structure in the sidebar, with MiniMax H3 first under video.
- Replace the broken family-card hover with a mouse-tracked Evervault-style glow (lazy pattern, reduced-motion / coarse-pointer gated) and show workload chips instead of repeating CUDA on every tile.
- Document CUDA vs MLX modes on Wan and MiniMax H3: FastMetal 5B is T2V in the checked-in example, `--refine` wins over `--fast-spatial`, and FastH3 VSA needs `--include-vsa` into a new export directory.

## Test plan
- [ ] Open `/cookbook/` and confirm sections are Video / Image / Audio / World, with no extra lede under each heading.
- [ ] Hover a ready card on a mouse + fine pointer; confirm no hover flood on touch / reduced motion.
- [ ] Open MiniMax H3, switch CUDA ↔ MLX, and confirm the modes table plus VSA note (`./FastH3-MLX-vsa`).
- [ ] Open Wan FastMetal recipes and confirm T2V-only MLX plus `--refine` vs `--fast-spatial`.
- [ ] `python3 -c 'from docs.generate_examples import validate_cookbook; validate_cookbook()'`