### PR TITLE
[bugfix] encoders: keep Qwen2.5-VL importable on transformers 5

### DIFF
--- a/fastvideo/models/encoders/qwen2_5_vl_custom.py
+++ b/fastvideo/models/encoders/qwen2_5_vl_custom.py
@@ -26,10 +26,19 @@ from torch.distributed._tensor import DTensor
 from torch.distributed.device_mesh import DeviceMesh
 from torch.nn import CrossEntropyLoss
 from transformers.activations import ACT2FN
-from transformers.cache_utils import Cache, DynamicCache, SlidingWindowCache, StaticCache
+from transformers.cache_utils import Cache, DynamicCache, StaticCache
 from transformers.modeling_attn_mask_utils import AttentionMaskConverter
 from transformers.modeling_outputs import BaseModelOutputWithPast, ModelOutput
 from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+try:
+    from transformers.cache_utils import SlidingWindowCache
+except ImportError:
+    # transformers 5 dropped the cache-level class; a sliding window is now a property of the
+    # cache's layers (DynamicSlidingWindowLayer / StaticSlidingWindowLayer), so no cache object
+    # can be an instance of it. isinstance() against an empty tuple is always False, which is
+    # the right answer there.
+    SlidingWindowCache = ()  # type: ignore[assignment,misc]
 
 try:
     from torch.distributed.tensor import Shard

--- a/fastvideo/tests/encoders/test_qwen2_5_vl_vision_dtype.py
+++ b/fastvideo/tests/encoders/test_qwen2_5_vl_vision_dtype.py
@@ -95,3 +95,19 @@ def test_conditional_generation_passes_parent_dtype_to_visual_tower():
     model = Qwen2_5_VLForConditionalGenerationSimple(_full_config("torch.bfloat16"))
 
     assert model.visual.dtype == torch.bfloat16
+
+
+def test_sliding_window_cache_check_survives_transformers_5():
+    """transformers 5 removed `cache_utils.SlidingWindowCache`.
+
+    The import here was unguarded and at module scope, so the whole encoder became
+    unimportable on the versions this repo asks for (`transformers>=5.0.0`), taking
+    `Reason1TextEncoder` -- and with it the Cosmos 2.5 and Kandinsky 5 pipelines -- with it.
+    A sliding window is a property of the cache's layers now, so nothing is an instance of
+    the old class and the check has to answer False rather than blow up.
+    """
+    from transformers.cache_utils import DynamicCache
+
+    from fastvideo.models.encoders import qwen2_5_vl_custom
+
+    assert isinstance(DynamicCache(), qwen2_5_vl_custom.SlidingWindowCache) is False


### PR DESCRIPTION
## Summary

`fastvideo/models/encoders/qwen2_5_vl_custom.py` cannot be imported on any transformers this
repo asks for. `pyproject.toml` requires `transformers>=5.0.0`; the module has, at module scope
and unguarded:

```python
from transformers.cache_utils import Cache, DynamicCache, SlidingWindowCache, StaticCache
```

```
transformers 5.3.0
ImportError: cannot import name 'SlidingWindowCache' from 'transformers.cache_utils'
```

transformers 5.0 removed the cache-level class — a sliding window became a property of the
cache's *layers* (`DynamicSlidingWindowLayer`, `StaticSlidingWindowLayer`). `Cache`,
`DynamicCache` and `StaticCache` are all still there; only this one went.

| transformers | `class SlidingWindowCache` |
| --- | --- |
| 4.57.1 | yes |
| 5.0.0, 5.3.0, 5.16.1 | no |

This is not a dead file. `Reason1TextEncoder` lives in `registry.py:88-89`, registered for
`Qwen2_5_VLForConditionalGeneration`, and is used by the Cosmos 2.5 and Kandinsky 5 pipeline
configs, so the failure lands on those pipelines.

It went unnoticed because `fastvideo/tests/encoders/test_qwen2_5_vl_vision_dtype.py` — which
imports this module and would have failed at collection — is not in the explicit test list
`ci-macos-mlx.yml` runs.

## The change

Import the removed class behind `try/except ImportError`, matching how this file already
handles `torch.distributed.tensor.Shard` and the Qwen2.5-VL config classes:

```python
try:
    from transformers.cache_utils import SlidingWindowCache
except ImportError:
    SlidingWindowCache = ()
```

`isinstance(x, ())` is `False`, which is the right answer on transformers 5: with no such class,
no cache object can be an instance of one. The two call sites
(`using_sliding_window_cache = isinstance(past_key_values, SlidingWindowCache)` and the
`config.sliding_window` branch below it) then behave as they did before for anything transformers
5 can hand them.

On this encoder's own path the question does not arise either way — `reason1.py:311` calls with
`use_cache=False`, and a cache is only built `if use_cache and past_key_values is None`, so
`past_key_values` is `None` there.

Not attempting to reconstruct the old behaviour from the new layer types: upstream Qwen2.5-VL
has had no `_update_causal_mask` and no `SlidingWindowCache` reference since 4.57 at the latest,
so this vendored copy has no upstream counterpart left to mirror. That is a bigger question than
making the module importable again.

## Test

Added to the existing encoder test file:
`test_sliding_window_cache_check_survives_transformers_5`.

Load-bearing — same test file against a clean `upstream/main` worktree, same environment:

```
$ pytest fastvideo/tests/encoders/test_qwen2_5_vl_vision_dtype.py     # upstream/main
ERROR fastvideo/tests/encoders/test_qwen2_5_vl_vision_dtype.py
Interrupted: 1 error during collection
  ImportError: cannot import name 'SlidingWindowCache' from 'transformers.cache_utils'

$ pytest fastvideo/tests/encoders/test_qwen2_5_vl_vision_dtype.py     # this branch
7 passed
```

Also confirmed `from fastvideo.models.encoders.reason1 import Reason1TextEncoder` imports again.

Lint, at the versions pinned in `.pre-commit-config.yaml`:

```
ruff 0.11.12   106 findings on this file before the change, 106 after — none new
yapf 0.43.0    no diff
```

(The 106 are pre-existing in this vendored file; I have not touched them.)
