### PR TITLE
[perf] Speed up exact MiniMax H3 MLX inference

### DIFF
--- a/fastvideo/mlx_runtime/minimax_h3.py
+++ b/fastvideo/mlx_runtime/minimax_h3.py
@@ -520,6 +520,19 @@ def _h3_rms_norm(x, weight, eps: float):
     return mx.fast.rms_norm(x, weight, eps)
 
 
+_compiled_modulation = None
+
+
+def _modulate(hidden_states, scale, shift):
+    """Apply row-expanded AdaLN scale and shift through one reusable graph."""
+    import mlx.core as mx
+
+    global _compiled_modulation
+    if _compiled_modulation is None:
+        _compiled_modulation = mx.compile(lambda value, scales, shifts: value * scales + shifts, shapeless=True)
+    return _compiled_modulation(hidden_states, scale, shift)
+
+
 def _attention(
     weights: dict[str, Any],
     x,
@@ -630,7 +643,7 @@ def _transformer_block(
 
     residual = hidden_states
     normed = _h3_rms_norm(hidden_states, weights["norm1.weight"], norm_eps)
-    normed = normed * (1.0 + scale_msa[adaln_indices]) + shift_msa[adaln_indices]
+    normed = _modulate(normed, (1.0 + scale_msa)[adaln_indices], shift_msa[adaln_indices])
     attn_output = _attention(
         weights,
         normed.astype(weight_dtype(weights["attn.to_q.weight"])),
@@ -651,7 +664,7 @@ def _transformer_block(
 
     residual = hidden_states
     normed = _h3_rms_norm(hidden_states, weights["norm2.weight"], norm_eps)
-    normed = normed * (1.0 + scale_mlp[adaln_indices]) + shift_mlp[adaln_indices]
+    normed = _modulate(normed, (1.0 + scale_mlp)[adaln_indices], shift_mlp[adaln_indices])
     ff_output = _feed_forward(weights, normed.astype(weight_dtype(weights["ff.net.0.proj.weight"])))
     return residual + gate_mlp[adaln_indices] * ff_output
 

--- a/fastvideo/mlx_runtime/minimax_h3_conditioner.py
+++ b/fastvideo/mlx_runtime/minimax_h3_conditioner.py
@@ -7,8 +7,8 @@ hidden states after the first 50 language-model layers plus the per-token
 modality tags for text prompts.
 
 Memory contract for the 36 GiB tier: the released conditioner is ~66 GB of
-BF16 and never becomes resident. Tensors are memory-mapped per-key from the
-safetensors shards and only the pieces a given forward needs are materialized:
+BF16 and never becomes resident. Tensors are read per-key from the safetensors
+shards and only the pieces a given forward needs are materialized:
 
 - token embedding table row-gathered per batch (full table never copied);
 - one decoder layer (~1 GB BF16) resident at a time, computed in FP32,
@@ -66,7 +66,7 @@ class ConditionerConfig:
 
 
 class _ShardIndex:
-    """Per-key memory-mapped access across the diffusers safetensors shards.
+    """Per-key access across the diffusers safetensors shards.
 
     Reads tensors directly through the safetensors header so BF16 weights
     stream from disk without loading a shard (and without torch).
@@ -109,6 +109,19 @@ class _ShardIndex:
         header, data_start = self._header_cache[shard]
         return _read_safetensors_bf16(shard, key, header, data_start)
 
+    def get_mlx(self, key: str) -> mx.array:
+        """Read one weight in FP32 without expanding BF16 on the CPU."""
+        shard = self.key_to_shard[key]
+        header, data_start = self._header_cache[shard]
+        if header[key]["dtype"] != "BF16":
+            return mx.array(np.asarray(self.get(key), dtype=np.float32))
+        raw = _read_bf16_words(shard, key, header, data_start)
+        weight = mx.array(raw).view(mx.bfloat16).astype(mx.float32)
+        # Finish each cast before constructing the layer graph, releasing its
+        # BF16 input instead of retaining a second copy of every layer weight.
+        mx.eval(weight)
+        return weight
+
     def get_row(self, key: str, row: int) -> np.ndarray:
         shard = self.key_to_shard[key]
         header, data_start = self._header_cache[shard]
@@ -121,6 +134,21 @@ class _ShardIndex:
 _DTYPES = {"F32": np.float32, "F16": np.float16, "I64": np.int64, "I32": np.int32}
 
 
+def _read_bf16_words(path: str, key: str, header: dict, data_start: int) -> np.ndarray:
+    """Bulk-read one BF16 tensor; avoid faulting in a large mmap during conversion."""
+    meta = header[key]
+    begin, end = meta["data_offsets"]
+    if begin < 0 or end < begin or (end - begin) % 2:
+        raise ValueError(f"Invalid BF16 data offsets {begin}:{end} in {path}:{key}")
+    count = (end - begin) // 2
+    with open(path, "rb") as handle:
+        handle.seek(data_start + begin)
+        raw = np.fromfile(handle, dtype=np.uint16, count=count)
+    if raw.size != count:
+        raise EOFError(f"Truncated safetensors tensor {path}:{key}: expected {count} BF16 values, got {raw.size}")
+    return raw.reshape(meta["shape"])
+
+
 def _read_safetensors_bf16(path: str, key: str, header: dict, data_start: int) -> np.ndarray:
     """Read one tensor (any dtype incl. BF16) without loading the shard."""
     meta = header[key]
@@ -128,8 +156,10 @@ def _read_safetensors_bf16(path: str, key: str, header: dict, data_start: int) -
     count = end - begin
     dtype = meta["dtype"]
     if dtype == "BF16":
-        raw = np.memmap(path, dtype=np.uint16, mode="r", offset=data_start + begin, shape=(count // 2, ))
-        return (raw.astype(np.uint32) << 16).view(np.float32).reshape(meta["shape"])
+        raw = _read_bf16_words(path, key, header, data_start)
+        expanded = raw.astype(np.uint32)
+        expanded <<= 16  # Shift the owned conversion buffer, never the read-only mapping.
+        return expanded.view(np.float32).reshape(meta["shape"])
     if dtype not in _DTYPES:
         raise ValueError(f"Unsupported safetensors dtype {dtype} in {path}:{key}")
     return np.asarray(
@@ -157,7 +187,9 @@ def _read_safetensors_row(path: str, key: str, row: int, header: dict, data_star
     begin = int(meta["data_offsets"][0]) + row * row_count * item_size
     if dtype == "BF16":
         raw = np.memmap(path, dtype=np.uint16, mode="r", offset=data_start + begin, shape=(row_count, ))
-        return (raw.astype(np.uint32) << 16).view(np.float32).reshape(shape[1:])
+        expanded = raw.astype(np.uint32)
+        expanded <<= 16
+        return expanded.view(np.float32).reshape(shape[1:])
     return np.array(
         np.memmap(path, dtype=_DTYPES[dtype], mode="r", offset=data_start + begin, shape=(row_count, )),
         copy=True,
@@ -276,7 +308,7 @@ class StreamedMiniMaxH3TextConditioner:
         prefix = f"model.language_model.layers.{index}."
 
         def w(name):
-            return mx.array(np.asarray(self.index.get(prefix + name)).astype(np.float32))
+            return self.index.get_mlx(prefix + name)
 
         # Self-attention block.
         residual = hidden

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_conditioner.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_conditioner.py
@@ -32,6 +32,9 @@ class _ArrayIndex:
     def get(self, key: str) -> np.ndarray:
         return self.weights[key]
 
+    def get_mlx(self, key: str):
+        return mx.array(np.asarray(self.get(key), dtype=np.float32))
+
 
 def test_bf16_embedding_row_read_does_not_materialize_full_table(tmp_path, monkeypatch) -> None:
     from safetensors.torch import save_file

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_modulation.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_modulation.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exactness gates for compiled MiniMax-H3 AdaLN modulation."""
+
+from __future__ import annotations
+
+import pytest
+
+mx = pytest.importorskip("mlx.core", reason="MLX is required for MiniMax-H3 modulation tests")
+
+import fastvideo.mlx_runtime.minimax_h3 as h3  # noqa: E402
+
+
+@pytest.mark.parametrize("hidden_dtype", [mx.float32, mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("table_dtype", [mx.float32, mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("strided", [False, True])
+def test_compiled_modulation_matches_eager_for_supported_dtypes(hidden_dtype, table_dtype, strided) -> None:
+    rows = 17
+    mx.random.seed(2026)
+    hidden = mx.random.normal((rows * 2 if strided else rows, 128), dtype=hidden_dtype)
+    if strided:
+        hidden = hidden[::2]
+    scale = mx.random.normal((9, 128), dtype=table_dtype)
+    shift = mx.random.normal((9, 128), dtype=table_dtype)
+    indices = mx.arange(rows) % 9
+
+    expected = hidden * (1.0 + scale[indices]) + shift[indices]
+    actual = h3._modulate(hidden, (1.0 + scale)[indices], shift[indices])
+    mx.eval(expected, actual)
+
+    assert bool(mx.array_equal(actual, expected).item())

--- a/fastvideo/tests/mlx/test_mlx_minimax_h3_weight_reads.py
+++ b/fastvideo/tests/mlx/test_mlx_minimax_h3_weight_reads.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Storage-bit and source-ownership checks for streamed H3 weights.
+
+These tests read tiny synthetic files. GPU conversion tests allocate only
+small MLX arrays and never load a model checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+
+import numpy as np
+import pytest
+
+mx = pytest.importorskip("mlx.core", reason="MLX runtime module import requires MLX")
+
+from fastvideo.mlx_runtime.minimax_h3_conditioner import (  # noqa: E402
+    _ShardIndex,
+    _read_safetensors_bf16,
+    _read_safetensors_row,
+)
+
+
+def _write_tensor(tmp_path, bits: np.ndarray, dtype: str):
+    prefix = b"prefix!!"
+    header = {
+        "prefix": {"dtype": "U8", "shape": [len(prefix)], "data_offsets": [0, len(prefix)]},
+        "weight": {
+            "dtype": dtype,
+            "shape": list(bits.shape),
+            "data_offsets": [len(prefix), len(prefix) + bits.nbytes],
+        },
+    }
+    encoded = json.dumps(header).encode()
+    encoded += b" " * (-len(encoded) % 8)
+    path = tmp_path / "weights.safetensors"
+    path.write_bytes(struct.pack("<Q", len(encoded)) + encoded + prefix + bits.tobytes())
+    return str(path), header, 8 + len(encoded)
+
+
+def test_bf16_reader_preserves_every_storage_bit_pattern(tmp_path) -> None:
+    """Include signed zero, subnormals, infinity, and all NaN payloads."""
+    bits = np.arange(65536, dtype=np.uint16).reshape(256, 256)
+    path, header, offset = _write_tensor(tmp_path, bits, "BF16")
+    actual = _read_safetensors_bf16(path, "weight", header, offset)
+    assert actual.dtype == np.float32
+    assert actual.shape == bits.shape
+    words = actual.view(np.uint32)
+    np.testing.assert_array_equal(words >> 16, bits)
+    assert not np.any(words & np.uint32(0xFFFF))
+
+
+@pytest.mark.parametrize("row", [0, 127, 255])
+def test_bf16_row_reader_matches_full_read(tmp_path, row: int) -> None:
+    bits = np.arange(65536, dtype=np.uint16).reshape(256, 256)
+    path, header, offset = _write_tensor(tmp_path, bits, "BF16")
+    full = _read_safetensors_bf16(path, "weight", header, offset)
+    actual = _read_safetensors_row(path, "weight", row, header, offset)
+    assert actual.shape == (256, )
+    assert actual.nbytes == 256 * np.dtype(np.float32).itemsize
+    np.testing.assert_array_equal(actual.view(np.uint32), full[row].view(np.uint32))
+
+
+@pytest.mark.parametrize("row_only", [False, True])
+def test_bf16_conversion_owns_writable_storage_without_changing_source(tmp_path, row_only: bool) -> None:
+    bits = np.array([[0x3F80, 0x8000, 0x7FC1], [0x0001, 0xFF80, 0xFFFF]], dtype=np.uint16)
+    path, header, offset = _write_tensor(tmp_path, bits, "BF16")
+    before = (tmp_path / "weights.safetensors").read_bytes()
+    if row_only:
+        actual = _read_safetensors_row(path, "weight", 1, header, offset)
+    else:
+        actual = _read_safetensors_bf16(path, "weight", header, offset)
+    assert actual.flags.writeable
+    actual[...] = 42.0
+    assert (tmp_path / "weights.safetensors").read_bytes() == before
+
+
+@pytest.mark.parametrize("row", [-1, 2])
+def test_bf16_row_reader_rejects_out_of_bounds(tmp_path, row: int) -> None:
+    path, header, offset = _write_tensor(tmp_path, np.zeros((2, 3), dtype=np.uint16), "BF16")
+    with pytest.raises(IndexError, match="outside leading dimension"):
+        _read_safetensors_row(path, "weight", row, header, offset)
+
+
+@pytest.mark.parametrize("dtype,code", [(np.float32, "F32"), (np.float16, "F16")])
+def test_native_float_reads_keep_values_and_mapping_immutable(tmp_path, dtype, code: str) -> None:
+    values = np.array([[1.5, -0.0, 0.25], [-2.0, 8.0, 16.0]], dtype=dtype)
+    path, header, offset = _write_tensor(tmp_path, values, code)
+    full = _read_safetensors_bf16(path, "weight", header, offset)
+    assert not full.flags.writeable
+    converted = np.asarray(full, dtype=np.float32)
+    np.testing.assert_array_equal(converted, values.astype(np.float32))
+    if dtype == np.float32:
+        assert np.shares_memory(converted, full)
+    else:
+        assert not np.shares_memory(converted, full)
+    row = _read_safetensors_row(path, "weight", 1, header, offset)
+    np.testing.assert_array_equal(row, values[1])
+    row[...] = 7.0
+    np.testing.assert_array_equal(full, values)
+
+
+def test_mlx_bf16_conversion_preserves_every_storage_bit_pattern(tmp_path) -> None:
+    bits = np.arange(65536, dtype=np.uint16).reshape(256, 256)
+    path, header, offset = _write_tensor(tmp_path, bits, "BF16")
+    index = _ShardIndex.__new__(_ShardIndex)
+    index.key_to_shard = {"weight": path}
+    index._header_cache = {path: (header, offset)}
+    before = (tmp_path / "weights.safetensors").read_bytes()
+    actual = index.get_mlx("weight")
+    assert actual.dtype == mx.float32
+    assert actual.shape == bits.shape
+    np.testing.assert_array_equal(np.asarray(actual.view(mx.uint32)), bits.astype(np.uint32) << 16)
+    assert (tmp_path / "weights.safetensors").read_bytes() == before
+
+
+@pytest.mark.parametrize("dtype,code", [(np.float32, "F32"), (np.float16, "F16")])
+def test_mlx_native_float_fallback_preserves_values(tmp_path, dtype, code: str) -> None:
+    values = np.array([[1.5, -0.0, 0.25], [-2.0, 8.0, 16.0]], dtype=dtype)
+    path, header, offset = _write_tensor(tmp_path, values, code)
+    index = _ShardIndex.__new__(_ShardIndex)
+    index.key_to_shard = {"weight": path}
+    index._header_cache = {path: (header, offset)}
+    actual = index.get_mlx("weight")
+    assert actual.dtype == mx.float32
+    np.testing.assert_array_equal(np.asarray(actual).view(np.uint32), values.astype(np.float32).view(np.uint32))
+
+
+def test_bulk_bf16_read_rejects_truncated_tensor(tmp_path) -> None:
+    path, header, offset = _write_tensor(tmp_path, np.ones((2, 3), dtype=np.uint16), "BF16")
+    file = tmp_path / "weights.safetensors"
+    file.write_bytes(file.read_bytes()[:-2])
+    with pytest.raises(EOFError, match="expected 6 BF16 values, got 5"):
+        _read_safetensors_bf16(path, "weight", header, offset)
+
+
+@pytest.mark.parametrize("offsets", [[8, 6], [8, 11], [-2, 10]])
+def test_bulk_bf16_read_rejects_invalid_offsets_before_reading(tmp_path, monkeypatch, offsets) -> None:
+    path, header, offset = _write_tensor(tmp_path, np.ones((2, 3), dtype=np.uint16), "BF16")
+    header["weight"]["data_offsets"] = offsets
+
+    def reject_read(*_args, **_kwargs):
+        raise AssertionError("invalid offsets reached np.fromfile")
+
+    monkeypatch.setattr(np, "fromfile", reject_read)
+    with pytest.raises(ValueError, match="Invalid BF16 data offsets"):
+        _read_safetensors_bf16(path, "weight", header, offset)


### PR DESCRIPTION
## Purpose

Uncached MiniMax H3 generation on Apple Silicon spends 79–82 seconds streaming and expanding the 66 GB BF16 conditioner before denoising. The H3 transformer also repeats row-expanded AdaLN scale and shift operations in every block.

This PR reduces both costs without changing the checkpoint, quantization, sampling schedule, spatial or temporal workload, conditioning values, or decoder path.

## Changes

- Read each requested conditioner BF16 tensor with one bounded file operation, reinterpret its storage in MLX, and materialize the FP32 conversion before building the decoder-layer graph. Embedding access remains row-scoped, and only one language-model layer is resident at a time.
- Apply gathered AdaLN scale and shift values through one reusable shapeless `mx.compile` graph.
- Add storage-bit, malformed-read, source-ownership, dtype, stride, and eager-parity tests for both paths.

The module documentation and comments record the streaming memory contract and explain why the BF16 cast is synchronized before layer evaluation. No user-facing option or cache format changes.

## Measured results

Environment: Apple M4 Max with 36 GB unified memory, macOS 27.0 build 26A5416b. Tests used the affine INT6 group-64 H3 checkpoint at 832×480, 124 frames, four denoising steps, and no spatial or temporal fast mode.

### Conditioner phase

The same 70-token speech prompt and layer-50 output were compared within each MLX runtime.

| MLX | Original | This PR | Reduction | Parity |
| --- | ---: | ---: | ---: | --- |
| 0.31.2 | 78.509 s | 15.228 s | 80.6% | Hidden features and tags exact |
| 0.32.2 | 82.462 s | 15.569 s | 81.1% | Hidden features and tags exact |

The conditioner MLX active-memory peak increases from about 1.88 GiB to 2.06 GiB. It remains well below the approximately 19.6 GiB denoise peak and does not load a full shard, embedding table, or conditioner model.

### AdaLN modulation

Each real-block result is the median of eight alternating baseline/candidate pairs at packed sequence length 14,937.

| MLX | Eager | Compiled | Reduction | Parity |
| --- | ---: | ---: | ---: | --- |
| 0.31.2 | 1.843257 s | 1.796039 s | 2.56% | Exact |
| 0.32.2 | 1.799464 s | 1.772093 s | 1.52% | Exact |

Two order-reversed four-step comparisons also favored the compiled path: 393.597 versus 443.541 seconds and 366.016 versus 392.436 seconds. Those runs paged heavily, so the 6.7–11.3% full-denoise range is directional evidence; the isolated real-block medians are the stable performance claim.

A complete uncached seed-2027 generation took 524.062 seconds: 17.163 conditioning, 396.085 denoise, 109.730 video decode, 0.696 audio decode, and 0.389 mux. It produced a 5.17-second 832×480 H.264 clip with stereo AAC audio. An eager replay produced bit-identical final video and audio latents.

## Test Plan

```bash
/Users/aryank/fvrelease/.venv/bin/python -m pytest \
  fastvideo/tests/mlx/test_mlx_minimax_h3_conditioner.py \
  fastvideo/tests/mlx/test_mlx_minimax_h3_weight_reads.py \
  fastvideo/tests/mlx/test_mlx_minimax_h3_modulation.py \
  fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py -q

PYTHONPATH=/Users/aryank/os/FastVideoH3YukonPerf/outputs/yukon/mlx0322 \
  /Users/aryank/fvrelease/.venv/bin/python -m pytest \
  fastvideo/tests/mlx/test_mlx_minimax_h3_conditioner.py \
  fastvideo/tests/mlx/test_mlx_minimax_h3_weight_reads.py \
  fastvideo/tests/mlx/test_mlx_minimax_h3_modulation.py \
  fastvideo/tests/mlx/test_mlx_minimax_h3_parity.py -q

/Users/aryank/os/FastVideo/.venv/bin/pre-commit run --all-files
```

Manual full-workload validation used seeds 2026 and 2027 with 832×480, 124 frames, four steps, and the unchanged audio/video decoders.

## Test Results

- MLX 0.31.2: 51 passed, 14 Torch deprecation warnings.
- MLX 0.32.2: 51 passed, 14 Torch deprecation warnings.
- Configured pre-commit: all hooks passed across the repository.
- Seed 2026: all four video velocities, all four audio velocities, and both final latents match the eager path bit-for-bit in both run orders.
- Seed 2027: final video and audio latents match the eager path bit-for-bit.
- Generated media: container, stream dimensions, duration, frame finiteness, audio finiteness, clipping, and representative frames checked.
- Not run: the four-GPU CUDA MiniMax H3 SSIM test. It does not exercise the MLX runtime changed here; the MLX comparisons instead gate exact conditioner, block, per-step, and final-latent values.

## Review notes

The conditioner gain applies to uncached prompts. Cached prompts bypass that phase. The compiled AdaLN graph is lazy and process-local, and it preserves the original multiply-then-add expression and output dtype.

The branch is based on `620bc36dc` and includes only these two performance commits. PR #1788's wide-matrix affine INT6 dispatch and PR #1789's optional spatial fast mode are already present in `main` and are not duplicated here.

## Checklist

- [x] I ran `pre-commit run --all-files` and fixed all issues
- [x] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

**For model/pipeline changes:**

- [ ] I verified SSIM regression tests pass (not run: the existing test is a four-GPU CUDA path and does not exercise MLX)
- [x] I confirmed no support-matrix change is required because this PR adds no model
