### PR TITLE
[bugfix] Write generated documentation as UTF-8

### DIFF
--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -586,7 +586,7 @@ def generate_flat_examples(examples: list[Example], category_indices: dict[str, 
 
         # Generate the example documentation
         doc_path = index.path.parent / f"{example.path.stem}.md"
-        with open(doc_path, "w+") as f:
+        with open(doc_path, "w+", encoding="utf-8") as f:
             f.write(example.generate())
         index.documents.append(example.path.stem)
 
@@ -613,7 +613,7 @@ def generate_nested_examples(nested_structures: dict[str, dict[str, dict[str, di
                 # Generate dataset examples using the Example class
                 for dataset, nested_struct in datasets.items():
                     doc_path = category_base_dir / f"{nested_struct.filename}.md"
-                    with open(doc_path, "w+") as f:
+                    with open(doc_path, "w+", encoding="utf-8") as f:
                         f.write(nested_struct.example.generate())
 
                 # Create model-level index
@@ -628,14 +628,14 @@ def generate_nested_examples(nested_structures: dict[str, dict[str, dict[str, di
                     model_index.documents.append(nested_struct.filename)
 
                 # Write model index
-                with open(model_index.path, "w+") as f:
+                with open(model_index.path, "w+", encoding="utf-8") as f:
                     f.write(model_index.generate())
 
                 # Add model to method index
                 method_index.documents.append(model)
 
             # Write method index
-            with open(method_index.path, "w+") as f:
+            with open(method_index.path, "w+", encoding="utf-8") as f:
                 f.write(method_index.generate())
 
             # Add method to main category index
@@ -688,12 +688,12 @@ def generate_examples(generate_main_index: bool = False) -> None:
                 examples_index.documents.insert(0, str(rel_path).replace("\\", "/").replace(".md", ""))
 
             # Write the category index file
-            with open(category_index.path, "w+") as f:
+            with open(category_index.path, "w+", encoding="utf-8") as f:
                 f.write(category_index.generate())
 
     # Write the main index file if requested
     if generate_main_index and examples_index:
-        with open(examples_index.path, "w+") as f:
+        with open(examples_index.path, "w+", encoding="utf-8") as f:
             f.write(examples_index.generate())
 
 


### PR DESCRIPTION
## Purpose

Make generated example documentation build reliably on Windows. Before this change, `python docs/generate_examples.py` could fail with `UnicodeEncodeError` when Python selected the system `cp1252` encoding and an example contained Unicode.

## Changes

- Write all generated Markdown files with explicit UTF-8 encoding.
- Keep source reads and generated writes on the same encoding without changing content on UTF-8-default systems.

## Test Plan

```bash
python docs/generate_examples.py
python scripts/check_docs_links.py
python -m py_compile docs/generate_examples.py
pre-commit run --files docs/generate_examples.py
python -m mkdocs build
```

## Test Results

<details>
<summary>Test output</summary>

```text
Generating example documentation...
Example documentation generated successfully!
Docs link check passed.
MkDocs build passed.
yapf, ruff, codespell, mypy, and repository filename checks passed.
```

</details>

## Checklist

- [ ] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [x] I updated documentation if needed
- [x] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model
