### PR TITLE
[feat] Add an H3 server cookbook and prompt playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ eggs/
 
 # MkDocs documentation
 site/
+docs/assets/cookbook-serving.json
+examples/serving/clients/node_modules/
 docs/getting_started/examples/
 docs/examples/
 docs/inference/examples/

--- a/docs/assets/cookbook-recipes.json
+++ b/docs/assets/cookbook-recipes.json
@@ -451,6 +451,10 @@
       "summary": "Run the DMD2-distilled FastH3 Preview with four DiT forwards, trained H3 sparse attention, compiled decode, and synchronized audio.",
       "model": "FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2",
       "source": "examples/inference/basic/basic_fasth3.py",
+      "serving": {
+        "source": "examples/serving/openai_fasth3.yaml",
+        "install": "UV_TORCH_BACKEND=cu130 uv pip install -e \".[fasth3]\""
+      },
       "command": "UV_TORCH_BACKEND=cu130 uv pip install -e \".[fasth3]\"\npython examples/inference/basic/basic_fasth3.py --prompt \"(S1) A presenter says <d>[English] FastVideo runs FastH3.</d>\" --profile all",
       "gpu_types": ["NVIDIA"],
       "hardware": {

--- a/docs/assets/cookbook-recipes.json
+++ b/docs/assets/cookbook-recipes.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "recipes": [
     {
       "id": "fastwan21-t2v",
@@ -471,6 +471,11 @@
     },
     {
       "id": "fasth3-preview-mlx",
+      "serving": {
+        "source": "examples/serving/mlx_fasth3.yaml",
+        "install": "uv pip install -e \".[mlx]\"",
+        "prepare": "hf download FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2 --local-dir ./FastH3-Preview-v0.2\npython scripts/checkpoint_conversion/convert_minimax_h3_mlx.py --model-root ./FastH3-Preview-v0.2/transformer --out ./FastH3-MLX --formats \"int6\""
+      },
       "group": "fasth3-preview",
       "group_label": "FastH3 Preview",
       "group_task": "4-step text to video + audio",

--- a/docs/assets/cookbook.js
+++ b/docs/assets/cookbook.js
@@ -349,16 +349,24 @@
           option.setAttribute("aria-pressed", String(selected));
         });
         servingAvailability.textContent = profile
-          ? "The server keeps the model loaded between requests. Python can do the same when you reuse the generator in one process."
+          ? "The playground and API clients share one server process. Both workflows can run on your own machine."
           : servingLoadFailed
             ? "Server examples could not be loaded. Open the H3 server guide below, or use Python directly."
-            : "This recipe uses Python directly. For the playground and API clients, choose FastH3 Preview with CUDA.";
+            : "This recipe uses Python directly. For the playground and API clients, choose FastH3 Preview with CUDA or MLX.";
         servingPanel.hidden = !useServer;
         commandBlock.hidden = useServer;
         root.querySelector("[data-cookbook-python-note]").hidden = useServer;
       }
 
       if (useServer) {
+        const isMLX = profile.runtime === "mlx";
+        servingPanel.querySelector("[data-cookbook-server-lifetime]").textContent = isMLX
+          ? "Start once, then change prompts in the playground or your app. MLX reuses its pipeline and prompt cache, but loads and releases model components between phases to limit unified-memory use. It does not keep all weights resident."
+          : "Start once, then change prompts in the playground or your app. CUDA requests reuse the loaded model. The Python SDK can also reuse a generator within one process.";
+        servingPanel.querySelector("[data-cookbook-install-guide]").href = isMLX
+          ? "../../getting_started/installation/mps/#run-fasth3-preview" : "../../getting_started/installation/gpu/";
+        servingPanel.querySelector("[data-cookbook-prepare]").hidden = !profile.prepare;
+        servingPanel.querySelector("[data-cookbook-server-prepare]").textContent = profile.prepare;
         servingPanel.querySelector("[data-cookbook-server-install]").textContent = profile.install;
         servingPanel.querySelector("[data-cookbook-server-command]").textContent = profile.command;
         servingPanel.querySelector("[data-cookbook-health-command]").textContent = profile.health_command;
@@ -395,7 +403,7 @@
       });
 
       description.textContent = useServer
-        ? "FastH3 Preview generates video with audio. This server profile uses the checked-in CUDA configuration."
+        ? `FastH3 Preview generates video with audio. This server profile uses the checked-in ${profile.runtime.toUpperCase()} configuration.`
         : recipe.summary;
       label.textContent = useServer ? `${recipe.group_label || recipe.label} · Server` : recipe.label;
       model.textContent = recipe.model;
@@ -415,7 +423,9 @@
       renderHardwareEvidence(hardwareState, hardwareBadge, activeRecipe);
 
       const limitations = useServer ? [
-        "This server config has no recorded serving benchmark. Compilation is disabled, unlike the measured Python performance profile.",
+        profile.runtime === "mlx"
+          ? "This MLX server config has no recorded hardware run. Measurements from the Python recipe are not server memory requirements. Only text-to-video/audio is wired; reference inputs and fast modes are not exposed here."
+          : "This server config has no recorded serving benchmark. Compilation is disabled, unlike the measured Python performance profile.",
         `${profile.sampling.width} × ${profile.sampling.height} · ${profile.sampling.num_frames} frames · ${profile.sampling.fps} fps. The server supplies these defaults; the client sends the model and prompt.`,
         "Generation is serialized. Job metadata is held in memory and is lost when the server restarts.",
       ] : recipe.limitations || [];

--- a/docs/assets/cookbook.js
+++ b/docs/assets/cookbook.js
@@ -220,6 +220,9 @@
     const count = root.querySelector("[data-cookbook-count]");
     const result = root.querySelector(".cookbook-result");
     const commandBlock = root.querySelector(".cookbook-command");
+    const servingPanel = root.querySelector("[data-cookbook-serving]");
+    const usage = root.querySelector("[data-cookbook-usage]");
+    const servingAvailability = root.querySelector("[data-cookbook-serving-availability]");
 
     modelOptions.setAttribute("aria-label", "Recipe");
     hardwareOptions.setAttribute("aria-label", "Runtime");
@@ -236,6 +239,18 @@
 
     const familyRecipes = recipes.filter((recipe) => recipe.family === family);
     if (!familyRecipes.length) return;
+
+    let servingProfiles = {};
+    let servingLoadFailed = false;
+    if (servingPanel && familyRecipes.some((recipe) => recipe.serving)) {
+      try {
+        const dataUrl = new URL(root.dataset.recipes, document.baseURI);
+        servingProfiles = await loadRecipes(new URL("cookbook-serving.json", dataUrl));
+      } catch (error) {
+        servingLoadFailed = true;
+        console.error("Failed to load FastVideo serving profiles", error);
+      }
+    }
 
     const byId = new Map(familyRecipes.map((recipe) => [recipe.id, recipe]));
     const groups = new Map();
@@ -263,13 +278,21 @@
 
     const query = new URLSearchParams(window.location.search);
     const requestedRecipe = query.get("recipe");
-    const defaultRecipeId = familyRecipes[0].id;
+    const defaultRecipeId = byId.has(root.dataset.defaultRecipe) ? root.dataset.defaultRecipe : familyRecipes[0].id;
     let selectedRecipeId = requestedRecipe && byId.has(requestedRecipe) ? requestedRecipe : defaultRecipeId;
     let selectedGroupId = groupIdFor(byId.get(selectedRecipeId));
     let renderedRuntimeGroup = null;
+    // Keep previously shared local/openai links working after renaming workflows.
+    const workflow = (value) => ["local", "python"].includes(value) ? "python" : "server";
+    let usagePreference = workflow(query.get("use"));
+    let selectedClient = ["python", "javascript", "curl"].includes(query.get("client")) ? query.get("client") : "curl";
+    const clientDetails = servingPanel?.querySelector(".cookbook-serving__code");
+    if (clientDetails && query.has("client")) clientDetails.open = true;
 
     const renderRuntimeOptions = () => {
       const groupRecipes = groups.get(selectedGroupId) || [];
+      const renderedIds = [...hardwareOptions.querySelectorAll("[data-recipe-id]")].map((option) => option.dataset.recipeId);
+      if (renderedIds.join(",") === groupRecipes.map((recipe) => recipe.id).join(",")) return;
       hardwareOptions.replaceChildren();
       groupRecipes.forEach((recipe) => {
         const runtime = runtimeFor(recipe);
@@ -313,6 +336,47 @@
         renderedRuntimeGroup = selectedGroupId;
       }
       const runtime = runtimeFor(recipe);
+      const profile = servingPanel && servingProfiles[recipe.id];
+      const useServer = Boolean(profile && usagePreference === "server");
+      // The measured local profile and the server config have separate evidence.
+      const activeRecipe = useServer ? { ...recipe, hardware: profile.hardware, evidence: "Source-backed" } : recipe;
+
+      if (usage) {
+        usage.querySelectorAll("[data-cookbook-mode]").forEach((option) => {
+          const selected = option.dataset.cookbookMode === (useServer ? "server" : "python");
+          option.disabled = option.dataset.cookbookMode === "server" && !profile;
+          option.classList.toggle("cookbook-option--selected", selected);
+          option.setAttribute("aria-pressed", String(selected));
+        });
+        servingAvailability.textContent = profile
+          ? "The server keeps the model loaded between requests. Python can do the same when you reuse the generator in one process."
+          : servingLoadFailed
+            ? "Server examples could not be loaded. Open the H3 server guide below, or use Python directly."
+            : "This recipe uses Python directly. For the playground and API clients, choose FastH3 Preview with CUDA.";
+        servingPanel.hidden = !useServer;
+        commandBlock.hidden = useServer;
+        root.querySelector("[data-cookbook-python-note]").hidden = useServer;
+      }
+
+      if (useServer) {
+        servingPanel.querySelector("[data-cookbook-server-install]").textContent = profile.install;
+        servingPanel.querySelector("[data-cookbook-server-command]").textContent = profile.command;
+        servingPanel.querySelector("[data-cookbook-health-command]").textContent = profile.health_command;
+        servingPanel.querySelector("[data-cookbook-playground]").href = profile.playground_url;
+        const client = profile.clients[selectedClient];
+        const filename = client.source.split("/").pop();
+        servingPanel.querySelector("[data-cookbook-client-install]").textContent = client.install;
+        const clientCode = servingPanel.querySelector("[data-cookbook-client-code]");
+        clientCode.className = `language-${selectedClient === "curl" ? "bash" : selectedClient}`;
+        clientCode.textContent = client.code;
+        servingPanel.querySelector("[data-cookbook-client-filename]").textContent = filename;
+        servingPanel.querySelector("[data-cookbook-client-source]").href = `https://github.com/hao-ai-lab/FastVideo/blob/main/${client.source}`;
+        const runner = { python: "python", javascript: "node", curl: "bash" }[selectedClient];
+        servingPanel.querySelector("[data-cookbook-client-run]").textContent = `Save as ${filename} and run ${runner} ${filename}. The MP4 is saved with the job ID as its filename.`;
+        servingPanel.querySelectorAll("[data-cookbook-client]").forEach((option) => {
+          option.setAttribute("aria-pressed", String(option.dataset.cookbookClient === selectedClient));
+        });
+      }
 
       modelOptions.querySelectorAll("button").forEach((option) => {
         const selected = option.dataset.recipeGroup === selectedGroupId;
@@ -323,26 +387,38 @@
         const selected = option.dataset.recipeId === recipe.id;
         option.classList.toggle("cookbook-option--selected", selected);
         option.setAttribute("aria-pressed", String(selected));
+        const candidate = byId.get(option.dataset.recipeId);
+        const candidateProfile = servingProfiles[candidate.id];
+        const candidateRuntime = runtimeFor(candidateProfile && usagePreference === "server"
+          ? { ...candidate, hardware: candidateProfile.hardware } : candidate);
+        option.querySelector("span").textContent = candidateRuntime.hint;
       });
 
-      description.textContent = recipe.summary;
-      label.textContent = recipe.label;
+      description.textContent = useServer
+        ? "FastH3 Preview generates video with audio. This server profile uses the checked-in CUDA configuration."
+        : recipe.summary;
+      label.textContent = useServer ? `${recipe.group_label || recipe.label} · Server` : recipe.label;
       model.textContent = recipe.model;
       task.textContent = recipe.task;
-      hardwareValue.textContent = runtimeSummary(recipe);
-      if (artifact) artifact.textContent = recipe.expected_artifact || "Not yet documented for this recipe.";
+      hardwareValue.textContent = runtimeSummary(activeRecipe);
+      if (artifact) artifact.textContent = useServer ? "MP4 with audio" : recipe.expected_artifact || "Not yet documented for this recipe.";
       if (evidenceCell) {
-        evidenceCell.textContent = recipe.evidence || "Source-backed";
-        evidenceCell.classList.toggle("cookbook-badge--verified", recipe.evidence === "Verified");
-        evidenceCell.classList.toggle("cookbook-badge--source-backed", recipe.evidence !== "Verified");
+        evidenceCell.textContent = activeRecipe.evidence || "Source-backed";
+        evidenceCell.classList.toggle("cookbook-badge--verified", activeRecipe.evidence === "Verified");
+        evidenceCell.classList.toggle("cookbook-badge--source-backed", activeRecipe.evidence !== "Verified");
       }
-      source.href = `https://github.com/hao-ai-lab/FastVideo/blob/main/${recipe.source}`;
+      source.href = `https://github.com/hao-ai-lab/FastVideo/blob/main/${useServer ? profile.source : recipe.source}`;
+      source.textContent = useServer ? "View server configuration" : "Open example source";
       modelLink.href = `https://huggingface.co/${recipe.model}`;
       command.textContent = recipe.command;
 
-      renderHardwareEvidence(hardwareState, hardwareBadge, recipe);
+      renderHardwareEvidence(hardwareState, hardwareBadge, activeRecipe);
 
-      const limitations = recipe.limitations || [];
+      const limitations = useServer ? [
+        "This server config has no recorded serving benchmark. Compilation is disabled, unlike the measured Python performance profile.",
+        `${profile.sampling.width} × ${profile.sampling.height} · ${profile.sampling.num_frames} frames · ${profile.sampling.fps} fps. The server supplies these defaults; the client sends the model and prompt.`,
+        "Generation is serialized. Job metadata is held in memory and is lost when the server restarts.",
+      ] : recipe.limitations || [];
       notes.replaceChildren();
       notes.hidden = limitations.length === 0;
       if (limitations.length) {
@@ -361,10 +437,16 @@
       nextQuery.set("recipe", recipe.id);
       nextQuery.set("runtime", runtime.id);
       nextQuery.delete("gpus");
+      if (usage) {
+        nextQuery.set("use", useServer ? "server" : "python");
+        if (useServer && clientDetails?.open) nextQuery.set("client", selectedClient);
+        else nextQuery.delete("client");
+      }
       const nextUrl = `${window.location.pathname}?${nextQuery.toString()}${window.location.hash}`;
       if (historyMode === "push") window.history.pushState({}, "", nextUrl);
       else if (historyMode === "replace") window.history.replaceState({}, "", nextUrl);
-      status.textContent = `${recipe.label} selected for ${runtime.label}.`;
+      const modeSummary = useServer ? " with a persistent server" : "";
+      status.textContent = `${recipe.label} selected for ${runtime.label}${modeSummary}.`;
     };
 
     modelOptions.addEventListener("click", (event) => {
@@ -380,6 +462,18 @@
       selectedGroupId = groupIdFor(byId.get(selectedRecipeId));
       render({ historyMode: "push" });
     });
+    usage?.addEventListener("click", (event) => {
+      const option = event.target.closest("button[data-cookbook-mode]");
+      if (!option || option.disabled) return;
+      usagePreference = option.dataset.cookbookMode;
+      render({ historyMode: "push" });
+    });
+    servingPanel?.addEventListener("click", (event) => {
+      const option = event.target.closest("button[data-cookbook-client]");
+      if (!option) return;
+      selectedClient = option.dataset.cookbookClient;
+      render({ historyMode: "push" });
+    });
 
     render();
 
@@ -389,6 +483,9 @@
       const nextRecipe = nextQuery.get("recipe");
       selectedRecipeId = nextRecipe && byId.has(nextRecipe) ? nextRecipe : defaultRecipeId;
       selectedGroupId = groupIdFor(byId.get(selectedRecipeId));
+      usagePreference = workflow(nextQuery.get("use"));
+      selectedClient = ["python", "javascript", "curl"].includes(nextQuery.get("client")) ? nextQuery.get("client") : "curl";
+      if (clientDetails) clientDetails.open = nextQuery.has("client");
       render({ historyMode: "none" });
     };
     bindFamilyPopstate();

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -1469,6 +1469,192 @@ img {
     }
 }
 
+.cookbook-serving[hidden],
+.cookbook-command[hidden],
+[data-cookbook-python-note][hidden] {
+    display: none;
+}
+
+.cookbook-serving {
+    min-width: 0;
+    font-size: 0.7rem;
+}
+
+.cookbook-serving__intro {
+    max-width: 70ch;
+    color: var(--md-default-fg-color--light);
+}
+
+.cookbook-serving__step {
+    margin-block: 1.8rem;
+    padding-block-start: 1.25rem;
+    border-block-start: 1px solid var(--cookbook-border);
+}
+
+.md-typeset .cookbook-serving__step h4 {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin-block: 0 0.6rem;
+    font-size: 0.85rem;
+}
+
+.cookbook-serving__step h4 > span {
+    display: grid;
+    flex-shrink: 0;
+    place-items: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border: 1px solid var(--cookbook-border);
+    border-radius: 50%;
+    font-size: 0.65rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.cookbook-serving__step > p {
+    max-width: 75ch;
+    color: var(--md-default-fg-color--light);
+}
+
+.cookbook-serving .cookbook-command {
+    margin-block: 0.65rem;
+}
+
+.cookbook-serving .cookbook-command pre > code {
+    min-height: 3.8rem;
+}
+
+.cookbook-command--client pre > code {
+    max-height: 28rem;
+    overflow: auto;
+}
+
+.cookbook-serving__clients {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-block: 1rem;
+}
+
+.cookbook-serving__clients button {
+    min-height: 2.2rem;
+    padding: 0.45rem 0.8rem;
+    border: 1px solid var(--cookbook-border);
+    border-radius: 0.45rem;
+    background: var(--cookbook-surface);
+    color: var(--md-default-fg-color);
+    font: inherit;
+    cursor: pointer;
+}
+
+.cookbook-serving__clients button[aria-pressed="true"] {
+    border-color: var(--cookbook-accent);
+    background: var(--cookbook-accent-soft);
+    color: var(--cookbook-accent-strong);
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+}
+
+.cookbook-serving__clients button:focus-visible {
+    outline: 2px solid var(--md-default-fg-color);
+    outline-offset: 3px;
+}
+
+.cookbook-option-grid button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.cookbook-serving__boundary {
+    padding-block: 0.8rem;
+    border-block-start: 1px solid var(--cookbook-border);
+    color: var(--md-default-fg-color--light);
+}
+
+/* Keep the H3 workflow compact without changing the other family pages. */
+[data-family="minimax_h3"] .cookbook-family-header {
+    padding-block: 0.75rem 1.75rem;
+}
+
+[data-family="minimax_h3"] .cookbook-family-header__body {
+    gap: 0.75rem;
+}
+
+[data-family="minimax_h3"] .cookbook-family-header__logo {
+    width: 4.5rem;
+    height: 4.5rem;
+    flex-basis: 4.5rem;
+}
+
+[data-family="minimax_h3"] .cookbook-family-header__logo img {
+    width: 3.25rem;
+    height: 3.25rem;
+}
+
+[data-family="minimax_h3"] .cookbook-selection-description {
+    margin-block: 1rem;
+}
+
+.cookbook-serving__playground {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.25rem;
+    padding: 1rem;
+    border: 1px solid var(--cookbook-border);
+    border-radius: 0.6rem;
+    background: var(--cookbook-surface-raised);
+}
+
+.cookbook-serving__playground p {
+    max-width: 50ch;
+    margin-block: 0.35rem 0;
+    color: var(--md-default-fg-color--light);
+}
+
+.md-typeset a.cookbook-serving__launch {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+    min-height: 2.2rem;
+    padding: 0.6rem 0.9rem;
+    border: 1px solid var(--cookbook-accent);
+    border-radius: 0.4rem;
+    background: var(--cookbook-accent-soft);
+    color: var(--cookbook-accent-strong);
+    font-weight: 600;
+}
+
+.cookbook-serving__launch:focus-visible {
+    outline: 2px solid var(--md-default-fg-color);
+    outline-offset: 3px;
+}
+
+.md-typeset .cookbook-serving__code {
+    margin-block: 1.2rem;
+    border-color: var(--cookbook-border);
+    box-shadow: none;
+    font-size: inherit;
+}
+
+.md-typeset .cookbook-serving__code > summary {
+    background: var(--cookbook-surface-raised);
+}
+
+.cookbook-serving__local-hint {
+    font-size: 0.65rem;
+}
+
+@media (max-width: 600px) {
+    .cookbook-serving__playground {
+        align-items: stretch;
+        flex-direction: column;
+    }
+}
+
 .md-typeset .copy-page-button.md-button {
     float: right;
     margin: 0 0 1rem 1rem;

--- a/docs/assets/custom.css
+++ b/docs/assets/custom.css
@@ -1475,6 +1475,10 @@ img {
     display: none;
 }
 
+[data-cookbook-prepare][hidden] {
+    display: none;
+}
+
 .cookbook-serving {
     min-width: 0;
     font-size: 0.7rem;
@@ -1594,6 +1598,21 @@ img {
 
 [data-family="minimax_h3"] .cookbook-selection-description {
     margin-block: 1rem;
+}
+
+[data-family="minimax_h3"] .cookbook-option-grid button.cookbook-option--selected strong {
+    color: var(--md-default-fg-color);
+}
+
+.md-typeset details.cookbook-modes {
+    margin-block: 0 1.6rem;
+    border-color: var(--cookbook-border);
+    box-shadow: none;
+}
+
+.md-typeset details.cookbook-modes > summary {
+    background: var(--cookbook-surface-raised);
+    font-size: 0.72rem;
 }
 
 .cookbook-serving__playground {

--- a/docs/cookbook/cosmos.md
+++ b/docs/cookbook/cosmos.md
@@ -5,7 +5,7 @@ hide:
 
 # Cosmos recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="cosmos" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="cosmos" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/flux.md
+++ b/docs/cookbook/flux.md
@@ -5,7 +5,7 @@ hide:
 
 # FLUX recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="flux" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="flux" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/glm-image.md
+++ b/docs/cookbook/glm-image.md
@@ -5,7 +5,7 @@ hide:
 
 # GLM-Image recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="glm_image" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="glm_image" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/hunyuan.md
+++ b/docs/cookbook/hunyuan.md
@@ -5,7 +5,7 @@ hide:
 
 # Hunyuan recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="hunyuan" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="hunyuan" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/index.md
+++ b/docs/cookbook/index.md
@@ -20,6 +20,7 @@ hide:
     <a class="cookbook-inline-link" href="../inference/support_matrix/">
       View the full support matrix <span aria-hidden="true">→</span>
     </a>
+    <a class="cookbook-inline-link" href="./openai-api/">Run FastH3 with a playground and API <span aria-hidden="true">→</span></a>
   </header>
 
   <section class="cookbook-section" id="video-models" aria-labelledby="video-models-heading">

--- a/docs/cookbook/kandinsky5.md
+++ b/docs/cookbook/kandinsky5.md
@@ -5,7 +5,7 @@ hide:
 
 # Kandinsky 5 recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="kandinsky5" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="kandinsky5" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/longcat.md
+++ b/docs/cookbook/longcat.md
@@ -5,7 +5,7 @@ hide:
 
 # LongCat recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="longcat" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="longcat" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/ltx.md
+++ b/docs/cookbook/ltx.md
@@ -5,7 +5,7 @@ hide:
 
 # LTX recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="ltx2" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="ltx2" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/matrix-game.md
+++ b/docs/cookbook/matrix-game.md
@@ -5,7 +5,7 @@ hide:
 
 # Matrix Game recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="matrixgame" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="matrixgame" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/minimax-h3.md
+++ b/docs/cookbook/minimax-h3.md
@@ -5,7 +5,7 @@ hide:
 
 # MiniMax H3 recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="minimax_h3" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="minimax_h3" data-default-recipe="fasth3-preview-cuda" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">
@@ -15,7 +15,7 @@ hide:
       <div>
         <p class="cookbook-eyebrow">Primary focus · Inference</p>
         <h2>MiniMax H3 recipes</h2>
-        <p>Generate synchronized video and audio with the full H3 checkpoint, the four-step FastH3 Preview, reference and frame-conditioned CUDA paths, or the native Apple Silicon MLX T2VA runtime.</p>
+        <p>Generate video and audio with H3. Keep a CUDA server running for prompt iteration, or use Python directly on CUDA and Apple Silicon MLX.</p>
         <span class="cookbook-count" data-cookbook-count>6 maintained recipes</span>
       </div>
     </div>
@@ -118,6 +118,17 @@ hide:
         </div>
 
         <p class="cookbook-selection-description" data-cookbook-description>Loading recipe details...</p>
+        <div class="cookbook-selection-row" data-cookbook-usage>
+          <div class="cookbook-selection-row__label">
+            <strong>Workflow</strong>
+            <span>Both can run locally</span>
+          </div>
+          <div class="cookbook-option-grid cookbook-option-grid--hardware" role="group" aria-label="How to run this recipe">
+            <button type="button" data-cookbook-mode="server" aria-pressed="false"><strong>Run a server</strong><span>Playground, cURL, or an API client</span></button>
+            <button type="button" data-cookbook-mode="python" aria-pressed="false"><strong>Use Python directly</strong><span>Call the model in your own process</span></button>
+          </div>
+        </div>
+        <p class="cookbook-hardware-note" data-cookbook-serving-availability></p>
         <p class="cookbook-hardware-note">Exact device and memory details appear only when a recorded run supports them.</p>
 
         <div class="cookbook-hardware-state" data-cookbook-hardware-state role="status" aria-live="polite">
@@ -146,7 +157,44 @@ hide:
           <div class="cookbook-command__bar">
             <span>Terminal</span>
           </div>
-          <pre><code class="language-bash" data-cookbook-command>Loading...</code></pre>
+          <pre id="cookbook-local-command"><code class="language-bash" data-cookbook-command>Loading...</code></pre>
+        </div>
+        <p class="cookbook-hardware-note" data-cookbook-python-note>Running this script again starts a new process and reloads the model. To iterate in Python, create the generator once and reuse it for multiple prompts.</p>
+
+        <div class="cookbook-serving" data-cookbook-serving hidden>
+          <p class="cookbook-serving__intro">Start once, then change prompts in the playground or your app. Each job reuses the loaded model. You can run the server and clients on the same machine.</p>
+          <section class="cookbook-serving__step" aria-labelledby="serving-install-heading">
+            <h4 id="serving-install-heading"><span aria-hidden="true">1</span> Install on the GPU machine</h4>
+            <p>Run from your FastVideo clone in an activated Python environment. See <a href="../../getting_started/installation/gpu/">installation requirements</a>.</p>
+            <div class="cookbook-command"><div class="cookbook-command__bar"><span>GPU machine · Terminal</span></div><pre id="cookbook-server-install"><code class="language-bash" data-cookbook-server-install></code></pre></div>
+          </section>
+          <section class="cookbook-serving__step" aria-labelledby="serving-start-heading">
+            <h4 id="serving-start-heading"><span aria-hidden="true">2</span> Start the server</h4>
+            <p>Keep this terminal running. The model loads at startup; later requests reuse the loaded pipeline.</p>
+            <div class="cookbook-command"><div class="cookbook-command__bar"><span>GPU machine · Terminal</span></div><pre id="cookbook-server-command"><code class="language-bash" data-cookbook-server-command></code></pre></div>
+            <details class="cookbook-serving__check"><summary>Check that the server is ready</summary><p>In another terminal, this returns <code>{"status":"ok"}</code> after startup.</p><div class="cookbook-command"><pre id="cookbook-health-command"><code class="language-bash" data-cookbook-health-command></code></pre></div></details>
+          </section>
+          <section class="cookbook-serving__step" aria-labelledby="serving-client-heading">
+            <h4 id="serving-client-heading"><span aria-hidden="true">3</span> Generate and download a video</h4>
+            <div class="cookbook-serving__playground">
+              <div><strong>Try prompts in your browser</strong><p>Edit a prompt, generate, and watch the result. The playground uses the same server as cURL and your app.</p></div>
+              <a class="cookbook-serving__launch" data-cookbook-playground href="http://127.0.0.1:8000/playground/" target="_blank" rel="noopener">Open playground <span aria-hidden="true">↗</span></a>
+            </div>
+            <p class="cookbook-serving__local-hint">Open after the server is ready. On a remote GPU machine, <a href="../openai-api/#connect-your-app">forward port 8000</a> to your computer first. This opens a local page, not a hosted demo.</p>
+            <details class="cookbook-serving__code"><summary>Use cURL or an SDK</summary>
+            <p>Each example submits a job, checks its status, and saves the MP4. The Python and JavaScript examples use OpenAI-compatible clients; no OpenAI account is needed.</p>
+            <div class="cookbook-serving__clients" role="group" aria-label="API client language">
+              <button type="button" data-cookbook-client="curl" aria-pressed="false">cURL</button>
+              <button type="button" data-cookbook-client="python" aria-pressed="true">Python</button>
+              <button type="button" data-cookbook-client="javascript" aria-pressed="false">JavaScript</button>
+            </div>
+            <div class="cookbook-command"><div class="cookbook-command__bar"><span>Client dependencies</span></div><pre id="cookbook-client-install"><code class="language-bash" data-cookbook-client-install></code></pre></div>
+            <div class="cookbook-command cookbook-command--client"><div class="cookbook-command__bar"><span data-cookbook-client-filename>video.py</span><a data-cookbook-client-source href="https://github.com/hao-ai-lab/FastVideo/tree/main/examples/serving/clients">View source</a></div><pre id="cookbook-client-code"><code data-cookbook-client-code></code></pre></div>
+            <p data-cookbook-client-run></p>
+            </details>
+          </section>
+          <p class="cookbook-serving__boundary">This is a local development server without built-in API-key authentication. The client key <code>local</code> is a placeholder. Keep the server on loopback; use an authenticated TLS proxy before exposing it publicly. Run the JavaScript client in your webapp's backend, not in a browser with a private key.</p>
+          <a href="../openai-api/">Server guide and API compatibility →</a>
         </div>
 
         <div class="cookbook-result__footer">
@@ -160,6 +208,7 @@ hide:
     <noscript>
       <div class="cookbook-noscript">
         JavaScript is needed for the guided selector. You can still browse the
+        <a href="../openai-api/">H3 server guide</a> or the
         <a href="../../inference/examples/examples_inference_index/">maintained inference examples</a>.
       </div>
     </noscript>

--- a/docs/cookbook/minimax-h3.md
+++ b/docs/cookbook/minimax-h3.md
@@ -15,7 +15,7 @@ hide:
       <div>
         <p class="cookbook-eyebrow">Primary focus · Inference</p>
         <h2>MiniMax H3 recipes</h2>
-        <p>Generate video and audio with H3. Keep a CUDA server running for prompt iteration, or use Python directly on CUDA and Apple Silicon MLX.</p>
+        <p>Generate video and audio with H3. Run a server on CUDA or Apple Silicon MLX to iterate on prompts, or call the pipeline directly from Python.</p>
         <span class="cookbook-count" data-cookbook-count>6 maintained recipes</span>
       </div>
     </div>
@@ -30,7 +30,8 @@ hide:
     </div>
   </header>
 
-  <section class="cookbook-modes" aria-labelledby="h3-modes-heading">
+  <details class="cookbook-modes">
+    <summary>Compare H3 modes and options</summary>
     <h2 id="h3-modes-heading">Supported modes</h2>
     <p>
       CUDA covers T2VA, FL2VA, and Ref2VA on the full checkpoint, plus FastH3
@@ -86,7 +87,7 @@ hide:
         </tbody>
       </table>
     </div>
-  </section>
+  </details>
 
   <section class="cookbook-builder" id="recipe-builder" aria-labelledby="builder-heading">
     <div class="cookbook-builder__intro">
@@ -162,15 +163,16 @@ hide:
         <p class="cookbook-hardware-note" data-cookbook-python-note>Running this script again starts a new process and reloads the model. To iterate in Python, create the generator once and reuse it for multiple prompts.</p>
 
         <div class="cookbook-serving" data-cookbook-serving hidden>
-          <p class="cookbook-serving__intro">Start once, then change prompts in the playground or your app. Each job reuses the loaded model. You can run the server and clients on the same machine.</p>
+          <p class="cookbook-serving__intro" data-cookbook-server-lifetime>Start once, then change prompts in the playground or your app. You can run the server and clients on the same machine.</p>
           <section class="cookbook-serving__step" aria-labelledby="serving-install-heading">
-            <h4 id="serving-install-heading"><span aria-hidden="true">1</span> Install on the GPU machine</h4>
-            <p>Run from your FastVideo clone in an activated Python environment. See <a href="../../getting_started/installation/gpu/">installation requirements</a>.</p>
+            <h4 id="serving-install-heading"><span aria-hidden="true">1</span> Prepare the machine</h4>
+            <p>Run from your FastVideo clone in an activated Python environment. See <a data-cookbook-install-guide href="../../getting_started/installation/gpu/">installation requirements</a>.</p>
             <div class="cookbook-command"><div class="cookbook-command__bar"><span>GPU machine · Terminal</span></div><pre id="cookbook-server-install"><code class="language-bash" data-cookbook-server-install></code></pre></div>
+            <details class="cookbook-serving__prepare" data-cookbook-prepare hidden><summary>Download and convert MLX weights once</summary><p>Skip this if the weights are already prepared. Edit the paths in <code>examples/serving/mlx_fasth3.yaml</code> to use your existing files. Install <code>ffmpeg</code> for video and audio output.</p><div class="cookbook-command"><pre id="cookbook-server-prepare"><code class="language-bash" data-cookbook-server-prepare></code></pre></div></details>
           </section>
           <section class="cookbook-serving__step" aria-labelledby="serving-start-heading">
             <h4 id="serving-start-heading"><span aria-hidden="true">2</span> Start the server</h4>
-            <p>Keep this terminal running. The model loads at startup; later requests reuse the loaded pipeline.</p>
+            <p>Keep this terminal running while you use the playground or API clients.</p>
             <div class="cookbook-command"><div class="cookbook-command__bar"><span>GPU machine · Terminal</span></div><pre id="cookbook-server-command"><code class="language-bash" data-cookbook-server-command></code></pre></div>
             <details class="cookbook-serving__check"><summary>Check that the server is ready</summary><p>In another terminal, this returns <code>{"status":"ok"}</code> after startup.</p><div class="cookbook-command"><pre id="cookbook-health-command"><code class="language-bash" data-cookbook-health-command></code></pre></div></details>
           </section>

--- a/docs/cookbook/mmaudio.md
+++ b/docs/cookbook/mmaudio.md
@@ -5,7 +5,7 @@ hide:
 
 # MMAudio recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="mmaudio" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="mmaudio" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/openai-api.md
+++ b/docs/cookbook/openai-api.md
@@ -1,0 +1,179 @@
+# Run H3 with a server and playground
+
+Load FastH3 once, then iterate on prompts in a browser, with cURL, or from your
+app. The server and clients can run on the same machine. Each job reuses the
+loaded model until you stop the server.
+
+The server supports the OpenAI-compatible video-job API. The Python and
+JavaScript client examples use that interface, but requests go to FastVideo.
+You do not need an OpenAI account or cloud key.
+
+The [H3 recipe selector](minimax-h3.md) provides the same workflow with runtime
+selection. MLX recipes use Python directly; they do not have a server adapter.
+
+The Python SDK can also keep a model loaded. Create one `VideoGenerator` and
+reuse it for multiple `generate()` calls in the same process. Re-running a
+standalone script creates a new process and loads the model again. Use a server
+when you want separate clients to share that process.
+
+## Install and start the server
+
+Use a FastVideo clone and an activated Python environment. Complete the
+[CUDA installation requirements](../getting_started/installation/gpu.md)
+before running these commands:
+
+```bash
+UV_TORCH_BACKEND=cu130 uv pip install -e ".[fasth3]"
+fastvideo serve --config examples/serving/openai_fasth3.yaml --server.host 127.0.0.1
+```
+
+The configuration loads `FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2` and
+advertises it as `fasth3`. It configures four CUDA GPUs but does not record
+a GPU model or VRAM requirement. This is a source-backed server profile, not
+the measured GB200 Python performance profile. Compilation is disabled.
+
+Keep the server running. In another terminal, check readiness:
+
+```bash
+curl --fail-with-body http://127.0.0.1:8000/health
+```
+
+After model loading completes, the response is `{"status":"ok"}`.
+
+## Open the playground
+
+Open [the local H3 playground](http://127.0.0.1:8000/playground/) after startup.
+Write a prompt, optionally set a seed, then select **Generate video**. The page
+checks the job status and shows the completed video with a download link. Edit
+the prompt and generate again without restarting the server.
+
+The playground sends requests to `/v1/videos` on the same server that serves
+the page. **Use this prompt with cURL** shows the equivalent submission. Recent
+jobs include requests from other clients, so a script and the playground can
+use the same model process. Opening the page or copying a command does not
+start generation.
+
+The page URL includes the active job ID. Reloading that URL resumes status
+checks without resubmitting the prompt. A failed connection or a 30-minute
+polling timeout does not cancel execution. Select **Check status** to reconnect.
+If submission itself is interrupted, check Recent jobs before submitting again.
+
+This first playground supports H3 text-to-video/audio. Reference-media inputs
+remain available through the API, not through the playground. It does not start
+or manage a GPU server for you.
+
+## Generate with cURL or an SDK
+
+These examples use the server's resolution, frame count, and sampling defaults.
+Do not copy Sora-specific durations or resolutions onto H3. The server config
+uses 1344 × 768, 124 frames, 24 fps, and the five-point distilled sigma schedule
+with four DiT forwards.
+
+Each client submits a job, checks for completion or failure, and downloads an
+MP4 named after the job ID. Polling stops after 30 minutes; a timeout does not
+cancel GPU execution. Keep the printed job ID to retrieve its status later.
+Transport retries are disabled to avoid accidental duplicate submissions.
+
+### OpenAI Python
+
+Install the tested client, then run the checked-in example:
+
+```bash
+python -m pip install openai==3.6.0
+python examples/serving/clients/video.py
+```
+
+```python
+--8<-- "examples/serving/clients/video.py"
+```
+
+### OpenAI JavaScript
+
+Use Node.js 22 or later on your computer or in your webapp's backend. Do not put a
+private server key in browser code.
+
+```bash
+npm ci --prefix examples/serving/clients
+node examples/serving/clients/video.mjs
+```
+
+```javascript
+--8<-- "examples/serving/clients/video.mjs"
+```
+
+### cURL
+
+Install `curl` and `jq`, then run:
+
+```bash
+bash examples/serving/clients/video.sh
+```
+
+```bash
+--8<-- "examples/serving/clients/video.sh"
+```
+
+## Connect your app
+
+Set `FASTVIDEO_BASE_URL` to the FastVideo endpoint, including `/v1`, and
+`FASTVIDEO_MODEL` to its advertised model alias. The examples default to
+`http://127.0.0.1:8000/v1` and `fasth3`.
+
+For a remote GPU machine, keep the server bound to loopback and forward the
+port. Replace `user@gpu-host` with your SSH destination:
+
+```bash
+ssh -N -L 8000:127.0.0.1:8000 user@gpu-host
+```
+
+Then open `http://127.0.0.1:8000/playground/` on your computer. The same forwarded
+address works for the cURL and SDK clients. If local port 8000 is occupied, use
+`-L 8001:127.0.0.1:8000`, open port 8001, and set `FASTVIDEO_BASE_URL` to
+`http://127.0.0.1:8001/v1` for the example clients.
+
+Your webapp backend can submit a job and return its ID to the browser. Poll
+from the backend, then proxy the completed download or store it in your own
+artifact store. Do not hold a browser request open for the entire generation.
+
+The client key `local` is a placeholder required by the SDK, not server
+authentication. FastVideo's HTTP server has no built-in API-key check. Before
+public deployment, put it behind an authenticated TLS proxy with restricted
+origins, request limits, and access controls. If your proxy uses bearer tokens,
+set `FASTVIDEO_API_KEY` on your backend. Never reuse an OpenAI cloud key here.
+
+## Compatibility and limits
+
+The client examples target the OpenAI video-job API, not Chat Completions.
+The compatibility tests cover real HTTP requests with the pinned SDKs and a
+fake generator. They establish client and protocol behavior, not GPU generation
+quality, latency, or memory use. The server configuration still needs a recorded
+H3 hardware run before it can be marked Verified in the cookbook.
+
+| Operation | Endpoint |
+| --- | --- |
+| List served models | `GET /v1/models` |
+| Create a video job | `POST /v1/videos` |
+| Retrieve status, including a failed job | `GET /v1/videos/{id}` |
+| List jobs | `GET /v1/videos` |
+| Download the MP4 | `GET /v1/videos/{id}/content` |
+| Delete a job and its artifact | `DELETE /v1/videos/{id}` |
+
+Failed jobs return HTTP 200 with `status: "failed"` and an `error` object so
+SDK polling can stop. Invalid requests return HTTP 400; missing jobs return
+HTTP 404. The download endpoint supports only the `video` variant, not
+thumbnails or spritesheets. Remix, extensions, characters, and an OpenAI Files
+store are not implemented. `/v1/videos/sync` is a FastVideo extension and is
+not used by these client examples.
+
+OpenAI marks its hosted Sora API as deprecated. FastVideo runs its own models;
+the [OpenAI video API reference](https://developers.openai.com/api/reference/python/resources/videos/methods/create)
+describes the client interface, not FastVideo model availability. The examples
+pin tested SDK versions because future SDKs may change or remove video helpers.
+
+The server serializes generation through one loaded pipeline. Job metadata is
+in memory and is lost on restart. Async artifacts remain on disk until deleted
+through the API; establish a retention policy for production use. Deleting an
+in-progress job does not interrupt an already running CUDA call.
+
+For model-specific request fields and reference media, see the
+[HTTP contract](../design/server_contracts/openai.md).

--- a/docs/cookbook/openai-api.md
+++ b/docs/cookbook/openai-api.md
@@ -1,22 +1,26 @@
 # Run H3 with a server and playground
 
-Load FastH3 once, then iterate on prompts in a browser, with cURL, or from your
-app. The server and clients can run on the same machine. Each job reuses the
-loaded model until you stop the server.
+Start FastH3 on CUDA or Apple Silicon MLX, then iterate on prompts in a browser,
+with cURL, or from your app. The server and clients can run on the same machine.
 
 The server supports the OpenAI-compatible video-job API. The Python and
 JavaScript client examples use that interface, but requests go to FastVideo.
 You do not need an OpenAI account or cloud key.
 
 The [H3 recipe selector](minimax-h3.md) provides the same workflow with runtime
-selection. MLX recipes use Python directly; they do not have a server adapter.
+selection. This guide covers FastH3 Preview text-to-video/audio. Other H3
+recipes keep their direct Python commands.
 
-The Python SDK can also keep a model loaded. Create one `VideoGenerator` and
-reuse it for multiple `generate()` calls in the same process. Re-running a
-standalone script creates a new process and loads the model again. Use a server
-when you want separate clients to share that process.
+CUDA requests reuse one loaded `VideoGenerator`. The Python SDK can do the same
+when you reuse the generator across `generate()` calls. MLX keeps one
+`MiniMaxH3MLXPipeline` and a prompt-embedding cache, but still loads and releases
+components between phases to fit unified memory. MLX serving does not keep all
+weights resident or remove phase-loading time. Use a server when you want
+separate clients to share the process without restarting scripts.
 
 ## Install and start the server
+
+### CUDA
 
 Use a FastVideo clone and an activated Python environment. Complete the
 [CUDA installation requirements](../getting_started/installation/gpu.md)
@@ -39,6 +43,47 @@ curl --fail-with-body http://127.0.0.1:8000/health
 ```
 
 After model loading completes, the response is `{"status":"ok"}`.
+
+### Apple Silicon MLX
+
+Complete the [Apple Silicon installation](../getting_started/installation/mps.md#run-fasth3-preview),
+including `ffmpeg`. From your FastVideo clone, install the MLX extra:
+
+```bash
+uv pip install -e ".[mlx]"
+```
+
+Download and convert the weights once. Skip this step if you already have the
+snapshot and converted DiT:
+
+```bash
+hf download FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2 --local-dir ./FastH3-Preview-v0.2
+python scripts/checkpoint_conversion/convert_minimax_h3_mlx.py --model-root ./FastH3-Preview-v0.2/transformer --out ./FastH3-MLX --formats "int6"
+```
+
+Edit `generator.model_root` and `generator.mlx_checkpoint` in
+`examples/serving/mlx_fasth3.yaml` if your weights are elsewhere. Paths are
+relative to the directory where you launch the server. Start it with:
+
+```bash
+python -m fastvideo.entrypoints.openai.mlx_server --config examples/serving/mlx_fasth3.yaml
+```
+
+This uses the native MLX pipeline, not PyTorch MPS. The default output is
+832 × 480, 124 frames at 24 fps, with four DiT forwards and the full H3 VAE.
+The HTTP field `num_inference_steps=5` describes five sigma points; the adapter
+passes `num_steps=4` to MLX. Temporal/spatial fast modes, VSA, reference inputs,
+LoRA selection, and alternate decoders are not exposed by this server adapter.
+Unsupported request options return HTTP 400 before a job starts.
+
+The server binds to `127.0.0.1:8000` and advertises `fasth3`, so the playground
+and clients below work unchanged. Do not run CUDA and MLX servers on the same
+port. MLX readiness means the pipeline is initialized; components load during
+generation. The first request can take longer than a repeated cached prompt.
+
+The MLX server has no recorded device or unified-memory requirement. The
+direct Python recipe's M4 Max measurements are not a server benchmark or a
+minimum-memory claim.
 
 ## Open the playground
 
@@ -65,9 +110,9 @@ or manage a GPU server for you.
 ## Generate with cURL or an SDK
 
 These examples use the server's resolution, frame count, and sampling defaults.
-Do not copy Sora-specific durations or resolutions onto H3. The server config
-uses 1344 × 768, 124 frames, 24 fps, and the five-point distilled sigma schedule
-with four DiT forwards.
+Do not copy Sora-specific durations or resolutions onto H3. Both server configs
+use 124 frames, 24 fps, and the five-point distilled sigma schedule with four
+DiT forwards. CUDA uses 1344 × 768; MLX uses 832 × 480.
 
 Each client submits a job, checks for completion or failure, and downloads an
 MP4 named after the job ID. Polling stops after 30 minutes; a timeout does not

--- a/docs/cookbook/stable-audio.md
+++ b/docs/cookbook/stable-audio.md
@@ -5,7 +5,7 @@ hide:
 
 # Stable Audio recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="stable_audio" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="stable_audio" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/stable-diffusion.md
+++ b/docs/cookbook/stable-diffusion.md
@@ -5,7 +5,7 @@ hide:
 
 # Stable Diffusion recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="sd35" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="sd35" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/turbodiffusion.md
+++ b/docs/cookbook/turbodiffusion.md
@@ -5,7 +5,7 @@ hide:
 
 # TurboDiffusion recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="turbodiffusion" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="turbodiffusion" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/wan.md
+++ b/docs/cookbook/wan.md
@@ -5,7 +5,7 @@ hide:
 
 # Wan recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="wan" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="wan" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/cookbook/z-image.md
+++ b/docs/cookbook/z-image.md
@@ -5,7 +5,7 @@ hide:
 
 # Z-Image recipes
 
-<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="zimage" data-recipes="../../assets/cookbook-recipes.json?v=5">
+<div class="cookbook-shell cookbook-family-page" data-cookbook data-family="zimage" data-recipes="../../assets/cookbook-recipes.json?v=6">
   <header class="cookbook-family-header">
     <a class="cookbook-back-link" href="../"><span aria-hidden="true">←</span> All model families</a>
     <div class="cookbook-family-header__body">

--- a/docs/design/server_contracts/openai.md
+++ b/docs/design/server_contracts/openai.md
@@ -40,6 +40,13 @@ browser client uses the video routes above and shares their loaded pipeline.
 `GET /playground/config` reports the model alias and operator-explicit sampling
 defaults. The playground does not add authentication or a second model process.
 
+For native FastH3 MLX, launch
+`python -m fastvideo.entrypoints.openai.mlx_server --config examples/serving/mlx_fasth3.yaml`.
+This adapter shares the video-job API and executes pipeline calls on one MLX
+thread. It rejects unsupported options before media fetching or job creation.
+Image routes are not mounted. MLX keeps its existing phase-memory policy, so a
+persistent server does not imply persistent residency of all model weights.
+
 ## Video requests
 
 The canonical shape follows vLLM-Omni and accepts SGLang's common flat

--- a/docs/design/server_contracts/openai.md
+++ b/docs/design/server_contracts/openai.md
@@ -30,6 +30,15 @@ requests. HTTP handling and job polling remain asynchronous.
 | `GET` | `/health` | Liveness probe |
 
 `POST /v1/videos/generations` remains an alias for older FastVideo clients.
+The OpenAI Python and JavaScript clients can create, retrieve, list, download,
+and delete video jobs. Use the [H3 server cookbook](../../cookbook/openai-api.md)
+for pinned client versions and executable examples. Download variants other
+than `video` return HTTP 400. Remix, extensions, and characters are not implemented.
+
+An H3 text-to-video/audio server also serves `/playground/`. This same-origin
+browser client uses the video routes above and shares their loaded pipeline.
+`GET /playground/config` reports the model alias and operator-explicit sampling
+defaults. The playground does not add authentication or a second model process.
 
 ## Video requests
 
@@ -160,8 +169,11 @@ Errors use the OpenAI envelope:
 ```
 
 Parse, model-selection, startup-LoRA, and unsupported-parameter failures are
-HTTP 400; missing resources are HTTP 404; generation failures are stored on
-asynchronous jobs and returned as HTTP 500 when that job is retrieved.
+HTTP 400; missing resources are HTTP 404. Generation failures are stored on
+asynchronous jobs. Retrieving a failed job returns HTTP 200 with `status: "failed"`
+and a string error code, so OpenAI SDK polling returns the terminal resource
+instead of retrying it as a transport error. Synchronous generation failures
+still return HTTP 500.
 Unknown top-level fields are rejected. `extra_params` accepts only the explicit
 request-batch passthrough fields supported by the typed request adapter.
 

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -8,6 +8,8 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 ROOT_DIR = Path(__file__).parent.parent.resolve()
 ROOT_DIR_RELATIVE = '../..'
 EXAMPLE_DIR = ROOT_DIR / "examples"
@@ -21,6 +23,12 @@ GENERATED_DOC_PREFIXES = (
     "distillation/examples/",
 )
 COOKBOOK_DATA = ROOT_DIR / "docs/assets/cookbook-recipes.json"
+COOKBOOK_SERVING_DATA = ROOT_DIR / "docs/assets/cookbook-serving.json"
+COOKBOOK_CLIENTS = {
+    "python": ("video.py", "python -m pip install openai==3.6.0"),
+    "javascript": ("video.mjs", "npm install openai@7.8.0"),
+    "curl": ("video.sh", "# Requires curl and jq"),
+}
 COOKBOOK_SOURCE_ROOTS = (
     ROOT_DIR / "examples/inference",
     ROOT_DIR / "scripts/inference",
@@ -170,6 +178,9 @@ def validate_cookbook() -> None:
         if recipe["source"] not in recipe["command"]:
             raise ValueError(f"Cookbook command does not invoke its source: {recipe['id']}")
 
+        if "serving" in recipe:
+            cookbook_serving_profile(recipe)
+
     # Second pass so `related` may point forward at recipes defined later.
     ids = {recipe["id"] for recipe in recipes}
     for recipe in recipes:
@@ -185,6 +196,66 @@ def validate_cookbook() -> None:
             continue
         if cache_bust not in text:
             raise ValueError(f"{page}: recipe JSON cache-bust must be {cache_bust}")
+
+
+def cookbook_serving_profile(recipe: dict) -> dict:
+    """Read server facts separately from the local inference run's evidence."""
+    serving = recipe["serving"]
+    if not isinstance(serving, dict) or not serving.get("source") or not serving.get("install"):
+        raise ValueError(f"Serving recipe needs source and install fields: {recipe['id']}")
+    if recipe["hardware"].get("platform", "cuda") != "cuda":
+        raise ValueError(f"Cookbook HTTP serving is only wired for CUDA: {recipe['id']}")
+    source = (ROOT_DIR / serving["source"]).resolve()
+    if not source.is_relative_to(ROOT_DIR / "examples/serving") or not source.is_file():
+        raise ValueError(f"Serving config must exist under examples/serving: {recipe['id']}")
+    config = yaml.safe_load(source.read_text(encoding="utf-8"))
+    generator = config["generator"]
+    if generator["model_path"] != recipe["model"]:
+        raise ValueError(f"Serving checkpoint does not match recipe: {recipe['id']}")
+    if config.get("streaming") is not None:
+        raise ValueError(f"Cookbook OpenAI serving requires a REST config: {recipe['id']}")
+    server = config["server"]
+    model = server["served_model_name"]
+    if not isinstance(model, str) or not re.fullmatch(r"[A-Za-z0-9._/-]+", model):
+        raise ValueError(f"Serving model alias must be safe for client examples: {recipe['id']}")
+    port = server["port"]
+    count = generator["engine"]["num_gpus"]
+    if type(port) is not int or not 1 <= port <= 65535 or type(count) is not int or count < 1:
+        raise ValueError(f"Serving config needs a valid port and GPU count: {recipe['id']}")
+    base_url = f"http://127.0.0.1:{port}/v1"
+    clients = {}
+    for language, (filename, install) in COOKBOOK_CLIENTS.items():
+        path = ROOT_DIR / "examples/serving/clients" / filename
+        text = path.read_text(encoding="utf-8")
+        # Keep displayed snippets identical to executable sources for the
+        # checked-in H3 profile, with only endpoint and alias substitutions.
+        text = text.replace("http://127.0.0.1:8000/v1", base_url)
+        text = text.replace('"fasth3"', json.dumps(model)).replace("${FASTVIDEO_MODEL:-fasth3}",
+                                                                   "${FASTVIDEO_MODEL:-" + model + "}")
+        clients[language] = {"source": path.relative_to(ROOT_DIR).as_posix(), "code": text, "install": install}
+    return {
+        "source": serving["source"],
+        "install": serving["install"],
+        "command": f"fastvideo serve --config {serving['source']} --server.host 127.0.0.1",
+        "model": model,
+        "base_url": base_url,
+        "playground_url": f"http://127.0.0.1:{port}/playground/",
+        "health_command": f"curl --fail-with-body http://127.0.0.1:{port}/health",
+        "hardware": {
+            "platform": "cuda",
+            "gpu_count": count,
+            "evidence": "source-configured"
+        },
+        "sampling": config["default_request"]["sampling"],
+        "clients": clients,
+    }
+
+
+def generate_cookbook_serving() -> None:
+    """Publish executable clients and config facts through the docs build."""
+    data = json.loads(COOKBOOK_DATA.read_text(encoding="utf-8"))
+    profiles = {recipe["id"]: cookbook_serving_profile(recipe) for recipe in data["recipes"] if "serving" in recipe}
+    COOKBOOK_SERVING_DATA.write_text(json.dumps(profiles, indent=2) + "\n", encoding="utf-8")
 
 
 def fix_case(text: str) -> str:
@@ -325,8 +396,18 @@ class Example:
         """ # noqa: E501
         if self.path.is_file():
             return []
-        is_other_file = lambda file: file.is_file() and file != self.main_file
-        return [file for file in self.path.rglob("*") if is_other_file(file)]  # type: ignore[no-untyped-call]
+        other_files = []
+        for directory, subdirectories, filenames in os.walk(self.path):
+            # Local client dependencies and caches are not example sources.
+            subdirectories[:] = [
+                name for name in subdirectories
+                if not name.startswith(".") and name not in {"node_modules", "__pycache__"}
+            ]
+            for name in filenames:
+                file = Path(directory) / name
+                if not name.startswith(".") and file != self.main_file:
+                    other_files.append(file)
+        return other_files
 
     def determine_title(self) -> str:
         return fix_case(self.path.stem.replace("_", " ").title())
@@ -703,6 +784,7 @@ def on_pre_build(config, **kwargs):
     This function is called automatically by MkDocs' native hook system.
     """
     validate_cookbook()
+    generate_cookbook_serving()
     print("Generating example documentation...")
     generate_examples(generate_main_index=True)
     print("Example documentation generated successfully!")
@@ -717,6 +799,7 @@ def on_page_context(context, page, **kwargs):
 
 if __name__ == "__main__":
     validate_cookbook()
+    generate_cookbook_serving()
     print("Generating example documentation...")
     generate_examples(generate_main_index=True)
     print("Example documentation generated successfully!")

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -203,12 +203,13 @@ def cookbook_serving_profile(recipe: dict) -> dict:
     serving = recipe["serving"]
     if not isinstance(serving, dict) or not serving.get("source") or not serving.get("install"):
         raise ValueError(f"Serving recipe needs source and install fields: {recipe['id']}")
-    if recipe["hardware"].get("platform", "cuda") != "cuda":
-        raise ValueError(f"Cookbook HTTP serving is only wired for CUDA: {recipe['id']}")
     source = (ROOT_DIR / serving["source"]).resolve()
     if not source.is_relative_to(ROOT_DIR / "examples/serving") or not source.is_file():
         raise ValueError(f"Serving config must exist under examples/serving: {recipe['id']}")
     config = yaml.safe_load(source.read_text(encoding="utf-8"))
+    runtime = config.get("runtime", "cuda")
+    if runtime not in {"cuda", "mlx"} or runtime != recipe["hardware"].get("platform", "cuda"):
+        raise ValueError(f"Serving runtime does not match recipe: {recipe['id']}")
     generator = config["generator"]
     if generator["model_path"] != recipe["model"]:
         raise ValueError(f"Serving checkpoint does not match recipe: {recipe['id']}")
@@ -219,9 +220,19 @@ def cookbook_serving_profile(recipe: dict) -> dict:
     if not isinstance(model, str) or not re.fullmatch(r"[A-Za-z0-9._/-]+", model):
         raise ValueError(f"Serving model alias must be safe for client examples: {recipe['id']}")
     port = server["port"]
-    count = generator["engine"]["num_gpus"]
-    if type(port) is not int or not 1 <= port <= 65535 or type(count) is not int or count < 1:
-        raise ValueError(f"Serving config needs a valid port and GPU count: {recipe['id']}")
+    if type(port) is not int or not 1 <= port <= 65535:
+        raise ValueError(f"Serving config needs a valid port: {recipe['id']}")
+    hardware = {"platform": runtime, "evidence": "source-configured"}
+    if runtime == "cuda":
+        count = generator["engine"]["num_gpus"]
+        if type(count) is not int or count < 1:
+            raise ValueError(f"Serving config needs a valid GPU count: {recipe['id']}")
+        hardware["gpu_count"] = count
+        command = f"fastvideo serve --config {serving['source']} --server.host 127.0.0.1"
+    else:
+        if server.get("host") != "127.0.0.1":
+            raise ValueError(f"MLX cookbook server must bind to loopback: {recipe['id']}")
+        command = f"python -m fastvideo.entrypoints.openai.mlx_server --config {serving['source']}"
     base_url = f"http://127.0.0.1:{port}/v1"
     clients = {}
     for language, (filename, install) in COOKBOOK_CLIENTS.items():
@@ -236,16 +247,14 @@ def cookbook_serving_profile(recipe: dict) -> dict:
     return {
         "source": serving["source"],
         "install": serving["install"],
-        "command": f"fastvideo serve --config {serving['source']} --server.host 127.0.0.1",
+        "command": command,
+        "runtime": runtime,
+        "prepare": serving.get("prepare", ""),
         "model": model,
         "base_url": base_url,
         "playground_url": f"http://127.0.0.1:{port}/playground/",
         "health_command": f"curl --fail-with-body http://127.0.0.1:{port}/health",
-        "hardware": {
-            "platform": "cuda",
-            "gpu_count": count,
-            "evidence": "source-configured"
-        },
+        "hardware": hardware,
         "sampling": config["default_request"]["sampling"],
         "clients": clients,
     }

--- a/examples/serving/README.md
+++ b/examples/serving/README.md
@@ -34,8 +34,15 @@ adapter also needs `attention_backend: VIDEO_SPARSE_ATTN_H3`, `VSA_sparsity`,
 and `VSA_tile_size` like the full-checkpoint config.
 
 After startup, open `http://127.0.0.1:8000/playground/` to generate and review
-H3 videos in your browser. New prompts reuse the loaded model. The playground
+H3 videos in your browser. CUDA prompts reuse the loaded model. The playground
 and API clients share the same server; both can run locally.
+
+For native Apple Silicon MLX, use
+`python -m fastvideo.entrypoints.openai.mlx_server --config examples/serving/mlx_fasth3.yaml`
+after preparing the weights and editing their paths in that configuration.
+The same playground and clients work with MLX. Its pipeline still loads and
+releases components between phases to limit unified-memory use. See the
+cookbook for setup and the supported text-to-video/audio request fields.
 
 Or submit, poll, and download with the OpenAI Python client:
 

--- a/examples/serving/README.md
+++ b/examples/serving/README.md
@@ -2,12 +2,16 @@
 
 The REST serving engine is model-agnostic. Any model supported by
 `VideoGenerator` can use the same `/v1/models`, `/v1/videos`, and `/v1/images`
-surface; the two configs here are FastH3 validation profiles.
+surface. The two FastH3 configs here are source-backed examples, not recorded
+serving benchmarks. Both configure four CUDA GPUs without a GPU model or VRAM claim.
+
+Use the [H3 server cookbook](https://haoailab.com/FastVideo/cookbook/openai-api/)
+for the guided install, server, and client workflow.
 
 Launch the full FastH3 checkpoint:
 
 ```bash
-fastvideo serve --config examples/serving/openai_fasth3.yaml
+fastvideo serve --config examples/serving/openai_fasth3.yaml --server.host 127.0.0.1
 ```
 
 Launch the dense FastH3 LoRA on the base MiniMax-H3 checkpoint:
@@ -18,6 +22,7 @@ adapter_path="$(hf download \
   dense-datafree/adapter_model.safetensors)"
 
 fastvideo serve --config examples/serving/openai_fasth3_lora.yaml \
+  --server.host 127.0.0.1 \
   --generator.pipeline.components.lora_path "$adapter_path"
 ```
 
@@ -28,16 +33,22 @@ selector, but its name, path, and scale must match that startup adapter. A VSA
 adapter also needs `attention_backend: VIDEO_SPARSE_ATTN_H3`, `VSA_sparsity`,
 and `VSA_tile_size` like the full-checkpoint config.
 
-Submit and poll an asynchronous job:
+After startup, open `http://127.0.0.1:8000/playground/` to generate and review
+H3 videos in your browser. New prompts reuse the loaded model. The playground
+and API clients share the same server; both can run locally.
+
+Or submit, poll, and download with the OpenAI Python client:
 
 ```bash
-job_id="$(curl -sS http://localhost:8000/v1/videos \
-  -H 'content-type: application/json' \
-  -d '{"model":"fasth3","prompt":"A fox runs through fresh snow."}' \
-  | jq -r .id)"
-
-curl -sS "http://localhost:8000/v1/videos/$job_id"
-curl -o result.mp4 "http://localhost:8000/v1/videos/$job_id/content"
+python -m pip install openai==3.6.0
+python examples/serving/clients/video.py
 ```
+
+The `clients/` directory also contains cURL and OpenAI JavaScript examples.
+They default to model `fasth3`; set `FASTVIDEO_MODEL` to the advertised alias
+when using the LoRA config. Set `FASTVIDEO_BASE_URL` for another endpoint.
+These clients call your FastVideo server, not OpenAI's cloud. The SDK key
+`local` is a placeholder, not authentication. Keep the server on loopback or
+use an authenticated proxy for remote access.
 
 For a blocking call, `POST /v1/videos/sync` returns the MP4 body directly.

--- a/examples/serving/clients/package-lock.json
+++ b/examples/serving/clients/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "fastvideo-openai-client-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fastvideo-openai-client-example",
+      "dependencies": {
+        "openai": "7.8.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-7.8.0.tgz",
+      "integrity": "sha512-/2g9JzdnXNcjX1W/UlSNu+OdSFDAaAVt0n9Onom0kPenH54o59G2WrX/xjTnr26UHNSh6hxcAf58doGYRme2rw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "undici": ">=5 <9",
+        "ws": "^8.21.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "undici": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/serving/clients/package.json
+++ b/examples/serving/clients/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fastvideo-openai-client-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "generate": "node video.mjs"
+  },
+  "dependencies": {
+    "openai": "7.8.0"
+  }
+}

--- a/examples/serving/clients/video.mjs
+++ b/examples/serving/clients/video.mjs
@@ -1,0 +1,36 @@
+// Run in Node.js 22+ or your webapp's backend, not in a browser with a private key.
+import OpenAI from "openai";
+import { writeFile } from "node:fs/promises";
+
+const client = new OpenAI({
+  baseURL: process.env.FASTVIDEO_BASE_URL || "http://127.0.0.1:8000/v1",
+  apiKey: process.env.FASTVIDEO_API_KEY || "local",
+  timeout: 60_000,
+  maxRetries: 0,
+});
+
+let video = await client.videos.create({
+  model: process.env.FASTVIDEO_MODEL || "fasth3",
+  prompt: "A fox runs through fresh snow.",
+});
+console.log(`Submitted ${video.id}`);
+
+// The deadline limits polling, not GPU execution. Keep the ID to resume later.
+const deadline = performance.now() + 1_800_000;
+while (video.status === "queued" || video.status === "in_progress") {
+  let remaining = deadline - performance.now();
+  if (remaining <= 0) throw new Error(`Polling timed out; job ${video.id} may still be running`);
+  await new Promise((resolve) => setTimeout(resolve, Math.min(2000, remaining)));
+  remaining = deadline - performance.now();
+  if (remaining <= 0) throw new Error(`Polling timed out; job ${video.id} may still be running`);
+  video = await client.videos.retrieve(video.id, { timeout: Math.min(60_000, remaining) });
+}
+
+if (video.status !== "completed") {
+  throw new Error(`Video ${video.id} failed: ${video.error?.message || video.status}`);
+}
+
+const content = await client.videos.downloadContent(video.id);
+const output = `${video.id}.mp4`;
+await writeFile(output, Buffer.from(await content.arrayBuffer()));
+console.log(`Saved ${output}`);

--- a/examples/serving/clients/video.py
+++ b/examples/serving/clients/video.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generate with a local FastVideo server through the OpenAI Python client.
+
+Install the tested client with: python -m pip install openai==3.6.0
+Start the server first. No OpenAI account or cloud API key is needed.
+"""
+
+import os
+import time
+from pathlib import Path
+
+from openai import OpenAI
+
+
+def main() -> None:
+    with OpenAI(
+            base_url=os.environ.get("FASTVIDEO_BASE_URL", "http://127.0.0.1:8000/v1"),
+            api_key=os.environ.get("FASTVIDEO_API_KEY", "local"),
+            timeout=60.0,
+            max_retries=0,
+    ) as client:
+        video = client.videos.create(
+            model=os.environ.get("FASTVIDEO_MODEL", "fasth3"),
+            prompt="A fox runs through fresh snow.",
+        )
+        print(f"Submitted {video.id}")
+
+        # This deadline limits polling, not GPU execution. Increase it for
+        # longer jobs. On timeout, use the printed ID to retrieve the job.
+        deadline = time.monotonic() + 1800
+        while video.status in {"queued", "in_progress"}:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"Polling timed out; job {video.id} may still be running")
+            time.sleep(min(2, remaining))
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"Polling timed out; job {video.id} may still be running")
+            video = client.videos.retrieve(video.id, timeout=min(60, remaining))
+
+        if video.status != "completed":
+            message = video.error.message if video.error else video.status
+            raise RuntimeError(f"Video {video.id} failed: {message}")
+
+        output = Path(f"{video.id}.mp4")
+        content = client.videos.download_content(video.id)
+        content.write_to_file(output)
+        print(f"Saved {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/serving/clients/video.sh
+++ b/examples/serving/clients/video.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Requires curl and jq. Run after starting the FastVideo server.
+set -euo pipefail
+
+base_url="${FASTVIDEO_BASE_URL:-http://127.0.0.1:8000/v1}"
+api_key="${FASTVIDEO_API_KEY:-local}"
+model="${FASTVIDEO_MODEL:-fasth3}"
+payload=$(jq -n --arg model "$model" \
+  '{model: $model, prompt: "A fox runs through fresh snow."}')
+
+job=$(curl --fail-with-body --silent --show-error --max-time 60 \
+  "$base_url/videos" \
+  -H "Authorization: Bearer $api_key" \
+  -H 'Content-Type: application/json' \
+  -d "$payload")
+job_id=$(jq -er '.id' <<< "$job")
+printf 'Submitted %s\n' "$job_id"
+deadline=$((SECONDS + 1800))
+
+while true; do
+  status=$(jq -er '.status' <<< "$job")
+  case "$status" in
+    completed) break ;;
+    failed) jq -r '.error.message' <<< "$job" >&2; exit 1 ;;
+    queued|in_progress) ;;
+    *) printf 'Unexpected job status: %s\n' "$status" >&2; exit 1 ;;
+  esac
+  remaining=$((deadline - SECONDS))
+  if (( remaining <= 0 )); then
+    printf 'Polling timed out; job %s may still be running\n' "$job_id" >&2
+    exit 1
+  fi
+  if (( remaining > 2 )); then sleep 2; else sleep "$remaining"; fi
+  remaining=$((deadline - SECONDS))
+  if (( remaining <= 0 )); then continue; fi
+  if (( remaining > 60 )); then remaining=60; fi
+  job=$(curl --fail-with-body --silent --show-error --max-time "$remaining" \
+    -H "Authorization: Bearer $api_key" "$base_url/videos/$job_id")
+done
+
+curl --fail-with-body --silent --show-error --max-time 300 \
+  -H "Authorization: Bearer $api_key" \
+  "$base_url/videos/$job_id/content" --output "$job_id.mp4"
+printf 'Saved %s.mp4\n' "$job_id"

--- a/examples/serving/mlx_fasth3.yaml
+++ b/examples/serving/mlx_fasth3.yaml
@@ -1,0 +1,23 @@
+# Native MLX H3 server. Run from the repository root after downloading and converting weights.
+runtime: mlx
+generator:
+  model_path: FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2
+  model_root: ./FastH3-Preview-v0.2
+  mlx_checkpoint: ./FastH3-MLX/int6
+  prompt_cache_dir: ./outputs/h3_prompt_cache
+  vae_dtype: fp32
+server:
+  host: 127.0.0.1
+  port: 8000
+  served_model_name: fasth3
+  output_dir: outputs/mlx_fasth3
+default_request:
+  sampling:
+    height: 480
+    width: 832
+    num_frames: 124
+    fps: 24
+    # HTTP convention: five sigma points, four DiT forwards. Native MLX uses num_steps=4.
+    num_inference_steps: 5
+    guidance_scale: 1.0
+    seed: 2026

--- a/fastvideo/entrypoints/openai/api_server.py
+++ b/fastvideo/entrypoints/openai/api_server.py
@@ -144,11 +144,13 @@ def create_app(
     # Import and mount routers
     from fastvideo.entrypoints.openai.common_api import router as common_router
     from fastvideo.entrypoints.openai.image_api import router as image_router
+    from fastvideo.entrypoints.openai.playground import router as playground_router
     from fastvideo.entrypoints.openai.video_api import router as video_router
 
     app.include_router(common_router)
     app.include_router(video_router)
     app.include_router(image_router)
+    app.include_router(playground_router)
 
     @app.get("/health")
     async def health():

--- a/fastvideo/entrypoints/openai/api_server.py
+++ b/fastvideo/entrypoints/openai/api_server.py
@@ -2,7 +2,7 @@
 # (https://github.com/sgl-project/sglang/blob/main/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py)
 
 from contextlib import asynccontextmanager
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 import os
 
 import uvicorn
@@ -18,7 +18,8 @@ from fastvideo.entrypoints.openai.state import (
     clear_state,
     set_state,
 )
-from fastvideo.entrypoints.openai.serving_engine import OpenAIServingEngine
+from fastvideo.entrypoints.openai.serving_engine import OpenAIServingEngine, ServingGenerator
+from fastvideo.entrypoints.openai.protocol import VideoGenerationRequest
 from fastvideo.entrypoints.video_generator import VideoGenerator
 from fastvideo.fastvideo_args import FastVideoArgs
 from fastvideo.logger import init_logger
@@ -60,10 +61,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     served_model_name: str | None = app.state.served_model_name
     default_request: GenerationRequest | None = getattr(app.state, "default_request", None)
 
-    logger.info("Loading model from %s ...", args.model_path)
-    generator = VideoGenerator.from_fastvideo_args(args)
-    serving_engine = OpenAIServingEngine(generator)
-    logger.info("Model loaded successfully.")
+    logger.info("Initializing %s generation runtime for %s ...", app.state.runtime, args.model_path)
+    factory = app.state.generator_factory
+    generator = factory() if factory is not None else VideoGenerator.from_fastvideo_args(args)
+    serving_engine = OpenAIServingEngine(generator, app.state.video_request_validator)
+    logger.info("Generation runtime ready.")
 
     set_state(
         generator,
@@ -91,6 +93,10 @@ def create_app(
     output_dir: str = DEFAULT_OUTPUT_DIR,
     default_request: GenerationRequest | None = None,
     served_model_name: str | None = None,
+    *,
+    generator_factory: Callable[[], ServingGenerator] | None = None,
+    video_request_validator: Callable[[VideoGenerationRequest], None] | None = None,
+    runtime: str = "cuda",
 ) -> FastAPI:
     """Build the FastAPI application with all routers mounted"""
 
@@ -103,6 +109,9 @@ def create_app(
     app.state.output_dir = output_dir
     app.state.default_request = default_request
     app.state.served_model_name = served_model_name
+    app.state.generator_factory = generator_factory
+    app.state.video_request_validator = video_request_validator
+    app.state.runtime = runtime
 
     app.add_middleware(
         CORSMiddleware,
@@ -149,7 +158,8 @@ def create_app(
 
     app.include_router(common_router)
     app.include_router(video_router)
-    app.include_router(image_router)
+    if runtime != "mlx":
+        app.include_router(image_router)
     app.include_router(playground_router)
 
     @app.get("/health")

--- a/fastvideo/entrypoints/openai/mlx_server.py
+++ b/fastvideo/entrypoints/openai/mlx_server.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Serve native FastH3 MLX through the shared video-job API and playground."""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import platform
+import shutil
+import time
+from types import SimpleNamespace
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+import uvicorn
+import yaml
+
+from fastvideo.api.compat import explicit_request_updates, normalize_generation_request
+from fastvideo.api.schema import GenerationRequest
+from fastvideo.entrypoints.openai.api_server import create_app
+from fastvideo.entrypoints.openai.protocol import VideoGenerationRequest
+
+MODEL: Literal["FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2"] = "FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2"
+
+
+class MLXGeneratorConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    model_path: Literal["FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2"] = MODEL
+    model_root: str
+    mlx_checkpoint: str
+    prompt_cache_dir: str = "outputs/h3_prompt_cache"
+    vae_dtype: Literal["fp32", "fp16", "bf16"] = "fp32"
+
+
+class MLXServerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    host: str = "127.0.0.1"
+    port: int = Field(default=8000, ge=1, le=65535)
+    output_dir: str = "outputs/mlx_fasth3"
+    served_model_name: str = Field(default="fasth3", min_length=1)
+
+
+class MLXServeConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    runtime: Literal["mlx"]
+    generator: MLXGeneratorConfig
+    server: MLXServerConfig = Field(default_factory=MLXServerConfig)
+    default_request: dict[str, Any]
+
+
+def validate_mlx_video_request(request: VideoGenerationRequest) -> None:
+    """Reject unsupported inputs before fetching media or creating a job."""
+    allowed = {
+        "model",
+        "prompt",
+        "seed",
+        "size",
+        "width",
+        "height",
+        "fps",
+        "num_frames",
+        "seconds",
+        "video_params",
+        "task",
+        "guidance_scale",
+        "num_inference_steps",
+        "negative_prompt",
+    }
+    unsupported = request.model_fields_set - allowed
+    if unsupported:
+        raise ValueError("H3 MLX serving does not support: " + ", ".join(sorted(unsupported)))
+    if request.task not in (None, "t2va"):
+        raise ValueError("H3 MLX serving supports task=t2va only.")
+    if request.guidance_scale not in (None, 1.0):
+        raise ValueError("FastH3 MLX requires guidance_scale=1.")
+    if request.negative_prompt not in (None, ""):
+        raise ValueError("FastH3 MLX does not use a negative prompt.")
+    if request.num_inference_steps not in (None, 5):
+        raise ValueError(
+            "FastH3 MLX serving uses five sigma points and four DiT forwards; num_inference_steps must be 5.")
+    if request.seed is not None and not 0 <= request.seed <= 2**32 - 1:
+        raise ValueError("H3 MLX seed must be between 0 and 4294967295.")
+
+
+class MLXH3Generator:
+    """Keep one pipeline on one MLX thread; preserve its phase-memory policy."""
+
+    def __init__(self, config: MLXGeneratorConfig) -> None:
+        self._worker = ThreadPoolExecutor(max_workers=1, thread_name_prefix="h3-mlx")
+        try:
+            self._pipeline = self._worker.submit(self._load, config).result()
+        except BaseException:
+            self._worker.shutdown(wait=True)
+            raise
+
+    @staticmethod
+    def _load(config: MLXGeneratorConfig):
+        if platform.system() != "Darwin" or platform.machine() != "arm64":
+            raise RuntimeError("H3 MLX serving requires an Apple Silicon Mac.")
+        if shutil.which("ffmpeg") is None:
+            raise RuntimeError("Install ffmpeg before starting the H3 MLX server.")
+        from fastvideo.mlx_runtime.minimax_h3_pipeline import MiniMaxH3MLXPipeline
+
+        return MiniMaxH3MLXPipeline(
+            model_root=Path(config.model_root).expanduser(),
+            mlx_dit_checkpoint=Path(config.mlx_checkpoint).expanduser(),
+            prompt_cache_dir=Path(config.prompt_cache_dir).expanduser(),
+            vae_dtype=config.vae_dtype,
+        )
+
+    def generate(self, request: GenerationRequest) -> dict[str, Any]:
+        return self._worker.submit(self._generate, request).result()
+
+    def _generate(self, request: GenerationRequest) -> dict[str, Any]:
+        started = time.perf_counter()
+        result = self._pipeline.generate(
+            request.prompt,
+            output_path=request.output.output_path,
+            width=request.sampling.width,
+            height=request.sampling.height,
+            num_frames=request.sampling.num_frames,
+            seed=request.sampling.seed,
+            num_steps=4,
+        )
+        # Do not retain decoded frames/waveforms or label phase peaks as total RAM.
+        return {"video_path": str(result.video_path), "generation_time": time.perf_counter() - started}
+
+    def shutdown(self) -> None:
+
+        def release():
+            self._pipeline = None
+            from fastvideo.mlx_runtime.minimax_h3_pipeline import _cleanup_mlx
+
+            _cleanup_mlx()
+
+        try:
+            self._worker.submit(release).result()
+        finally:
+            self._worker.shutdown(wait=True)
+
+
+def load_config(path: str) -> MLXServeConfig:
+    with open(path, encoding="utf-8") as source:
+        return MLXServeConfig.model_validate(yaml.safe_load(source))
+
+
+def create_mlx_app(config: MLXServeConfig):
+    request = normalize_generation_request(config.default_request)
+    explicit = explicit_request_updates(request)
+    supported = {
+        "width", "height", "num_frames", "fps", "seed", "num_inference_steps", "guidance_scale", "negative_prompt"
+    }
+    if set(explicit) - supported:
+        raise ValueError("MLX default_request contains unsupported fields: " +
+                         ", ".join(sorted(set(explicit) - supported)))
+    required = {"width", "height", "num_frames", "fps", "seed", "num_inference_steps", "guidance_scale"}
+    if required - set(explicit):
+        raise ValueError("MLX default_request must set: " + ", ".join(sorted(required - set(explicit))))
+    validate_mlx_video_request(VideoGenerationRequest(prompt="validate config", **explicit))
+    # Transport admission uses the registered H3 family, not CUDA engine options.
+    args = SimpleNamespace(model_path=MODEL,
+                           lora_path=None,
+                           lora_nickname="default",
+                           lora_strength=1.0,
+                           override_pipeline_cls_name=None)
+    from fastvideo.entrypoints.openai.request_adapter import build_generation_request
+
+    build_generation_request("config-check",
+                             VideoGenerationRequest(prompt="validate config"),
+                             args,
+                             served_model_name=config.server.served_model_name,
+                             output_dir=config.server.output_dir,
+                             default_request=request)
+    return create_app(
+        args,
+        config.server.output_dir,
+        request,
+        config.server.served_model_name,
+        generator_factory=lambda: MLXH3Generator(config.generator),
+        video_request_validator=validate_mlx_video_request,
+        runtime="mlx",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config",
+                        required=True,
+                        help="H3 MLX serving YAML; paths are relative to the working directory")
+    args = parser.parse_args()
+    config = load_config(args.config)
+    uvicorn.run(create_mlx_app(config), host=config.server.host, port=config.server.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/fastvideo/entrypoints/openai/playground.py
+++ b/fastvideo/entrypoints/openai/playground.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Same-origin prompt UI for the H3 text-to-video/audio server."""
+
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import FileResponse
+
+from fastvideo.api.compat import explicit_request_updates
+from fastvideo.entrypoints.openai.state import get_default_request, get_served_model_name, get_server_args
+from fastvideo.registry import get_preset_selection
+
+ASSETS = Path(__file__).with_name("static")
+HEADERS = {
+    "Cache-Control":
+    "no-store",
+    "X-Content-Type-Options":
+    "nosniff",
+    "Content-Security-Policy":
+    ("default-src 'none'; script-src 'self'; style-src 'self'; connect-src 'self'; "
+     "media-src 'self'; img-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'"),
+}
+
+
+def require_h3() -> None:
+    args = get_server_args()
+    _, family = get_preset_selection(args.model_path)
+    override = getattr(args, "override_pipeline_cls_name", None)
+    if family != "minimax_h3" or (override and override != "MiniMaxH3ModularPipeline"):
+        raise HTTPException(status_code=404, detail="The playground requires an H3 text-to-video/audio server.")
+
+
+router = APIRouter(prefix="/playground", dependencies=[Depends(require_h3)], include_in_schema=False)
+
+
+@router.get("/")
+async def playground() -> FileResponse:
+    return FileResponse(ASSETS / "playground.html", headers=HEADERS)
+
+
+@router.get("/config")
+async def playground_config() -> dict:
+    request = get_default_request()
+    # Report operator defaults only; do not guess model presets or hardware.
+    sampling = explicit_request_updates(request) if request is not None else {}
+    fields = ("width", "height", "num_frames", "fps", "seed")
+    return {
+        "model": get_served_model_name(),
+        "defaults": {
+            field: sampling.get(field)
+            for field in fields
+        },
+    }
+
+
+@router.get("/{asset}")
+async def playground_asset(asset: str) -> FileResponse:
+    if asset not in {"playground.css", "playground.js"}:
+        raise HTTPException(status_code=404, detail="Playground asset not found.")
+    return FileResponse(ASSETS / asset, headers=HEADERS)

--- a/fastvideo/entrypoints/openai/playground.py
+++ b/fastvideo/entrypoints/openai/playground.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import FileResponse
 
 from fastvideo.api.compat import explicit_request_updates
@@ -39,13 +39,14 @@ async def playground() -> FileResponse:
 
 
 @router.get("/config")
-async def playground_config() -> dict:
+async def playground_config(raw_request: Request) -> dict:
     request = get_default_request()
     # Report operator defaults only; do not guess model presets or hardware.
     sampling = explicit_request_updates(request) if request is not None else {}
     fields = ("width", "height", "num_frames", "fps", "seed")
     return {
         "model": get_served_model_name(),
+        "runtime": raw_request.app.state.runtime,
         "defaults": {
             field: sampling.get(field)
             for field in fields

--- a/fastvideo/entrypoints/openai/serving_engine.py
+++ b/fastvideo/entrypoints/openai/serving_engine.py
@@ -5,12 +5,21 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from typing import Any, TypeVar
+from typing import Any, Protocol, TypeVar
 
 from fastvideo.api.schema import GenerationRequest
-from fastvideo.entrypoints.video_generator import VideoGenerator
+from fastvideo.entrypoints.openai.protocol import VideoGenerationRequest
 
 _T = TypeVar("_T")
+
+
+class ServingGenerator(Protocol):
+
+    def generate(self, request: GenerationRequest) -> Any:
+        ...
+
+    def shutdown(self) -> None:
+        ...
 
 
 class OpenAIServingEngine:
@@ -24,15 +33,22 @@ class OpenAIServingEngine:
     the lock without changing the transport contract.
     """
 
-    def __init__(self, generator: VideoGenerator) -> None:
+    def __init__(self,
+                 generator: ServingGenerator,
+                 video_request_validator: Callable[[VideoGenerationRequest], None] | None = None) -> None:
         self._generator = generator
+        self._video_request_validator = video_request_validator
         self._generation_lock = asyncio.Lock()
         self._closed = False
         self._unhealthy_reason: str | None = None
 
     @property
-    def generator(self) -> VideoGenerator:
+    def generator(self) -> ServingGenerator:
         return self._generator
+
+    def validate_video_request(self, request: VideoGenerationRequest) -> None:
+        if self._video_request_validator is not None:
+            self._video_request_validator(request)
 
     @property
     def closed(self) -> bool:

--- a/fastvideo/entrypoints/openai/state.py
+++ b/fastvideo/entrypoints/openai/state.py
@@ -11,13 +11,12 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from fastvideo.api.schema import GenerationRequest
-    from fastvideo.entrypoints.openai.serving_engine import OpenAIServingEngine
-    from fastvideo.entrypoints.video_generator import VideoGenerator
+    from fastvideo.entrypoints.openai.serving_engine import OpenAIServingEngine, ServingGenerator
     from fastvideo.fastvideo_args import FastVideoArgs
 
 DEFAULT_OUTPUT_DIR = "outputs"
 
-_generator: VideoGenerator | None = None
+_generator: ServingGenerator | None = None
 _serving_engine: OpenAIServingEngine | None = None
 _fastvideo_args: FastVideoArgs | None = None
 _output_dir: str = DEFAULT_OUTPUT_DIR
@@ -25,7 +24,7 @@ _served_model_name: str | None = None
 _default_request: GenerationRequest | None = None
 
 
-def get_generator() -> VideoGenerator:
+def get_generator() -> ServingGenerator:
     """Return the global VideoGenerator instance (set during startup)."""
     assert _generator is not None, "Server not initialized — generator is None"
     return _generator
@@ -62,7 +61,7 @@ def get_default_request() -> GenerationRequest | None:
 
 
 def set_state(
-    generator: VideoGenerator,
+    generator: ServingGenerator,
     serving_engine: OpenAIServingEngine,
     fastvideo_args: FastVideoArgs,
     output_dir: str,

--- a/fastvideo/entrypoints/openai/static/playground.css
+++ b/fastvideo/entrypoints/openai/static/playground.css
@@ -1,0 +1,105 @@
+:root {
+  color-scheme: light dark;
+  --page: #fafafa;
+  --surface: #fff;
+  --inset: #f4f4f5;
+  --text: #202026;
+  --muted: #60606b;
+  --line: #dedee5;
+  --accent: #4f46e5;
+  --accent-soft: #eeecff;
+  --error: #a42030;
+  font: 16px/1.55 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--page);
+  color: var(--text);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page: #1e1e25;
+    --surface: #25252e;
+    --inset: #1a1a21;
+    --text: #f1f1f5;
+    --muted: #b2b2c0;
+    --line: #41414e;
+    --accent: #b0a9ff;
+    --accent-soft: #343044;
+    --error: #ffabb6;
+  }
+}
+* { box-sizing: border-box; }
+[hidden] { display: none !important; }
+body { margin: 0; }
+a { color: var(--accent); text-underline-offset: 3px; }
+button, input, textarea { font: inherit; }
+button, .button { min-height: 44px; padding: 10px 16px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); color: var(--text); cursor: pointer; text-decoration: none; }
+button { transition: background-color 150ms ease-out, transform 150ms ease-out; }
+button:not(:disabled):active { transform: scale(0.96); }
+button:hover:not(:disabled), .button:hover { background: var(--inset); }
+button:disabled { opacity: 0.55; cursor: not-allowed; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 4px; }
+.skip-link { position: absolute; inset-block-start: -80px; padding: 12px; background: var(--surface); z-index: 1; }
+.skip-link:focus { inset-block-start: 0; }
+.site-header { max-width: 1240px; margin-inline: auto; padding: 24px 32px; display: flex; justify-content: space-between; align-items: center; gap: 16px; border-block-end: 1px solid var(--line); font-size: 14px; }
+.wordmark { font-size: 19px; font-weight: 700; color: var(--text); text-decoration: none; }
+.wordmark span { margin-inline-start: 8px; font-size: 14px; font-weight: 400; color: var(--muted); }
+main { max-width: 1240px; padding: 44px 32px 24px; margin-inline: auto; }
+h1, h2, h3, p { margin-block: 0; }
+h1 { font-size: clamp(28px, 3vw, 38px); line-height: 1.2; font-weight: 600; letter-spacing: -0.035em; margin-block: 8px 14px; text-wrap: balance; }
+h2 { font-size: 19px; font-weight: 600; }
+h3 { font-size: 16px; font-weight: 600; }
+.eyebrow { font-size: 12px; font-weight: 600; color: var(--accent); letter-spacing: 0.09em; text-transform: uppercase; }
+.intro > p:last-child { max-width: 72ch; color: var(--muted); }
+.connection-bar { display: flex; flex-wrap: wrap; gap: 8px 24px; justify-content: space-between; margin-block: 28px 20px; padding: 12px 16px; border: 1px solid var(--line); border-radius: 8px; font-size: 13px; }
+#connection { font-weight: 600; }
+#model { color: var(--muted); overflow-wrap: anywhere; }
+.workspace { display: grid; grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr); gap: 24px; align-items: start; }
+.composer, .output { min-width: 0; padding: 24px; background: var(--surface); border: 1px solid var(--line); border-radius: 16px; }
+.composer h2 { margin-block-end: 24px; }
+label { display: block; font-size: 14px; font-weight: 600; }
+.hint, .settings { font-size: 13px; color: var(--muted); }
+.hint { margin-block: 6px 12px; }
+textarea, input { width: 100%; padding: 12px; border: 1px solid var(--line); border-radius: 8px; color: var(--text); background: var(--inset); }
+textarea { resize: vertical; min-height: 172px; }
+textarea::placeholder, input::placeholder { color: var(--muted); opacity: 1; }
+.seed-row { display: grid; grid-template-columns: minmax(0, 1fr) 140px; gap: 12px; align-items: center; margin-block: 20px; }
+.seed-row .hint { margin-block-end: 0; }
+.optional { font-weight: 400; color: var(--muted); }
+.settings { padding-block: 14px; border-block: 1px solid var(--line); margin-block-end: 20px; }
+button.primary { display: flex; justify-content: space-between; align-items: center; width: 100%; background: var(--accent); color: var(--page); border-color: transparent; font-weight: 600; }
+button.primary:hover:not(:disabled) { background: var(--accent); filter: brightness(1.1); }
+.request-details { margin-block-start: 20px; padding-block-start: 20px; border-block-start: 1px solid var(--line); }
+summary { cursor: pointer; min-height: 32px; font-size: 14px; }
+pre { padding: 16px; font-size: 12px; background: var(--inset); border-radius: 8px; white-space: pre-wrap; overflow-wrap: anywhere; }
+#copy-status { display: block; font-size: 13px; margin-block-start: 8px; }
+.section-heading { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 12px; margin-block-end: 18px; }
+.state { padding: 4px 10px; border-radius: 6px; background: var(--inset); font-size: 12px; }
+.state[data-status="in_progress"], .state[data-status="queued"] { background: var(--accent-soft); color: var(--accent); }
+.preview { min-height: 240px; aspect-ratio: 7 / 4; display: grid; place-items: center; overflow: hidden; border-radius: 8px; background: var(--inset); border: 1px solid var(--line); text-align: center; }
+#empty-preview { padding: 24px; }
+.play-mark { display: block; font-size: 36px; color: var(--muted); margin-block-end: 12px; }
+#empty-preview p { color: var(--muted); font-size: 13px; margin-block-start: 6px; }
+video { width: 100%; max-height: 420px; }
+#job-status, .error { margin-block-start: 16px; font-size: 14px; }
+.error { color: var(--error); overflow-wrap: anywhere; }
+.result-actions { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; margin-block-start: 16px; font-size: 14px; }
+.job-id { color: var(--muted); font: 12px/1.5 ui-monospace, monospace; overflow-wrap: anywhere; margin-block-start: 12px; }
+.history { border-block-start: 1px solid var(--line); margin-block-start: 28px; padding-block-start: 20px; }
+.history .section-heading { margin-block-end: 0; }
+.history button { font-size: 13px; }
+#jobs { padding: 0; margin-block: 16px 0; list-style: none; }
+#jobs li + li { margin-block-start: 8px; }
+#jobs button { width: 100%; text-align: start; display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+#jobs button[aria-current="true"] { border-color: var(--accent); background: var(--accent-soft); }
+#jobs .job-prompt { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+#jobs .job-state { flex-shrink: 0; color: var(--muted); font-size: 12px; }
+footer { color: var(--muted); font-size: 12px; max-width: 90ch; padding-block: 28px 8px; }
+@media (max-width: 800px) { .workspace { grid-template-columns: minmax(0, 1fr); } }
+@media (max-width: 480px) {
+  main { padding: 28px 16px 16px; }
+  .site-header { padding: 16px; }
+  .wordmark span { display: block; margin-inline: 0; }
+  .composer, .output { padding: 18px; }
+  .seed-row { grid-template-columns: minmax(0, 1fr); }
+  .preview { min-height: 200px; }
+}
+@media (prefers-reduced-motion: reduce) { button { transition: none; } button:not(:disabled):active { transform: none; } }

--- a/fastvideo/entrypoints/openai/static/playground.html
+++ b/fastvideo/entrypoints/openai/static/playground.html
@@ -17,7 +17,7 @@
   <main>
     <div class="intro">
       <p class="eyebrow">Text to video + audio</p>
-      <h1>A new prompt. The same loaded model.</h1>
+      <h1>A new prompt. The same running server.</h1>
       <p>Generate, watch, and refine. This page and your API clients share one running FastVideo server.</p>
     </div>
     <div class="connection-bar">
@@ -37,7 +37,7 @@
           </div>
           <p class="settings" id="settings">Resolution and sampling come from the server configuration.</p>
           <button class="primary" id="generate" type="submit" disabled>Generate video <span aria-hidden="true">↗</span></button>
-          <p class="hint">The model stays loaded until you stop the server. Closing this page does not cancel a job.</p>
+          <p class="hint" id="lifetime">Closing this page does not cancel a job.</p>
         </form>
         <details class="request-details">
           <summary>Use this prompt with cURL</summary>

--- a/fastvideo/entrypoints/openai/static/playground.html
+++ b/fastvideo/entrypoints/openai/static/playground.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <title>H3 playground · FastVideo</title>
+  <link rel="stylesheet" href="./playground.css">
+  <script src="./playground.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#prompt">Skip to prompt</a>
+  <header class="site-header">
+    <a class="wordmark" href="./">FastVideo <span> / H3 playground</span></a>
+    <a href="/docs">API reference <span aria-hidden="true">↗</span></a>
+  </header>
+  <main>
+    <div class="intro">
+      <p class="eyebrow">Text to video + audio</p>
+      <h1>A new prompt. The same loaded model.</h1>
+      <p>Generate, watch, and refine. This page and your API clients share one running FastVideo server.</p>
+    </div>
+    <div class="connection-bar">
+      <span id="connection" role="status">Connecting to server…</span>
+      <span id="model">Reading model…</span>
+    </div>
+    <div class="workspace">
+      <section class="composer" aria-labelledby="compose-heading">
+        <h2 id="compose-heading">Create a video</h2>
+        <form id="generate-form">
+          <label for="prompt">Prompt</label>
+          <p class="hint" id="prompt-hint">Describe the scene, motion, and sound you want.</p>
+          <textarea id="prompt" name="prompt" rows="7" required aria-describedby="prompt-hint" placeholder="A fox runs through fresh snow. The camera follows at ground level as snow crunches under its paws."></textarea>
+          <div class="seed-row">
+            <div><label for="seed">Seed <span class="optional">optional</span></label><p class="hint" id="seed-hint">Keep it fixed while changing the prompt.</p></div>
+            <input id="seed" name="seed" type="number" min="0" max="4294967295" step="1" placeholder="Server default" aria-describedby="seed-hint">
+          </div>
+          <p class="settings" id="settings">Resolution and sampling come from the server configuration.</p>
+          <button class="primary" id="generate" type="submit" disabled>Generate video <span aria-hidden="true">↗</span></button>
+          <p class="hint">The model stays loaded until you stop the server. Closing this page does not cancel a job.</p>
+        </form>
+        <details class="request-details">
+          <summary>Use this prompt with cURL</summary>
+          <p class="hint">This creates the same job from a terminal on this machine. Copying does not submit it.</p>
+          <pre><code id="curl-command"></code></pre>
+          <button id="copy-curl" type="button" disabled>Copy cURL</button>
+          <span id="copy-status" role="status"></span>
+        </details>
+      </section>
+      <section class="output" aria-labelledby="output-heading">
+        <div class="section-heading"><h2 id="output-heading">Result</h2><span class="state" id="job-state">No job yet</span></div>
+        <div class="preview">
+          <div id="empty-preview"><span class="play-mark" aria-hidden="true">▷</span><h3>Your video will appear here</h3><p>Write a prompt, then select Generate video.</p></div>
+          <video id="video" controls playsinline preload="metadata" aria-label="Generated video" hidden></video>
+        </div>
+        <p id="job-status" role="status" aria-live="polite">No generation starts until you submit a prompt.</p>
+        <p class="error" id="error" role="alert" hidden></p>
+        <div class="result-actions">
+          <a class="button" id="download" hidden>Download MP4</a>
+          <button id="check-status" type="button" hidden>Check status</button>
+          <a id="job-link" hidden>View job JSON</a>
+        </div>
+        <p class="job-id" id="job-id"></p>
+        <section class="history" aria-labelledby="history-heading">
+          <div class="section-heading"><h3 id="history-heading">Recent jobs</h3><button id="refresh-jobs" type="button">Refresh jobs</button></div>
+          <p class="hint">Shared with other clients. Job history clears when the server restarts.</p>
+          <ul id="jobs"></ul>
+          <p class="hint" id="history-status" role="status">Loading recent jobs…</p>
+        </section>
+      </section>
+    </div>
+    <footer>Local development only. FastVideo does not check API keys. Keep the server on loopback or behind an authenticated proxy.</footer>
+    <noscript>This playground needs JavaScript. Use the cURL examples in the FastVideo cookbook instead.</noscript>
+  </main>
+</body>
+</html>

--- a/fastvideo/entrypoints/openai/static/playground.js
+++ b/fastvideo/entrypoints/openai/static/playground.js
@@ -1,0 +1,200 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+(() => {
+  "use strict";
+  const $ = (id) => document.getElementById(id);
+  const labels = { queued: "Queued", in_progress: "Generating", completed: "Completed", failed: "Failed" };
+  const active = (job) => ["queued", "in_progress"].includes(job.status);
+  let model = "";
+  let busy = false;
+  let currentJob = null;
+  let pollVersion = 0;
+
+  const api = async (path, options = {}) => {
+    const response = await fetch(path, { ...options, signal: AbortSignal.timeout(15000) });
+    const body = await response.json();
+    if (!response.ok) throw new Error(body.error?.message || `Request failed (HTTP ${response.status}).`);
+    return body;
+  };
+  const setBusy = (value) => {
+    busy = value;
+    $("generate").disabled = value || !model;
+    $("generate").textContent = value ? "Waiting for this job…" : "Generate video ↗";
+  };
+  const showError = (message = "") => {
+    $("error").textContent = message;
+    $("error").hidden = !message;
+  };
+  const payload = () => {
+    const body = { model, prompt: $("prompt").value.trim() };
+    if ($("seed").value !== "") body.seed = Number($("seed").value);
+    return body;
+  };
+  const updateCurl = () => {
+    const quote = (text) => "'" + text.replaceAll("'", "'\\''") + "'";
+    $("curl-command").textContent = `curl --fail-with-body ${quote(location.origin + "/v1/videos")} \\\n  -H 'Content-Type: application/json' \\\n  --data-raw ${quote(JSON.stringify(payload(), null, 2))}`;
+    $("copy-curl").disabled = !model || !$("prompt").value.trim() || !$("seed").validity.valid;
+    $("copy-status").textContent = "";
+  };
+  const refreshJobs = async () => {
+    $("refresh-jobs").disabled = true;
+    try {
+      const result = await api("/v1/videos?limit=8&order=desc");
+      $("jobs").replaceChildren();
+      result.data.forEach((job) => {
+        const item = document.createElement("li");
+        const button = document.createElement("button");
+        button.type = "button";
+        button.setAttribute("aria-current", String(job.id === currentJob?.id));
+        const prompt = document.createElement("span");
+        prompt.className = "job-prompt";
+        prompt.textContent = job.prompt || job.id;
+        const state = document.createElement("span");
+        state.className = "job-state";
+        state.textContent = labels[job.status] || job.status;
+        button.append(prompt, state);
+        button.addEventListener("click", () => {
+          if (busy) {
+            showError("Wait for this job, or open another playground tab to inspect a different job.");
+            return;
+          }
+          $("prompt").value = job.prompt || "";
+          // Jobs do not report the seed; do not pair an old seed with this prompt.
+          $("seed").value = "";
+          updateCurl();
+          followJob(job.id);
+        });
+        item.append(button);
+        $("jobs").append(item);
+      });
+      $("history-status").textContent = result.data.length ? "Showing the latest jobs from this server." : "No jobs yet. Submit a prompt to start.";
+    } catch (error) {
+      $("history-status").textContent = `Could not load jobs. Check the server and select Refresh jobs. ${error.message}`;
+    } finally {
+      $("refresh-jobs").disabled = false;
+    }
+  };
+  const renderJob = (job) => {
+    currentJob = job;
+    $("job-state").textContent = labels[job.status] || job.status;
+    $("job-state").dataset.status = job.status;
+    $("job-id").textContent = `Job ${job.id}`;
+    const path = `/v1/videos/${encodeURIComponent(job.id)}`;
+    $("job-link").href = path;
+    $("job-link").hidden = false;
+    const complete = job.status === "completed";
+    $("video").hidden = !complete;
+    $("empty-preview").hidden = complete;
+    $("download").hidden = !complete;
+    if (complete) {
+      $("video").src = `${path}/content`;
+      $("download").href = `${path}/content`;
+      $("download").download = `${job.id}.mp4`;
+      $("job-status").textContent = "Video ready. Change the prompt and generate again with the same loaded model.";
+    } else {
+      $("video").pause();
+      $("video").removeAttribute("src");
+      $("empty-preview").querySelector("h3").textContent = job.status === "failed" ? "Generation failed" : "Your job is on the server";
+      $("empty-preview").querySelector("p").textContent = job.status === "failed" ? "Read the error below before trying again." : "You can keep editing the next prompt while you wait.";
+      $("job-status").textContent = job.status === "queued" ? "Queued. The server runs one generation at a time." : job.status === "failed" ? "The server could not complete this job." : "Generating video and audio. This page checks the job status automatically.";
+    }
+    if (job.status === "failed") showError(job.error?.message || "Check the server logs before submitting another job.");
+  };
+  const followJob = async (id) => {
+    const version = ++pollVersion;
+    const url = new URL(location.href);
+    url.searchParams.set("job", id);
+    history.replaceState({}, "", url);
+    showError();
+    setBusy(true);
+    $("check-status").hidden = true;
+    const deadline = Date.now() + 30 * 60 * 1000;
+    try {
+      while (version === pollVersion) {
+        const job = await api(`/v1/videos/${encodeURIComponent(id)}`);
+        if (version !== pollVersion) return;
+        renderJob(job);
+        if (!active(job)) break;
+        if (Date.now() >= deadline) throw new Error("Stopped checking after 30 minutes. The job may still be running.");
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+    } catch (error) {
+      if (version !== pollVersion) return;
+      showError(`${error.message} Select Check status to reconnect. A connection error does not cancel generation. If the job is missing, the server may have restarted or the job was deleted.`);
+      $("check-status").hidden = false;
+    } finally {
+      if (version === pollVersion) {
+        setBusy(false);
+        await refreshJobs();
+      }
+    }
+  };
+  $("generate-form").addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (busy || !model) return;
+    if (!$("prompt").value.trim()) {
+      showError("Write a prompt before generating a video.");
+      $("prompt").focus();
+      return;
+    }
+    showError();
+    setBusy(true);
+    $("job-status").textContent = "Submitting the prompt…";
+    try {
+      const job = await api("/v1/videos", {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload()),
+      });
+      renderJob(job);
+      await followJob(job.id);
+    } catch (error) {
+      showError(`${error.message} Check Recent jobs before submitting again; the server may have received the prompt. Submissions are never retried automatically.`);
+      $("job-status").textContent = "Could not confirm the submission.";
+      setBusy(false);
+      await refreshJobs();
+    }
+  });
+  $("prompt").addEventListener("input", updateCurl);
+  $("seed").addEventListener("input", updateCurl);
+  $("refresh-jobs").addEventListener("click", refreshJobs);
+  $("check-status").addEventListener("click", () => {
+    const id = new URL(location.href).searchParams.get("job");
+    if (id) followJob(id);
+  });
+  $("video").addEventListener("error", () => {
+    if (!$("video").hasAttribute("src")) return;
+    showError("The browser could not play this video. Download the MP4 to check it, or inspect the server logs.");
+  });
+  $("copy-curl").addEventListener("click", async () => {
+    try {
+      await navigator.clipboard.writeText($("curl-command").textContent);
+      $("copy-status").textContent = "Copied. Run it in a terminal to create a job.";
+    } catch {
+      $("copy-status").textContent = "Clipboard access is unavailable. Select and copy the command above.";
+    }
+  });
+  const connect = async () => {
+    try {
+      await api("/health");
+      const config = await api("/playground/config");
+      model = config.model;
+      $("connection").textContent = "Server ready · model loaded";
+      $("model").textContent = model;
+      const d = config.defaults;
+      const facts = [];
+      if (d.width && d.height) facts.push(`${d.width} × ${d.height}`);
+      if (d.num_frames) facts.push(`${d.num_frames} frames`);
+      if (d.fps) facts.push(`${d.fps} fps`);
+      if (d.seed != null) $("seed").placeholder = String(d.seed);
+      $("settings").textContent = facts.length ? `Server defaults · ${facts.join(" · ")}` : "Resolution and sampling come from the server configuration.";
+      setBusy(false);
+      updateCurl();
+      const id = new URL(location.href).searchParams.get("job");
+      if (id) await followJob(id);
+      else await refreshJobs();
+    } catch (error) {
+      $("connection").textContent = "Server unavailable";
+      $("history-status").textContent = "Start the H3 server, then reload this page.";
+      showError(`${error.message} Check the server terminal and reload this page when model loading completes.`);
+    }
+  };
+  connect();
+})();

--- a/fastvideo/entrypoints/openai/static/playground.js
+++ b/fastvideo/entrypoints/openai/static/playground.js
@@ -5,6 +5,7 @@
   const labels = { queued: "Queued", in_progress: "Generating", completed: "Completed", failed: "Failed" };
   const active = (job) => ["queued", "in_progress"].includes(job.status);
   let model = "";
+  let readyLabel = "Server ready";
   let busy = false;
   let currentJob = null;
   let pollVersion = 0;
@@ -89,7 +90,7 @@
       $("video").src = `${path}/content`;
       $("download").href = `${path}/content`;
       $("download").download = `${job.id}.mp4`;
-      $("job-status").textContent = "Video ready. Change the prompt and generate again with the same loaded model.";
+      $("job-status").textContent = "Video ready. Change the prompt and generate again without restarting the server.";
     } else {
       $("video").pause();
       $("video").removeAttribute("src");
@@ -108,10 +109,17 @@
     setBusy(true);
     $("check-status").hidden = true;
     const deadline = Date.now() + 30 * 60 * 1000;
+    let restorePrompt = !$("prompt").value.trim();
     try {
       while (version === pollVersion) {
         const job = await api(`/v1/videos/${encodeURIComponent(id)}`);
         if (version !== pollVersion) return;
+        $("connection").textContent = readyLabel;
+        if (restorePrompt) {
+          $("prompt").value = job.prompt || "";
+          updateCurl();
+          restorePrompt = false;
+        }
         renderJob(job);
         if (!active(job)) break;
         if (Date.now() >= deadline) throw new Error("Stopped checking after 30 minutes. The job may still be running.");
@@ -119,6 +127,7 @@
       }
     } catch (error) {
       if (version !== pollVersion) return;
+      $("connection").textContent = "Job status unavailable · check the server";
       showError(`${error.message} Select Check status to reconnect. A connection error does not cancel generation. If the job is missing, the server may have restarted or the job was deleted.`);
       $("check-status").hidden = false;
     } finally {
@@ -176,7 +185,11 @@
       await api("/health");
       const config = await api("/playground/config");
       model = config.model;
-      $("connection").textContent = "Server ready · model loaded";
+      readyLabel = config.runtime === "mlx" ? "Server ready · MLX" : "Server ready · model loaded";
+      $("connection").textContent = readyLabel;
+      $("lifetime").textContent = config.runtime === "mlx"
+        ? "MLX keeps the server and prompt cache available, but releases model components between phases to limit unified-memory use. Closing this page does not cancel a job."
+        : "The model stays loaded until you stop the server. Closing this page does not cancel a job.";
       $("model").textContent = model;
       const d = config.defaults;
       const facts = [];

--- a/fastvideo/entrypoints/openai/video_api.py
+++ b/fastvideo/entrypoints/openai/video_api.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Path, Query, Request
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse
 from pydantic import ValidationError
 from starlette.background import BackgroundTask
 from starlette.datastructures import UploadFile
@@ -233,7 +233,7 @@ async def _run_generation(
             {
                 "status": VideoGenerationStatus.FAILED,
                 "error": {
-                    "code": 500,
+                    "code": "generation_failed",
                     "message": str(error)
                 },
                 "inference_time_s": time.perf_counter() - started if started else 0.0,
@@ -421,15 +421,14 @@ async def list_videos(
     )
 
 
-@router.get("/{video_id}", response_model=None)
-async def retrieve_video(video_id: str = Path(...)) -> VideoResponse | JSONResponse:
+@router.get("/{video_id}", response_model=VideoResponse)
+async def retrieve_video(video_id: str = Path(...)) -> VideoResponse:
     job = await VIDEO_STORE.get(video_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Video not found")
-    response = VideoResponse(**job)
-    if response.status is VideoGenerationStatus.FAILED:
-        return JSONResponse(status_code=500, content=response.model_dump(mode="json"))
-    return response
+    # A failed generation is still a successfully retrieved resource. SDK
+    # polling helpers need its terminal status, not a retryable HTTP error.
+    return VideoResponse(**job)
 
 
 @router.delete("/{video_id}", response_model=VideoDeleteResponse)
@@ -457,7 +456,8 @@ async def delete_video(video_id: str = Path(...)) -> VideoDeleteResponse:
 
 @router.get("/{video_id}/content")
 async def download_video_content(video_id: str = Path(...), variant: str | None = Query(None)) -> FileResponse:
-    del variant
+    if variant not in {None, "video"}:
+        raise HTTPException(status_code=400, detail="Only the video content variant is supported")
     job = await VIDEO_STORE.get(video_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Video not found")

--- a/fastvideo/entrypoints/openai/video_api.py
+++ b/fastvideo/entrypoints/openai/video_api.py
@@ -331,6 +331,7 @@ async def _parse_video_request(raw_request: Request) -> VideoGenerationRequest:
 
 async def _adapt_request(request_id: str, request: VideoGenerationRequest) -> GenerationRequest:
     try:
+        get_serving_engine().validate_video_request(request)
         validate_model_and_lora(request, get_server_args(), get_served_model_name())
         await prepare_reference_media(request_id, request, get_output_dir())
         return await asyncio.to_thread(

--- a/fastvideo/tests/entrypoints/test_openai_video_client.py
+++ b/fastvideo/tests/entrypoints/test_openai_video_client.py
@@ -23,6 +23,8 @@ from fastvideo.entrypoints.cli.inference_config import build_serve_config
 from fastvideo.entrypoints.openai.api_server import create_app
 from fastvideo.entrypoints.openai.stores import VIDEO_STORE
 from fastvideo.api.compat import normalize_generation_request
+from fastvideo.entrypoints.openai.mlx_server import MLXH3Generator, create_mlx_app, load_config, validate_mlx_video_request
+from fastvideo.entrypoints.openai.protocol import VideoGenerationRequest
 
 ROOT = Path(__file__).resolve().parents[3]
 MODEL = "FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2"
@@ -48,9 +50,12 @@ class FileGenerator:
         pass
 
 
-@pytest.fixture
-def local_server(monkeypatch, tmp_path):
+@pytest.fixture(params=["cuda", "mlx"])
+def local_server(request, monkeypatch, tmp_path):
     generator = FileGenerator()
+    generator.runtime = request.param
+    generator.native_calls = []
+    generator.thread_ids = []
     def load(args):
         generator.loads += 1
         return generator
@@ -71,6 +76,28 @@ def local_server(monkeypatch, tmp_path):
     assert config.generator.model_path == MODEL
     assert config.generator.engine.num_gpus == 4
     app = create_app(args, str(tmp_path / "server"), config.default_request, config.server.served_model_name)
+    if request.param == "mlx":
+        def native_generate(prompt, **kwargs):
+            generator.thread_ids.append(threading.get_ident())
+            generator.native_calls.append(kwargs)
+            request = normalize_generation_request({
+                "prompt": prompt,
+                "sampling": {key: kwargs[key] for key in ["height", "width", "num_frames", "seed"]},
+                "output": {"output_path": kwargs["output_path"]},
+            })
+            request.sampling.num_inference_steps = kwargs["num_steps"] + 1
+            return generator.generate(request)
+
+        def load_native(config):
+            generator.loads += 1
+            generator.thread_ids.append(threading.get_ident())
+            return SimpleNamespace(generate=native_generate)
+
+        monkeypatch.setattr(MLXH3Generator, "_load", staticmethod(load_native))
+        monkeypatch.setattr("fastvideo.mlx_runtime.minimax_h3_pipeline._cleanup_mlx", lambda: None)
+        mlx_config = load_config(str(ROOT / "examples/serving/mlx_fasth3.yaml"))
+        mlx_config.server.output_dir = str(tmp_path / "server")
+        app = create_mlx_app(mlx_config)
     server = uvicorn.Server(uvicorn.Config(app, log_level="error"))
     with socket.socket() as listener:
         listener.bind(("127.0.0.1", 0))
@@ -97,7 +124,7 @@ def test_openai_video_lifecycle(local_server):
     video = client.videos.create_and_poll(model="fasth3", prompt="a fox", poll_interval_ms=1)
     assert video.status == "completed"
     assert video.model == "fasth3"
-    assert video.size == "1344x768"
+    assert video.size == ("832x480" if generator.runtime == "mlx" else "1344x768")
     assert video.error is None
     request = generator.requests[0]
     assert request.sampling.num_frames == 124
@@ -149,6 +176,9 @@ def test_prompt_iteration_reuses_the_loaded_generator(local_server):
     assert first.status == second.status == "completed"
     assert [request.prompt for request in generator.requests] == ["a fox", "a fox in snow"]
     assert generator.loads == 1
+    if generator.runtime == "mlx":
+        assert len(set(generator.thread_ids)) == 1
+        assert [call["num_steps"] for call in generator.native_calls] == [4, 4]
 
 
 def test_playground_assets_and_config_do_not_generate(local_server):
@@ -168,7 +198,10 @@ def test_playground_assets_and_config_do_not_generate(local_server):
         config = json.load(response)
     assert config == {
         "model": "fasth3",
-        "defaults": {"width": 1344, "height": 768, "num_frames": 124, "fps": 24, "seed": 1000},
+        "runtime": generator.runtime,
+        "defaults": {"width": 832, "height": 480, "num_frames": 124, "fps": 24, "seed": 2026}
+        if generator.runtime == "mlx" else
+        {"width": 1344, "height": 768, "num_frames": 124, "fps": 24, "seed": 1000},
     }
     with pytest.raises(HTTPError) as error:
         urlopen(origin + "/playground/api_server.py")
@@ -200,6 +233,34 @@ def test_playground_is_limited_to_h3_text_generation(local_server, monkeypatch, 
         urlopen(base_url.removesuffix("/v1") + "/playground/")
     assert error.value.code == 404
     assert not generator.requests
+
+
+@pytest.mark.parametrize("fields", [
+    {"image_reference": "https://example.com/input.png"}, {"task": "fl2va"},
+    {"guidance_scale": 2}, {"num_inference_steps": 4}, {"negative_prompt": "bad"},
+    {"seed": -1}, {"seed": 2**32}, {"extra_params": {"vsa_mode": "exempt"}},
+    {"enable_frame_interpolation": True},
+])
+def test_mlx_rejects_unsupported_options_before_generation(fields):
+    if "image_reference" in fields:
+        fields = {"image_reference": {"image_url": fields["image_reference"]}}
+    with pytest.raises(ValueError):
+        validate_mlx_video_request(VideoGenerationRequest(prompt="a fox", **fields))
+
+
+def test_mlx_http_rejects_reference_media_and_image_routes(local_server):
+    client, generator, base_url = local_server
+    if generator.runtime != "mlx":
+        return
+    with pytest.raises(openai.BadRequestError, match="image_reference"):
+        client.videos.create(model="fasth3", prompt="a fox", extra_body={
+            "image_reference": {"image_url": "http://127.0.0.1:1/must-not-fetch"},
+        })
+    assert not generator.requests
+    assert not client.videos.list().data
+    with urlopen(base_url.removesuffix("/v1") + "/openapi.json") as response:
+        spec = json.load(response)
+    assert "/v1/images" not in spec["paths"]
 
 
 @pytest.mark.parametrize("filename,runner", [("video.py", sys.executable), ("video.sh", "bash"), ("video.mjs", "node")])

--- a/fastvideo/tests/entrypoints/test_openai_video_client.py
+++ b/fastvideo/tests/entrypoints/test_openai_video_client.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Real OpenAI SDK and HTTP routes with a fake generator, no GPU or cloud calls."""
+
+import asyncio
+import os
+from pathlib import Path
+import socket
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from types import SimpleNamespace
+from urllib.error import HTTPError
+from urllib.request import urlopen
+import json
+
+import openai
+import pytest
+import uvicorn
+
+from fastvideo.entrypoints.cli.inference_config import build_serve_config
+from fastvideo.entrypoints.openai.api_server import create_app
+from fastvideo.entrypoints.openai.stores import VIDEO_STORE
+from fastvideo.api.compat import normalize_generation_request
+
+ROOT = Path(__file__).resolve().parents[3]
+MODEL = "FastVideo/FastVideo-Minimax-FastH3-Preview-v0.2"
+ARTIFACT = b"fake-video-content-for-transport-tests"
+
+
+class FileGenerator:
+    def __init__(self):
+        self.requests = []
+        self.fail = False
+        self.loads = 0
+
+    def generate(self, request):
+        self.requests.append(request)
+        if self.fail or request.prompt == "fail":
+            raise RuntimeError("Test generation failure")
+        output = Path(request.output.output_path)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(ARTIFACT)
+        return SimpleNamespace(video_path=str(output), generation_time=0.01)
+
+    def shutdown(self):
+        pass
+
+
+@pytest.fixture
+def local_server(monkeypatch, tmp_path):
+    generator = FileGenerator()
+    def load(args):
+        generator.loads += 1
+        return generator
+
+    monkeypatch.setattr(
+        "fastvideo.entrypoints.openai.api_server.VideoGenerator.from_fastvideo_args",
+        load,
+    )
+    args = SimpleNamespace(
+        model_path=MODEL, lora_path=None, lora_nickname="default",
+        lora_strength=1.0, override_pipeline_cls_name=None,
+    )
+    config = build_serve_config(
+        SimpleNamespace(config=str(ROOT / "examples/serving/openai_fasth3.yaml")),
+        overrides=["--server.host", "127.0.0.1"],
+    )
+    assert config.server.host == "127.0.0.1"
+    assert config.generator.model_path == MODEL
+    assert config.generator.engine.num_gpus == 4
+    app = create_app(args, str(tmp_path / "server"), config.default_request, config.server.served_model_name)
+    server = uvicorn.Server(uvicorn.Config(app, log_level="error"))
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        base_url = f"http://127.0.0.1:{listener.getsockname()[1]}/v1"
+        thread = threading.Thread(target=server.run, kwargs={"sockets": [listener]}, daemon=True)
+        thread.start()
+        try:
+            deadline = time.monotonic() + 15
+            while not server.started and thread.is_alive() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert server.started, "Local test server did not start"
+            with openai.OpenAI(base_url=base_url, api_key="local", max_retries=0, timeout=5) as client:
+                yield client, generator, base_url
+        finally:
+            server.should_exit = True
+            thread.join(timeout=10)
+            assert not thread.is_alive(), "Local test server did not stop"
+            asyncio.run(VIDEO_STORE.clear())
+
+
+def test_openai_video_lifecycle(local_server):
+    client, generator, _ = local_server
+    assert client.models.list().data[0].id == "fasth3"
+    video = client.videos.create_and_poll(model="fasth3", prompt="a fox", poll_interval_ms=1)
+    assert video.status == "completed"
+    assert video.model == "fasth3"
+    assert video.size == "1344x768"
+    assert video.error is None
+    request = generator.requests[0]
+    assert request.sampling.num_frames == 124
+    assert request.sampling.num_inference_steps == 5
+    assert request.sampling.guidance_scale == 1.0
+    assert client.videos.retrieve(video.id).status == "completed"
+    assert client.videos.list(limit=1).data[0].id == video.id
+    assert client.videos.download_content(video.id, variant="video").read() == ARTIFACT
+    assert client.videos.delete(video.id).deleted
+    with pytest.raises(openai.NotFoundError):
+        client.videos.retrieve(video.id)
+
+
+def test_openai_poll_returns_failed_resource(local_server):
+    client, _, _ = local_server
+    video = client.videos.create_and_poll(model="fasth3", prompt="fail", poll_interval_ms=1)
+    assert video.status == "failed"
+    assert video.error.code == "generation_failed"
+    assert video.error.message == "Test generation failure"
+    assert client.videos.retrieve(video.id).status == "failed"
+    with pytest.raises(openai.UnprocessableEntityError):
+        client.videos.download_content(video.id)
+
+
+def test_openai_admission_errors_are_not_jobs(local_server):
+    client, generator, _ = local_server
+    for params in [{"model": "missing", "prompt": "a fox"}, {"model": "fasth3", "prompt": " "}]:
+        with pytest.raises(openai.BadRequestError):
+            client.videos.create(**params)
+    assert not client.videos.list().data
+    assert not generator.requests
+
+
+def test_openai_extra_body_and_unsupported_content_variant(local_server):
+    client, generator, _ = local_server
+    video = client.videos.create_and_poll(
+        model="fasth3", prompt="a fox", extra_body={"seed": 42}, poll_interval_ms=1,
+    )
+    assert generator.requests[0].sampling.seed == 42
+    with pytest.raises(openai.BadRequestError, match="Only the video"):
+        client.videos.download_content(video.id, variant="thumbnail")
+
+
+def test_prompt_iteration_reuses_the_loaded_generator(local_server):
+    client, generator, _ = local_server
+    first = client.videos.create_and_poll(model="fasth3", prompt="a fox", poll_interval_ms=1)
+    second = client.videos.create_and_poll(model="fasth3", prompt="a fox in snow", poll_interval_ms=1)
+    assert first.id != second.id
+    assert first.status == second.status == "completed"
+    assert [request.prompt for request in generator.requests] == ["a fox", "a fox in snow"]
+    assert generator.loads == 1
+
+
+def test_playground_assets_and_config_do_not_generate(local_server):
+    _, generator, base_url = local_server
+    origin = base_url.removesuffix("/v1")
+    with urlopen(origin + "/playground/") as response:
+        assert response.status == 200
+        assert "frame-ancestors 'none'" in response.headers["Content-Security-Policy"]
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        html = response.read().decode()
+        assert "Generate video" in html
+        assert 'src="./playground.js"' in html
+    for asset in ["playground.js", "playground.css"]:
+        with urlopen(origin + "/playground/" + asset) as response:
+            assert response.status == 200
+    with urlopen(origin + "/playground/config") as response:
+        config = json.load(response)
+    assert config == {
+        "model": "fasth3",
+        "defaults": {"width": 1344, "height": 768, "num_frames": 124, "fps": 24, "seed": 1000},
+    }
+    with pytest.raises(HTTPError) as error:
+        urlopen(origin + "/playground/api_server.py")
+    assert error.value.code == 404
+    assert not generator.requests
+    assert generator.loads == 1
+
+
+def test_playground_does_not_advertise_implicit_defaults(local_server, monkeypatch):
+    _, _, base_url = local_server
+    request = normalize_generation_request({"sampling": {"seed": 42}})
+    monkeypatch.setattr("fastvideo.entrypoints.openai.playground.get_default_request", lambda: request)
+    with urlopen(base_url.removesuffix("/v1") + "/playground/config") as response:
+        config = json.load(response)
+    assert config["defaults"] == {"width": None, "height": None, "num_frames": None, "fps": None, "seed": 42}
+
+
+@pytest.mark.parametrize("model,override", [
+    ("Wan-AI/Wan2.1-T2V-1.3B-Diffusers", None),
+    (MODEL, "MiniMaxH3Ref2VAModularPipeline"),
+])
+def test_playground_is_limited_to_h3_text_generation(local_server, monkeypatch, model, override):
+    _, generator, base_url = local_server
+    monkeypatch.setattr(
+        "fastvideo.entrypoints.openai.playground.get_server_args",
+        lambda: SimpleNamespace(model_path=model, override_pipeline_cls_name=override),
+    )
+    with pytest.raises(HTTPError) as error:
+        urlopen(base_url.removesuffix("/v1") + "/playground/")
+    assert error.value.code == 404
+    assert not generator.requests
+
+
+@pytest.mark.parametrize("filename,runner", [("video.py", sys.executable), ("video.sh", "bash"), ("video.mjs", "node")])
+@pytest.mark.parametrize("fail", [False, True])
+def test_cookbook_clients_handle_completion_and_failure(local_server, tmp_path, filename, runner, fail):
+    if filename == "video.sh" and not shutil.which("jq"):
+        pytest.skip("The cURL example requires jq")
+    if filename == "video.mjs" and (
+        not shutil.which("node") or not (ROOT / "examples/serving/clients/node_modules/openai").is_dir()
+    ):
+        pytest.skip("Run npm ci --prefix examples/serving/clients to test the JavaScript example")
+    _, generator, base_url = local_server
+    generator.fail = fail
+    env = dict(os.environ, FASTVIDEO_BASE_URL=base_url, FASTVIDEO_MODEL="fasth3", FASTVIDEO_API_KEY="local")
+    result = subprocess.run(
+        [runner, str(ROOT / "examples/serving/clients" / filename)],
+        env=env, cwd=tmp_path, capture_output=True, text=True, timeout=15,
+    )
+    outputs = list(tmp_path.glob("*.mp4"))
+    if fail:
+        assert result.returncode != 0
+        assert "Test generation failure" in result.stderr
+        assert not outputs
+        return
+    assert result.returncode == 0, result.stderr
+    assert len(outputs) == 1
+    assert outputs[0].read_bytes() == ARTIFACT

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
     - V1 API: getting_started/v1_api.md
   - Cookbook:
     - Overview: cookbook/index.md
+    - H3 server and playground: cookbook/openai-api.md
     - Video:
       - MiniMax H3: cookbook/minimax-h3.md
       - Wan: cookbook/wan.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ lint = [
 
 test = [
     "av",
+    "openai==3.6.0",  # OpenAI video-client compatibility tests; no cloud requests.
     "pytorch-msssim>=1.0.0",
     "pytest",
     "pandas",
@@ -234,6 +235,7 @@ where = [".", "apps/dreamverse"]
 exclude = ["assets*", "docker*", "docs", "scripts*", "apps*", "dreamverse.tests*"]
 
 [tool.setuptools.package-data]
+"fastvideo.entrypoints.openai" = ["static/*.html", "static/*.css", "static/*.js"]
 dreamverse = ["prompts/*.md"]
 "fastvideo.third_party.rife_mlx" = ["LICENSE"]
 "fastvideo.third_party.taehv" = ["LICENSE"]

--- a/tests/local_tests/test_cookbook_serving.py
+++ b/tests/local_tests/test_cookbook_serving.py
@@ -1,0 +1,73 @@
+"""Check serving snippets against their executable sources, without model imports."""
+
+import copy
+import json
+from pathlib import Path
+from html.parser import HTMLParser
+
+import pytest
+
+from docs.generate_examples import COOKBOOK_DATA, Example, cookbook_serving_profile, validate_cookbook
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def serving_recipe():
+    recipes = json.loads(COOKBOOK_DATA.read_text())["recipes"]
+    return next(recipe for recipe in recipes if recipe["id"] == "fasth3-preview-cuda")
+
+
+def test_cookbook_serving_does_not_inherit_local_benchmark():
+    recipe = serving_recipe()
+    assert recipe["hardware"]["evidence"] == "validated"
+    profile = cookbook_serving_profile(recipe)
+    assert profile["hardware"] == {"platform": "cuda", "gpu_count": 4, "evidence": "source-configured"}
+    assert profile["model"] == "fasth3"
+    assert profile["sampling"]["num_frames"] == 124
+    assert "--server.host 127.0.0.1" in profile["command"]
+    assert profile["playground_url"] == "http://127.0.0.1:8000/playground/"
+    for client in profile["clients"].values():
+        assert client["code"] == (ROOT / client["source"]).read_text()
+    validate_cookbook()
+
+
+@pytest.mark.parametrize("field,value", [("model", "wrong-checkpoint"), ("hardware", {"platform": "mlx"})])
+def test_cookbook_rejects_mismatched_serving_recipe(field, value):
+    recipe = copy.deepcopy(serving_recipe())
+    recipe[field] = value
+    with pytest.raises(ValueError):
+        cookbook_serving_profile(recipe)
+
+
+def test_cookbook_rejects_config_outside_serving_examples():
+    recipe = serving_recipe()
+    recipe["serving"]["source"] = "pyproject.toml"
+    with pytest.raises(ValueError, match="examples/serving"):
+        cookbook_serving_profile(recipe)
+
+
+def test_example_docs_exclude_installed_client_dependencies(tmp_path):
+    (tmp_path / "README.md").write_text("# Example")
+    (tmp_path / "client.mjs").write_text("// example")
+    for dirname in ["node_modules", ".venv", "__pycache__"]:
+        dependency = tmp_path / dirname
+        dependency.mkdir()
+        (dependency / "README.md").write_text("Not example documentation")
+    assert Example(tmp_path).other_files == [tmp_path / "client.mjs"]
+
+
+def test_h3_command_blocks_have_unique_copy_targets():
+    class CodeBlocks(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.ids = []
+
+        def handle_starttag(self, tag, attrs):
+            if tag == "pre":
+                self.ids.append(dict(attrs).get("id"))
+
+    parser = CodeBlocks()
+    parser.feed((ROOT / "docs/cookbook/minimax-h3.md").read_text())
+    assert len(parser.ids) == 6
+    assert all(parser.ids)
+    assert len(set(parser.ids)) == len(parser.ids)

--- a/tests/local_tests/test_cookbook_serving.py
+++ b/tests/local_tests/test_cookbook_serving.py
@@ -31,6 +31,20 @@ def test_cookbook_serving_does_not_inherit_local_benchmark():
     validate_cookbook()
 
 
+def test_mlx_serving_profile_has_native_launcher_and_no_invented_memory():
+    recipes = json.loads(COOKBOOK_DATA.read_text())["recipes"]
+    recipe = next(item for item in recipes if item["id"] == "fasth3-preview-mlx")
+    profile = cookbook_serving_profile(recipe)
+    assert profile["hardware"] == {"platform": "mlx", "evidence": "source-configured"}
+    assert profile["command"] == (
+        "python -m fastvideo.entrypoints.openai.mlx_server --config examples/serving/mlx_fasth3.yaml"
+    )
+    assert profile["prepare"] in recipe["command"]
+    assert profile["sampling"]["num_inference_steps"] == 5
+    for client in profile["clients"].values():
+        assert client["code"] == (ROOT / client["source"]).read_text()
+
+
 @pytest.mark.parametrize("field,value", [("model", "wrong-checkpoint"), ("hardware", {"platform": "mlx"})])
 def test_cookbook_rejects_mismatched_serving_recipe(field, value):
     recipe = copy.deepcopy(serving_recipe())
@@ -68,6 +82,6 @@ def test_h3_command_blocks_have_unique_copy_targets():
 
     parser = CodeBlocks()
     parser.feed((ROOT / "docs/cookbook/minimax-h3.md").read_text())
-    assert len(parser.ids) == 6
+    assert len(parser.ids) == 7
     assert all(parser.ids)
     assert len(set(parser.ids)) == len(parser.ids)


### PR DESCRIPTION
## Purpose

Add an H3 prompt-iteration workflow to the cookbook introduced in #1787. Start a server once, then use the browser playground, cURL, or an SDK client against the same process.

## Changes

- Add a same-origin H3 playground with prompt and seed inputs, job status, playback, downloads, recent jobs, and a matching cURL request.
- Replace the misleading API-versus-local choice with **Run a server** and **Use Python directly**. Both can run locally. The Python SDK can also reuse a generator in one process.
- Generate cookbook commands from the checked-in server configuration and executable client sources. Keep server evidence separate from recorded Python/GB200 benchmarks.
- Return failed video jobs as HTTP 200 terminal resources so OpenAI SDK polling stops on failure. Reject unsupported download variants.

## Test Plan

```bash
python -m pytest fastvideo/tests/entrypoints/test_openai_video_client.py fastvideo/tests/entrypoints/test_openai_serving_engine.py fastvideo/tests/entrypoints/test_openai_api.py tests/local_tests/test_cookbook_serving.py -q --disable-warnings --tb=short
pre-commit run --files <changed paths>
mkdocs build --clean
```

## Test Results

- 126 tests passed after rebasing onto current main. Real HTTP tests use the pinned OpenAI Python and JavaScript clients, cURL, and fake CUDA/MLX generators. They cover job success/failure, download, input validation, static playground routes, MLX option rejection, and prompt changes through one runtime instance.
- Changed-file pre-commit checks passed, including mypy. Documentation build passed with existing API-reference warnings. A wheel build contains the playground and MLX launcher.
- Desktop and 390 px browser QA passed with CPU-only test doubles for completed and failed jobs, refresh recovery, no horizontal overflow, and safe rendering of prompt text containing HTML. No generated model output is claimed.
- Not run: H3 CUDA/GB200 generation, real MLX generation, performance or quality comparisons.

![H3 playground with the MLX CPU test double](https://raw.githubusercontent.com/aryan5v/FastVideo/aryan/h3-server-playground/docs/assets/cookbook-previews/h3-playground.jpg)

## Draft status and boundaries

The native H3 MLX adapter is limited to text-to-video/audio. It reuses one pipeline object and prompt cache on one MLX thread, but keeps the runtime's phase-memory policy. It does not keep all weights resident. The cookbook does not carry the M4 Max Python measurements into the unmeasured server profile.

The existing server has no built-in API-key authentication. Examples bind to loopback. Job metadata is in memory, and generation is serialized. A browser or client timeout does not cancel a running generation.

## Checklist

- [x] Added regression tests
- [x] Updated documentation
- [x] Kept hardware claims tied to evidence
- [x] Complete MLX adapter and final UI verification
- [ ] Record real-hardware generation results
