### PR TITLE
[bugfix] fix(metrics): set SceneMetric device_map for any non-CPU device

### DIFF
--- a/fastvideo/eval/metrics/vbench/scene/metric.py
+++ b/fastvideo/eval/metrics/vbench/scene/metric.py
@@ -63,7 +63,7 @@ class SceneMetric(BaseMetric):
         self._model = Qwen2_5OmniForConditionalGeneration.from_pretrained(
             self._model_path,
             torch_dtype=torch.bfloat16,
-            device_map=str(self.device) if self.device.type == "cuda" else None,
+            device_map=str(self.device) if self.device.type != "cpu" else None,
         )
         self._model.disable_talker()
         self._model.eval()


### PR DESCRIPTION
## Problem

`SceneMetric.setup()` only passes a `device_map` to `Qwen2_5OmniForConditionalGeneration.from_pretrained` when `self.device.type == "cuda"`:

```python
device_map=str(self.device) if self.device.type == "cuda" else None,
```

On any non-CUDA accelerator (Ascend NPU, Apple MPS, Intel XPU, AMD ROCm) `device_map` is `None`, so the Qwen2.5-Omni model silently loads on CPU. The scene metric then runs on CPU (slow) even when a GPU/NPU is available.

## Root cause

Hardcoded CUDA device-type assumption: only CUDA tensors get a `device_map`.

## Fix

Pass a `device_map` for every non-CPU device type:

```python
device_map=str(self.device) if self.device.type != "cpu" else None,
```

This is device-agnostic and matches the caller-selected device.

## Verification

On Ascend 910B (`torch.accelerator.current_accelerator()` returns `npu`, `torch.device("npu:0").type == "npu"`), the new condition is `True` and a `device_map` is passed, so the metric loads on NPU instead of CPU. On CUDA behaviour is unchanged. One-line change, device-agnostic.

Fixes #1815