### PR TITLE
[bugfix] fix(cosmos): make AdaLayerNorm autocast device-agnostic

### DIFF
--- a/fastvideo/models/dits/cosmos.py
+++ b/fastvideo/models/dits/cosmos.py
@@ -91,7 +91,7 @@ class CosmosAdaLayerNorm(nn.Module):
             embedded_timestep = embedded_timestep + temb[..., :2 * self.embedding_dim]
 
         shift, scale = embedded_timestep.chunk(2, dim=-1)
-        with torch.autocast(device_type="cuda", enabled=False):
+        with torch.autocast(device_type=hidden_states.device.type, enabled=False):
             hidden_states = self.norm(hidden_states)
 
         if embedded_timestep.ndim == 2:
@@ -131,7 +131,7 @@ class CosmosAdaLayerNormZero(nn.Module):
 
         shift, scale, gate = embedded_timestep.chunk(3, dim=-1)
 
-        with torch.autocast(device_type="cuda", enabled=False):
+        with torch.autocast(device_type=hidden_states.device.type, enabled=False):
             hidden_states = self.norm(hidden_states)
 
         if embedded_timestep.ndim == 2:


### PR DESCRIPTION
## Problem

`CosmosAdaLayerNorm` and `CosmosAdaLayerNormZero` in `fastvideo/models/dits/cosmos.py` wrap their LayerNorm call in a hardcoded CUDA autocast context:

```python
with torch.autocast(device_type="cuda", enabled=False):
    hidden_states = self.norm(hidden_states)
```

`device_type="cuda"` only disables autocast for CUDA tensors. On other accelerators (Ascend NPU, Apple MPS, Intel XPU, AMD ROCm) the autocast context does not apply to the tensor, so the norm may be computed in the wrong precision (e.g. bf16) instead of the intended fp32, which can cause numerical differences or dtype mismatches downstream.

## Root cause

Hardcoded CUDA device-type assumption in `torch.autocast()`.

## Fix

Use the tensor's actual device type:

```python
with torch.autocast(device_type=hidden_states.device.type, enabled=False):
```

This is device-agnostic: the autocast context follows the tensor's device (npu, mps, cuda, xpu, etc.).

## Verification

Verified on Ascend 910B: `torch.autocast(device_type="npu", enabled=False)` is valid and correctly disables autocast for NPU tensors. On CUDA the behaviour is identical to the original code.

Fixes #1816