### PR TITLE
Disable old SSIM models

### DIFF
--- a/fastvideo/tests/ssim/test_dreamx_world_similarity.py
+++ b/fastvideo/tests/ssim/test_dreamx_world_similarity.py
@@ -17,6 +17,7 @@ from fastvideo.tests.ssim.inference_similarity_utils import (
 logger = init_logger(__name__)
 
 REQUIRED_GPUS = 1
+pytestmark = pytest.mark.skip(reason="Disabled pending removal of DreamX World support.")
 
 device_reference_folder = resolve_inference_device_reference_folder(logger)
 

--- a/fastvideo/tests/ssim/test_gamecraft_similarity.py
+++ b/fastvideo/tests/ssim/test_gamecraft_similarity.py
@@ -36,6 +36,7 @@ from fastvideo.worker.multiproc_executor import MultiprocExecutor
 logger = init_logger(__name__)
 
 REQUIRED_GPUS = 1
+pytestmark = pytest.mark.skip(reason="Disabled pending removal of HunyuanGameCraft support.")
 
 # ---------------------------------------------------------------------------
 # Device-dependent reference folder

--- a/fastvideo/tests/ssim/test_glm_image_similarity.py
+++ b/fastvideo/tests/ssim/test_glm_image_similarity.py
@@ -19,6 +19,7 @@ from fastvideo.tests.ssim.reference_utils import (
 logger = init_logger(__name__)
 
 REQUIRED_GPUS = 1
+pytestmark = pytest.mark.skip(reason="Disabled pending removal of GLM-Image support.")
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 LOCAL_WEIGHTS_DIR = Path(os.getenv("GLM_IMAGE_LOCAL_WEIGHTS_DIR", REPO_ROOT / "official_weights" / "glm_image"))

--- a/fastvideo/tests/ssim/test_longcat_similarity.py
+++ b/fastvideo/tests/ssim/test_longcat_similarity.py
@@ -34,6 +34,7 @@ from fastvideo.tests.utils import compute_video_ssim_torchvision, write_ssim_res
 logger = init_logger(__name__)
 
 REQUIRED_GPUS = 1
+pytestmark = pytest.mark.skip(reason="Disabled pending removal of LongCat support.")
 
 # Device-specific reference folder
 device_reference_folder = resolve_device_reference_folder(

--- a/fastvideo/tests/ssim/test_matrixgame2_similarity.py
+++ b/fastvideo/tests/ssim/test_matrixgame2_similarity.py
@@ -24,6 +24,7 @@ from fastvideo.worker.multiproc_executor import MultiprocExecutor
 logger = init_logger(__name__)
 
 REQUIRED_GPUS = 1
+pytestmark = pytest.mark.skip(reason="Disabled pending removal of Matrix Game 2.0 support.")
 
 device_reference_folder = resolve_device_reference_folder(
     (

--- a/fastvideo/tests/ssim/test_turbodiffusion_similarity.py
+++ b/fastvideo/tests/ssim/test_turbodiffusion_similarity.py
@@ -19,6 +19,7 @@ from fastvideo.tests.ssim.reference_utils import (
 logger = init_logger(__name__)
 
 REQUIRED_GPUS = 4
+pytestmark = pytest.mark.skip(reason="Disabled pending removal of TurboDiffusion and TurboWan support.")
 
 device_name = get_cuda_device_name()
 device_reference_folder = resolve_device_reference_folder(

--- a/fastvideo/tests/ssim/test_zimage_similarity.py
+++ b/fastvideo/tests/ssim/test_zimage_similarity.py
@@ -19,6 +19,7 @@ from fastvideo.tests.ssim.reference_utils import (
 logger = init_logger(__name__)
 
 REQUIRED_GPUS = 1
+pytestmark = pytest.mark.skip(reason="Disabled pending removal of Z-Image support.")
 ZIMAGE_MIN_SSIM = 0.98
 
 ZIMAGE_MODEL_PATH = os.getenv(


### PR DESCRIPTION
## Summary

- mark the DreamX World, HunyuanGameCraft, GLM-Image, LongCat, Matrix Game 2.0, TurboDiffusion/TurboWan, and Z-Image SSIM modules as skipped with standard pytest markers
- leave the active Slurm scheduler and dormant Modal fallback unchanged
- leave SSIM references and runtime model registrations unchanged

## Tests

- Python syntax compilation for all seven changed SSIM modules
- static validation that every changed module declares exactly one expected `pytest.mark.skip` reason
- `pre-commit run --files <changed files>`

Direct pytest collection is unavailable on this CPU-only host because the package-level test configuration imports FastVideo/Triton before the test modules and Triton requires an active GPU driver.
