### PR TITLE
[bugfix]: drop dead h3_sequential_load from Spark FastH3 presets

### DIFF
--- a/examples/inference/basic/basic_fasth3_spark.yaml
+++ b/examples/inference/basic/basic_fasth3_spark.yaml
@@ -38,7 +38,6 @@ generator:
       inference_torch_compile: true
       vae_parallel_decode: true
       vae_parallel_decode_strategy: gather
-      h3_sequential_load: true
 request:
   prompt: >-
     A wide cinematic shot of an alpine meadow at sunrise, pale pink mountain

--- a/examples/inference/basic/basic_fasth3_spark_pair.yaml
+++ b/examples/inference/basic/basic_fasth3_spark_pair.yaml
@@ -38,7 +38,6 @@ generator:
       inference_torch_compile: true
       vae_parallel_decode: true
       vae_parallel_decode_strategy: gather
-      h3_sequential_load: true
 request:
   prompt: >-
     A wide cinematic shot of an alpine meadow at sunrise, pale pink mountain

--- a/examples/serving/openai_fasth3_spark.yaml
+++ b/examples/serving/openai_fasth3_spark.yaml
@@ -35,7 +35,6 @@ generator:
       inference_torch_compile: false
       vae_parallel_decode: true
       vae_parallel_decode_strategy: gather
-      h3_sequential_load: true
 
 server:
   host: 0.0.0.0

--- a/tests/local_tests/test_cookbook_serving.py
+++ b/tests/local_tests/test_cookbook_serving.py
@@ -8,6 +8,7 @@ from html.parser import HTMLParser
 import pytest
 
 from docs.generate_examples import COOKBOOK_DATA, Example, cookbook_serving_profile, validate_cookbook
+from fastvideo.api import load_run_config, load_serve_config
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -29,6 +30,22 @@ def test_cookbook_serving_does_not_inherit_local_benchmark():
     for client in profile["clients"].values():
         assert client["code"] == (ROOT / client["source"]).read_text()
     validate_cookbook()
+
+
+@pytest.mark.parametrize(
+    "config_path,loader",
+    [
+        ("examples/inference/basic/basic_fasth3_spark.yaml", load_run_config),
+        ("examples/inference/basic/basic_fasth3_spark_pair.yaml", load_run_config),
+        ("examples/serving/openai_fasth3_spark.yaml", load_serve_config),
+    ],
+)
+def test_spark_configs_use_lazy_load_not_sequential(config_path, loader):
+    cfg = loader(str(ROOT / config_path))
+    offload = cfg.generator.engine.offload
+    assert offload.lazy_module_load is True
+    experimental = cfg.generator.pipeline.experimental
+    assert "h3_sequential_load" not in experimental
 
 
 def test_spark_preview_is_a_runtime_with_one_or_two_devices():

--- a/tests/local_tests/test_cookbook_serving.py
+++ b/tests/local_tests/test_cookbook_serving.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from html.parser import HTMLParser
 
 import pytest
+import yaml
 
 from docs.generate_examples import COOKBOOK_DATA, Example, cookbook_serving_profile, validate_cookbook
-from fastvideo.api import load_run_config, load_serve_config
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -33,18 +33,18 @@ def test_cookbook_serving_does_not_inherit_local_benchmark():
 
 
 @pytest.mark.parametrize(
-    "config_path,loader",
+    "config_path",
     [
-        ("examples/inference/basic/basic_fasth3_spark.yaml", load_run_config),
-        ("examples/inference/basic/basic_fasth3_spark_pair.yaml", load_run_config),
-        ("examples/serving/openai_fasth3_spark.yaml", load_serve_config),
+        "examples/inference/basic/basic_fasth3_spark.yaml",
+        "examples/inference/basic/basic_fasth3_spark_pair.yaml",
+        "examples/serving/openai_fasth3_spark.yaml",
     ],
 )
-def test_spark_configs_use_lazy_load_not_sequential(config_path, loader):
-    cfg = loader(str(ROOT / config_path))
-    offload = cfg.generator.engine.offload
-    assert offload.lazy_module_load is True
-    experimental = cfg.generator.pipeline.experimental
+def test_spark_configs_use_lazy_load_not_sequential(config_path):
+    cfg = yaml.safe_load((ROOT / config_path).read_text())
+    offload = cfg["generator"]["engine"]["offload"]
+    assert offload["lazy_module_load"] is True
+    experimental = cfg["generator"]["pipeline"]["experimental"]
     assert "h3_sequential_load" not in experimental
 
 


### PR DESCRIPTION
lazy_module_load owns deferral on GB10 and suppresses h3_sequential_load. Remove the inert flag from the three Spark YAML presets and add a regression test.

<!--
PR TITLE: Must start with a type tag, e.g.:
  [feat] Add new model       [bugfix] Fix VAE tiling      [refactor] Restructure pipeline
  [perf] Optimize kernel     [ci] Update tests             [docs] Add guide
  [misc] Cleanup configs     [new-model] Port Flux2        [infra] Add trace hooks
  [skill] Add agent skill

MERGE WORKFLOW:
  1. Ensure pre-commit passes and you have at least 1 approval
  2. Comment /merge (or add the "ready" label) to enter the Merge Queue
  3. A path-aware merge gate runs only relevant integration tests → auto-merge on success

ON-DEMAND TESTING (write access required):
  /test full       — Explicit all-lane run  /test ssim        — Full SSIM regression
  /test training   — Training pipeline      /test encoder     — Encoder tests
  /test transformer — Transformer tests     /test vae         — VAE tests
  /test kernel     — CUDA kernel tests      /test unit        — Unit tests
  See docs/contributing/pull_requests.md for all 17 test commands
-->

## Purpose

<!-- What does this PR do? Link the related issue if applicable. -->

Fixes #

## Changes

<!-- Describe your changes concisely. What approach did you take? -->

-

## Test Plan

<!-- How did you verify your changes? Paste exact commands and output. -->

```bash
# Commands you ran
```

## Test Results

<!-- Paste test output, before/after comparisons, or SSIM scores for model changes. -->

<details>
<summary>Test output</summary>

```
# Paste output here
```

</details>

## Checklist

- [ ] I ran `pre-commit run --all-files` and fixed all issues
- [ ] I added or updated tests for my changes
- [ ] I updated documentation if needed
- [ ] I considered GPU memory impact of my changes

**For model/pipeline changes, also check:**
- [ ] I verified SSIM regression tests pass
- [ ] I updated the support matrix if adding a new model
